### PR TITLE
Correct minors

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -9,5 +9,4 @@ filter=-build/include
 filter=-build/include_what_you_use
 filter=-build/include_order
 filter=-runtime/references
-filter=-build/c++11 # for unaproved header warnings
 filter=-runtime/string

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Build
 To build DynaFlow launcher, you must first deploy the Dynawo library with c++11 enabled. Then generate the cmake cache in your build directory:
 
-`cmake <SRC_DIR> -DDYNAWO_HOME=<DYNAWO_HOME> -DBOOST_ROOT=<DYNAWO_HOME> -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>`
+`cmake <SRC_DIR> -DCMAKE_BUILD_TYPE=Release -DDYNAWO_HOME=<DYNAWO_HOME> -DBOOST_ROOT=<DYNAWO_HOME> -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>`
 
 where:
 * SRC_DIR is the root directory of the dynaflow launcher repository


### PR DESCRIPTION
By default no optimization is done so we must precise in readme the release
CPPLINT must not filter unauthorized c++11 headers because in old compilers, these headers don't exist