### PR TITLE
Par-fields: added Pref and Uref fields

### DIFF
--- a/sources/Outputs/src/Par.cpp
+++ b/sources/Outputs/src/Par.cpp
@@ -166,6 +166,8 @@ Par::writeGenerator(const algo::GeneratorDefinition& def, const std::string& bas
   set->addReference(helper::buildReference("generator_Q0Pu", "q_pu", "DOUBLE"));
   set->addReference(helper::buildReference("generator_U0Pu", "v_pu", "DOUBLE"));
   set->addReference(helper::buildReference("generator_UPhase0", "angle_pu", "DOUBLE"));
+  set->addReference(helper::buildReference("generator_Pref0Pu", "targetP_pu", "DOUBLE"));
+  set->addReference(helper::buildReference("generator_Uref0Pu", "targetV_pu", "DOUBLE"));
 
   return set;
 }

--- a/sources/Outputs/src/Par.cpp
+++ b/sources/Outputs/src/Par.cpp
@@ -86,6 +86,8 @@ Par::updateSignalNGenerator(boost::shared_ptr<parameters::ParametersSet> set) {
   set->addReference(helper::buildReference("generator_Q0Pu", "q_pu", "DOUBLE"));
   set->addReference(helper::buildReference("generator_U0Pu", "v_pu", "DOUBLE"));
   set->addReference(helper::buildReference("generator_UPhase0", "angle_pu", "DOUBLE"));
+  set->addReference(helper::buildReference("generator_Pref0Pu", "targetP_pu", "DOUBLE"));
+  set->addReference(helper::buildReference("generator_Uref0Pu", "targetV_pu", "DOUBLE"));
 }
 
 std::vector<boost::shared_ptr<parameters::ParametersSet>>
@@ -99,8 +101,8 @@ Par::writeConstantSets(unsigned int nb_generators) {
   set->addParameter(helper::buildParameter("load_UMaxPu", 1.05));
   set->addParameter(helper::buildParameter("load_UMinPu", 0.95));
   set->addParameter(helper::buildParameter("load_tFilter", 10.));
-  set->addReference(helper::buildReference("load_P0Pu", "p_pu", "DOUBLE"));
-  set->addReference(helper::buildReference("load_Q0Pu", "q_pu", "DOUBLE"));
+  set->addReference(helper::buildReference("load_P0Pu", "p0_pu", "DOUBLE"));
+  set->addReference(helper::buildReference("load_Q0Pu", "q0_pu", "DOUBLE"));
   set->addReference(helper::buildReference("load_U0Pu", "v_pu", "DOUBLE"));
   set->addReference(helper::buildReference("load_UPhase0", "angle_pu", "DOUBLE"));
 

--- a/tests/outputs/reference/TestPar/TestPar.par
+++ b/tests/outputs/reference/TestPar/TestPar.par
@@ -17,9 +17,11 @@
     <reference type="DOUBLE" name="generator_PMax" origData="IIDM" origName="pMax"/>
     <reference type="DOUBLE" name="generator_PMin" origData="IIDM" origName="pMin"/>
     <reference type="DOUBLE" name="generator_PNom" origData="IIDM" origName="p_pu"/>
+    <reference type="DOUBLE" name="generator_Pref0Pu" origData="IIDM" origName="targetP_pu"/>
     <reference type="DOUBLE" name="generator_Q0Pu" origData="IIDM" origName="q_pu"/>
     <reference type="DOUBLE" name="generator_U0Pu" origData="IIDM" origName="v_pu"/>
     <reference type="DOUBLE" name="generator_UPhase0" origData="IIDM" origName="angle_pu"/>
+    <reference type="DOUBLE" name="generator_Uref0Pu" origData="IIDM" origName="targetV_pu"/>
   </set>
   <set id="6320417593396202500">
     <par name="generator_KGover" type="DOUBLE" value="1"/>
@@ -34,9 +36,11 @@
     <reference type="DOUBLE" name="generator_PMax" origData="IIDM" origName="pMax"/>
     <reference type="DOUBLE" name="generator_PMin" origData="IIDM" origName="pMin"/>
     <reference type="DOUBLE" name="generator_PNom" origData="IIDM" origName="p_pu"/>
+    <reference type="DOUBLE" name="generator_Pref0Pu" origData="IIDM" origName="targetP_pu"/>
     <reference type="DOUBLE" name="generator_Q0Pu" origData="IIDM" origName="q_pu"/>
     <reference type="DOUBLE" name="generator_U0Pu" origData="IIDM" origName="v_pu"/>
     <reference type="DOUBLE" name="generator_UPhase0" origData="IIDM" origName="angle_pu"/>
+    <reference type="DOUBLE" name="generator_Uref0Pu" origData="IIDM" origName="targetV_pu"/>
   </set>
   <set id="GenericRestorativeLoad">
     <par name="load_Alpha" type="DOUBLE" value="1.5"/>

--- a/tests/outputs/reference/TestPar/TestPar.par
+++ b/tests/outputs/reference/TestPar/TestPar.par
@@ -44,8 +44,8 @@
     <par name="load_UMaxPu" type="DOUBLE" value="1.05"/>
     <par name="load_UMinPu" type="DOUBLE" value="0.94999999999999996"/>
     <par name="load_tFilter" type="DOUBLE" value="10"/>
-    <reference type="DOUBLE" name="load_P0Pu" origData="IIDM" origName="p_pu"/>
-    <reference type="DOUBLE" name="load_Q0Pu" origData="IIDM" origName="q_pu"/>
+    <reference type="DOUBLE" name="load_P0Pu" origData="IIDM" origName="p0_pu"/>
+    <reference type="DOUBLE" name="load_Q0Pu" origData="IIDM" origName="q0_pu"/>
     <reference type="DOUBLE" name="load_U0Pu" origData="IIDM" origName="v_pu"/>
     <reference type="DOUBLE" name="load_UPhase0" origData="IIDM" origName="angle_pu"/>
   </set>
@@ -64,9 +64,11 @@
     <par name="line_XPu" type="DOUBLE" value="0.0001"/>
     <reference type="DOUBLE" name="generator_P0Pu" origData="IIDM" origName="p_pu"/>
     <reference type="DOUBLE" name="generator_PNom" origData="IIDM" origName="p_pu"/>
+    <reference type="DOUBLE" name="generator_Pref0Pu" origData="IIDM" origName="targetP_pu"/>
     <reference type="DOUBLE" name="generator_Q0Pu" origData="IIDM" origName="q_pu"/>
     <reference type="DOUBLE" name="generator_U0Pu" origData="IIDM" origName="v_pu"/>
     <reference type="DOUBLE" name="generator_UPhase0" origData="IIDM" origName="angle_pu"/>
+    <reference type="DOUBLE" name="generator_Uref0Pu" origData="IIDM" origName="targetV_pu"/>
   </set>
   <set id="signalNGenerator">
     <par name="generator_KGover" type="DOUBLE" value="1"/>
@@ -76,8 +78,10 @@
     <par name="generator_QMin" type="DOUBLE" value="-1.7976931348623157e+308"/>
     <reference type="DOUBLE" name="generator_P0Pu" origData="IIDM" origName="p_pu"/>
     <reference type="DOUBLE" name="generator_PNom" origData="IIDM" origName="p_pu"/>
+    <reference type="DOUBLE" name="generator_Pref0Pu" origData="IIDM" origName="targetP_pu"/>
     <reference type="DOUBLE" name="generator_Q0Pu" origData="IIDM" origName="q_pu"/>
     <reference type="DOUBLE" name="generator_U0Pu" origData="IIDM" origName="v_pu"/>
     <reference type="DOUBLE" name="generator_UPhase0" origData="IIDM" origName="angle_pu"/>
+    <reference type="DOUBLE" name="generator_Uref0Pu" origData="IIDM" origName="targetV_pu"/>
   </set>
 </parametersSet>


### PR DESCRIPTION
Signed-off-by: Guillaume Pernin <guillaume.pernin@rte-france.com>

Added Pref and Uref fields in par file, but need to know if they should be added to the writeGenerator function too.

Changed the reference of Load_P0Pu and load_Q0Pu