### PR TITLE
#128 Allow node breaker topologies

### DIFF
--- a/etc/DFLMessages_en_GB.dic
+++ b/etc/DFLMessages_en_GB.dic
@@ -16,7 +16,6 @@ ConnexityError                =     Slack node of id %1% not present in main con
 ConnexityErrorReCompute       =     Slack node of id %1% not present in main connex component: compute slack node only in main connex component
 SimulateInfo                  =     Initializing %1% simulation
 NetworkFileNotFound           =     Network file %1% does not exist
-NodeBreakerInterface          =     Node breaker topology for voltage level interface is not supported (%1%)
 ContextProcessError           =     Processing of the network %1% failed
 SimulationEnded               =     Simulation %1% ended successfully (wall-time: %2%s)
 DFLEnded                      =     DynaFlowLauncher %1% ended successfully (wall-time: %2%s)

--- a/sources/Inputs/src/NetworkManager.cpp
+++ b/sources/Inputs/src/NetworkManager.cpp
@@ -56,12 +56,6 @@ NetworkManager::buildTree() {
 
   const auto& voltageLevels = network->getVoltageLevels();
   for (auto it_v = voltageLevels.begin(); it_v != voltageLevels.end(); ++it_v) {
-    if ((*it_v)->getVoltageLevelTopologyKind() == DYN::VoltageLevelInterface::NODE_BREAKER) {
-      LOG(error) << MESS(NodeBreakerInterface, (*it_v)->getID()) << LOG_ENDL;
-      // This is done in class constructor so we exit directly
-      std::exit(EXIT_FAILURE);
-    }
-
     auto vl = std::make_shared<VoltageLevel>((*it_v)->getID());
     voltagelevels_.push_back(vl);
 


### PR DESCRIPTION
Following changes already merged in Dynawo to support PowSyBl IIDM 1.3.2, node/breaker topologies are now allowed in DynaFlow launcher. 

Must be used with a Dynawo release that also supports node/breaker topologies (see dynawo/dynawo#1532 and related pull request dynawo/dynawo#1536).