### PR TITLE
#209 Add runtime string filter

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -10,3 +10,4 @@ filter=-build/include
 filter=-build/include_what_you_use
 filter=-build/include_order
 filter=-runtime/references
+filter=-runtime/string


### PR DESCRIPTION
closes #209 

required to avoid cpplint errors on static const string in DFL