### PR TITLE
#229 Slack node not fictitious

### DIFF
--- a/sources/Algo/src/Algo.cpp
+++ b/sources/Algo/src/Algo.cpp
@@ -33,6 +33,9 @@ SlackNodeAlgorithm::SlackNodeAlgorithm(NodePtr& slackNode) : NodeAlgorithm(), sl
 
 void
 SlackNodeAlgorithm::operator()(const NodePtr& node) {
+  if (node->fictitious) {
+    return;
+  }
   if (!slackNode_) {
     slackNode_ = node;
   } else {

--- a/sources/Inputs/include/Node.h
+++ b/sources/Inputs/include/Node.h
@@ -197,6 +197,22 @@ class Node {
    * @param id the node id
    * @param vl the voltage level element containing the node
    * @param nominalVoltage the nominal voltage of the node
+   * @param fictitious the flag to mark the node is fictitious
+   * @param shunts the list of the shunts connectable to this node
+   *
+   * @returns the built node
+   */
+  static std::shared_ptr<Node> build(const NodeId& id, const std::shared_ptr<VoltageLevel>& vl, double nominalVoltage, bool fictitious,
+                                     const std::vector<Shunt>& shunts);
+
+  /**
+   * @brief Builder for node
+   *
+   * This builder will perform connections for voltage level element
+   *
+   * @param id the node id
+   * @param vl the voltage level element containing the node
+   * @param nominalVoltage the nominal voltage of the node
    * @param shunts the list of the shunts connectable to this node
    *
    * @returns the built node
@@ -206,6 +222,7 @@ class Node {
   const NodeId id;                                   ///< node id
   const std::weak_ptr<VoltageLevel> voltageLevel;    ///< voltage level containing the node
   const double nominalVoltage;                       ///< Nominal voltage of the node
+  const bool fictitious;                             ///< Flag to mark the node is fictitious
   const std::vector<Shunt> shunts;                   ///< Shunts connectable to the node
   std::vector<std::weak_ptr<Line>> lines;            ///< Lines connected to this node
   std::vector<std::weak_ptr<Tfo>> tfos;              ///< Transformers connected to this node
@@ -226,9 +243,10 @@ class Node {
    * @param id the node id
    * @param vl the voltage level element containing the node
    * @param nominalVoltage the voltage level associated with the node
+   * @param fictitious the flag to mark if node is fictitious
    * @param shunts the list of the shunts connectable to this node
    */
-  Node(const NodeId& id, const std::shared_ptr<VoltageLevel> vl, double nominalVoltage, const std::vector<Shunt>& shunts);
+  Node(const NodeId& id, const std::shared_ptr<VoltageLevel> vl, double nominalVoltage, bool fictitious, const std::vector<Shunt>& shunts);
 };
 
 /**

--- a/sources/Inputs/include/Node.h
+++ b/sources/Inputs/include/Node.h
@@ -197,33 +197,19 @@ class Node {
    * @param id the node id
    * @param vl the voltage level element containing the node
    * @param nominalVoltage the nominal voltage of the node
+   * @param shunts the list of the shunts connectable to this node
    * @param fictitious the flag to mark the node is fictitious
-   * @param shunts the list of the shunts connectable to this node
    *
    * @returns the built node
    */
-  static std::shared_ptr<Node> build(const NodeId& id, const std::shared_ptr<VoltageLevel>& vl, double nominalVoltage, bool fictitious,
-                                     const std::vector<Shunt>& shunts);
-
-  /**
-   * @brief Builder for node
-   *
-   * This builder will perform connections for voltage level element
-   *
-   * @param id the node id
-   * @param vl the voltage level element containing the node
-   * @param nominalVoltage the nominal voltage of the node
-   * @param shunts the list of the shunts connectable to this node
-   *
-   * @returns the built node
-   */
-  static std::shared_ptr<Node> build(const NodeId& id, const std::shared_ptr<VoltageLevel>& vl, double nominalVoltage, const std::vector<Shunt>& shunts);
+  static std::shared_ptr<Node> build(const NodeId& id, const std::shared_ptr<VoltageLevel>& vl, double nominalVoltage, const std::vector<Shunt>& shunts,
+                                     bool fictitious = false);
 
   const NodeId id;                                   ///< node id
   const std::weak_ptr<VoltageLevel> voltageLevel;    ///< voltage level containing the node
   const double nominalVoltage;                       ///< Nominal voltage of the node
-  const bool fictitious;                             ///< Flag to mark the node is fictitious
   const std::vector<Shunt> shunts;                   ///< Shunts connectable to the node
+  const bool fictitious;                             ///< Flag to mark the node is fictitious
   std::vector<std::weak_ptr<Line>> lines;            ///< Lines connected to this node
   std::vector<std::weak_ptr<Tfo>> tfos;              ///< Transformers connected to this node
   std::vector<std::shared_ptr<Node>> neighbours;     ///< list of neighbours
@@ -243,10 +229,10 @@ class Node {
    * @param id the node id
    * @param vl the voltage level element containing the node
    * @param nominalVoltage the voltage level associated with the node
-   * @param fictitious the flag to mark if node is fictitious
    * @param shunts the list of the shunts connectable to this node
+   * @param fictitious the flag to mark if node is fictitious
    */
-  Node(const NodeId& id, const std::shared_ptr<VoltageLevel> vl, double nominalVoltage, bool fictitious, const std::vector<Shunt>& shunts);
+  Node(const NodeId& id, const std::shared_ptr<VoltageLevel> vl, double nominalVoltage, const std::vector<Shunt>& shunts, bool fictitious);
 };
 
 /**

--- a/sources/Inputs/src/NetworkManager.cpp
+++ b/sources/Inputs/src/NetworkManager.cpp
@@ -90,8 +90,8 @@ NetworkManager::buildTree() {
       assert(nodes_.count(nodeId) == 0);
 #endif
       auto found = shuntsMap.find(nodeId);
-      nodes_[nodeId] = Node::build(nodeId, vl, networkVL->getVNom(), (found != shuntsMap.end()) ? found->second : std::vector<Shunt>{});
-      LOG(debug) << "Node " << nodeId << " created" << LOG_ENDL;
+      nodes_[nodeId] = Node::build(nodeId, vl, networkVL->getVNom(), bus->isFictitious(), (found != shuntsMap.end()) ? found->second : std::vector<Shunt>{});
+      LOG(debug) << "Node " << nodeId << " created" << (bus->isFictitious() ? " (fictitious)" : "") << LOG_ENDL;
       if (opt_id && *opt_id == nodeId) {
         LOG(debug) << "Slack node with id " << *opt_id << " found in network" << LOG_ENDL;
         slackNode_ = nodes_[nodeId];

--- a/sources/Inputs/src/NetworkManager.cpp
+++ b/sources/Inputs/src/NetworkManager.cpp
@@ -90,7 +90,7 @@ NetworkManager::buildTree() {
       assert(nodes_.count(nodeId) == 0);
 #endif
       auto found = shuntsMap.find(nodeId);
-      nodes_[nodeId] = Node::build(nodeId, vl, networkVL->getVNom(), bus->isFictitious(), (found != shuntsMap.end()) ? found->second : std::vector<Shunt>{});
+      nodes_[nodeId] = Node::build(nodeId, vl, networkVL->getVNom(), (found != shuntsMap.end()) ? found->second : std::vector<Shunt>{}, bus->isFictitious());
       LOG(debug) << "Node " << nodeId << " created" << (bus->isFictitious() ? " (fictitious)" : "") << LOG_ENDL;
       if (opt_id && *opt_id == nodeId) {
         LOG(debug) << "Slack node with id " << *opt_id << " found in network" << LOG_ENDL;

--- a/sources/Inputs/src/Node.cpp
+++ b/sources/Inputs/src/Node.cpp
@@ -21,26 +21,18 @@ namespace dfl {
 namespace inputs {
 
 std::shared_ptr<Node>
-Node::build(const NodeId& id, const std::shared_ptr<VoltageLevel>& vl, double nominalVoltage, const std::vector<Shunt>& shunts) {
-  bool fictitious = false;
-  auto ret = std::shared_ptr<Node>(new Node(id, vl, nominalVoltage, fictitious, shunts));
+Node::build(const NodeId& id, const std::shared_ptr<VoltageLevel>& vl, double nominalVoltage, const std::vector<Shunt>& shunts, bool fictitious) {
+  auto ret = std::shared_ptr<Node>(new Node(id, vl, nominalVoltage, shunts, fictitious));
   vl->nodes.push_back(ret);
   return ret;
 }
 
-std::shared_ptr<Node>
-Node::build(const NodeId& id, const std::shared_ptr<VoltageLevel>& vl, double nominalVoltage, bool fictitious, const std::vector<Shunt>& shunts) {
-  auto ret = std::shared_ptr<Node>(new Node(id, vl, nominalVoltage, fictitious, shunts));
-  vl->nodes.push_back(ret);
-  return ret;
-}
-
-Node::Node(const NodeId& idNode, const std::shared_ptr<VoltageLevel> vl, double nominalVoltageNode, bool fictitious, const std::vector<Shunt>& shunts) :
+Node::Node(const NodeId& idNode, const std::shared_ptr<VoltageLevel> vl, double nominalVoltageNode, const std::vector<Shunt>& shunts, bool fictitious) :
     id(idNode),
     voltageLevel(vl),
     nominalVoltage{nominalVoltageNode},
-    fictitious(fictitious),
     shunts(shunts),
+    fictitious(fictitious),
     neighbours{} {}
 
 bool

--- a/sources/Inputs/src/Node.cpp
+++ b/sources/Inputs/src/Node.cpp
@@ -22,15 +22,24 @@ namespace inputs {
 
 std::shared_ptr<Node>
 Node::build(const NodeId& id, const std::shared_ptr<VoltageLevel>& vl, double nominalVoltage, const std::vector<Shunt>& shunts) {
-  auto ret = std::shared_ptr<Node>(new Node(id, vl, nominalVoltage, shunts));
+  bool fictitious = false;
+  auto ret = std::shared_ptr<Node>(new Node(id, vl, nominalVoltage, fictitious, shunts));
   vl->nodes.push_back(ret);
   return ret;
 }
 
-Node::Node(const NodeId& idNode, const std::shared_ptr<VoltageLevel> vl, double nominalVoltageNode, const std::vector<Shunt>& shunts) :
+std::shared_ptr<Node>
+Node::build(const NodeId& id, const std::shared_ptr<VoltageLevel>& vl, double nominalVoltage, bool fictitious, const std::vector<Shunt>& shunts) {
+  auto ret = std::shared_ptr<Node>(new Node(id, vl, nominalVoltage, fictitious, shunts));
+  vl->nodes.push_back(ret);
+  return ret;
+}
+
+Node::Node(const NodeId& idNode, const std::shared_ptr<VoltageLevel> vl, double nominalVoltageNode, bool fictitious, const std::vector<Shunt>& shunts) :
     id(idNode),
     voltageLevel(vl),
     nominalVoltage{nominalVoltageNode},
+    fictitious(fictitious),
     shunts(shunts),
     neighbours{} {}
 

--- a/tests/algo/TestAlgo.cpp
+++ b/tests/algo/TestAlgo.cpp
@@ -134,6 +134,32 @@ TEST(SlackNodeAlgo, Base) {
   ASSERT_EQ("5", slack_node->id);
 }
 
+TEST(SlackNodeAlgo, BaseNonFictitious) {
+  auto vl = std::make_shared<dfl::inputs::VoltageLevel>("VL");
+  bool fictitious = true;
+  std::vector<std::shared_ptr<dfl::inputs::Node>> nodes{
+      dfl::inputs::Node::build("0", vl, 0.0, {}), dfl::inputs::Node::build("1", vl, 1.0, {}), dfl::inputs::Node::build("2", vl, 2.0, {}),
+      dfl::inputs::Node::build("3", vl, 3.0, {}), dfl::inputs::Node::build("4", vl, 4.0, {}), dfl::inputs::Node::build("5", vl, 5.0, fictitious, {}),
+      dfl::inputs::Node::build("6", vl, 0.0, {}),
+  };
+
+  nodes[0]->neighbours.push_back(nodes[1]);
+  nodes[0]->neighbours.push_back(nodes[2]);
+  nodes[0]->neighbours.push_back(nodes[3]);
+
+  nodes[4]->neighbours.push_back(nodes[1]);
+  nodes[4]->neighbours.push_back(nodes[2]);
+  nodes[4]->neighbours.push_back(nodes[3]);
+
+  std::shared_ptr<dfl::inputs::Node> slack_node;
+  dfl::algo::SlackNodeAlgorithm algo(slack_node);
+
+  std::for_each(nodes.begin(), nodes.end(), algo);
+
+  ASSERT_NE(nullptr, slack_node);
+  ASSERT_EQ("4", slack_node->id);  // Node 5 is discarded because it is fictitious
+}
+
 TEST(SlackNodeAlgo, neighbours) {
   auto vl = std::make_shared<dfl::inputs::VoltageLevel>("VL");
   std::vector<std::shared_ptr<dfl::inputs::Node>> nodes{

--- a/tests/algo/TestAlgo.cpp
+++ b/tests/algo/TestAlgo.cpp
@@ -139,7 +139,7 @@ TEST(SlackNodeAlgo, BaseNonFictitious) {
   bool fictitious = true;
   std::vector<std::shared_ptr<dfl::inputs::Node>> nodes{
       dfl::inputs::Node::build("0", vl, 0.0, {}), dfl::inputs::Node::build("1", vl, 1.0, {}), dfl::inputs::Node::build("2", vl, 2.0, {}),
-      dfl::inputs::Node::build("3", vl, 3.0, {}), dfl::inputs::Node::build("4", vl, 4.0, {}), dfl::inputs::Node::build("5", vl, 5.0, fictitious, {}),
+      dfl::inputs::Node::build("3", vl, 3.0, {}), dfl::inputs::Node::build("4", vl, 4.0, {}), dfl::inputs::Node::build("5", vl, 5.0, {}, fictitious),
       dfl::inputs::Node::build("6", vl, 0.0, {}),
   };
 


### PR DESCRIPTION
Closes #229.
Requires Dynawo explicit flag for fictitious bus component interface: dynawo/dynawo#1954