### PR TITLE
#237 Allow contingencies on open-ended branches and 3-winding transformers

### DIFF
--- a/scripts/diffContingencies.py
+++ b/scripts/diffContingencies.py
@@ -63,14 +63,26 @@ if __name__ == "__main__":
     options = parser.parse_args()
     total_diffs = 0
 
+    reference_root = full_path(options.root, "reference", options.testdir)
     results_root = full_path(options.root, "results", options.testdir)
 
+    # Check that all references have a result file
+    # FIXME(Luma): allow this code to execute when Static Var Compensators are allowed in contingencies
+    if False:
+        for folder in os.listdir(reference_root):
+            reference_path = full_path(options.root, "reference", options.testdir, folder, "outputIIDM.xml")
+            if os.path.exists(reference_path):
+                result_path = full_path(options.root, "results", options.testdir, folder, "outputs/finalState/outputIIDM.xml")
+                if not os.path.exists(result_path):
+                    print(folder + ": Reference exists but no results produced")
+                    total_diffs += 1
+
+    # Check that all result files are equal to the corresponding reference
     print(results_root)
     for folder in os.listdir(results_root):
-
         if os.path.isdir(os.path.join(results_root, folder)):
             nb_differences = compare_file(options, folder)
-
             total_diffs += nb_differences
+
 
     sys.exit(total_diffs)

--- a/sources/Inputs/src/NetworkManager.cpp
+++ b/sources/Inputs/src/NetworkManager.cpp
@@ -186,7 +186,7 @@ NetworkManager::buildTree() {
   for (const auto& line : lines) {
     auto bus1 = line->getBusInterface1();
     auto bus2 = line->getBusInterface2();
-    if (line->getInitialConnected1() && line->getInitialConnected2()) {
+    if (line->getInitialConnected1() || line->getInitialConnected2()) {
 #if _DEBUG_
       assert(nodes_.count(bus1->getID()) > 0);
       assert(nodes_.count(bus2->getID()) > 0);
@@ -202,7 +202,7 @@ NetworkManager::buildTree() {
   for (const auto& transfo : transfos) {
     auto bus1 = transfo->getBusInterface1();
     auto bus2 = transfo->getBusInterface2();
-    if (transfo->getInitialConnected1() && transfo->getInitialConnected2()) {
+    if (transfo->getInitialConnected1() || transfo->getInitialConnected2()) {
       auto tfo = Tfo::build(transfo->getID(), nodes_.at(bus1->getID()), nodes_.at(bus2->getID()));
       tfos_.push_back(tfo);
 
@@ -215,7 +215,7 @@ NetworkManager::buildTree() {
     auto bus1 = transfo->getBusInterface1();
     auto bus2 = transfo->getBusInterface2();
     auto bus3 = transfo->getBusInterface3();
-    if (transfo->getInitialConnected1() && transfo->getInitialConnected2() && transfo->getInitialConnected3()) {
+    if (transfo->getInitialConnected1() || transfo->getInitialConnected2() || transfo->getInitialConnected3()) {
       auto tfo = Tfo::build(transfo->getID(), nodes_.at(bus1->getID()), nodes_.at(bus2->getID()), nodes_.at(bus3->getID()));
       tfos_.push_back(tfo);
 

--- a/tests/main_sa/reference/launch/BaseCase/outputIIDM.xml
+++ b/tests/main_sa/reference/launch/BaseCase/outputIIDM.xml
@@ -31,8 +31,8 @@
                     <iidm:alias>_bea273f1-1e21-476d-b0d0-92dd6cb9a2d4</iidm:alias>
                     <iidm:alias>_c94e6b68-da6c-43d1-94fd-09ad60c74134</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_047abdd7-c766-11e1-8775-005056c00008-BREAKER" name="BREAKER-Jay LD" kind="BREAKER" retained="true" open="false" node1="0" node2="8"/>
                 <iidm:internalConnection node1="7" node2="0"/>
-                <iidm:internalConnection node1="8" node2="0"/>
                 <iidm:internalConnection node1="9" node2="1"/>
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="4"/>
@@ -47,9 +47,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="124.69165266371481" angle="7.3265114706812122" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.79227694146184" angle="-3.8304291083000113" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047abdd7-c766-11e1-8775-005056c00008" name="Jay LD" loadType="UNDEFINED" p0="14" q0="8" node="8" p="13.998798160986878" q="7.9988554241696059">
+            <iidm:load id="_047abdd7-c766-11e1-8775-005056c00008" name="Jay LD" loadType="UNDEFINED" p0="14" q0="8" node="8" p="13.998842287628941" q="7.9988974471819896">
                 <iidm:alias>_04590500-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -139,12 +139,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="127.71874633231927" angle="10.741556031172914" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="127.91088530210716" angle="-0.6073188025111067" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045b00d5-c766-11e1-8775-005056c00008" name="Madison LD" loadType="UNDEFINED" p0="62" q0="13" node="14" p="61.999052931415058" q="12.999669036857126">
+            <iidm:load id="_045b00d5-c766-11e1-8775-005056c00008" name="Madison LD" loadType="UNDEFINED" p0="62" q0="13" node="14" p="61.999279631742155" q="12.999748259379501">
                 <iidm:alias>_045b27e3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_04689566-c766-11e1-8775-005056c00008" name="Madison NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="15" p="8.9998625223021858" q="0">
+            <iidm:load id="_04689566-c766-11e1-8775-005056c00008" name="Madison NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="15" p="8.9998954304141829" q="0">
                 <iidm:alias>_04765100-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -272,16 +272,16 @@
                 <iidm:internalConnection node1="61" node2="12"/>
                 <iidm:internalConnection node1="62" node2="15"/>
                 <iidm:internalConnection node1="63" node2="18"/>
-                <iidm:bus v="126.06001985094952" angle="-7.5417681336975821" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63"/>
+                <iidm:bus v="126.06000647567201" angle="-18.730053496668255" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_046c3ee7-c766-11e1-8775-005056c00008" name="Torrey SM" energySource="THERMAL" minP="20" maxP="80" ratedS="100" voltageRegulatorOn="true" targetP="48" targetV="126.06" targetQ="0" node="21" p="-53.151775932706116" q="-7.2685691625645408">
+            <iidm:generator id="_046c3ee7-c766-11e1-8775-005056c00008" name="Torrey SM" energySource="THERMAL" minP="20" maxP="80" ratedS="100" voltageRegulatorOn="true" targetP="48" targetV="126.06" targetQ="0" node="21" p="-53.142615141354355" q="-7.2794377562406494">
                 <iidm:alias>_047147f3-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_b97aee41-3115-4cfd-9071-b52fb44d0b66"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_5005c073-28d1-4a7d-b257-649dec43ec73"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-30" maxQ="85"/>
             </iidm:generator>
-            <iidm:load id="_044afb44-c766-11e1-8775-005056c00008" name="Torrey LD" loadType="UNDEFINED" p0="113" q0="32" node="20" p="113.00002669154428" q="32.000012597780007">
+            <iidm:load id="_044afb44-c766-11e1-8775-005056c00008" name="Torrey LD" loadType="UNDEFINED" p0="113" q0="32" node="20" p="113.00000870717449" q="32.000004109580992">
                 <iidm:alias>_04522737-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -332,9 +332,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="123.83811963948784" angle="8.2385917031194662" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="123.82774307795093" angle="-3.0042418823257031" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04481515-c766-11e1-8775-005056c00008" name="Darrah LD" loadType="UNDEFINED" p0="68" q0="36" node="8" p="68.000043329932083" q="36.000038232301129">
+            <iidm:load id="_04481515-c766-11e1-8775-005056c00008" name="Darrah LD" loadType="UNDEFINED" p0="68" q0="36" node="8" p="68.000009481875679" q="36.000008366361271">
                 <iidm:alias>_044e7db8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -385,9 +385,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.46455823186903" angle="22.649869995956326" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.45869429117809" angle="11.429295070843853" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044c0cb3-c766-11e1-8775-005056c00008" name="Smythe LD" loadType="UNDEFINED" p0="5" q0="3" node="8" p="4.9999792522939481" q="2.9999792523226456">
+            <iidm:load id="_044c0cb3-c766-11e1-8775-005056c00008" name="Smythe LD" loadType="UNDEFINED" p0="5" q0="3" node="8" p="4.999976644433958" q="2.9999766444703235">
                 <iidm:alias>_045163e8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -514,9 +514,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="125.90823564116218" angle="-7.7141252413775119" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="125.9081898659455" angle="-18.902474884436835" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0450a093-c766-11e1-8775-005056c00008" name="Sunnysde LD" loadType="UNDEFINED" p0="84" q0="18" node="20" p="84.000020426702434" q="18.000007295251457">
+            <iidm:load id="_0450a093-c766-11e1-8775-005056c00008" name="Sunnysde LD" loadType="UNDEFINED" p0="84" q0="18" node="20" p="84.000007006198658" q="18.000002502213881">
                 <iidm:alias>_045f4695-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -568,12 +568,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="126.73311473426629" angle="8.0967565293292498" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="126.73549335312282" angle="-3.1631216164503275" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044b2251-c766-11e1-8775-005056c00008" name="Bellefnt LD" loadType="UNDEFINED" p0="68" q0="27" node="8" p="68.000234291982949" q="27.000155046343256">
+            <iidm:load id="_044b2251-c766-11e1-8775-005056c00008" name="Bellefnt LD" loadType="UNDEFINED" p0="68" q0="27" node="8" p="68.000223835492321" q="27.000148126591274">
                 <iidm:alias>_04622cc1-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0449e9d5-c766-11e1-8775-005056c00008" name="Bellefnt SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.40300000000001" targetDeadband="1" node="9" q="-11.066223553101358">
+            <iidm:shunt id="_0449e9d5-c766-11e1-8775-005056c00008" name="Bellefnt SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.40300000000001" targetDeadband="1" node="9" q="-11.066638954791552">
                 <iidm:alias>_047bcf48-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_6cc38790-c6a6-4309-99f4-a3258e24e785"/>
                 <iidm:shuntLinearModel bPerSection="0.00013779999999999999" gPerSection="0" maximumSectionCount="10"/>
@@ -665,12 +665,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="126.06602611557975" angle="8.3104898665180968" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="126.06596956997664" angle="-2.9166719299250263" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04682035-c766-11e1-8775-005056c00008" name="Fieldale LD" loadType="UNDEFINED" p0="39" q0="30" node="14" p="39.000049799984019" q="30.000063846160536">
+            <iidm:load id="_04682035-c766-11e1-8775-005056c00008" name="Fieldale LD" loadType="UNDEFINED" p0="39" q0="30" node="14" p="39.000032607460639" q="30.000041804448362">
                 <iidm:alias>_0478c20a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_045c6067-c766-11e1-8775-005056c00008" name="Fieldale SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.066" targetDeadband="1" node="15" q="-5.4670691715574682">
+            <iidm:shunt id="_045c6067-c766-11e1-8775-005056c00008" name="Fieldale SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.066" targetDeadband="1" node="15" q="-5.4670642671646883">
                 <iidm:alias>_0451b209-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_2d222dd9-7306-4afd-baa5-fd303b0eeb40"/>
                 <iidm:shuntLinearModel bPerSection="6.8800000000000005e-05" gPerSection="0" maximumSectionCount="10"/>
@@ -780,7 +780,7 @@
                 <iidm:internalConnection node1="51" node2="9"/>
                 <iidm:internalConnection node1="52" node2="12"/>
                 <iidm:internalConnection node1="53" node2="15"/>
-                <iidm:bus v="138.01489729429804" angle="4.2525978502248512" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
+                <iidm:bus v="138.01483897832313" angle="-6.9373296281039245" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="_047f0391-c766-11e1-8775-005056c00008" name="Muskngum SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="392" targetV="138.59999099999999" targetQ="0" node="18" p="-0" q="-0">
                 <iidm:alias>_047eb572-c766-11e1-8775-005056c00008</iidm:alias>
@@ -789,7 +789,7 @@
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
-            <iidm:load id="_047e1936-c766-11e1-8775-005056c00008" name="Muskngum LD" loadType="UNDEFINED" p0="39" q0="18" node="17" p="38.999759261678001" q="17.999814817056418">
+            <iidm:load id="_047e1936-c766-11e1-8775-005056c00008" name="Muskngum LD" loadType="UNDEFINED" p0="39" q0="18" node="17" p="38.999752779804986" q="17.999809831021047">
                 <iidm:alias>_046e88d5-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -876,9 +876,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="221.10004971053735" angle="9.4154042711378079" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="221.10002034239457" angle="-1.7776257607529677" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0458ddf1-c766-11e1-8775-005056c00008" name="Muskngum SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="391" targetV="221.09999999999999" targetQ="0" node="14" p="-432.96550811850193" q="-159.69101557061151">
+            <iidm:generator id="_0458ddf1-c766-11e1-8775-005056c00008" name="Muskngum SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="391" targetV="221.09999999999999" targetQ="0" node="14" p="-432.89088583894903" q="-159.60943377839664">
                 <iidm:alias>_04522732-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_5036c3a5-56f9-489c-9ecb-8c15aa7c70c5"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_12b01822-ca11-4cf8-a6b4-2f8ff805ca20"/>
@@ -886,7 +886,7 @@
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045cae83-c766-11e1-8775-005056c00008" name="65-66" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="42" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="273.32553361724553" q1="97.438079398318592" p2="-273.32553361724558" q2="-70.472484007571936">
+        <iidm:twoWindingsTransformer id="_045cae83-c766-11e1-8775-005056c00008" name="65-66" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="42" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="273.16157317336422" q1="97.424133830949643" p2="-273.16157317336422" q2="-70.48809691641577">
             <iidm:alias>_044b2254-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_044b4964-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_045645e1-c766-11e1-8775-005056c00008</iidm:alias>
@@ -961,9 +961,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="124.08402337518451" angle="5.4975651572333728" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.12720127585716" angle="-5.53730159629787" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0453d4e2-c766-11e1-8775-005056c00008" name="Adams LD" loadType="UNDEFINED" p0="18" q0="3" node="8" p="17.99823079312576" q="2.9995085697475217">
+            <iidm:load id="_0453d4e2-c766-11e1-8775-005056c00008" name="Adams LD" loadType="UNDEFINED" p0="18" q0="3" node="8" p="17.998274870733038" q="2.9995208127350144">
                 <iidm:alias>_0448ff77-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1053,16 +1053,16 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="133.32009362912027" angle="14.051801636323713" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="133.32005525086427" angle="2.8250394068502716" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_046bf0c4-c766-11e1-8775-005056c00008" name="Claytor SM" energySource="THERMAL" minP="0" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="40" targetV="133.31999200000001" targetQ="0" node="15" p="-44.29314661058843" q="-83.070087597840597">
+            <iidm:generator id="_046bf0c4-c766-11e1-8775-005056c00008" name="Claytor SM" energySource="THERMAL" minP="0" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="40" targetV="133.31999200000001" targetQ="0" node="15" p="-44.285512617795298" q="-83.074013033558941">
                 <iidm:alias>_0460a627-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e56da2eb-bb6a-4133-953c-40073c5bc5f4"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_d41be6b4-155e-4c8f-b46b-16b50c49f0f4"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-60" maxQ="170"/>
             </iidm:generator>
-            <iidm:load id="_048433b6-c766-11e1-8775-005056c00008" name="Claytor LD" loadType="UNDEFINED" p0="23" q0="16" node="14" p="23.000026299171374" q="16.00003049180452">
+            <iidm:load id="_048433b6-c766-11e1-8775-005056c00008" name="Claytor LD" loadType="UNDEFINED" p0="23" q0="16" node="14" p="23.000016367800836" q="16.000018977164892">
                 <iidm:alias>_0480ff6b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1133,12 +1133,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="129.73941256007288" angle="-4.3830807370349962" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="129.73435504483012" angle="-15.551805100788059" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0449e9d7-c766-11e1-8775-005056c00008" name="N.Newark LD" loadType="UNDEFINED" p0="53" q0="22" node="11" p="52.99779396438641" q="21.998473833014749">
+            <iidm:load id="_0449e9d7-c766-11e1-8775-005056c00008" name="N.Newark LD" loadType="UNDEFINED" p0="53" q0="22" node="11" p="52.997779808732915" q="21.998464040067979">
                 <iidm:alias>_04531191-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_04684741-c766-11e1-8775-005056c00008" name="N.Newark SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.32300000000001" targetDeadband="1" node="12" q="-9.6617489084024246">
+            <iidm:shunt id="_04684741-c766-11e1-8775-005056c00008" name="N.Newark SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.32300000000001" targetDeadband="1" node="12" q="-9.6609956524874772">
                 <iidm:alias>_04607f19-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_eae61817-d3cb-488f-a1f3-13bc8e31431b"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -1191,9 +1191,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.95184011618446" angle="11.019488463915426" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="131.03788852171832" angle="-0.36084546592108629" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0448d86a-c766-11e1-8775-005056c00008" name="Hillsbro NegG LD" loadType="UNDEFINED" p0="12" q0="0" node="8" p="11.999880367280385" q="0">
+            <iidm:load id="_0448d86a-c766-11e1-8775-005056c00008" name="Hillsbro NegG LD" loadType="UNDEFINED" p0="12" q0="0" node="8" p="11.999893028242123" q="0">
                 <iidm:alias>_044ef2e8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1244,9 +1244,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="125.32375616344306" angle="-6.0209603429432104" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="125.27618859547795" angle="-17.129451902872379" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047dcb12-c766-11e1-8775-005056c00008" name="S.Kenton LD" loadType="UNDEFINED" p0="18" q0="7" node="8" p="17.996580822900636" q="6.997784007019157">
+            <iidm:load id="_047dcb12-c766-11e1-8775-005056c00008" name="S.Kenton LD" loadType="UNDEFINED" p0="18" q0="7" node="8" p="17.996557046813091" q="6.997768598550409">
                 <iidm:alias>_0451b205-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1281,6 +1281,9 @@
                     <iidm:alias>_8ef85f09-3622-4a12-87bf-fefcecc01e4a</iidm:alias>
                     <iidm:alias>_a0244ab3-80e5-4c20-b201-a142d50e6ec1</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_dffdb415-95a8-496a-ad1a-93cdeb444fae-1" name="DISCONNECTOR723-1" kind="DISCONNECTOR" retained="false" open="false" node1="24" node2="25"/>
+                <iidm:switch id="_aa063f2e-1205-4d1a-a549-3ccc5b31e65d-1" name="BREAKER362-1" kind="BREAKER" retained="false" open="false" node1="23" node2="24"/>
+                <iidm:switch id="_28b3e895-483c-478d-a5a3-7b9d7c9e11f3-1" name="DISCONNECTOR724-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="23"/>
                 <iidm:internalConnection node1="7" node2="0"/>
                 <iidm:internalConnection node1="8" node2="0"/>
                 <iidm:internalConnection node1="9" node2="1"/>
@@ -1297,9 +1300,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="125.20892983088584" angle="21.156417329181469" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.17904004337055" angle="10.032206258610907" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044afb49-c766-11e1-8775-005056c00008" name="Hazard LD" loadType="UNDEFINED" p0="21" q0="10" node="8" p="20.998300728025413" q="9.998651407825049">
+            <iidm:load id="_044afb49-c766-11e1-8775-005056c00008" name="Hazard LD" loadType="UNDEFINED" p0="21" q0="10" node="8" p="20.997914180158624" q="9.9983446422359012">
                 <iidm:alias>_045e5c31-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1320,6 +1323,9 @@
                     <iidm:alias>_2a61ce12-8d9c-4aae-8bc7-c8f820ecae6c</iidm:alias>
                     <iidm:alias>_a3d5e8cc-be34-4d4a-a586-ce582737826b</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_83a05cd7-017e-4e7a-bc5e-a01ee9681f9f-1" name="DISCONNECTOR725-1" kind="DISCONNECTOR" retained="false" open="false" node1="14" node2="15"/>
+                <iidm:switch id="_cf4393c0-21c2-4e35-b330-c1acda2647ba-1" name="BREAKER363-1" kind="BREAKER" retained="false" open="true" node1="13" node2="14"/>
+                <iidm:switch id="_b9ab29b9-3d90-4536-8d1a-7757d8c22ae4-1" name="DISCONNECTOR726-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="13"/>
                 <iidm:internalConnection node1="4" node2="0"/>
                 <iidm:internalConnection node1="5" node2="0"/>
                 <iidm:internalConnection node1="6" node2="1"/>
@@ -1329,14 +1335,14 @@
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="3"/>
-                <iidm:bus v="31.302232457721459" angle="21.156417329181462" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="31.044760010842637" angle="10.032206258610907" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13"/>
             </iidm:nodeBreakerTopology>
             <iidm:staticVarCompensator id="_047fc6e6-c766-11e1-8775-005056c00008" name="Pinevlle SVC" bMin="-10" bMax="10" voltageSetpoint="33.494999999999997" regulationMode="VOLTAGE" node="5" p="0" q="0">
                 <iidm:alias>_046ab846-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_98f667da-02d1-4a31-b826-44314a1fbbfe"/>
             </iidm:staticVarCompensator>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045e3525-c766-11e1-8775-005056c00008" name="86-87" r="0.30796918750000002" x="2.2585859312499998" g="0" b="-0.0040863184000000004" ratedU1="132" ratedU2="33" node1="22" voltageLevelId1="_0484f70a-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_04555b88-c766-11e1-8775-005056c00008" p1="3.8337388819087437e-14" q1="4.0038963642314105" p2="2.8506121928969741e-15" q2="-7.3659306760158943e-15">
+        <iidm:twoWindingsTransformer id="_045e3525-c766-11e1-8775-005056c00008" name="86-87" r="0.30796918750000002" x="2.2585859312499998" g="0" b="-0.0040863184000000004" ratedU1="132" ratedU2="33" node1="22" voltageLevelId1="_0484f70a-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_04555b88-c766-11e1-8775-005056c00008" p1="-2.4286128663675299e-15" q1="3.9383001958348389" p2="1.5288182858671002e-14" q2="-2.6463573444806995e-14">
             <iidm:alias>_0452755a-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04682034-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_048c7110-c766-11e1-8775-005056c00008</iidm:alias>
@@ -1412,6 +1418,82 @@
                 <iidm:temporaryLimit name="_257d56c1-d70a-4a96-b85c-d928ade03ad4" acceptableDuration="60" value="12246"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
+        <iidm:twoWindingsTransformer id="_045e3525-c766-11e1-8775-005056c00008-1" name="86-87-open-ended" r="0.30796918750000002" x="2.2585859312499998" g="0" b="-0.0040863184000000004" ratedU1="132" ratedU2="33" node1="25" voltageLevelId1="_0484f70a-c766-11e1-8775-005056c00008" node2="15" voltageLevelId2="_04555b88-c766-11e1-8775-005056c00008" p1="0" q1="3.9383001958348305" p2="0" q2="0">
+            <iidm:alias>_0452755a-c766-11e1-8775-005056c00008-1</iidm:alias>
+            <iidm:alias>_04682034-c766-11e1-8775-005056c00008-1</iidm:alias>
+            <iidm:alias>_048c7110-c766-11e1-8775-005056c00008-1</iidm:alias>
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="31" loadTapChangingCapabilities="false">
+                <iidm:step r="-78.460970487743992" x="-78.460970487743992" g="364.27347129590328" b="364.27347129590328" rho="0.4641016"/>
+                <iidm:step r="-76.770985444658564" x="-76.770985444658564" g="330.49609255595948" b="330.49609255595948" rho="0.48196488000000004"/>
+                <iidm:step r="-75.017181047101431" x="-75.017181047101431" g="300.27508580410921" b="300.27508580410921" rho="0.49982816000000002"/>
+                <iidm:step r="-73.199557295072623" x="-73.199557295072623" g="273.1281647135425" b="273.1281647135425" rho="0.51769144000000011"/>
+                <iidm:step r="-71.318114188572153" x="-71.318114188572153" g="248.65210975826625" b="248.65210975826625" rho="0.53555472000000004"/>
+                <iidm:step r="-69.372851727600008" x="-69.372851727600008" g="226.50770848984379" b="226.50770848984379" rho="0.55341799999999997"/>
+                <iidm:step r="-67.363769912156158" x="-67.363769912156158" g="206.40793906293555" b="206.40793906293555" rho="0.57128128"/>
+                <iidm:step r="-65.290868742240633" x="-65.290868742240633" g="188.10862264852744" b="188.10862264852744" rho="0.58914456000000004"/>
+                <iidm:step r="-63.154148217853432" x="-63.154148217853432" g="171.40097232995538" b="171.40097232995538" rho="0.60700784000000008"/>
+                <iidm:step r="-60.953608338994556" x="-60.953608338994556" g="156.10561116167679" b="156.10561116167679" rho="0.62487112"/>
+                <iidm:step r="-58.689249105663997" x="-58.689249105663997" g="142.06773741726079" b="142.06773741726079" rho="0.64273440000000004"/>
+                <iidm:step r="-56.361070517861769" x="-56.361070517861769" g="129.15319231405709" b="129.15319231405709" rho="0.66059767999999996"/>
+                <iidm:step r="-53.969072575587838" x="-53.969072575587838" g="117.24524269951107" b="117.24524269951107" rho="0.67846096"/>
+                <iidm:step r="-51.51325527884223" x="-51.51325527884223" g="106.24193390397649" b="106.24193390397649" rho="0.69632424000000004"/>
+                <iidm:step r="-48.993618627624947" x="-48.993618627624947" g="96.053900138385018" b="96.053900138385018" rho="0.71418752000000008"/>
+                <iidm:step r="-46.410162621936003" x="-46.410162621936003" g="86.602544237115268" b="86.602544237115268" rho="0.7320508"/>
+                <iidm:step r="-43.762887261775354" x="-43.762887261775354" g="77.81851722275475" b="77.81851722275475" rho="0.74991407999999993"/>
+                <iidm:step r="-41.051792547143037" x="-41.051792547143037" g="69.640442552852292" b="69.640442552852292" rho="0.76777735999999996"/>
+                <iidm:step r="-38.276878478039045" x="-38.276878478039045" g="62.013841060226049" b="62.013841060226049" rho="0.78564064"/>
+                <iidm:step r="-35.438145054463355" x="-35.438145054463355" g="54.890221299184191" b="54.890221299184191" rho="0.80350392000000004"/>
+                <iidm:step r="-32.53559227641599" x="-32.53559227641599" g="48.2263068397802" b="48.2263068397802" rho="0.82136720000000008"/>
+                <iidm:step r="-29.569220143896956" x="-29.569220143896956" g="41.983377444222199" b="41.983377444222199" rho="0.83923048"/>
+                <iidm:step r="-26.53902865690624" x="-26.53902865690624" g="36.126705339843348" b="36.126705339843348" rho="0.85709376000000004"/>
+                <iidm:step r="-23.445017815443848" x="-23.445017815443848" g="30.625071218648301" b="30.625071218648301" rho="0.87495704000000007"/>
+                <iidm:step r="-20.287187619509762" x="-20.287187619509762" g="25.450347332714429" b="25.450347332714429" rho="0.89282032000000011"/>
+                <iidm:step r="-17.06553806910399" x="-17.06553806910399" g="20.577137262099331" b="20.577137262099331" rho="0.91068360000000004"/>
+                <iidm:step r="-13.780069164226571" x="-13.780069164226571" g="15.982463718828566" b="15.982463718828566" rho="0.92854687999999996"/>
+                <iidm:step r="-10.430780904877434" x="-10.430780904877434" g="11.645497203453271" b="11.645497203453271" rho="0.94641016"/>
+                <iidm:step r="-7.0176732910566368" x="-7.0176732910566368" g="7.5473195169912355" b="7.5473195169912355" rho="0.96427344000000004"/>
+                <iidm:step r="-3.5407463227641656" x="-3.5407463227641656" g="3.6707171036300279" b="3.6707171036300279" rho="0.98213671999999985"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1"/>
+                <iidm:step r="3.6045656772358381" x="3.6045656772358381" g="-3.4791571719583358" b="-3.4791571719583358" rho="1.01786328"/>
+                <iidm:step r="7.272950708943382" x="7.272950708943382" g="-6.7798551833225922" b="-6.7798551833225922" rho="1.0357265600000001"/>
+                <iidm:step r="11.005155095122543" x="11.005155095122543" g="-9.9140937064517427" b="-9.9140937064517427" rho="1.0535898399999999"/>
+                <iidm:step r="14.801178835773431" x="14.801178835773431" g="-12.892880531259154" b="-12.892880531259154" rho="1.0714531199999999"/>
+                <iidm:step r="18.661021930895984" x="18.661021930895984" g="-15.726328348801433" b="-15.726328348801433" rho="1.0893164"/>
+                <iidm:step r="22.584684380490238" x="22.584684380490238" g="-18.423740693731116" b="-18.423740693731116" rho="1.10717968"/>
+                <iidm:step r="26.572166184556178" x="26.572166184556178" g="-20.993688411566747" b="-20.993688411566747" rho="1.12504296"/>
+                <iidm:step r="30.623467343093779" x="30.623467343093779" g="-23.444077826121855" b="-23.444077826121855" rho="1.1429062400000001"/>
+                <iidm:step r="34.738587856103067" x="34.738587856103067" g="-25.782211620922489" b="-25.782211620922489" rho="1.1607695200000001"/>
+                <iidm:step r="38.917527723583987" x="38.917527723583987" g="-28.014843311220961" b="-28.014843311220961" rho="1.1786327999999999"/>
+                <iidm:step r="43.16028694553664" x="43.16028694553664" g="-30.148226066322692" b="-30.148226066322692" rho="1.19649608"/>
+                <iidm:step r="47.466865521960955" x="47.466865521960955" g="-32.188156542116317" b="-32.188156542116317" rho="1.21435936"/>
+                <iidm:step r="51.837263452856973" x="51.837263452856973" g="-34.140014298236885" b="-34.140014298236885" rho="1.23222264"/>
+                <iidm:step r="56.271480738224653" x="56.271480738224653" g="-36.0087973009527" b="-36.0087973009527" rho="1.2500859200000001"/>
+                <iidm:step r="60.769517378063973" x="60.769517378063973" g="-37.799153949786998" b="-37.799153949786998" rho="1.2679491999999999"/>
+                <iidm:step r="65.331373372375026" x="65.331373372375026" g="-39.515412011505823" b="-39.515412011505823" rho="1.2858124799999999"/>
+                <iidm:step r="69.957048721157761" x="69.957048721157761" g="-41.161604798123854" b="-41.161604798123854" rho="1.30367576"/>
+                <iidm:step r="74.646543424412172" x="74.646543424412172" g="-42.741494884907091" b="-42.741494884907091" rho="1.32153904"/>
+                <iidm:step r="79.399857482138245" x="79.399857482138245" g="-44.258595629064871" b="-44.258595629064871" rho="1.33940232"/>
+                <iidm:step r="84.216990894335964" x="84.216990894335964" g="-45.716190719151165" b="-45.716190719151165" rho="1.3572655999999998"/>
+                <iidm:step r="89.097943661005473" x="89.097943661005473" g="-47.11735195848069" b="-47.11735195848069" rho="1.3751288800000001"/>
+                <iidm:step r="94.04271578214653" x="94.04271578214653" g="-48.464955462553469" b="-48.464955462553469" rho="1.3929921599999999"/>
+                <iidm:step r="99.051307257759348" x="99.051307257759348" g="-49.761696430103783" b="-49.761696430103783" rho="1.41085544"/>
+                <iidm:step r="104.12371808784383" x="104.12371808784383" g="-51.010102629540867" b="-51.010102629540867" rho="1.42871872"/>
+                <iidm:step r="109.25994827240002" x="109.25994827240002" g="-52.212546726893493" b="-52.212546726893493" rho="1.446582"/>
+                <iidm:step r="114.45999781142788" x="114.45999781142788" g="-53.371257567609966" b="-53.371257567609966" rho="1.4644452800000001"/>
+                <iidm:step r="119.72386670492732" x="119.72386670492732" g="-54.488330512455207" b="-54.488330512455207" rho="1.4823085599999999"/>
+                <iidm:step r="125.05155495289854" x="125.05155495289854" g="-55.565736917068101" b="-55.565736917068101" rho="1.5001718399999999"/>
+                <iidm:step r="130.44306255534144" x="130.44306255534144" g="-56.605332835313817" b="-56.605332835313817" rho="1.51803512"/>
+                <iidm:step r="135.89838951225599" x="135.89838951225599" g="-57.608867018227542" b="-57.608867018227542" rho="1.5358984"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="2186">
+                <iidm:temporaryLimit name="_580d3b53-5508-4d8d-97cc-4ea463e0cdb9-1" acceptableDuration="900" value="2514"/>
+                <iidm:temporaryLimit name="_a867e68a-58d1-49cb-955f-bb8e59cf2a11-1" acceptableDuration="60" value="3061"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="8747">
+                <iidm:temporaryLimit name="_1a7f23f9-e2c0-46a6-a93c-687f2209e33d-1" acceptableDuration="900" value="10059"/>
+                <iidm:temporaryLimit name="_257d56c1-d70a-4a96-b85c-d928ade03ad4-1" acceptableDuration="60" value="12246"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
     </iidm:substation>
     <iidm:substation id="_045beb3a-c766-11e1-8775-005056c00008" name="Minas Tirith" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
         <iidm:voltageLevel id="_048a9c58-c766-11e1-8775-005056c00008" name="MNT132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -1460,12 +1542,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="132.73961700936741" angle="12.125453728970392" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="132.85836365191074" angle="0.1377658091529935" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0447ee05-c766-11e1-8775-005056c00008" name="NwCarlsl NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="8" p="8.9998667322399122" q="0">
+            <iidm:load id="_0447ee05-c766-11e1-8775-005056c00008" name="NwCarlsl NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="8" p="8.9998768033718406" q="0">
                 <iidm:alias>_04731cb7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_047a48a8-c766-11e1-8775-005056c00008" name="NwCarlsl LD" loadType="UNDEFINED" p0="30" q0="12" node="9" p="29.999555774133039" q="11.999703850883783">
+            <iidm:load id="_047a48a8-c766-11e1-8775-005056c00008" name="NwCarlsl LD" loadType="UNDEFINED" p0="30" q0="12" node="9" p="29.999589344572801" q="11.999726230964376">
                 <iidm:alias>_044c0cb9-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1516,9 +1598,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.62201279518656" angle="9.3291254351219628" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.62195075949469" angle="-1.8977872914328962" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044ecbd1-c766-11e1-8775-005056c00008" name="Blaine LD" loadType="UNDEFINED" p0="2" q0="1" node="8" p="2.0000026854582704" q="1.0000022378828937">
+            <iidm:load id="_044ecbd1-c766-11e1-8775-005056c00008" name="Blaine LD" loadType="UNDEFINED" p0="2" q0="1" node="8" p="2.0000018149766592" q="1.0000015124810067">
                 <iidm:alias>_04700f74-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1569,9 +1651,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="133.18512601746608" angle="15.344985024370851" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="133.16031627384376" angle="4.119577351998629" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046b7b95-c766-11e1-8775-005056c00008" name="Sundial LD" loadType="UNDEFINED" p0="15" q0="9" node="8" p="14.999909920229273" q="8.9999099204095927">
+            <iidm:load id="_046b7b95-c766-11e1-8775-005056c00008" name="Sundial LD" loadType="UNDEFINED" p0="15" q0="9" node="8" p="14.999896825963987" q="8.9998968262005423">
                 <iidm:alias>_046efe07-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1622,9 +1704,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.69988890005938" angle="7.3188719038795824" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.74825404358788" angle="-4.502346243239133" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045645e2-c766-11e1-8775-005056c00008" name="Riversde LD" loadType="UNDEFINED" p0="51" q0="27" node="8" p="50.999631385308334" q="26.999674752526246">
+            <iidm:load id="_045645e2-c766-11e1-8775-005056c00008" name="Riversde LD" loadType="UNDEFINED" p0="51" q0="27" node="8" p="50.999666717308365" q="26.999705927677375">
                 <iidm:alias>_0476ed4b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1675,9 +1757,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.82539088462997" angle="10.150614453158489" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.96627454708364" angle="-1.1457738896468039" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04887973-c766-11e1-8775-005056c00008" name="Randolph LD" loadType="UNDEFINED" p0="10" q0="5" node="8" p="9.9993540810678176" q="4.9994617458124653">
+            <iidm:load id="_04887973-c766-11e1-8775-005056c00008" name="Randolph LD" loadType="UNDEFINED" p0="10" q0="5" node="8" p="9.999387020642537" q="4.999489194306177">
                 <iidm:alias>_0462f018-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1728,9 +1810,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.48473688401799" angle="-6.9148180146919316" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.48449303107893" angle="-18.10229103380976" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0477627b-c766-11e1-8775-005056c00008" name="WNwPhil2 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="11.999993824536743" q="2.9999974268907508">
+            <iidm:load id="_0477627b-c766-11e1-8775-005056c00008" name="WNwPhil2 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="11.999992055002838" q="2.999996689585247">
                 <iidm:alias>_045841b6-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1800,9 +1882,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="126.73067346215429" angle="10.059286560438533" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="126.73061055245152" angle="-1.16740227344426" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0476781a-c766-11e1-8775-005056c00008" name="Cloverdl LD" loadType="UNDEFINED" p0="43" q0="16" node="11" p="43.000058020547513" q="16.000035981751072">
+            <iidm:load id="_0476781a-c766-11e1-8775-005056c00008" name="Cloverdl LD" loadType="UNDEFINED" p0="43" q0="16" node="11" p="43.000039516981317" q="16.000024506662591">
                 <iidm:alias>_0481749a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1872,9 +1954,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="128.11700374035317" angle="11.428558564217761" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="128.11695175112965" angle="0.20185355755572351" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046b0665-c766-11e1-8775-005056c00008" name="Hancock LD" loadType="UNDEFINED" p0="38" q0="25" node="11" p="38.000047617363023" q="25.000052212042668">
+            <iidm:load id="_046b0665-c766-11e1-8775-005056c00008" name="Hancock LD" loadType="UNDEFINED" p0="38" q0="25" node="11" p="38.0000312513667" q="25.00003426685884">
                 <iidm:alias>_0464c4d5-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1926,12 +2008,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="128.6651176991729" angle="-5.5019210483011429" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="128.64911574890445" angle="-16.654906346450755" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044bbe92-c766-11e1-8775-005056c00008" name="WMVernon LD" loadType="UNDEFINED" p0="16" q0="8" node="8" p="15.99866009404098" q="7.9988834428703459">
+            <iidm:load id="_044bbe92-c766-11e1-8775-005056c00008" name="WMVernon LD" loadType="UNDEFINED" p0="16" q0="8" node="8" p="15.998651670704925" q="7.9988764238167605">
                 <iidm:alias>_04500452-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_047825c8-c766-11e1-8775-005056c00008" name="WMVernon SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.21199999999999" targetDeadband="1" node="9" q="-9.502404982199117">
+            <iidm:shunt id="_047825c8-c766-11e1-8775-005056c00008" name="WMVernon SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.21199999999999" targetDeadband="1" node="9" q="-9.5000415202276596">
                 <iidm:alias>_047084aa-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_2a6c1dcd-201b-4911-83b2-c16acc50a0f4"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -1965,9 +2047,9 @@
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="3"/>
-                <iidm:bus v="231.00001474637338" angle="34.731298259976391" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="230.99999586266108" angle="22.437154158342771" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_045868c0-c766-11e1-8775-005056c00008" name="Breed SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="450" targetV="230.99998500000001" targetQ="0" node="5" p="-498.29789936911982" q="23.577749394508942">
+            <iidm:generator id="_045868c0-c766-11e1-8775-005056c00008" name="Breed SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="450" targetV="230.99998500000001" targetQ="0" node="5" p="-498.2120169501971" q="27.225401885404359">
                 <iidm:alias>_045b7606-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_f26d4eb3-ebdb-4025-8080-f856ce656b42"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_7566f2a7-61eb-42fe-a59a-8276257fdbc6"/>
@@ -2041,9 +2123,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="127.47344799892316" angle="-5.8097901617370855" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="127.47310555992874" angle="-16.996615216393977" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044d1e22-c766-11e1-8775-005056c00008" name="Newcmrst LD" loadType="UNDEFINED" p0="17" q0="8" node="11" p="16.999984328130207" q="7.9999877083411928">
+            <iidm:load id="_044d1e22-c766-11e1-8775-005056c00008" name="Newcmrst LD" loadType="UNDEFINED" p0="17" q0="8" node="11" p="16.999981973620969" q="7.9999858616685033">
                 <iidm:alias>_048a754b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2113,9 +2195,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="138.60000476063487" angle="24.349360480595173" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="138.59999526477887" angle="12.494714383354207" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_045ab2b0-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="220" targetV="138.59999099999999" targetQ="0" node="11" p="-243.6123063582364" q="-48.43193861248843">
+            <iidm:generator id="_045ab2b0-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="220" targetV="138.59999099999999" targetQ="0" node="11" p="-243.57031939787416" q="-45.756621105278548">
                 <iidm:alias>_046ba2a5-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_56975783-9739-40fc-8ec1-e1de8cb06c9a"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b8449cd9-5a17-497e-bf04-70f728b0f9f2"/>
@@ -2168,9 +2250,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="223.30002307802255" angle="26.758035635477018" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="223.30000710949088" angle="14.646955058711882" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0483224a-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="314" targetV="223.30000000000001" targetQ="0" node="8" p="-347.70120089311922" q="-23.079171977366631">
+            <iidm:generator id="_0483224a-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="314" targetV="223.30000000000001" targetQ="0" node="8" p="-347.6412740496931" q="-18.507049918702464">
                 <iidm:alias>_045cd594-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_05df66ba-3f64-40cb-8b18-c66d26c4e2c1"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_c1d29442-5f57-41d1-bb60-4b74b4994c20"/>
@@ -2178,7 +2260,7 @@
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045b7604-c766-11e1-8775-005056c00008" name="26-25" r="0" x="6.6559680000000006" g="0" b="0" ratedU1="220" ratedU2="132" node1="22" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="122.13734792210391" q1="22.749652862611452" p2="-122.13734792210387" q2="-17.47513851349261">
+        <iidm:twoWindingsTransformer id="_045b7604-c766-11e1-8775-005056c00008" name="26-25" r="0" x="6.6559680000000006" g="0" b="0" ratedU1="220" ratedU2="132" node1="22" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="109.14072070539005" q1="22.232083008980684" p2="-109.14072070539011" q2="-17.992685303719881">
             <iidm:alias>_0447c6f3-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0463b364-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04803c1c-c766-11e1-8775-005056c00008</iidm:alias>
@@ -2321,9 +2403,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="136.62004645906691" angle="14.74444584263337" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="136.6200231444476" angle="3.5196410187203964" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_048aea70-c766-11e1-8775-005056c00008" name="Sporn SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="513.43743900000004" targetV="136.62" targetQ="-62.132553100000003" node="20" p="-568.54399402480146" q="50.458790340414353">
+            <iidm:generator id="_048aea70-c766-11e1-8775-005056c00008" name="Sporn SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="513.43743900000004" targetV="136.62" targetQ="-62.132553100000003" node="20" p="-568.44600458207515" q="50.688278997794711">
                 <iidm:alias>_04555b84-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_27799004-aa1e-4889-ba95-ee6fdae64895"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_827a9c80-183d-4e33-9e73-ef0aab3dfb13"/>
@@ -2413,9 +2495,9 @@
                 <iidm:internalConnection node1="39" node2="9"/>
                 <iidm:internalConnection node1="40" node2="12"/>
                 <iidm:internalConnection node1="41" node2="3"/>
-                <iidm:bus v="219.70668150005034" angle="10.954510493060518" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41"/>
+                <iidm:bus v="219.70741902744044" angle="-0.25244038989795908" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41"/>
             </iidm:nodeBreakerTopology>
-            <iidm:danglingLine id="_0482fb33-c766-11e1-8775-005056c00008" name="68-116" p0="184" q0="0" r="0.16456000000000001" x="1.9601999999999999" g="0" b="0.00033884300000000002" ucteXnodeCode="XWE_BR21" node="41" p="184.11567727543945" q="-14.97965939473927">
+            <iidm:danglingLine id="_0482fb33-c766-11e1-8775-005056c00008" name="68-116" p0="184" q0="0" r="0.16456000000000001" x="1.9601999999999999" g="0" b="0.00033884300000000002" ucteXnodeCode="XWE_BR21" node="41" p="184.11561877699938" q="-14.979780551142904">
                 <iidm:alias>_0459c855-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_04684742-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_5631ccc0-d9d2-11e2-bb49-005056c00008</iidm:alias>
@@ -2428,7 +2510,7 @@
                 </iidm:currentLimits>
             </iidm:danglingLine>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_044f6815-c766-11e1-8775-005056c00008" name="68-69" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-197.4877522234685" q1="102.06307503840004" p2="197.48775222346842" q2="-86.035366523282931">
+        <iidm:twoWindingsTransformer id="_044f6815-c766-11e1-8775-005056c00008" name="68-69" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-196.55938456003219" q1="102.01288207824997" p2="196.55938456003219" q2="-86.107248181662897">
             <iidm:alias>_047e8e67-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04840ca7-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0487dd39-c766-11e1-8775-005056c00008</iidm:alias>
@@ -2535,9 +2617,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="131.60567641459477" angle="2.9176079690510184" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="131.60566182088672" angle="-8.2740407075399691" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04547126-c766-11e1-8775-005056c00008" name="Natrium LD" loadType="UNDEFINED" p0="77" q0="14" node="14" p="76.999930491994988" q="13.99997893697452">
+            <iidm:load id="_04547126-c766-11e1-8775-005056c00008" name="Natrium LD" loadType="UNDEFINED" p0="77" q0="14" node="14" p="76.999915741269291" q="13.999974467060614">
                 <iidm:alias>_047b3307-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2588,9 +2670,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="123.82325910634022" angle="-5.0515267319255344" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="123.75649269925877" angle="-16.129265515714124" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045d4ac9-c766-11e1-8775-005056c00008" name="Sterling LD" loadType="UNDEFINED" p0="31" q0="17" node="8" p="30.992093897808942" q="16.992774606934756">
+            <iidm:load id="_045d4ac9-c766-11e1-8775-005056c00008" name="Sterling LD" loadType="UNDEFINED" p0="31" q0="17" node="8" p="30.992036353629217" q="16.992722021767172">
                 <iidm:alias>_0477b094-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2698,9 +2780,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="130.29512258784811" angle="17.88797922160445" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="130.27259983113194" angle="6.6638879448604689" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0466246a-c766-11e1-8775-005056c00008" name="Switchbk LD" loadType="UNDEFINED" p0="30" q0="16" node="17" p="29.99974751646301" q="15.999775570818956">
+            <iidm:load id="_0466246a-c766-11e1-8775-005056c00008" name="Switchbk LD" loadType="UNDEFINED" p0="30" q0="16" node="17" p="29.999720877455026" q="15.99975189184061">
                 <iidm:alias>_04882b59-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2751,9 +2833,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="135.08668021832474" angle="15.155806103119867" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="135.0866730356303" angle="3.9301952289287945" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046adf5a-c766-11e1-8775-005056c00008" name="Bradley LD" loadType="UNDEFINED" p0="34" q0="8" node="8" p="34.000012165150814" q="8.0000047706479442">
+            <iidm:load id="_046adf5a-c766-11e1-8775-005056c00008" name="Bradley LD" loadType="UNDEFINED" p0="34" q0="8" node="8" p="34.00000019699921" q="8.0000000772545903">
                 <iidm:alias>_04555b85-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2788,6 +2870,9 @@
                     <iidm:alias>_7f359893-b7c5-41b0-ada8-8df06cf7a8e6</iidm:alias>
                     <iidm:alias>_a4edf081-2fb2-4da4-94db-98a2a596247f</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_312f25f3-55bc-4417-848c-236d31d823f4-1" name="DISCONNECTOR524-1" kind="DISCONNECTOR" retained="false" open="false" node1="24" node2="25"/>
+                <iidm:switch id="_686e884a-a0b1-454e-b7d1-33c7ad46f89f-1" name="BREAKER262-1" kind="BREAKER" retained="false" open="false" node1="23" node2="24"/>
+                <iidm:switch id="_346a5319-3ec2-40a2-aefd-38dfacbbe97c-1" name="DISCONNECTOR523-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="23"/>
                 <iidm:internalConnection node1="7" node2="0"/>
                 <iidm:internalConnection node1="8" node2="0"/>
                 <iidm:internalConnection node1="9" node2="1"/>
@@ -2804,9 +2889,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.89115896549963" angle="8.9227813526841491" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.16480142471627" angle="-2.3256703893165356" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047a48a2-c766-11e1-8775-005056c00008" name="Mullin LD" loadType="UNDEFINED" p0="17" q0="7" node="8" p="16.999837087700172" q="6.9998881977984331">
+            <iidm:load id="_047a48a2-c766-11e1-8775-005056c00008" name="Mullin LD" loadType="UNDEFINED" p0="17" q0="7" node="8" p="16.999909228267189" q="6.9999377057844354">
                 <iidm:alias>_0474553a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2972,16 +3057,16 @@
                 <iidm:internalConnection node1="81" node2="18"/>
                 <iidm:internalConnection node1="82" node2="21"/>
                 <iidm:internalConnection node1="83" node2="24"/>
-                <iidm:bus v="134.24408695846364" angle="17.592305521796405" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
+                <iidm:bus v="134.24404900900035" angle="6.3658884787836874" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_044cd00a-c766-11e1-8775-005056c00008" name="Glen Lyn SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="252" targetV="134.243988" targetQ="0" node="27" p="-279.04682364670714" q="-83.970202180628334">
+            <iidm:generator id="_044cd00a-c766-11e1-8775-005056c00008" name="Glen Lyn SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="252" targetV="134.243988" targetQ="0" node="27" p="-278.99872949211033" q="-84.322393830856342">
                 <iidm:alias>_045e5c30-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e54b499b-436c-4b89-9803-b1d75e2fa364"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_32c8ab65-80f7-4c17-b3f5-ff075cce0ba5"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
-            <iidm:load id="_04566cf5-c766-11e1-8775-005056c00008" name="Glen Lyn LD" loadType="UNDEFINED" p0="37" q0="18" node="26" p="37.0000409120425" q="18.000033171938579">
+            <iidm:load id="_04566cf5-c766-11e1-8775-005056c00008" name="Glen Lyn LD" loadType="UNDEFINED" p0="37" q0="18" node="26" p="37.000025222730301" q="18.000020450867055">
                 <iidm:alias>_04577e64-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3032,9 +3117,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.56345523723593" angle="9.7706489662531926" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.63641159990459" angle="-2.0931058690379536" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044ea4c0-c766-11e1-8775-005056c00008" name="Kankakee LD" loadType="UNDEFINED" p0="52" q0="22" node="8" p="51.999553205002222" q="21.999684953147476">
+            <iidm:load id="_044ea4c0-c766-11e1-8775-005056c00008" name="Kankakee LD" loadType="UNDEFINED" p0="52" q0="22" node="8" p="51.999593858059093" q="21.999713618607768">
                 <iidm:alias>_047e6758-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3143,12 +3228,12 @@
                 <iidm:internalConnection node1="51" node2="9"/>
                 <iidm:internalConnection node1="52" node2="12"/>
                 <iidm:internalConnection node1="53" node2="15"/>
-                <iidm:bus v="127.42290734222856" angle="10.326343257918683" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
+                <iidm:bus v="127.42285730159952" angle="-0.90040428233649794" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0484cffb-c766-11e1-8775-005056c00008" name="Roanoke LD" loadType="UNDEFINED" p0="31" q0="26" node="17" p="31.00003760210388" q="26.000052562101949">
+            <iidm:load id="_0484cffb-c766-11e1-8775-005056c00008" name="Roanoke LD" loadType="UNDEFINED" p0="31" q0="26" node="17" p="31.000024217861561" q="26.00003385293358">
                 <iidm:alias>_0454983a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0489d903-c766-11e1-8775-005056c00008" name="Roanoke SC" sectionCount="5" voltageRegulatorOn="true" targetV="127.423" targetDeadband="1" node="18" q="-18.639613718246995">
+            <iidm:shunt id="_0489d903-c766-11e1-8775-005056c00008" name="Roanoke SC" sectionCount="5" voltageRegulatorOn="true" targetV="127.423" targetDeadband="1" node="18" q="-18.639599078213553">
                 <iidm:alias>_0476c638-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_5be38d1a-9d01-42d8-b8bb-e9a26cfbcf1a"/>
                 <iidm:shuntLinearModel bPerSection="0.0002296" gPerSection="0" maximumSectionCount="10"/>
@@ -3240,12 +3325,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="120.60295451689338" angle="-10.296405722099362" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="120.5689381675197" angle="-21.439671095739193" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047a219a-c766-11e1-8775-005056c00008" name="Howard LD" loadType="UNDEFINED" p0="37" q0="23" node="14" p="36.991975541809509" q="22.991686973171714">
+            <iidm:load id="_047a219a-c766-11e1-8775-005056c00008" name="Howard LD" loadType="UNDEFINED" p0="37" q0="23" node="14" p="36.991916021934024" q="22.991625317385026">
                 <iidm:alias>_04882b51-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_04488a49-c766-11e1-8775-005056c00008" name="Howard NegG LD" loadType="UNDEFINED" p0="59" q0="0" node="15" p="58.98720424234488" q="0">
+            <iidm:load id="_04488a49-c766-11e1-8775-005056c00008" name="Howard NegG LD" loadType="UNDEFINED" p0="59" q0="0" node="15" p="58.987109332273171" q="0">
                 <iidm:alias>_046d9e74-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3295,7 +3380,7 @@
                 <iidm:internalConnection node1="19" node2="6"/>
                 <iidm:internalConnection node1="20" node2="3"/>
                 <iidm:internalConnection node1="21" node2="6"/>
-                <iidm:bus v="218.77306238099877" angle="12.74762513860513" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
+                <iidm:bus v="218.77342337310722" angle="1.5337820489564962" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_046efe09-c766-11e1-8775-005056c00008" name="CRI132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -3458,20 +3543,20 @@
                 <iidm:internalConnection node1="81" node2="18"/>
                 <iidm:internalConnection node1="82" node2="21"/>
                 <iidm:internalConnection node1="83" node2="24"/>
-                <iidm:bus v="137.28006700511574" angle="15.644831697247342" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
+                <iidm:bus v="137.28003720656068" angle="4.4196956252757902" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_045868c1-c766-11e1-8775-005056c00008" name="CabinCrk SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="477" targetV="137.28" targetQ="0" node="27" p="-528.19577333126699" q="-139.99287017057088">
+            <iidm:generator id="_045868c1-c766-11e1-8775-005056c00008" name="CabinCrk SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="477" targetV="137.28" targetQ="0" node="27" p="-528.10473796720885" q="-140.83277658121847">
                 <iidm:alias>_0487dd36-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_a6ec9760-88da-48df-a23f-7877e7c85ccd"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_e6131af8-c298-413b-84e3-4e21c3b6b06f"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-225" maxQ="640"/>
             </iidm:generator>
-            <iidm:load id="_04747c44-c766-11e1-8775-005056c00008" name="CabinCrk LD" loadType="UNDEFINED" p0="130" q0="26" node="26" p="130.00009517773282" q="26.000031725918682">
+            <iidm:load id="_04747c44-c766-11e1-8775-005056c00008" name="CabinCrk LD" loadType="UNDEFINED" p0="130" q0="26" node="26" p="130.00005285023184" q="26.00001761674633">
                 <iidm:alias>_046a9138-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_0488c79b-c766-11e1-8775-005056c00008" name="81-80" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="21" voltageLevelId1="_048a272b-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-151.09953176946263" q1="71.524927125576184" p2="151.09953176946257" q2="-62.383457871366055">
+        <iidm:twoWindingsTransformer id="_0488c79b-c766-11e1-8775-005056c00008" name="81-80" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="21" voltageLevelId1="_048a272b-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-150.51127776143534" q1="71.501014040252571" p2="150.51127776143537" q2="-62.41872910011206">
             <iidm:alias>_044974a0-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_045a3d83-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_046adf57-c766-11e1-8775-005056c00008</iidm:alias>
@@ -3551,12 +3636,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="134.74737767621977" angle="-1.1029153267665801" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="134.74747451271142" angle="-12.287085101240912" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04524e4a-c766-11e1-8775-005056c00008" name="Zanesvll LD" loadType="UNDEFINED" p0="20" q0="11" node="8" p="20.000006080644784" q="11.000005573924948">
+            <iidm:load id="_04524e4a-c766-11e1-8775-005056c00008" name="Zanesvll LD" loadType="UNDEFINED" p0="20" q0="11" node="8" p="20.000003933041445" q="11.000003605288224">
                 <iidm:alias>_045c1240-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_048b5fa9-c766-11e1-8775-005056c00008" name="Zanesvll SC" sectionCount="5" voltageRegulatorOn="true" targetV="134.72300000000001" targetDeadband="1" node="9" q="-15.633052835721934">
+            <iidm:shunt id="_048b5fa9-c766-11e1-8775-005056c00008" name="Zanesvll SC" sectionCount="5" voltageRegulatorOn="true" targetV="134.72300000000001" targetDeadband="1" node="9" q="-15.633075305183835">
                 <iidm:alias>_04736ad5-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_99c6c4ad-5247-4058-96d4-ee8495103e85"/>
                 <iidm:shuntLinearModel bPerSection="0.00017220000000000001" gPerSection="0" maximumSectionCount="10"/>
@@ -3609,9 +3694,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.77506928129085" angle="20.640646584959221" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.75947032872949" angle="9.419016719591065" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044ca8f2-c766-11e1-8775-005056c00008" name="Tazewell LD" loadType="UNDEFINED" p0="12" q0="7" node="8" p="11.999902908138553" q="6.9999056053892881">
+            <iidm:load id="_044ca8f2-c766-11e1-8775-005056c00008" name="Tazewell LD" loadType="UNDEFINED" p0="12" q0="7" node="8" p="11.999894119571772" q="6.9998970609975366">
                 <iidm:alias>_04542305-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3662,9 +3747,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="119.83395246285181" angle="-8.5300091389992616" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="119.77216926814609" angle="-19.631363026397889" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04778989-c766-11e1-8775-005056c00008" name="NwLibrty LD" loadType="UNDEFINED" p0="27" q0="11" node="8" p="26.992265172771646" q="10.994748458362718">
+            <iidm:load id="_04778989-c766-11e1-8775-005056c00008" name="NwLibrty LD" loadType="UNDEFINED" p0="27" q0="11" node="8" p="26.992203722661333" q="10.994706740980067">
                 <iidm:alias>_0483e592-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3697,12 +3782,12 @@
                 <iidm:internalConnection node1="11" node2="2"/>
                 <iidm:internalConnection node1="12" node2="3"/>
                 <iidm:internalConnection node1="13" node2="3"/>
-                <iidm:bus v="122.60539648395246" angle="5.6633327060969467" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13"/>
+                <iidm:bus v="122.60534029301175" angle="-5.5638299227460877" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0463da70-c766-11e1-8775-005056c00008" name="Danville LD" loadType="UNDEFINED" p0="25" q0="13" node="5" p="25.000032165850637" q="13.000027877082509">
+            <iidm:load id="_0463da70-c766-11e1-8775-005056c00008" name="Danville LD" loadType="UNDEFINED" p0="25" q0="13" node="5" p="25.000021138050215" q="13.000018319648685">
                 <iidm:alias>_0488eeab-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_0448b150-c766-11e1-8775-005056c00008" name="Danville NegG LD" loadType="UNDEFINED" p0="43" q0="0" node="6" p="43.000055325263098" q="0">
+            <iidm:load id="_0448b150-c766-11e1-8775-005056c00008" name="Danville NegG LD" loadType="UNDEFINED" p0="43" q0="0" node="6" p="43.000036357446369" q="0">
                 <iidm:alias>_0457cc88-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3753,9 +3838,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.59318955847201" angle="26.420886110528571" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.45620283432925" angle="15.216491962473119" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045cae82-c766-11e1-8775-005056c00008" name="Fremont LD" loadType="UNDEFINED" p0="48" q0="10" node="8" p="47.999253784075918" q="9.9997408985912699">
+            <iidm:load id="_045cae82-c766-11e1-8775-005056c00008" name="Fremont LD" loadType="UNDEFINED" p0="48" q0="10" node="8" p="47.999103458424095" q="9.9996887027798493">
                 <iidm:alias>_045f4693-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3901,9 +3986,9 @@
                 <iidm:internalConnection node1="70" node2="15"/>
                 <iidm:internalConnection node1="71" node2="18"/>
                 <iidm:internalConnection node1="72" node2="21"/>
-                <iidm:bus v="132.35177915217523" angle="13.33586121154889" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
+                <iidm:bus v="132.33290837881233" angle="2.1069091132673141" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0448d863-c766-11e1-8775-005056c00008" name="Turner LD" loadType="UNDEFINED" p0="61" q0="28" node="23" p="60.999820151487896" q="27.999862411109568">
+            <iidm:load id="_0448d863-c766-11e1-8775-005056c00008" name="Turner LD" loadType="UNDEFINED" p0="61" q0="28" node="23" p="60.999778360586134" q="27.999830439998036">
                 <iidm:alias>_046e3ab3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3938,6 +4023,9 @@
                     <iidm:alias>_0b877750-4384-4ec3-bb38-08ee5ccf16d3</iidm:alias>
                     <iidm:alias>_1ed822d3-f3ab-4432-80f0-4c55ae3b4b78</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_3be2355e-0065-43df-a264-57a295042faa-1" name="DISCONNECTOR526-1" kind="DISCONNECTOR" retained="false" open="false" node1="24" node2="25"/>
+                <iidm:switch id="_2463ff2c-7690-4dd6-bf44-039f9f475bb1-1" name="BREAKER263-1" kind="BREAKER" retained="false" open="true" node1="23" node2="24"/>
+                <iidm:switch id="_ddcf7aac-e7c3-45e9-bd81-6146e951addd-1" name="DISCONNECTOR525-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="23"/>
                 <iidm:internalConnection node1="7" node2="0"/>
                 <iidm:internalConnection node1="8" node2="0"/>
                 <iidm:internalConnection node1="9" node2="1"/>
@@ -3954,9 +4042,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.13826796774028" angle="7.8261693162299162" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.20628673520143" angle="-3.2832206261531502" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047d7cf6-c766-11e1-8775-005056c00008" name="Grant LD" loadType="UNDEFINED" p0="24" q0="4" node="8" p="23.999942173423687" q="3.9999839370750365">
+            <iidm:load id="_047d7cf6-c766-11e1-8775-005056c00008" name="Grant LD" loadType="UNDEFINED" p0="24" q0="4" node="8" p="23.99996791237033" q="3.9999910867735085">
                 <iidm:alias>_0481e9c0-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4026,9 +4114,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="221.03166728446209" angle="18.137899854731874" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="221.49059569147516" angle="5.8721501318743501" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04867dab-c766-11e1-8775-005056c00008" name="Olive NegG LD" loadType="UNDEFINED" p0="28" q0="0" node="11" p="27.999335333657132" q="0">
+            <iidm:load id="_04867dab-c766-11e1-8775-005056c00008" name="Olive NegG LD" loadType="UNDEFINED" p0="28" q0="0" node="11" p="27.999402331178992" q="0">
                 <iidm:alias>_048433b8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4134,15 +4222,15 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="133.19436282606478" angle="12.616763499700394" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="133.32102573196107" angle="0.60630634796600535" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:shunt id="_0447c6f6-c766-11e1-8775-005056c00008" name="Olive SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.67599999999999" targetDeadband="1" node="17" q="-40.732735110720618">
+            <iidm:shunt id="_0447c6f6-c766-11e1-8775-005056c00008" name="Olive SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.67599999999999" targetDeadband="1" node="17" q="-40.810242591502252">
                 <iidm:alias>_045e8340-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_c701959a-91c1-4a35-9a37-71fb790426ca"/>
                 <iidm:shuntLinearModel bPerSection="0.00045919999999999999" gPerSection="0" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_04575750-c766-11e1-8775-005056c00008" name="8-5" r="0" x="4.6522079999999999" g="0" b="0" ratedU1="220" ratedU2="132" node1="32" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="370.87687217349566" q1="59.679780131381122" p2="-370.87687217349583" q2="-23.465322935113221">
+        <iidm:twoWindingsTransformer id="_04575750-c766-11e1-8775-005056c00008" name="8-5" r="0" x="4.6522079999999999" g="0" b="0" ratedU1="220" ratedU2="132" node1="32" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="354.84901019216619" q1="62.635291172290465" p2="-354.84901019216625" q2="-29.451166889296527">
             <iidm:alias>_045eaa55-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_046b2d74-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04745533-c766-11e1-8775-005056c00008</iidm:alias>
@@ -4213,9 +4301,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.77744550870167" angle="19.571425405695628" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.77397866912037" angle="8.347972394352583" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047b0bf0-c766-11e1-8775-005056c00008" name="Wythe LD" loadType="UNDEFINED" p0="22" q0="15" node="8" p="21.999943452813746" q="14.999935741888857">
+            <iidm:load id="_047b0bf0-c766-11e1-8775-005056c00008" name="Wythe LD" loadType="UNDEFINED" p0="22" q0="15" node="8" p="21.9999331335686" q="14.999924015495846">
                 <iidm:alias>_0479d376-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4266,9 +4354,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="123.89187968821633" angle="-5.0818290849893852" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="123.82540744789789" angle="-16.160183167260982" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0458ddf5-c766-11e1-8775-005056c00008" name="WestLima LD" loadType="UNDEFINED" p0="33" q0="9" node="8" p="32.991593883631616" q="8.9961793624624526">
+            <iidm:load id="_0458ddf5-c766-11e1-8775-005056c00008" name="WestLima LD" loadType="UNDEFINED" p0="33" q0="9" node="8" p="32.991532918593776" q="8.9961516558048462">
                 <iidm:alias>_04492686-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4376,9 +4464,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="128.45027967847557" angle="22.482492693437319" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="128.11511432680851" angle="11.28722897180671" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044b2257-c766-11e1-8775-005056c00008" name="BeaverCk LD" loadType="UNDEFINED" p0="24" q0="15" node="17" p="23.999209115724277" q="14.999176171262269">
+            <iidm:load id="_044b2257-c766-11e1-8775-005056c00008" name="BeaverCk LD" loadType="UNDEFINED" p0="24" q0="15" node="17" p="23.999049958523518" q="14.999010386520201">
                 <iidm:alias>_045868c4-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4437,6 +4525,9 @@
                     <iidm:alias>_2b636cdd-aa2f-4a65-92fc-12b4fc392e5f</iidm:alias>
                     <iidm:alias>_c96e50b9-ea15-4421-b6c8-bd9c9158a69a</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_e5318967-afcc-4fcc-b0de-d5f2522a95a6-1" name="DISCONNECTOR699-1" kind="DISCONNECTOR" retained="false" open="false" node1="43" node2="44"/>
+                <iidm:switch id="_e9f91b69-a29b-44ea-aa0f-cff86ee80320-1" name="BREAKER350-1" kind="BREAKER" retained="true" open="true" node1="42" node2="43"/>
+                <iidm:switch id="_ad86e83d-6334-4dd8-b642-b4c16d65329a-1" name="DISCONNECTOR700-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="42"/>
                 <iidm:internalConnection node1="13" node2="0"/>
                 <iidm:internalConnection node1="14" node2="1"/>
                 <iidm:internalConnection node1="15" node2="2"/>
@@ -4466,7 +4557,7 @@
                 <iidm:internalConnection node1="39" node2="9"/>
                 <iidm:internalConnection node1="40" node2="12"/>
                 <iidm:internalConnection node1="41" node2="3"/>
-                <iidm:bus v="214.61141854553529" angle="15.681745796735903" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41"/>
+                <iidm:bus v="215.62264347503401" angle="2.9506457889161362" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_047bcf46-c766-11e1-8775-005056c00008" name="STN132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -4546,6 +4637,9 @@
                     <iidm:alias>_4aab41d6-d1b6-4dbe-a6aa-cb7ccd941912</iidm:alias>
                     <iidm:alias>_e9315b98-af75-40bb-bf8e-05bd03d43db5</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_b8b0b9a9-af8b-41d2-a4f8-940637e63f70-1" name="DISCONNECTOR701-1" kind="DISCONNECTOR" retained="false" open="false" node1="64" node2="65"/>
+                <iidm:switch id="_0b78ffaa-9859-4658-af17-c8d355633556-1" name="BREAKER351-1" kind="BREAKER" retained="true" open="false" node1="63" node2="64"/>
+                <iidm:switch id="_9dfeeaef-5c49-4c2c-97b1-03876970bee4-1" name="DISCONNECTOR702-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="63"/>
                 <iidm:internalConnection node1="19" node2="0"/>
                 <iidm:internalConnection node1="20" node2="0"/>
                 <iidm:internalConnection node1="21" node2="1"/>
@@ -4590,9 +4684,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="129.38637986111206" angle="8.9971637181934287" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="129.32241473423852" angle="-1.610341219213292" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045dbff4-c766-11e1-8775-005056c00008" name="Sorenson LD" loadType="UNDEFINED" p0="11" q0="3" node="20" p="10.999377131379898" q="2.9997168832438619">
+            <iidm:load id="_045dbff4-c766-11e1-8775-005056c00008" name="Sorenson LD" loadType="UNDEFINED" p0="11" q0="3" node="20" p="10.999401831171637" q="2.9997281100065032">
                 <iidm:alias>_044d4536-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4613,6 +4707,9 @@
                     <iidm:alias>_340082f1-db9c-446d-97df-80e45aa0058b</iidm:alias>
                     <iidm:alias>_90c04b95-703a-4bae-82b8-7edf3075aa24</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_4d08a684-cdcb-484a-a767-03b10f4ada7f-1" name="DISCONNECTOR735-1" kind="DISCONNECTOR" retained="false" open="false" node1="14" node2="15"/>
+                <iidm:switch id="_f468d841-1bf6-470e-85d4-55d34fab8bff-1" name="BREAKER368-1" kind="BREAKER" retained="true" open="false" node1="13" node2="14"/>
+                <iidm:switch id="_f193bd8f-badf-4600-82ac-f212d1f33534-1" name="DISCONNECTOR736-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="13"/>
                 <iidm:internalConnection node1="4" node2="0"/>
                 <iidm:internalConnection node1="5" node2="1"/>
                 <iidm:internalConnection node1="6" node2="2"/>
@@ -4622,13 +4719,13 @@
                 <iidm:internalConnection node1="10" node2="3"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="0"/>
-                <iidm:bus v="384.36820961555486" angle="15.459020487387583" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="389.21392289584395" angle="2.3779714473627726e-69" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15"/>
             </iidm:nodeBreakerTopology>
             <iidm:lccConverterStation id="_7393a68e-c4e6-48dd-9347-543858363fdb" name="Conv1" lossFactor="0" powerFactor="0.80000000000000004" node="12" p="10" q="6">
                 <iidm:alias>_739658a7-e08b-4395-8d79-93e87b7855e3</iidm:alias>
             </iidm:lccConverterStation>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_047120e9-c766-11e1-8775-005056c00008" name="30-17" r="0" x="6.7605125399999997" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_047b8123-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="298.81868077251448" q1="111.60945834130975" p2="-298.81868077251443" q2="-73.375853812965076">
+        <iidm:twoWindingsTransformer id="_047120e9-c766-11e1-8775-005056c00008" name="30-17" r="0" x="6.7605125399999997" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_047b8123-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="204.99629194155767" q1="116.63932739680018" p2="-204.99629194155773" q2="-95.931909789259635">
             <iidm:alias>_044f6811-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0463b36a-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_047d2ed8-c766-11e1-8775-005056c00008</iidm:alias>
@@ -4647,7 +4744,7 @@
                 <iidm:temporaryLimit name="_f62f2fc6-4b6c-4571-a8c5-40d6a89ac703" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_b08e9e50-4e0c-4ac0-9f21-4a27429caeb2" name="PowTrans1" r="0.4840000000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_3bbfa58a-a1ad-4b23-a526-3d76b096c1f4" node2="41" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="-9.9999997627740083" q1="-6.0000013140678581" p2="10.001436039798426" q2="6.0538617024789323">
+        <iidm:twoWindingsTransformer id="_b08e9e50-4e0c-4ac0-9f21-4a27429caeb2" name="PowTrans1" r="0.4840000000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_3bbfa58a-a1ad-4b23-a526-3d76b096c1f4" node2="41" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="-132.0139084639481" q1="20.726329860286672" p2="132.19782979563169" q2="-13.829279922151594">
             <iidm:alias>_046ba2aa-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_a5bf9702-545a-437d-9663-773550202828</iidm:alias>
             <iidm:alias>_ee9505e1-96d7-49b3-9d1a-924397ffb27e</iidm:alias>
@@ -4667,6 +4764,32 @@
                 <iidm:temporaryLimit name="_611bb05e-9b9a-469c-b1d1-80a944c3ce2f" acceptableDuration="60" value="1400"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
+        <iidm:threeWindingsTransformer id="_86d83c7d-7826-4c16-b161-4ce17174e77f-1" name="T422" r1="-1.5199999809265099" x1="23.199999999999999" g1="0" b1="0" ratedU1="400" r2="2.0000000630528461" x2="19.999999999999996" g2="0" b2="0" ratedU2="220" r3="1.2000000564689806" x3="12" g3="0" b3="0" ratedU3="132" ratedU0="400" node1="15" voltageLevelId1="_3bbfa58a-a1ad-4b23-a526-3d76b096c1f4" node2="44" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" node3="65" voltageLevelId3="_047bcf46-c766-11e1-8775-005056c00008" p1="122.01390910938332" q1="-26.726329473025505" p2="0" q2="0" p3="-122.04686589181664" q3="30.351576396513824">
+            <iidm:alias>_1b2d419c-ac88-4dae-8dfe-2eb92d18c40a-1</iidm:alias>
+            <iidm:alias>_206474da-93c8-46b1-863f-9a308bfc2117-1</iidm:alias>
+            <iidm:alias>_9ac069ea-557b-4b8c-b12e-f9f2aecc3bf5-1</iidm:alias>
+            <iidm:alias>_ae46e10e-1fbe-4139-b493-ed8e2844ee8d-1</iidm:alias>
+            <iidm:ratioTapChanger1 lowTapPosition="1" tapPosition="11" targetDeadband="0" loadTapChangingCapabilities="true" regulating="false" targetV="220">
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.95238095238095233"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.96385542168674687"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.97560975609756106"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.98765432098765438"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0126582278481011"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0256410256410258"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0389610389610389"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0526315789473684"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0666666666666667"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0810810810810809"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.095890410958904"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.1111111111111112"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.1267605633802817"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.1428571428571428"/>
+            </iidm:ratioTapChanger1>
+            <iidm:currentLimits1 permanentLimit="500">
+                <iidm:temporaryLimit name="_3fd18f6e-749a-4fa7-af1b-b0c2d3952638-1" acceptableDuration="1800" value="533"/>
+            </iidm:currentLimits1>
+        </iidm:threeWindingsTransformer>
     </iidm:substation>
     <iidm:substation id="_04642898-c766-11e1-8775-005056c00008" name="Rómenna" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
         <iidm:voltageLevel id="_0457f394-c766-11e1-8775-005056c00008" name="RÓM132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -4905,16 +5028,16 @@
                 <iidm:internalConnection node1="121" node2="30"/>
                 <iidm:internalConnection node1="122" node2="33"/>
                 <iidm:internalConnection node1="123" node2="36"/>
-                <iidm:bus v="135.30001296269796" angle="-0.2849208760214989" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123"/>
+                <iidm:bus v="135.3000026178704" angle="-11.470033694374417" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04859346-c766-11e1-8775-005056c00008" name="Philo SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="204" targetV="135.30000000000001" targetQ="0" node="39" p="-225.89504771400101" q="-175.16678569804824">
+            <iidm:generator id="_04859346-c766-11e1-8775-005056c00008" name="Philo SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="204" targetV="135.30000000000001" targetQ="0" node="39" p="-225.85611435075603" q="-175.16777189599031">
                 <iidm:alias>_048719e2-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e3753d6d-b894-4cce-b6fa-307c50dc107f"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_dff93c01-9c84-4c1f-8529-66c054ed9e37"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
-            <iidm:load id="_045163e2-c766-11e1-8775-005056c00008" name="Philo LD" loadType="UNDEFINED" p0="87" q0="30" node="38" p="87.000012502824276" q="30.000007185531537">
+            <iidm:load id="_045163e2-c766-11e1-8775-005056c00008" name="Philo LD" loadType="UNDEFINED" p0="87" q0="30" node="38" p="87.000002524996916" q="30.000001451147675">
                 <iidm:alias>_04513cd3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4965,9 +5088,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.79910232221299" angle="20.480869113803614" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.51297348374007" angle="9.2747838635143669" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04524e46-c766-11e1-8775-005056c00008" name="BetsyLne LD" loadType="UNDEFINED" p0="11" q0="7" node="8" p="10.999637111151511" q="6.9996151221203879">
+            <iidm:load id="_04524e46-c766-11e1-8775-005056c00008" name="BetsyLne LD" loadType="UNDEFINED" p0="11" q0="7" node="8" p="10.999571527160981" q="6.9995455650106297">
                 <iidm:alias>_04549830-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5020,15 +5143,15 @@
                 <iidm:internalConnection node1="22" node2="6"/>
                 <iidm:internalConnection node1="23" node2="3"/>
                 <iidm:internalConnection node1="24" node2="6"/>
-                <iidm:bus v="124.75924965200323" angle="7.3516768014993019" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24"/>
+                <iidm:bus v="124.75919319436372" angle="-3.8750423196958979" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04566cf3-c766-11e1-8775-005056c00008" name="Reusens NegG LD" loadType="UNDEFINED" p0="22" q0="0" node="8" p="22.000026305373503" q="0">
+            <iidm:load id="_04566cf3-c766-11e1-8775-005056c00008" name="Reusens NegG LD" loadType="UNDEFINED" p0="22" q0="0" node="8" p="22.000016817161853" q="0">
                 <iidm:alias>_0483be81-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_0482fb36-c766-11e1-8775-005056c00008" name="Reusens LD" loadType="UNDEFINED" p0="28" q0="12" node="9" p="28.000033479566277" q="12.000023913985441">
+            <iidm:load id="_0482fb36-c766-11e1-8775-005056c00008" name="Reusens LD" loadType="UNDEFINED" p0="28" q0="12" node="9" p="28.000021403660547" q="12.000015288332852">
                 <iidm:alias>_0486cbc1-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_04558293-c766-11e1-8775-005056c00008" name="Reusens SC" sectionCount="5" voltageRegulatorOn="true" targetV="124.76300000000001" targetDeadband="1" node="10" q="-5.3543154085634201">
+            <iidm:shunt id="_04558293-c766-11e1-8775-005056c00008" name="Reusens SC" sectionCount="5" voltageRegulatorOn="true" targetV="124.76300000000001" targetDeadband="1" node="10" q="-5.3543105625589495">
                 <iidm:alias>_04893ccc-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_99303cd3-6b53-4ee2-a5ce-fe8d5feeb304"/>
                 <iidm:shuntLinearModel bPerSection="6.8800000000000005e-05" gPerSection="0" maximumSectionCount="10"/>
@@ -5101,12 +5224,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="126.42445135261407" angle="24.681105497872334" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="126.4226167084678" angle="13.464708753770019" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045c8777-c766-11e1-8775-005056c00008" name="Holston NegG LD" loadType="UNDEFINED" p0="85" q0="0" node="11" p="84.99990637395905" q="0">
+            <iidm:load id="_045c8777-c766-11e1-8775-005056c00008" name="Holston NegG LD" loadType="UNDEFINED" p0="85" q0="0" node="11" p="84.999863008419723" q="0">
                 <iidm:alias>_0487dd31-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_0451d918-c766-11e1-8775-005056c00008" name="Holston LD" loadType="UNDEFINED" p0="78" q0="42" node="12" p="77.999914084338911" q="41.99992289622989">
+            <iidm:load id="_0451d918-c766-11e1-8775-005056c00008" name="Holston LD" loadType="UNDEFINED" p0="78" q0="42" node="12" p="77.999874290079276" q="41.999887183465084">
                 <iidm:alias>_0485ba54-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5214,9 +5337,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="127.73116380573437" angle="9.1946893415778543" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="127.72918323403684" angle="-2.0572573791040845" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04742e27-c766-11e1-8775-005056c00008" name="SthPoint LD" loadType="UNDEFINED" p0="47" q0="11" node="17" p="47.000135823643227" q="11.000052980904778">
+            <iidm:load id="_04742e27-c766-11e1-8775-005056c00008" name="SthPoint LD" loadType="UNDEFINED" p0="47" q0="11" node="17" p="47.000123905627419" q="11.000048332024804">
                 <iidm:alias>_047b3303-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5268,12 +5391,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="132.92239773399811" angle="13.352451207796957" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="132.90972640831779" angle="2.1247312822690945" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04716f06-c766-11e1-8775-005056c00008" name="CapitlHl LD" loadType="UNDEFINED" p0="39" q0="32" node="8" p="38.999925546187384" q="31.999898182885151">
+            <iidm:load id="_04716f06-c766-11e1-8775-005056c00008" name="CapitlHl LD" loadType="UNDEFINED" p0="39" q0="32" node="8" p="38.999902595058884" q="31.999866796772615">
                 <iidm:alias>_04700f70-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0466c0a0-c766-11e1-8775-005056c00008" name="CapitlHl SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.00200000000001" targetDeadband="1" node="9" q="-20.283281664619757">
+            <iidm:shunt id="_0466c0a0-c766-11e1-8775-005056c00008" name="CapitlHl SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.00200000000001" targetDeadband="1" node="9" q="-20.279414689276106">
                 <iidm:alias>_045e8346-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_99931a87-ee15-4fd0-b251-9556df7fe598"/>
                 <iidm:shuntLinearModel bPerSection="0.0002296" gPerSection="0" maximumSectionCount="10"/>
@@ -5326,9 +5449,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="132.06056944647227" angle="13.036471927999695" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="132.04379653798179" angle="1.8078206312833154" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046efe03-c766-11e1-8775-005056c00008" name="Chemical LD" loadType="UNDEFINED" p0="71" q0="26" node="8" p="70.999813782134964" q="25.999886346003333">
+            <iidm:load id="_046efe03-c766-11e1-8775-005056c00008" name="Chemical LD" loadType="UNDEFINED" p0="71" q0="26" node="8" p="70.99976681925331" q="25.99985768326815">
                 <iidm:alias>_045d71d5-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5379,9 +5502,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.5207380070629" angle="9.229480647024058" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.565059991026" angle="-2.5778303462024361" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046a4319-c766-11e1-8775-005056c00008" name="JacksnRd LD" loadType="UNDEFINED" p0="19" q0="2" node="8" p="18.999898904070221" q="1.9999822639034253">
+            <iidm:load id="_046a4319-c766-11e1-8775-005056c00008" name="JacksnRd LD" loadType="UNDEFINED" p0="19" q0="2" node="8" p="18.999907874060373" q="1.9999838375805741">
                 <iidm:alias>_046c8d06-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5527,9 +5650,9 @@
                 <iidm:internalConnection node1="70" node2="15"/>
                 <iidm:internalConnection node1="71" node2="18"/>
                 <iidm:internalConnection node1="72" node2="21"/>
-                <iidm:bus v="130.60660457378518" angle="24.345634424092964" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
+                <iidm:bus v="130.59983731538412" angle="13.12654944222168" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0458ddf4-c766-11e1-8775-005056c00008" name="Saltvlle LD" loadType="UNDEFINED" p0="65" q0="10" node="23" p="64.999721359527427" q="9.9999285538270737">
+            <iidm:load id="_0458ddf4-c766-11e1-8775-005056c00008" name="Saltvlle LD" loadType="UNDEFINED" p0="65" q0="10" node="23" p="64.999685280843792" q="9.9999193029106976">
                 <iidm:alias>_045645e4-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5599,9 +5722,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="131.60831481390943" angle="13.830963784893866" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="131.74220379982111" angle="2.361882137497993" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0476ed42-c766-11e1-8775-005056c00008" name="Trenton NegG LD" loadType="UNDEFINED" p0="13" q0="0" node="11" p="12.999726362737729" q="0">
+            <iidm:load id="_0476ed42-c766-11e1-8775-005056c00008" name="Trenton NegG LD" loadType="UNDEFINED" p0="13" q0="0" node="11" p="12.999750457885401" q="0">
                 <iidm:alias>_0471e432-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5671,9 +5794,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="128.34799073371613" angle="8.2495876308336822" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="128.40809222948423" angle="-3.6009070196220487" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044a5f08-c766-11e1-8775-005056c00008" name="HickryCk LD" loadType="UNDEFINED" p0="39" q0="10" node="11" p="38.999675378335603" q="9.9998612731778991">
+            <iidm:load id="_044a5f08-c766-11e1-8775-005056c00008" name="HickryCk LD" loadType="UNDEFINED" p0="39" q0="10" node="11" p="38.999704376674309" q="9.9998736655646407">
                 <iidm:alias>_047d7cf3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5802,9 +5925,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="125.33000840704095" angle="-4.2324594189160711" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="125.265524761648" angle="-15.312733695795556" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:shunt id="_0450eeb7-c766-11e1-8775-005056c00008" name="EastLima SC" sectionCount="5" voltageRegulatorOn="true" targetV="131.565" targetDeadband="1" node="20" q="-22.540421795488353">
+            <iidm:shunt id="_0450eeb7-c766-11e1-8775-005056c00008" name="EastLima SC" sectionCount="5" voltageRegulatorOn="true" targetV="131.565" targetDeadband="1" node="20" q="-22.517233180618849">
                 <iidm:alias>_044aad27-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_6c36f421-303e-4932-93a9-5b0ff86cb7d4"/>
                 <iidm:shuntLinearModel bPerSection="0.00028699999999999998" gPerSection="0" maximumSectionCount="10"/>
@@ -5892,16 +6015,16 @@
                 <iidm:internalConnection node1="41" node2="7"/>
                 <iidm:internalConnection node1="42" node2="12"/>
                 <iidm:internalConnection node1="43" node2="11"/>
-                <iidm:bus v="218.90697928380683" angle="6.7135665738291479" nodes="0,1,2,3,8,9,10,13,17,18,21,22,23,24,25,26,31,32,33,34,35,39,40"/>
-                <iidm:bus v="237.9377327685504" angle="-5.0330874185903482" nodes="11,15,37,43"/>
-                <iidm:bus v="226.19472284880271" angle="6.713566573687654" nodes="12,16,38,42"/>
-                <iidm:bus v="214.7002936925636" angle="-5.0330874185903491" nodes="4,5,6,7,14,19,20,27,28,29,30,36,41"/>
+                <iidm:bus v="218.9070924313653" angle="-4.4789649641354892" nodes="0,1,2,3,8,9,10,13,17,18,21,22,23,24,25,26,31,32,33,34,35,39,40"/>
+                <iidm:bus v="237.93770263436522" angle="-16.223690749958173" nodes="11,15,37,43"/>
+                <iidm:bus v="226.19469283804889" angle="-4.4789649636331834" nodes="12,16,38,42"/>
+                <iidm:bus v="214.70026650133869" angle="-16.223690749958173" nodes="4,5,6,7,14,19,20,27,28,29,30,36,41"/>
             </iidm:nodeBreakerTopology>
-            <iidm:vscConverterStation id="_b46bfb8e-7af6-459e-acf3-53a42c943a7c" name="VSC2" voltageRegulatorOn="true" lossFactor="0.32362458" voltageSetpoint="218.47" reactivePowerSetpoint="0" node="42" p="-0" q="-27.474139911736216">
+            <iidm:vscConverterStation id="_b46bfb8e-7af6-459e-acf3-53a42c943a7c" name="VSC2" voltageRegulatorOn="true" lossFactor="0.32362458" voltageSetpoint="218.47" reactivePowerSetpoint="0" node="42" p="-0" q="-27.473603863094176">
                 <iidm:alias>_a168e701-bd48-4f66-8f0b-0f69b2545530</iidm:alias>
                 <iidm:minMaxReactiveLimits minQ="-1.7976931348623157e+308" maxQ="1.7976931348623157e+308"/>
             </iidm:vscConverterStation>
-            <iidm:vscConverterStation id="_b48ce7cf-abf5-413f-bc51-9e1d3103c9bd" name="VSC1" voltageRegulatorOn="true" lossFactor="0.32467531999999999" voltageSetpoint="213.53999999999999" reactivePowerSetpoint="0" node="43" p="-0" q="-92.151020935019986">
+            <iidm:vscConverterStation id="_b48ce7cf-abf5-413f-bc51-9e1d3103c9bd" name="VSC1" voltageRegulatorOn="true" lossFactor="0.32467531999999999" voltageSetpoint="213.53999999999999" reactivePowerSetpoint="0" node="43" p="-0" q="-92.151020935010848">
                 <iidm:alias>_071bb138-ff00-4874-8acc-a884aa5cf4a9</iidm:alias>
                 <iidm:minMaxReactiveLimits minQ="-1.7976931348623157e+308" maxQ="1.7976931348623157e+308"/>
             </iidm:vscConverterStation>
@@ -5969,7 +6092,7 @@
                 <iidm:internalConnection node1="29" node2="6"/>
                 <iidm:internalConnection node1="30" node2="9"/>
                 <iidm:internalConnection node1="31" node2="3"/>
-                <iidm:bus v="201.8151826709996" angle="-0.26107780548815707" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
+                <iidm:bus v="201.76482581420959" angle="-11.369532691315642" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_0448d867-c766-11e1-8775-005056c00008" name="EDO132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -6055,9 +6178,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="131.34002952140614" angle="4.3077138468705813" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="131.34001211298369" angle="-6.884380096443679" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0472a789-c766-11e1-8775-005056c00008" name="W.Kammer SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="160" targetV="131.34" targetQ="0" node="14" p="-177.17258644235372" q="94.096765144496132">
+            <iidm:generator id="_0472a789-c766-11e1-8775-005056c00008" name="W.Kammer SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="160" targetV="131.34" targetQ="0" node="14" p="-177.14205047118119" q="94.093511587769655">
                 <iidm:alias>_04697fc0-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_17852426-f663-4add-9a2b-0a635d51f101"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b512ea0a-96d0-4a48-9de1-a5cf499bf0dd"/>
@@ -6206,16 +6329,16 @@
                 <iidm:internalConnection node1="71" node2="15"/>
                 <iidm:internalConnection node1="72" node2="18"/>
                 <iidm:internalConnection node1="73" node2="21"/>
-                <iidm:bus v="130.02002719580543" angle="-5.03308741859035" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
+                <iidm:bus v="130.02001072911253" angle="-16.22369074995817" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04839777-c766-11e1-8775-005056c00008" name="Tidd SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="155" targetV="130.02000000000001" targetQ="0" node="24" p="-171.63594311603018" q="-94.864276704251097">
+            <iidm:generator id="_04839777-c766-11e1-8775-005056c00008" name="Tidd SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="155" targetV="130.02000000000001" targetQ="0" node="24" p="-171.6063613939568" q="-94.866200822275573">
                 <iidm:alias>_045fe2d8-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_d2a96d8d-65be-4fd6-a012-ceeeabd2bee6"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_29df1e0b-36ca-4536-97b4-6f98b84d49d8"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-90" maxQ="255"/>
             </iidm:generator>
-            <iidm:load id="_04798556-c766-11e1-8775-005056c00008" name="Tidd LD" loadType="UNDEFINED" p0="277" q0="113" node="23" p="277.0000869086121" q="113.00005908949574">
+            <iidm:load id="_04798556-c766-11e1-8775-005056c00008" name="Tidd LD" loadType="UNDEFINED" p0="277" q0="113" node="23" p="277.00003428662001" q="113.00002331160184">
                 <iidm:alias>_04502b62-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6245,13 +6368,13 @@
                 <iidm:internalConnection node1="10" node2="3"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="0"/>
-                <iidm:bus v="360.98407727579212" angle="6.7724745381046919e-60" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="360.8933176948421" angle="-11.108324127936553" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
             </iidm:nodeBreakerTopology>
             <iidm:lccConverterStation id="_9793118d-5ba1-4a9c-b2e0-db1d15be5913" name="Conv2" lossFactor="0" powerFactor="-0.75741000000000003" node="12" p="-10" q="8.6206896551724146">
                 <iidm:alias>_453bdc57-5855-4eb5-8712-d6a0255e0da8</iidm:alias>
             </iidm:lccConverterStation>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045c1248-c766-11e1-8775-005056c00008" name="38-37" r="0" x="6.5340005399999992" g="0" b="0" ratedU1="220" ratedU2="132" node1="30" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="172.04440640596624" q1="88.756278923484416" p2="-172.04440640596627" q2="-74.156156025400605">
+        <iidm:twoWindingsTransformer id="_045c1248-c766-11e1-8775-005056c00008" name="38-37" r="0" x="6.5340005399999992" g="0" b="0" ratedU1="220" ratedU2="132" node1="30" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="170.69503391581523" q1="89.28425713928128" p2="-170.69503391581526" q2="-74.8204687560807">
             <iidm:alias>_0453d4e8-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0477d7aa-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_047df228-c766-11e1-8775-005056c00008</iidm:alias>
@@ -6275,7 +6398,7 @@
                 <iidm:temporaryLimit name="_c97df399-5a91-4c8b-b72c-496cade334b5" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_0485ba57-c766-11e1-8775-005056c00008" name="64-61" r="0" x="4.669632" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="157.4373798653501" q1="60.540593814977207" p2="-157.43737986535018" q2="-53.068513883593084">
+        <iidm:twoWindingsTransformer id="_0485ba57-c766-11e1-8775-005056c00008" name="64-61" r="0" x="4.669632" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="157.40882129083562" q1="60.541887587378753" p2="-157.40882129083556" q2="-53.072135630726848">
             <iidm:alias>_04549831-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0472ce92-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0489d905-c766-11e1-8775-005056c00008</iidm:alias>
@@ -6301,7 +6424,7 @@
                 <iidm:temporaryLimit name="_f6b1a81c-eda7-4a08-b290-bd29a5ed9fa4" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_044cd007-c766-11e1-8775-005056c00008" name="63-59" r="0" x="6.7256646120000001" g="0" b="0" ratedU1="220" ratedU2="132" node1="41" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="73" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="6.9388939039072284e-14" q1="83.151416571290611" p2="-3.0531133177191805e-14" q2="-80.568863938033246">
+        <iidm:twoWindingsTransformer id="_044cd007-c766-11e1-8775-005056c00008" name="63-59" r="0" x="6.7256646120000001" g="0" b="0" ratedU1="220" ratedU2="132" node1="41" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="73" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="1.9428902930940239e-14" q1="83.151395509477439" p2="-5.5511151231257827e-14" q2="-80.568843530367189">
             <iidm:alias>_044e7db4-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_046eafe5-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0488797a-c766-11e1-8775-005056c00008</iidm:alias>
@@ -6347,7 +6470,7 @@
                 <iidm:temporaryLimit name="_f2daef4d-6f1a-44d1-9c9b-228acff12575" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_ffd940c8-03c8-4dcf-ad46-62018a0d813d" name="PowTrans2" r="0.3932500000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_04f97116-552a-4a34-afd9-4862f62ac7aa" node2="31" voltageLevelId2="_04742e21-c766-11e1-8775-005056c00008" p1="9.9999921661336497" q1="-8.6206829018392206" p2="-9.9982963499986415" q2="8.6989513388405069">
+        <iidm:twoWindingsTransformer id="_ffd940c8-03c8-4dcf-ad46-62018a0d813d" name="PowTrans2" r="0.3932500000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_04f97116-552a-4a34-afd9-4862f62ac7aa" node2="31" voltageLevelId2="_04742e21-c766-11e1-8775-005056c00008" p1="9.9999890617270317" q1="-8.6206874179179813" p2="-9.9982923923837053" q2="8.698995233772191">
             <iidm:alias>_04479fea-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_c089eb25-9f67-4d82-88a8-635dd4808bae</iidm:alias>
             <iidm:alias>_ea8cd467-31f0-40dc-95d7-4064463724c4</iidm:alias>
@@ -6414,9 +6537,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="124.78818720222134" angle="-8.2040128785186166" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.78799781998048" angle="-19.39178975634098" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0481c2b3-c766-11e1-8775-005056c00008" name="Wooster LD" loadType="UNDEFINED" p0="23" q0="11" node="8" p="22.999988776329744" q="10.999991053597629">
+            <iidm:load id="_0481c2b3-c766-11e1-8775-005056c00008" name="Wooster LD" loadType="UNDEFINED" p0="23" q0="11" node="8" p="22.999985284523728" q="10.999988270275038">
                 <iidm:alias>_04614268-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6486,9 +6609,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="125.56954532684964" angle="-7.9664630015494691" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="125.56949822212262" angle="-19.154931471739594" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044974a8-c766-11e1-8775-005056c00008" name="Wagenhls LD" loadType="UNDEFINED" p0="63" q0="22" node="11" p="63.000014820969163" q="22.000008625961559">
+            <iidm:load id="_044974a8-c766-11e1-8775-005056c00008" name="Wagenhls LD" loadType="UNDEFINED" p0="63" q0="22" node="11" p="63.000004652474132" q="22.000002707789239">
                 <iidm:alias>_048481d4-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6539,9 +6662,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.27532580114956" angle="7.2953155266096514" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.32911105821778" angle="-4.2870740513545282" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047fedf2-c766-11e1-8775-005056c00008" name="Concord LD" loadType="UNDEFINED" p0="34" q0="16" node="8" p="33.998883199740163" q="15.999124087818101">
+            <iidm:load id="_047fedf2-c766-11e1-8775-005056c00008" name="Concord LD" loadType="UNDEFINED" p0="34" q0="16" node="8" p="33.998926213640971" q="15.999157823486351">
                 <iidm:alias>_046d9e75-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6649,9 +6772,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="127.43890436042166" angle="9.8754978657846877" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="127.56323200013482" angle="-1.3644499196582913" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045f94ba-c766-11e1-8775-005056c00008" name="Delaware LD" loadType="UNDEFINED" p0="59" q0="23" node="17" p="58.998901753379194" q="22.999286454363073">
+            <iidm:load id="_045f94ba-c766-11e1-8775-005056c00008" name="Delaware LD" loadType="UNDEFINED" p0="59" q0="23" node="17" p="58.999070323687761" q="22.99939597619008">
                 <iidm:alias>_0463654a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6759,9 +6882,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="125.27154131227526" angle="5.0715235104251404" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="125.21081637719644" angle="-5.8126920011615013" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04697fc9-c766-11e1-8775-005056c00008" name="FtWayne LD" loadType="UNDEFINED" p0="90" q0="30" node="17" p="89.991410853758694" q="29.995228403886959">
+            <iidm:load id="_04697fc9-c766-11e1-8775-005056c00008" name="FtWayne LD" loadType="UNDEFINED" p0="90" q0="30" node="17" p="89.99150164578343" q="29.995278840708451">
                 <iidm:alias>_044d1e25-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6812,9 +6935,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.01478594586678" angle="-5.9644763100292071" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.01455452992883" angle="-17.151758361654668" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0474f170-c766-11e1-8775-005056c00008" name="WNwPhil1 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="11.999995981154184" q="2.9999983254810973">
+            <iidm:load id="_0474f170-c766-11e1-8775-005056c00008" name="WNwPhil1 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="11.999994243456422" q="2.9999976014405596">
                 <iidm:alias>_0466c0a7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6885,12 +7008,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="129.61395183142878" angle="15.315232439216068" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="129.50965877267089" angle="4.0899766052116284" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044a5f05-c766-11e1-8775-005056c00008" name="Logan LD" loadType="UNDEFINED" p0="54" q0="27" node="11" p="53.999033050373171" q="26.999194213453936">
+            <iidm:load id="_044a5f05-c766-11e1-8775-005056c00008" name="Logan LD" loadType="UNDEFINED" p0="54" q0="27" node="11" p="53.998897632690358" q="26.999081366826406">
                 <iidm:alias>_04767811-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0475dbd6-c766-11e1-8775-005056c00008" name="Logan SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.41900000000001" targetDeadband="1" node="12" q="-19.286143432745213">
+            <iidm:shunt id="_0475dbd6-c766-11e1-8775-005056c00008" name="Logan SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.41900000000001" targetDeadband="1" node="12" q="-19.25511896929487">
                 <iidm:alias>_04577e67-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_a7768441-642e-48a2-b4a8-0ae06bebf676"/>
                 <iidm:shuntLinearModel bPerSection="0.0002296" gPerSection="0" maximumSectionCount="10"/>
@@ -6964,19 +7087,19 @@
                 <iidm:internalConnection node1="32" node2="3"/>
                 <iidm:internalConnection node1="33" node2="6"/>
                 <iidm:internalConnection node1="34" node2="9"/>
-                <iidm:bus v="132.66000891568137" angle="-1.8464033858467301" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34"/>
+                <iidm:bus v="132.66000105349946" angle="-13.02701182858118" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04633e31-c766-11e1-8775-005056c00008" name="W.Lancst SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="19" targetV="132.66" targetQ="0" node="13" p="-21.039244640029501" q="1.4881422607842305">
+            <iidm:generator id="_04633e31-c766-11e1-8775-005056c00008" name="W.Lancst SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="19" targetV="132.66" targetQ="0" node="13" p="-21.035618493452766" q="1.4907046699941682">
                 <iidm:alias>_047bcf42-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_83fae784-1da1-4055-8108-ba978276d1b6"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_5f711f63-f631-45d3-b26c-33821ab2ee56"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-15" maxQ="45"/>
             </iidm:generator>
-            <iidm:load id="_048a9c51-c766-11e1-8775-005056c00008" name="W.Lancst LD" loadType="UNDEFINED" p0="28" q0="10" node="11" p="28.000002822694292" q="10.000001680175229">
+            <iidm:load id="_048a9c51-c766-11e1-8775-005056c00008" name="W.Lancst LD" loadType="UNDEFINED" p0="28" q0="10" node="11" p="28.000000333536708" q="10.000000198533753">
                 <iidm:alias>_044e7db6-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_045b00d9-c766-11e1-8775-005056c00008" name="W.Lancst SC" sectionCount="5" voltageRegulatorOn="true" targetV="132.66" targetDeadband="1" node="12" q="-10.101641152201969">
+            <iidm:shunt id="_045b00d9-c766-11e1-8775-005056c00008" name="W.Lancst SC" sectionCount="5" voltageRegulatorOn="true" targetV="132.66" targetDeadband="1" node="12" q="-10.101639954841312">
                 <iidm:alias>_04758db6-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_be267a3c-f7a7-4bdf-bb17-71b773247fbf"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -7086,9 +7209,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="129.88495881079365" angle="9.6968522618354047" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="129.90082928662173" angle="-1.5886728132719963" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045dbff2-c766-11e1-8775-005056c00008" name="Portsmth LD" loadType="UNDEFINED" p0="66" q0="20" node="17" p="66.000187379772939" q="20.000094636338513">
+            <iidm:load id="_045dbff2-c766-11e1-8775-005056c00008" name="Portsmth LD" loadType="UNDEFINED" p0="66" q0="20" node="17" p="66.000196590715632" q="20.000099288338795">
                 <iidm:alias>_0454bf45-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7159,16 +7282,16 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="127.64400197958356" angle="7.9057662608552377" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="127.64400000026428" angle="-3.152877398074085" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04856c34-c766-11e1-8775-005056c00008" name="DeerCrk SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="7" targetV="127.64400000000001" targetQ="0" node="12" p="-7.7513006568529761" q="-39.308635475735024">
+            <iidm:generator id="_04856c34-c766-11e1-8775-005056c00008" name="DeerCrk SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="7" targetV="127.64400000000001" targetQ="0" node="12" p="-7.7499647081141783" q="-37.155035780390889">
                 <iidm:alias>_0477d7a5-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e5a479a8-ab8d-4a54-bb52-376874ae2784"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b55d80d5-720f-46f9-897f-ff8c5eaf8b44"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-15" maxQ="45"/>
             </iidm:generator>
-            <iidm:load id="_04791028-c766-11e1-8775-005056c00008" name="DeerCrk LD" loadType="UNDEFINED" p0="43" q0="27" node="11" p="43.000001000306632" q="27.000001046832534">
+            <iidm:load id="_04791028-c766-11e1-8775-005056c00008" name="DeerCrk LD" loadType="UNDEFINED" p0="43" q0="27" node="11" p="43.000000000133539" q="27.00000000013975">
                 <iidm:alias>_04486337-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7219,9 +7342,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.85770696748764" angle="9.6924208698240104" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.01741931531053" angle="-1.5995259324467328" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0462c904-c766-11e1-8775-005056c00008" name="Medford LD" loadType="UNDEFINED" p0="22" q0="7" node="8" p="21.999612732222225" q="6.9997946319289532">
+            <iidm:load id="_0462c904-c766-11e1-8775-005056c00008" name="Medford LD" loadType="UNDEFINED" p0="22" q0="7" node="8" p="21.999688079658647" q="6.9998345884795174">
                 <iidm:alias>_0489b1f7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7310,9 +7433,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="132.03516440204126" angle="15.43540310622318" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="132.17099759915172" angle="3.9198071997056614" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046205b5-c766-11e1-8775-005056c00008" name="CollCrnr LD" loadType="UNDEFINED" p0="7" q0="3" node="14" p="6.9998439812461957" q="2.9998885588609521">
+            <iidm:load id="_046205b5-c766-11e1-8775-005056c00008" name="CollCrnr LD" loadType="UNDEFINED" p0="7" q0="3" node="14" p="6.9998592954930023" q="2.99989949745411">
                 <iidm:alias>_04486334-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7363,9 +7486,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.92780571441821" angle="16.468182997006146" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.8936264956493" angle="5.2433438096183904" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0483be82-c766-11e1-8775-005056c00008" name="Caldwell LD" loadType="UNDEFINED" p0="42" q0="31" node="8" p="41.999521144208792" q="30.999410933606679">
+            <iidm:load id="_0483be82-c766-11e1-8775-005056c00008" name="Caldwell LD" loadType="UNDEFINED" p0="42" q0="31" node="8" p="41.999472060764766" q="30.99935055366198">
                 <iidm:alias>_045841b9-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7416,9 +7539,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.33159859795488" angle="8.954372721811211" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.3315361493984" angle="-2.2726081404634946" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045f94b4-c766-11e1-8775-005056c00008" name="Franklin LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="8.0000107768971489" q="3.0000067355637419">
+            <iidm:load id="_045f94b4-c766-11e1-8775-005056c00008" name="Franklin LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="8.0000072828929358" q="3.0000045518094662">
                 <iidm:alias>_047da403-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7469,9 +7592,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="124.92050798131132" angle="5.8603855339641235" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.8458881639241" angle="-4.8778663776110669" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045f6da2-c766-11e1-8775-005056c00008" name="McKinley LD" loadType="UNDEFINED" p0="60" q0="34" node="8" p="59.994536406460831" q="33.994840096061665">
+            <iidm:load id="_045f6da2-c766-11e1-8775-005056c00008" name="McKinley LD" loadType="UNDEFINED" p0="60" q0="34" node="8" p="59.994619060082087" q="33.994918153111989">
                 <iidm:alias>_0465d641-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7618,19 +7741,19 @@
                 <iidm:internalConnection node1="71" node2="18"/>
                 <iidm:internalConnection node1="72" node2="21"/>
                 <iidm:internalConnection node1="73" node2="12"/>
-                <iidm:bus v="130.68000966523829" angle="8.7119179517552396" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
+                <iidm:bus v="130.68000806563035" angle="-3.0024748135730674" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_044ca8f0-c766-11e1-8775-005056c00008" name="TwinBrch SM" energySource="THERMAL" minP="50" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="85" targetV="130.68000799999999" targetQ="0" node="24" p="-94.122936547500416" q="-90.69960688782335">
+            <iidm:generator id="_044ca8f0-c766-11e1-8775-005056c00008" name="TwinBrch SM" energySource="THERMAL" minP="50" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="85" targetV="130.68000799999999" targetQ="0" node="24" p="-94.106714312815015" q="-86.912736202000829">
                 <iidm:alias>_04633e38-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_0f6ab5a4-6b72-42f4-92bc-1993e1ae58a3"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_668eb671-5c36-4351-a95d-53ca850581db"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-60" maxQ="170"/>
             </iidm:generator>
-            <iidm:load id="_048740f1-c766-11e1-8775-005056c00008" name="TwinBrch LD" loadType="UNDEFINED" p0="47" q0="10" node="23" p="47.000000898372292" q="10.00000031857174">
+            <iidm:load id="_048740f1-c766-11e1-8775-005056c00008" name="TwinBrch LD" loadType="UNDEFINED" p0="47" q0="10" node="23" p="47.000000035406636" q="10.000000012555546">
                 <iidm:alias>_044ecbda-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:danglingLine id="_045338a1-c766-11e1-8775-005056c00008" name="12-117" p0="20" q0="8" r="5.7324960000000003" x="24.393599999999999" g="0" b="0.00020546369999999999" ucteXnodeCode="XMO_TE32" node="73" p="20.161794129256581" q="5.1797256572079089">
+            <iidm:danglingLine id="_045338a1-c766-11e1-8775-005056c00008" name="12-117" p0="20" q0="8" r="5.7324960000000003" x="24.393599999999999" g="0" b="0.00020546369999999999" ucteXnodeCode="XMO_TE32" node="73" p="20.161793636193501" q="5.1797255290913702">
                 <iidm:alias>_044afb42-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_0457f391-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_5631f3d0-d9d2-11e2-bb49-005056c00008</iidm:alias>
@@ -7728,9 +7851,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="124.11790434596777" angle="4.3189413681199706" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="124.06321863810773" angle="-6.5497749666550042" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0479fa87-c766-11e1-8775-005056c00008" name="Lincoln LD" loadType="UNDEFINED" p0="45" q0="25" node="14" p="44.995053628847195" q="24.99542019452166">
+            <iidm:load id="_0479fa87-c766-11e1-8775-005056c00008" name="Lincoln LD" loadType="UNDEFINED" p0="45" q0="25" node="14" p="44.995100540124312" q="24.995463627721392">
                 <iidm:alias>_047fc6e2-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7781,9 +7904,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="134.64620313981899" angle="15.660045689169962" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="134.64618943617697" angle="4.4339973552389074" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044c81e4-c766-11e1-8775-005056c00008" name="Hinton NegG LD" loadType="UNDEFINED" p0="42" q0="0" node="8" p="42.000023977285963" q="0">
+            <iidm:load id="_044c81e4-c766-11e1-8775-005056c00008" name="Hinton NegG LD" loadType="UNDEFINED" p0="42" q0="0" node="8" p="42.000007718178601" q="0">
                 <iidm:alias>_04494d96-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7834,9 +7957,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.25311852313231" angle="8.0146689275467224" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.22567568235195" angle="-3.3521066587511821" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_048bfbe0-c766-11e1-8775-005056c00008" name="N. E. LD" loadType="UNDEFINED" p0="25" q0="10" node="8" p="24.999535360578374" q="9.9996902423046077">
+            <iidm:load id="_048bfbe0-c766-11e1-8775-005056c00008" name="N. E. LD" loadType="UNDEFINED" p0="25" q0="10" node="8" p="24.999550983686287" q="9.9997006575830021">
                 <iidm:alias>_0480b140-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7887,9 +8010,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.13873100155296" angle="-6.8884547722847875" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.13837392765384" angle="-18.075535953321015" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04854525-c766-11e1-8775-005056c00008" name="SCoshoct LD" loadType="UNDEFINED" p0="18" q0="5" node="8" p="17.999981272471789" q="4.9999913298510581">
+            <iidm:load id="_04854525-c766-11e1-8775-005056c00008" name="SCoshoct LD" loadType="UNDEFINED" p0="18" q0="5" node="8" p="17.999978716699552" q="4.9999901466240475">
                 <iidm:alias>_04747c42-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7940,9 +8063,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="125.04910812550176" angle="8.2867891050230718" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="125.04322658368662" angle="-2.9609780945528947" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044aad24-c766-11e1-8775-005056c00008" name="WHuntngd LD" loadType="UNDEFINED" p0="33" q0="15" node="8" p="33.000068442312873" q="15.000051850272872">
+            <iidm:load id="_044aad24-c766-11e1-8775-005056c00008" name="WHuntngd LD" loadType="UNDEFINED" p0="33" q0="15" node="8" p="33.000056094883405" q="15.000042496147872">
                 <iidm:alias>_04784cd2-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7974,9 +8097,9 @@
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="3"/>
-                <iidm:bus v="129.36010579276956" angle="9.867174892091624" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="129.36006711655142" angle="-1.3603311704523073" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0452ea80-c766-11e1-8775-005056c00008" name="DanRiver SM" energySource="THERMAL" minP="20" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="36" targetV="129.36000000000001" targetQ="0" node="5" p="-39.863831949529583" q="-20.273217866101763">
+            <iidm:generator id="_0452ea80-c766-11e1-8775-005056c00008" name="DanRiver SM" energySource="THERMAL" minP="20" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="36" targetV="129.36000000000001" targetQ="0" node="5" p="-39.856961356015766" q="-20.275209262373934">
                 <iidm:alias>_046a4316-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_fec62959-21c5-4921-90b2-7c85e9f3bfab"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_9db08c95-4586-4a2b-87e3-5a17c944b43a"/>
@@ -8049,9 +8172,9 @@
                 <iidm:internalConnection node1="29" node2="3"/>
                 <iidm:internalConnection node1="30" node2="9"/>
                 <iidm:internalConnection node1="31" node2="6"/>
-                <iidm:bus v="130.14420626976388" angle="9.7950787988175971" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
+                <iidm:bus v="130.17232597641058" angle="-1.506037973076312" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
             </iidm:nodeBreakerTopology>
-            <iidm:danglingLine id="_044ef2e7-c766-11e1-8775-005056c00008" name="71-73" p0="6" q0="0" r="1.508918" x="7.9104960000000002" g="0" b="6.76079e-05" ucteXnodeCode="XMO_TE31" node="31" p="6.003213927814155" q="-1.1282780160522861">
+            <iidm:danglingLine id="_044ef2e7-c766-11e1-8775-005056c00008" name="71-73" p0="6" q0="0" r="1.508918" x="7.9104960000000002" g="0" b="6.76079e-05" ucteXnodeCode="XMO_TE31" node="31" p="6.0032107956620866" q="-1.1287802761444892">
                 <iidm:alias>_04670ec2-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_046b2d7a-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_26a070b9-db0c-47cd-9991-0a461576aec2</iidm:alias>
@@ -8111,9 +8234,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="134.29664339104971" angle="2.8369504610442862" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="134.29658154690225" angle="-8.353756917562615" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0453add4-c766-11e1-8775-005056c00008" name="Summerfl LD" loadType="UNDEFINED" p0="28" q0="7" node="8" p="27.9999122862714" q="6.9999634526512464">
+            <iidm:load id="_0453add4-c766-11e1-8775-005056c00008" name="Summerfl LD" loadType="UNDEFINED" p0="28" q0="7" node="8" p="27.999907337583501" q="6.9999613907023823">
                 <iidm:alias>_04851e16-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8240,9 +8363,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="132.66011807453643" angle="31.007625229319846" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="132.66007496449294" angle="19.792156141683687" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0489b1fa-c766-11e1-8775-005056c00008" name="ClinchRv SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="607" targetV="132.66" targetQ="0" node="20" p="-672.14849981567943" q="-45.977952143150837">
+            <iidm:generator id="_0489b1fa-c766-11e1-8775-005056c00008" name="ClinchRv SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="607" targetV="132.66" targetQ="0" node="20" p="-672.03265397504367" q="-49.027472979005644">
                 <iidm:alias>_04840caa-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_2621b09a-22e3-4630-b3bd-32c102e36741"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b0d662e5-64c9-4d59-b8e0-9b1ed175769b"/>
@@ -8297,9 +8420,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.47128488833928" angle="7.7813288049517668" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.4884106486162" angle="-3.973063424224748" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0485e168-c766-11e1-8775-005056c00008" name="Pokagon LD" loadType="UNDEFINED" p0="20" q0="9" node="8" p="19.999945288783675" q="8.9999589666251705">
+            <iidm:load id="_0485e168-c766-11e1-8775-005056c00008" name="Pokagon LD" loadType="UNDEFINED" p0="20" q0="9" node="8" p="19.999950210512139" q="8.9999626579150878">
                 <iidm:alias>_0462c902-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8350,9 +8473,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.0489261708195" angle="7.316563280889941" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.05262977490949" angle="-4.1835966547855188" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04812679-c766-11e1-8775-005056c00008" name="GoshenJt LD" loadType="UNDEFINED" p0="14" q0="1" node="8" p="13.999640199228706" q="0.99995716694178727">
+            <iidm:load id="_04812679-c766-11e1-8775-005056c00008" name="GoshenJt LD" loadType="UNDEFINED" p0="14" q0="1" node="8" p="13.999647939322543" q="0.99995808836591227">
                 <iidm:alias>_045b9d17-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8403,9 +8526,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="118.00623935429799" angle="-11.025549611406932" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="117.95494016818972" angle="-22.147384128474982" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0489b1f2-c766-11e1-8775-005056c00008" name="S.Tiffin LD" loadType="UNDEFINED" p0="37" q0="10" node="8" p="36.989562766722855" q="9.9952989856565626">
+            <iidm:load id="_0489b1f2-c766-11e1-8775-005056c00008" name="S.Tiffin LD" loadType="UNDEFINED" p0="37" q0="10" node="8" p="36.98948069588657" q="9.9952620237913479">
                 <iidm:alias>_046476b8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8456,9 +8579,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="123.60732770119766" angle="-0.19160340543910842" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="123.52510259688115" angle="-11.168592409784846" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045cfca7-c766-11e1-8775-005056c00008" name="Haviland LD" loadType="UNDEFINED" p0="23" q0="9" node="8" p="22.995772011853774" q="8.9972427853890284">
+            <iidm:load id="_045cfca7-c766-11e1-8775-005056c00008" name="Haviland LD" loadType="UNDEFINED" p0="23" q0="9" node="8" p="22.995750447440969" q="8.9972287233695116">
                 <iidm:alias>_0482ad17-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8528,9 +8651,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="131.0072532591623" angle="2.9559761133317037" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="131.0072657226788" angle="-8.2359354605178048" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04555b82-c766-11e1-8775-005056c00008" name="SWKammer LD" loadType="UNDEFINED" p0="78" q0="3" node="11" p="77.999947142759623" q="2.9999966117161261">
+            <iidm:load id="_04555b82-c766-11e1-8775-005056c00008" name="SWKammer LD" loadType="UNDEFINED" p0="78" q0="3" node="11" p="77.999931852170803" q="2.9999956315506826">
                 <iidm:alias>_0474ca6b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8638,9 +8761,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="130.40094935095698" angle="15.743749940225221" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="130.35297369318212" angle="4.518333890125974" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04817492-c766-11e1-8775-005056c00008" name="Baileysv LD" loadType="UNDEFINED" p0="38" q0="15" node="17" p="37.999527705528799" q="14.99968928124045">
+            <iidm:load id="_04817492-c766-11e1-8775-005056c00008" name="Baileysv LD" loadType="UNDEFINED" p0="38" q0="15" node="17" p="37.999475252082576" q="14.999654772696067">
                 <iidm:alias>_0474f17b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8691,9 +8814,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.0463049174576" angle="24.21479986683833" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.04249486626426" angle="12.997300887206919" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0461b790-c766-11e1-8775-005056c00008" name="HolstonT NegG LD" loadType="UNDEFINED" p0="10" q0="0" node="8" p="9.999975641696599" q="0">
+            <iidm:load id="_0461b790-c766-11e1-8775-005056c00008" name="HolstonT NegG LD" loadType="UNDEFINED" p0="10" q0="0" node="8" p="9.999970357404516" q="0">
                 <iidm:alias>_0464ebe7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8744,9 +8867,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.89458306277621" angle="9.6776111329516645" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.04919423870804" angle="-1.6066614931156484" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044c81e5-c766-11e1-8775-005056c00008" name="WMedford LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="7.9998576598646158" q="2.9999110379430092">
+            <iidm:load id="_044c81e5-c766-11e1-8775-005056c00008" name="WMedford LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="7.9998844870340386" q="2.9999278047437552">
                 <iidm:alias>_04570939-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8836,12 +8959,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="124.66849408401627" angle="-4.5188224193946187" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="124.60187572636698" angle="-15.59440482610631" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04854520-c766-11e1-8775-005056c00008" name="Rockhill LD" loadType="UNDEFINED" p0="59" q0="26" node="14" p="58.985619998093995" q="25.98943927475662">
+            <iidm:load id="_04854520-c766-11e1-8775-005056c00008" name="Rockhill LD" loadType="UNDEFINED" p0="59" q0="26" node="14" p="58.985516356969946" q="25.989363166570641">
                 <iidm:alias>_0461b799-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0460cd38-c766-11e1-8775-005056c00008" name="Rockhill SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.81399999999999" targetDeadband="1" node="15" q="-12.480413433992648">
+            <iidm:shunt id="_0460cd38-c766-11e1-8775-005056c00008" name="Rockhill SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.81399999999999" targetDeadband="1" node="15" q="-12.467078829926789">
                 <iidm:alias>_048b86b4-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_069d84c6-bd26-4c26-ac6c-e801a0202a00"/>
                 <iidm:shuntLinearModel bPerSection="0.0001606" gPerSection="0" maximumSectionCount="10"/>
@@ -8914,12 +9037,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="128.70714785995537" angle="17.046779816378002" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="128.53070808091573" angle="5.82563444939146" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047a48a5-c766-11e1-8775-005056c00008" name="Sprigg LD" loadType="UNDEFINED" p0="20" q0="10" node="11" p="19.999483408380051" q="9.9995695106898701">
+            <iidm:load id="_047a48a5-c766-11e1-8775-005056c00008" name="Sprigg LD" loadType="UNDEFINED" p0="20" q0="10" node="11" p="19.999406535516218" q="9.999505451155196">
                 <iidm:alias>_0472ce97-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_04553478-c766-11e1-8775-005056c00008" name="Sprigg SC" sectionCount="5" voltageRegulatorOn="true" targetV="129.935" targetDeadband="1" node="12" q="-9.5086141684802943">
+            <iidm:shunt id="_04553478-c766-11e1-8775-005056c00008" name="Sprigg SC" sectionCount="5" voltageRegulatorOn="true" targetV="129.935" targetDeadband="1" node="12" q="-9.4825620359546257">
                 <iidm:alias>_045bc428-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_f4cdc674-4a66-4ab8-8d4f-552cb066e259"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -9011,12 +9134,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="118.46992738283893" angle="-10.093145003199465" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="118.41310807467693" angle="-21.206109704448497" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04819ba4-c766-11e1-8775-005056c00008" name="West End NegG LD" loadType="UNDEFINED" p0="46" q0="0" node="14" p="45.986712304475191" q="0">
+            <iidm:load id="_04819ba4-c766-11e1-8775-005056c00008" name="West End NegG LD" loadType="UNDEFINED" p0="46" q0="0" node="14" p="45.986606179630243" q="0">
                 <iidm:alias>_04627ae0-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_04555b89-c766-11e1-8775-005056c00008" name="West End LD" loadType="UNDEFINED" p0="20" q0="23" node="15" p="19.994222741076172" q="22.988927986631012">
+            <iidm:load id="_04555b89-c766-11e1-8775-005056c00008" name="West End LD" loadType="UNDEFINED" p0="20" q0="23" node="15" p="19.994176599839239" q="22.988839566359921">
                 <iidm:alias>_04592c18-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9067,9 +9190,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.16939941481868" angle="9.0014538683200342" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.13120321286252" angle="-1.6866686555346988" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046d0232-c766-11e1-8775-005056c00008" name="Deer Crk NegG LD" loadType="UNDEFINED" p0="6" q0="0" node="8" p="5.9996885098663757" q="0">
+            <iidm:load id="_046d0232-c766-11e1-8775-005056c00008" name="Deer Crk NegG LD" loadType="UNDEFINED" p0="6" q0="0" node="8" p="5.9997027433022909" q="0">
                 <iidm:alias>_0480150a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9139,9 +9262,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="133.9217041592654" angle="0.53083617785643733" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="133.92477676787033" angle="-10.658119744402988" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046c3ee3-c766-11e1-8775-005056c00008" name="Crooksvl LD" loadType="UNDEFINED" p0="34" q0="0" node="11" p="33.999810179238928" q="0">
+            <iidm:load id="_046c3ee3-c766-11e1-8775-005056c00008" name="Crooksvl LD" loadType="UNDEFINED" p0="34" q0="0" node="11" p="33.999807443674662" q="0">
                 <iidm:alias>_047e4047-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9192,9 +9315,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="132.05308863714902" angle="-2.7071986915818238" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="132.0528837279586" angle="-13.893062292973191" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046dc585-c766-11e1-8775-005056c00008" name="WCambrdg LD" loadType="UNDEFINED" p0="17" q0="4" node="8" p="16.999994042587868" q="3.9999976637602215">
+            <iidm:load id="_046dc585-c766-11e1-8775-005056c00008" name="WCambrdg LD" loadType="UNDEFINED" p0="17" q0="4" node="8" p="16.999991916146865" q="3.9999968298620172">
                 <iidm:alias>_045dbff8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9283,9 +9406,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="130.23789307472239" angle="9.2684794476463175" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="130.29473448081424" angle="-2.5162715632555188" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_048b5fa5-c766-11e1-8775-005056c00008" name="SouthBnd LD" loadType="UNDEFINED" p0="70" q0="23" node="14" p="69.999294306701557" q="22.999613550206647">
+            <iidm:load id="_048b5fa5-c766-11e1-8775-005056c00008" name="SouthBnd LD" loadType="UNDEFINED" p0="70" q0="23" node="14" p="69.999343428788578" q="22.999640450222657">
                 <iidm:alias>_04522734-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9335,11 +9458,11 @@
                 <iidm:internalConnection node1="19" node2="6"/>
                 <iidm:internalConnection node1="20" node2="3"/>
                 <iidm:internalConnection node1="21" node2="6"/>
-                <iidm:bus v="227.78157429351182" angle="26.304751537319365" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
+                <iidm:bus v="228.02749886543026" angle="14.016224401515093" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:line id="_044cd006-c766-11e1-8775-005056c00008" name="31-32" r="5.1923519999999996" x="17.16264" g1="0" b1="7.20271e-05" g2="0" b2="7.20271e-05" node1="31" voltageLevelId1="_04636548-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="-29.26769297404751" q1="9.7664646039959333" p2="29.578820442713027" q2="-11.081379058872301">
+    <iidm:line id="_044cd006-c766-11e1-8775-005056c00008" name="31-32" r="5.1923519999999996" x="17.16264" g1="0" b1="7.20271e-05" g2="0" b2="7.20271e-05" node1="31" voltageLevelId1="_04636548-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="-26.831342751970393" q1="8.0068034935342265" p2="27.087630101868392" q2="-9.5052682813012606">
         <iidm:alias>_04682030-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0471bd25-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9347,7 +9470,7 @@
             <iidm:temporaryLimit name="_de6da3cb-8cb5-4900-9c33-8ad45632b535" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045a3d89-c766-11e1-8775-005056c00008" name="2-12" r="3.2582879999999999" x="10.7331839" g1="0" b1="4.5110200000000001e-05" g2="0" b2="4.5110200000000001e-05" node1="21" voltageLevelId1="_045d4ac5-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-30.551565463228037" q1="-17.701068548524926" p2="30.792592233461818" q2="16.980142208470859">
+    <iidm:line id="_045a3d89-c766-11e1-8775-005056c00008" name="2-12" r="3.2582879999999999" x="10.7331839" g1="0" b1="4.5110200000000001e-05" g2="0" b2="4.5110200000000001e-05" node1="21" voltageLevelId1="_045d4ac5-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-31.49345408163774" q1="-17.195680673739382" p2="31.742616787571361" q2="16.501356568353319">
         <iidm:alias>_046adf51-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046fe868-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9355,7 +9478,7 @@
             <iidm:temporaryLimit name="_6bd63dd1-1344-4183-b7bd-af326919f4eb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04513cd7-c766-11e1-8775-005056c00008" name="32-114" r="2.3522400000000001" x="10.6634884" g1="0" b1="4.6717149999999997e-05" g2="0" b2="4.6717149999999997e-05" node1="49" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04791027-c766-11e1-8775-005056c00008" p1="6.3649255686724056" q1="4.3514603151709892" p2="-6.3552756730084399" q2="-5.8186826769826716">
+    <iidm:line id="_04513cd7-c766-11e1-8775-005056c00008" name="32-114" r="2.3522400000000001" x="10.6634884" g1="0" b1="4.6717149999999997e-05" g2="0" b2="4.6717149999999997e-05" node1="49" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04791027-c766-11e1-8775-005056c00008" p1="7.4231795060036188" q1="3.7651523201296575" p2="-7.4122537554938726" q2="-5.2299061524977972">
         <iidm:alias>_046d0237-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0470d2c7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9363,7 +9486,7 @@
             <iidm:temporaryLimit name="_5f05650a-c63d-46e5-a426-2db4f036929f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045d71d4-c766-11e1-8775-005056c00008" name="24-72" r="8.5029120000000002" x="34.151040000000002" g1="0" b1="0.00014003675" g2="0" b2="0.00014003675" node1="30" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="24.043664617793517" q1="-5.2746266309091894" p2="-23.755886329212313" q2="1.6035121073435459">
+    <iidm:line id="_045d71d4-c766-11e1-8775-005056c00008" name="24-72" r="8.5029120000000002" x="34.151040000000002" g1="0" b1="0.00014003675" g2="0" b2="0.00014003675" node1="30" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="23.381536439451857" q1="-4.9643647327440599" p2="-23.110558020761843" q2="1.2176807031099375">
         <iidm:alias>_04667281-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d0234-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9371,7 +9494,7 @@
             <iidm:temporaryLimit name="_d2074163-ab09-4251-a1d7-6983091dc4f1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045f94b8-c766-11e1-8775-005056c00008" name="17-18" r="2.1431520000000002" x="8.7991200000000003" g1="0" b1="3.7247499999999999e-05" g2="0" b2="3.7247499999999999e-05" node1="57" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04689563-c766-11e1-8775-005056c00008" p1="110.61674960313977" q1="40.854536484483745" p2="-108.8300469334559" q2="-34.723693777926158">
+    <iidm:line id="_045f94b8-c766-11e1-8775-005056c00008" name="17-18" r="2.1431520000000002" x="8.7991200000000003" g1="0" b1="3.7247499999999999e-05" g2="0" b2="3.7247499999999999e-05" node1="57" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04689563-c766-11e1-8775-005056c00008" p1="114.54130219874155" q1="40.254287109166903" p2="-112.64593726351357" q2="-33.676000125281448">
         <iidm:alias>_045e0e17-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0485ba59-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9379,7 +9502,7 @@
             <iidm:temporaryLimit name="_2b6693c7-4e29-4c2c-91d0-3485bbe8fe87" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048963d8-c766-11e1-8775-005056c00008" name="17-113" r="1.590811" x="5.244624" g1="0" b1="2.2038549999999999e-05" g2="0" b2="2.2038549999999999e-05" node1="58" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="1.2683741778858071" q1="4.5993090319659116" p2="-1.2658757306440813" q2="-5.327723165493313">
+    <iidm:line id="_048963d8-c766-11e1-8775-005056c00008" name="17-113" r="1.590811" x="5.244624" g1="0" b1="2.2038549999999999e-05" g2="0" b2="2.2038549999999999e-05" node1="58" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="5.1948312186293997" q1="2.7734496551022452" p2="-5.1913252341034966" q2="-3.4979599794384044">
         <iidm:alias>_045841b5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046958b4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9387,7 +9510,7 @@
             <iidm:temporaryLimit name="_786432da-fa4d-4751-a275-87d0e20529f1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0458ddf0-c766-11e1-8775-005056c00008" name="49-50" r="4.6522079999999999" x="13.102848099999999" g1="0" b1="5.3776400000000002e-05" g2="0" b2="5.3776400000000002e-05" node1="112" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044d1e26-c766-11e1-8775-005056c00008" p1="62.134422847368413" q1="11.700677202764972" p2="-61.112396321233" q2="-10.744350172756057">
+    <iidm:line id="_0458ddf0-c766-11e1-8775-005056c00008" name="49-50" r="4.6522079999999999" x="13.102848099999999" g1="0" b1="5.3776400000000002e-05" g2="0" b2="5.3776400000000002e-05" node1="112" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044d1e26-c766-11e1-8775-005056c00008" p1="62.151063044126772" q1="11.69752900790518" p2="-61.128531073678417" q2="-10.73977534359555">
         <iidm:alias>_0464ebe8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f9fd8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9395,7 +9518,7 @@
             <iidm:temporaryLimit name="_1f0844a5-ea5c-42b2-abcb-6fac2c426092" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04535fb7-c766-11e1-8775-005056c00008" name="1-3" r="2.2476959999999999" x="7.3877759999999997" g1="0" b1="3.1049149999999997e-05" g2="0" b2="3.1049149999999997e-05" node1="21" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_047eb579-c766-11e1-8775-005056c00008" p1="-40.514999553362919" q1="-16.146369061967842" p2="40.779119514042691" q2="16.004577499542737">
+    <iidm:line id="_04535fb7-c766-11e1-8775-005056c00008" name="1-3" r="2.2476959999999999" x="7.3877759999999997" g1="0" b1="3.1049149999999997e-05" g2="0" b2="3.1049149999999997e-05" node1="21" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_047eb579-c766-11e1-8775-005056c00008" p1="-39.576657137313539" q1="-16.662130428508164" p2="39.832354576993232" q2="16.491795806414395">
         <iidm:alias>_044ef2e9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047c4474-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9403,7 +9526,7 @@
             <iidm:temporaryLimit name="_4ea43e34-67a3-42b8-9601-2189db7790d4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0478e912-c766-11e1-8775-005056c00008" name="92-102" r="2.1431520000000002" x="9.7400160000000007" g1="0" b1="4.2011000000000001e-05" g2="0" b2="4.2011000000000001e-05" node1="66" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="49.939745131900999" q1="-9.0342540602491219" p2="-49.617713455927813" q2="9.0660999058270555">
+    <iidm:line id="_0478e912-c766-11e1-8775-005056c00008" name="92-102" r="2.1431520000000002" x="9.7400160000000007" g1="0" b1="4.2011000000000001e-05" g2="0" b2="4.2011000000000001e-05" node1="66" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="49.976040579369744" q1="-9.0531044268711316" p2="-49.653480253460941" q2="9.0874913752304938">
         <iidm:alias>_045a1673-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0468bc79-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9411,7 +9534,7 @@
             <iidm:temporaryLimit name="_23cc194e-9273-46e9-a793-84a9c2911737" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04547127-c766-11e1-8775-005056c00008" name="93-94" r="3.8855520000000001" x="12.7543688" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="21" voltageLevelId1="_04789af0-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="57.212647564811817" q1="-22.097987111150573" p2="-56.353854440465966" q2="23.096413033208606">
+    <iidm:line id="_04547127-c766-11e1-8775-005056c00008" name="93-94" r="3.8855520000000001" x="12.7543688" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="21" voltageLevelId1="_04789af0-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="57.268068056380386" q1="-22.041288458744702" p2="-56.408155994871358" q2="23.043921183782778">
         <iidm:alias>_04500450-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047b0bfb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9419,7 +9542,7 @@
             <iidm:temporaryLimit name="_1a9fe09e-3f63-4904-8e36-aa38c5e16c59" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04791021-c766-11e1-8775-005056c00008" name="46-48" r="10.4718237" x="32.931359999999998" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044778d3-c766-11e1-8775-005056c00008" p1="-8.8118418809884602" q1="-7.94459969254354" p2="8.8764463537153215" q2="3.304844394284765">
+    <iidm:line id="_04791021-c766-11e1-8775-005056c00008" name="46-48" r="10.4718237" x="32.931359999999998" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044778d3-c766-11e1-8775-005056c00008" p1="-8.7814551441589206" q1="-7.9551200636758885" p2="8.8458112078042852" q2="3.3145803265953901">
         <iidm:alias>_0459ef69-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04640186-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9427,7 +9550,7 @@
             <iidm:temporaryLimit name="_467ba04d-dbad-4fe1-81c8-3bc87b41fcd1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046958b6-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="113" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-92.486694760975197" q1="-2.4723953394523481" p2="93.952420318999827" q2="7.2973814268894248">
+    <iidm:line id="_046958b6-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="113" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-92.393956693688949" q1="-2.4979024760235808" p2="93.856755334442283" q2="7.3079463701532639">
         <iidm:alias>_04776270-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a96c8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9435,7 +9558,7 @@
             <iidm:temporaryLimit name="_d0737ab4-5a3a-46c8-8aeb-789313f0f332" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046f4c26-c766-11e1-8775-005056c00008" name="75-118" r="2.5264799999999998" x="8.3809430000000003" g1="0" b1="3.4377849999999998e-05" g2="0" b2="3.4377849999999998e-05" node1="48" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="39.044581539585735" q1="28.784501060074003" p2="-38.675157304811513" q2="-28.657491119614935">
+    <iidm:line id="_046f4c26-c766-11e1-8775-005056c00008" name="75-118" r="2.5264799999999998" x="8.3809430000000003" g1="0" b1="3.4377849999999998e-05" g2="0" b2="3.4377849999999998e-05" node1="48" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="38.931074627580678" q1="28.875341754497274" p2="-38.562182805697859" q2="-28.750029994809605">
         <iidm:alias>_04619088-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04814d8a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9443,7 +9566,7 @@
             <iidm:temporaryLimit name="_173dc7ff-ae18-4410-b2e1-a4c2abac8ff6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c3954-c766-11e1-8775-005056c00008" name="94-96" r="4.6870560000000001" x="15.1414566" g1="0" b1="6.60009e-05" g2="0" b2="6.60009e-05" node1="49" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="38.277905716699344" q1="-13.094414504582479" p2="-37.83380179125276" q2="12.286293327157097">
+    <iidm:line id="_045c3954-c766-11e1-8775-005056c00008" name="94-96" r="4.6870560000000001" x="15.1414566" g1="0" b1="6.60009e-05" g2="0" b2="6.60009e-05" node1="49" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="38.342896220986077" q1="-12.89445273663965" p2="-37.898572416499434" q2="12.088254875273719">
         <iidm:alias>_046ba2a0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0472ce94-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9451,7 +9574,7 @@
             <iidm:temporaryLimit name="_efde58bf-c92e-496d-b558-d0095a271083" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04518af7-c766-11e1-8775-005056c00008" name="62-67" r="4.4953919999999998" x="20.38608" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="39" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="-2.4890493845229607" q1="-18.363004483436779" p2="2.5641064966262213" q2="15.558221353481821">
+    <iidm:line id="_04518af7-c766-11e1-8775-005056c00008" name="62-67" r="4.4953919999999998" x="20.38608" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="39" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="-2.502572491522999" q1="-18.359735098298184" p2="2.5776185966226342" q2="15.55490387223862">
         <iidm:alias>_04544a10-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04814d86-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9459,7 +9582,7 @@
             <iidm:temporaryLimit name="_8a81d4ae-2bc8-4038-8650-27a6150946b1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0452c375-c766-11e1-8775-005056c00008" name="47-49" r="3.3279839999999998" x="10.890000000000001" g1="0" b1="4.6028449999999998e-05" g2="0" b2="4.6028449999999998e-05" node1="30" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="114" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="16.975160224985675" q1="-22.794487172873254" p2="-16.832133818588762" q2="21.594383106431536">
+    <iidm:line id="_0452c375-c766-11e1-8775-005056c00008" name="47-49" r="3.3279839999999998" x="10.890000000000001" g1="0" b1="4.6028449999999998e-05" g2="0" b2="4.6028449999999998e-05" node1="30" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="114" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="16.883638235179003" q1="-22.730612151475484" p2="-16.741713678151179" q2="21.526864805006934">
         <iidm:alias>_0465fd54-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0471e431-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9467,7 +9590,7 @@
             <iidm:temporaryLimit name="_8d6a074c-900d-4a37-830c-5da4c1de1ab5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046c17d9-c766-11e1-8775-005056c00008" name="100-106" r="10.54152" x="39.900959999999998" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="76" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="59.401411893088728" q1="10.058542039273757" p2="-57.234503251263504" q2="-7.9202649135733054">
+    <iidm:line id="_046c17d9-c766-11e1-8775-005056c00008" name="100-106" r="10.54152" x="39.900959999999998" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="76" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="59.403329234629219" q1="10.058376429449718" p2="-57.23628872216613" q2="-7.9195955073662869">
         <iidm:alias>_045d98e5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0480d851-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9475,7 +9598,7 @@
             <iidm:temporaryLimit name="_3154dc30-b0e5-4570-8e52-9333bae20ef2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046b2d77-c766-11e1-8775-005056c00008" name="77-78" r="0.655142" x="2.1605759999999998" g1="0" b1="3.6271800000000001e-05" g2="0" b2="3.6271800000000001e-05" node1="66" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044fb634-c766-11e1-8775-005056c00008" p1="43.696236304270585" q1="4.0640678285016785" p2="-43.623999520318598" q2="-5.093792848584477">
+    <iidm:line id="_046b2d77-c766-11e1-8775-005056c00008" name="77-78" r="0.655142" x="2.1605759999999998" g1="0" b1="3.6271800000000001e-05" g2="0" b2="3.6271800000000001e-05" node1="66" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044fb634-c766-11e1-8775-005056c00008" p1="43.610459616248534" q1="3.9589717780570464" p2="-43.538518998649366" q2="-4.9893316702417003">
         <iidm:alias>_046ed6fb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04893cc3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9483,7 +9606,7 @@
             <iidm:temporaryLimit name="_cce754c5-b9d5-4105-a431-32da96e4a6cf" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c8776-c766-11e1-8775-005056c00008" name="6-7" r="0.79976199999999997" x="3.6241919999999999" g1="0" b1="1.5782850000000001e-05" g2="0" b2="1.5782850000000001e-05" node1="21" voltageLevelId1="_044f6818-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047eb571-c766-11e1-8775-005056c00008" p1="42.716979921165873" q1="-7.9468908298794068" p2="-42.62860544589028" q2="7.8094489025747489">
+    <iidm:line id="_045c8776-c766-11e1-8775-005056c00008" name="6-7" r="0.79976199999999997" x="3.6241919999999999" g1="0" b1="1.5782850000000001e-05" g2="0" b2="1.5782850000000001e-05" node1="21" voltageLevelId1="_044f6818-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047eb571-c766-11e1-8775-005056c00008" p1="38.542850593450254" q1="-6.0343861965274455" p2="-38.471675319015596" q2="5.8185211768985248">
         <iidm:alias>_046efe08-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04720b4a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9491,7 +9614,7 @@
             <iidm:temporaryLimit name="_361a9cc3-fb33-4037-9b9a-c20adb90b66b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047ba839-c766-11e1-8775-005056c00008" name="77-80" r="5.1226560000000001" x="18.295200000000001" g1="0" b1="6.5426999999999995e-05" g2="0" b2="6.5426999999999995e-05" node1="67" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="76" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-46.149666869502077" q1="-23.070259427148677" p2="46.913068123324884" q2="23.417582890833334">
+    <iidm:line id="_047ba839-c766-11e1-8775-005056c00008" name="77-80" r="5.1226560000000001" x="18.295200000000001" g1="0" b1="6.5426999999999995e-05" g2="0" b2="6.5426999999999995e-05" node1="67" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="76" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-46.239047329616731" q1="-23.173551882904679" p2="47.00641412683175" q2="23.535365331943066">
         <iidm:alias>_047c6b85-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0480b148-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9499,7 +9622,7 @@
             <iidm:temporaryLimit name="_da00c66f-a882-4938-923b-f2455f7f9a81" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04592c16-c766-11e1-8775-005056c00008" name="78-79" r="0.95135000000000003" x="4.2514560000000001" g1="0" b1="1.8595050000000001e-05" g2="0" b2="1.8595050000000001e-05" node1="22" voltageLevelId1="_044fb634-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04481510-c766-11e1-8775-005056c00008" p1="-27.375826665526525" q1="-20.906094155390942" p2="27.439816225220206" q2="20.539213276201835">
+    <iidm:line id="_04592c16-c766-11e1-8775-005056c00008" name="78-79" r="0.95135000000000003" x="4.2514560000000001" g1="0" b1="1.8595050000000001e-05" g2="0" b2="1.8595050000000001e-05" node1="22" voltageLevelId1="_044fb634-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04481510-c766-11e1-8775-005056c00008" p1="-27.461253160035671" q1="-21.010528081153513" p2="27.525749927338573" q2="20.646058853714049">
         <iidm:alias>_0453add6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045b7605-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9507,7 +9630,7 @@
             <iidm:temporaryLimit name="_ba4abe9d-8490-4c19-b19b-c9d2c3597fc9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047b3301-c766-11e1-8775-005056c00008" name="103-104" r="8.1195839999999997" x="27.599615100000001" g1="0" b1="0.00011679295" g2="0" b2="0.00011679295" node1="40" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="33.049099008812917" q1="13.983392442403689" p2="-32.432329831774105" q2="-15.879849094211501">
+    <iidm:line id="_047b3301-c766-11e1-8775-005056c00008" name="103-104" r="8.1195839999999997" x="27.599615100000001" g1="0" b1="0.00011679295" g2="0" b2="0.00011679295" node1="40" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="33.048520735901874" q1="13.983593535505214" p2="-32.431765731473973" q2="-15.880095611013337">
         <iidm:alias>_0459a142-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045d98e6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9515,7 +9638,7 @@
             <iidm:temporaryLimit name="_2320da74-eda7-4f7f-ade9-1ed0e994f3af" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045e5c32-c766-11e1-8775-005056c00008" name="95-96" r="2.9795039999999999" x="9.5309279999999994" g1="0" b1="4.2298000000000001e-05" g2="0" b2="4.2298000000000001e-05" node1="21" voltageLevelId1="_044f4108-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="14.682184980852202" q1="-25.079626308254312" p2="-14.537034371780249" q2="24.121592667586171">
+    <iidm:line id="_045e5c32-c766-11e1-8775-005056c00008" name="95-96" r="2.9795039999999999" x="9.5309279999999994" g1="0" b1="4.2298000000000001e-05" g2="0" b2="4.2298000000000001e-05" node1="21" voltageLevelId1="_044f4108-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="14.740170896700572" q1="-24.905383431904042" p2="-14.596152129469861" q2="23.944631098081125">
         <iidm:alias>_04597a34-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04801509-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9523,7 +9646,7 @@
             <iidm:temporaryLimit name="_3bc03415-e95f-47a7-8e92-01089d304a9c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045ed169-c766-11e1-8775-005056c00008" name="77-80" r="2.9620799999999998" x="8.4506409999999992" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="68" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="77" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-100.69312687807086" q1="-42.518063428112576" p2="102.68015189788957" q2="43.261756036484847">
+    <iidm:line id="_045ed169-c766-11e1-8775-005056c00008" name="77-80" r="2.9620799999999998" x="8.4506409999999992" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="68" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="77" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-100.89645936960343" q1="-42.724627179690209" p2="102.89380613555295" q2="43.498444757319263">
         <iidm:alias>_0464289a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04828605-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9531,7 +9654,7 @@
             <iidm:temporaryLimit name="_f93b6d4c-39fa-4f6f-a42d-c63a4cf21a67" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047f78c2-c766-11e1-8775-005056c00008" name="5-11" r="3.5370720000000002" x="11.8831682" g1="0" b1="4.987375e-05" g2="0" b2="4.987375e-05" node1="48" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="88.062848964061473" q1="8.5329395232061582" p2="-86.498994047322256" q2="-5.0097543569053729">
+    <iidm:line id="_047f78c2-c766-11e1-8775-005056c00008" name="5-11" r="3.5370720000000002" x="11.8831682" g1="0" b1="4.987375e-05" g2="0" b2="4.987375e-05" node1="48" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="83.024976786155818" q1="10.524112643713568" p2="-81.627351269686628" q2="-7.5618149637789731">
         <iidm:alias>_045bc426-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0476c633-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9539,7 +9662,7 @@
             <iidm:temporaryLimit name="_3bc4ab96-7a0d-4e18-b9f5-d89f63a82f0a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04845ac7-c766-11e1-8775-005056c00008" name="71-72" r="7.7711040000000002" x="31.363201100000001" g1="0" b1="0.00012752525" g2="0" b2="0.00012752525" node1="29" voltageLevelId1="_04664b78-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="-11.693222102179126" q1="-2.4899108194640744" p2="11.756005829178061" q2="-1.6035147056496877">
+    <iidm:line id="_04845ac7-c766-11e1-8775-005056c00008" name="71-72" r="7.7711040000000002" x="31.363201100000001" g1="0" b1="0.00012752525" g2="0" b2="0.00012752525" node1="29" voltageLevelId1="_04664b78-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="-11.054368827956528" q1="-2.9057339107043694" p2="11.110665216484819" q2="-1.2176820903274088">
         <iidm:alias>_04642891-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046b0661-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9547,7 +9670,7 @@
             <iidm:temporaryLimit name="_bcb69c6e-125e-449c-acb3-a4deb151668d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047343c2-c766-11e1-8775-005056c00008" name="66-67" r="3.9029759999999998" x="17.685359999999999" g1="0" b1="7.6962800000000001e-05" g2="0" b2="7.6962800000000001e-05" node1="50" voltageLevelId1="_047147f4-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="30.863162225077456" q1="21.05961163481917" p2="-30.564019603187838" q2="-22.558187038927404">
+    <iidm:line id="_047343c2-c766-11e1-8775-005056c00008" name="66-67" r="3.9029759999999998" x="17.685359999999999" g1="0" b1="7.6962800000000001e-05" g2="0" b2="7.6962800000000001e-05" node1="50" voltageLevelId1="_047147f4-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="30.876816789223643" q1="21.056966977161025" p2="-30.577525599193894" q2="-22.554866664595703">
         <iidm:alias>_0465af34-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04860874-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9555,7 +9678,7 @@
             <iidm:temporaryLimit name="_b4b8a31d-dc3c-4b51-88ad-a22e070eb96c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04569409-c766-11e1-8775-005056c00008" name="34-43" r="7.1961120000000003" x="29.289743399999999" g1="0" b1="0.0001212695" g2="0" b2="0.0001212695" node1="40" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_045e8349-c766-11e1-8775-005056c00008" p1="12.583604918759439" q1="-7.582164144474274" p2="-12.495260527816306" q2="4.152282098918251">
+    <iidm:line id="_04569409-c766-11e1-8775-005056c00008" name="34-43" r="7.1961120000000003" x="29.289743399999999" g1="0" b1="0.0001212695" g2="0" b2="0.0001212695" node1="40" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_045e8349-c766-11e1-8775-005056c00008" p1="12.843542545063366" q1="-7.715622791812569" p2="-12.751316181912031" q2="4.3050006025575609">
         <iidm:alias>_04500454-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04505274-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9563,7 +9686,7 @@
             <iidm:temporaryLimit name="_5585c67a-0839-48e6-8847-4393e1e9b9c7" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04817498-c766-11e1-8775-005056c00008" name="52-53" r="7.0567200000000003" x="28.488240000000001" g1="0" b1="0.00011644859999999999" g2="0" b2="0.00011644859999999999" node1="21" voltageLevelId1="_04806326-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04876804-c766-11e1-8775-005056c00008" p1="13.381688152720145" q1="0.95796590054190411" p2="-13.298764579864352" q2="-4.2893599217580229">
+    <iidm:line id="_04817498-c766-11e1-8775-005056c00008" name="52-53" r="7.0567200000000003" x="28.488240000000001" g1="0" b1="0.00011644859999999999" g2="0" b2="0.00011644859999999999" node1="21" voltageLevelId1="_04806326-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04876804-c766-11e1-8775-005056c00008" p1="13.387814141016975" q1="0.95585295763625855" p2="-13.304822659022939" q2="-4.2869568332958599">
         <iidm:alias>_045115c7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0472a784-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9571,7 +9694,7 @@
             <iidm:temporaryLimit name="_e7c9dfab-fb45-4470-964f-4ba9e391f60b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044b7078-c766-11e1-8775-005056c00008" name="105-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="49" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="23" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="26.894263834508912" q1="1.3280979422533632" p2="-26.475802934268451" q2="-4.1905844348091374">
+    <iidm:line id="_044b7078-c766-11e1-8775-005056c00008" name="105-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="49" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="23" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="26.894017966203538" q1="1.3281789400112332" p2="-26.475563940985737" q2="-4.1906855355179946">
         <iidm:alias>_0452c378-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0481c2b7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9579,7 +9702,7 @@
             <iidm:temporaryLimit name="_fff133bf-25fd-46b2-b144-a227c31ee882" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048ac367-c766-11e1-8775-005056c00008" name="100-101" r="4.8264480000000001" x="21.9890881" g1="0" b1="9.4123049999999997e-05" g2="0" b2="9.4123049999999997e-05" node1="77" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046ed6f7-c766-11e1-8775-005056c00008" p1="-21.774104721900517" q1="24.72324424238581" p2="22.088012576164072" q2="-26.599091908312694">
+    <iidm:line id="_048ac367-c766-11e1-8775-005056c00008" name="100-101" r="4.8264480000000001" x="21.9890881" g1="0" b1="9.4123049999999997e-05" g2="0" b2="9.4123049999999997e-05" node1="77" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046ed6f7-c766-11e1-8775-005056c00008" p1="-21.808101338136563" q1="24.753049389874047" p2="22.122828181249435" q2="-26.62507947232962">
         <iidm:alias>_044afb45-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b5fa2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9587,7 +9710,7 @@
             <iidm:temporaryLimit name="_217e3c95-24b5-438f-a721-d2257e1a43b4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0481c2b1-c766-11e1-8775-005056c00008" name="56-57" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="57" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="-30.792638480862617" q1="-5.4788129421327634" p2="31.157324049360223" q2="4.2669510971170705">
+    <iidm:line id="_0481c2b1-c766-11e1-8775-005056c00008" name="56-57" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="57" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="-30.807808888209948" q1="-5.4714871491313319" p2="31.172822865095434" q2="4.2605551244363671">
         <iidm:alias>_045e0e12-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0487dd35-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9595,7 +9718,7 @@
             <iidm:temporaryLimit name="_f5547027-3d48-4a53-937b-bd5ba63ef70d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047a6fb7-c766-11e1-8775-005056c00008" name="47-69" r="14.705855400000001" x="48.403869999999998" g1="0" b1="0.00020351240000000001" g2="0" b2="0.00020351240000000001" node1="31" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="57" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-83.826866939261976" q1="25.923783911028707" p2="90.305759461294841" q2="-12.047274810971365">
+    <iidm:line id="_047a6fb7-c766-11e1-8775-005056c00008" name="47-69" r="14.705855400000001" x="48.403869999999998" g1="0" b1="0.00020351240000000001" g2="0" b2="0.00020351240000000001" node1="31" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="57" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-83.632614402096479" q1="25.815257304922874" p2="90.079292948324607" q2="-12.044945705466141">
         <iidm:alias>_04758db9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0485ba56-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9603,7 +9726,7 @@
             <iidm:temporaryLimit name="_e9fec217-cf6f-4d39-9495-26ed10c05100" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0453fbf0-c766-11e1-8775-005056c00008" name="110-111" r="3.8332799999999998" x="13.1551189" g1="0" b1="5.7392100000000002e-05" g2="0" b2="5.7392100000000002e-05" node1="40" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_046a1c00-c766-11e1-8775-005056c00008" p1="-39.39660128383921" q1="-20.542090312568444" p2="39.863905868322192" q2="20.273280871809639">
+    <iidm:line id="_0453fbf0-c766-11e1-8775-005056c00008" name="110-111" r="3.8332799999999998" x="13.1551189" g1="0" b1="5.7392100000000002e-05" g2="0" b2="5.7392100000000002e-05" node1="40" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_046a1c00-c766-11e1-8775-005056c00008" p1="-39.389811585101732" q1="-20.544427701489727" p2="39.857009705818406" q2="20.275254288992677">
         <iidm:alias>_0447c6f5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04812675-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9611,7 +9734,7 @@
             <iidm:temporaryLimit name="_ea48fee0-31b6-4990-a332-25d08b7d731f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04778984-c766-11e1-8775-005056c00008" name="41-42" r="7.14384" x="23.522401800000001" g1="0" b1="9.8714400000000005e-05" g2="0" b2="9.8714400000000005e-05" node1="21" voltageLevelId1="_048c4a08-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="-10.657913203804299" q1="-11.115901232359656" p2="10.764866168830684" q2="8.6576106776132011">
+    <iidm:line id="_04778984-c766-11e1-8775-005056c00008" name="41-42" r="7.14384" x="23.522401800000001" g1="0" b1="9.8714400000000005e-05" g2="0" b2="9.8714400000000005e-05" node1="21" voltageLevelId1="_048c4a08-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="-10.46915164988053" q1="-11.255907627762172" p2="10.575572750400248" q2="8.7978705435995987">
         <iidm:alias>_044d1e2a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046512f1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9619,7 +9742,7 @@
             <iidm:temporaryLimit name="_063af52c-fe10-4c1e-85d4-dd80dcc1d2f9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04653a08-c766-11e1-8775-005056c00008" name="80-99" r="7.9104960000000002" x="35.893439999999998" g1="0" b1="0.00015668044999999999" g2="0" b2="0.00015668044999999999" node1="78" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04644fa4-c766-11e1-8775-005056c00008" p1="1.9868655905070556" q1="6.6829887719391774" p2="-1.9462358612490083" q2="-12.291958558560063">
+    <iidm:line id="_04653a08-c766-11e1-8775-005056c00008" name="80-99" r="7.9104960000000002" x="35.893439999999998" g1="0" b1="0.00015668044999999999" g2="0" b2="0.00015668044999999999" node1="78" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04644fa4-c766-11e1-8775-005056c00008" p1="1.9946714066953051" q1="6.6812038867994969" p2="-1.9540430616810531" q2="-12.290178094274266">
         <iidm:alias>_04773b69-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0477b092-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9627,7 +9750,7 @@
             <iidm:temporaryLimit name="_c05229ce-6abb-4209-ad4f-0dcd4a070f28" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04581aa5-c766-11e1-8775-005056c00008" name="54-59" r="8.7642720000000001" x="39.953229999999998" g1="0" b1="0.0001716024" g2="0" b2="0.0001716024" node1="58" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-19.664749176920971" q1="-10.514634761118376" p2="19.91147172496806" q2="6.0114260005053977">
+    <iidm:line id="_04581aa5-c766-11e1-8775-005056c00008" name="54-59" r="8.7642720000000001" x="39.953229999999998" g1="0" b1="0.0001716024" g2="0" b2="0.0001716024" node1="58" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-19.649075337559189" q1="-10.518787571760523" p2="19.895493779807307" q2="6.0141938133655604">
         <iidm:alias>_0457cc82-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045cae81-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9635,7 +9758,7 @@
             <iidm:temporaryLimit name="_ac528cbe-6fc1-41dd-ba9d-d8b7a4c77576" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04690a93-c766-11e1-8775-005056c00008" name="92-94" r="8.3809430000000003" x="27.529920000000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="67" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="65.129516696584105" q1="-16.415087594070833" p2="-62.943145531686781" q2="19.631662524070091">
+    <iidm:line id="_04690a93-c766-11e1-8775-005056c00008" name="92-94" r="8.3809430000000003" x="27.529920000000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="67" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="65.186577365534788" q1="-16.352391928299326" p2="-62.997209934346422" q2="19.579698745536522">
         <iidm:alias>_044c33c1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0483706b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9643,7 +9766,7 @@
             <iidm:temporaryLimit name="_6ac84228-6b04-4b10-b560-29655c8e93b4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046009e3-c766-11e1-8775-005056c00008" name="37-39" r="5.5931040000000003" x="18.469439999999999" g1="0" b1="7.7479350000000006e-05" g2="0" b2="7.7479350000000006e-05" node1="57" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046bf0c7-c766-11e1-8775-005056c00008" p1="66.796579662269068" q1="18.136482285729695" p2="-65.074474512564578" q2="-14.779412528103208">
+    <iidm:line id="_046009e3-c766-11e1-8775-005056c00008" name="37-39" r="5.5931040000000003" x="18.469439999999999" g1="0" b1="7.7479350000000006e-05" g2="0" b2="7.7479350000000006e-05" node1="57" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046bf0c7-c766-11e1-8775-005056c00008" p1="67.007254626687541" q1="18.056527483610534" p2="-65.274446264382036" q2="-14.661714795195916">
         <iidm:alias>_044c33c9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04789afa-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9651,7 +9774,7 @@
             <iidm:temporaryLimit name="_2ccdc288-c132-40d1-a928-3887bec4ff67" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0458b6e8-c766-11e1-8775-005056c00008" name="46-47" r="6.6211200000000003" x="22.12848" g1="0" b1="9.0679499999999998e-05" g2="0" b2="9.0679499999999998e-05" node1="33" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_0457f396-c766-11e1-8775-005056c00008" p1="-32.452633410630547" q1="1.2414992855087845" p2="32.851895834766907" q2="-3.1293004590609561">
+    <iidm:line id="_0458b6e8-c766-11e1-8775-005056c00008" name="46-47" r="6.6211200000000003" x="22.12848" g1="0" b1="9.0679499999999998e-05" g2="0" b2="9.0679499999999998e-05" node1="33" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_0457f396-c766-11e1-8775-005056c00008" p1="-32.352461927741118" q1="1.1882324345454756" p2="32.749169410817842" q2="-3.0846469289893235">
         <iidm:alias>_04507980-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0464c4da-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9659,7 +9782,7 @@
             <iidm:temporaryLimit name="_06ca3245-2668-448f-a5c6-961924217a5c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044f8f22-c766-11e1-8775-005056c00008" name="82-83" r="1.9514879999999999" x="6.3858959999999998" g1="0" b1="0.0001089302" g2="0" b2="0.0001089302" node1="31" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728074-c766-11e1-8775-005056c00008" p1="-66.716964275869486" q1="38.156452061749036" p2="67.41974974598962" q2="-39.491201609534997">
+    <iidm:line id="_044f8f22-c766-11e1-8775-005056c00008" name="82-83" r="1.9514879999999999" x="6.3858959999999998" g1="0" b1="0.0001089302" g2="0" b2="0.0001089302" node1="31" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728074-c766-11e1-8775-005056c00008" p1="-66.325275800383025" q1="39.491129487026996" p2="67.035728347824801" q2="-40.792902063240824">
         <iidm:alias>_047a48a6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b3891-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9667,7 +9790,7 @@
             <iidm:temporaryLimit name="_dfbd2f07-76ab-41e3-910f-dc706979ea4b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045cfca6-c766-11e1-8775-005056c00008" name="108-109" r="1.82952" x="5.0181120000000004" g1="0" b1="2.1809000000000001e-05" g2="0" b2="2.1809000000000001e-05" node1="21" voltageLevelId1="_046c65f4-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b7b99-c766-11e1-8775-005056c00008" p1="20.783654304576558" q1="-0.53083382177885463" p2="-20.734360135110503" q2="-0.031690439706270196">
+    <iidm:line id="_045cfca6-c766-11e1-8775-005056c00008" name="108-109" r="1.82952" x="5.0181120000000004" g1="0" b1="2.1809000000000001e-05" g2="0" b2="2.1809000000000001e-05" node1="21" voltageLevelId1="_046c65f4-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b7b99-c766-11e1-8775-005056c00008" p1="20.786992329181466" q1="-0.5320189102565912" p2="-20.737682228065417" q2="-0.030460966252822234">
         <iidm:alias>_04481514-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04716f00-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9675,7 +9798,7 @@
             <iidm:temporaryLimit name="_11451cec-81c7-4f83-a7db-df7dcaffa94e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04784cd5-c766-11e1-8775-005056c00008" name="70-74" r="6.9870239999999999" x="23.051952400000001" g1="0" b1="9.6648299999999994e-05" g2="0" b2="9.6648299999999994e-05" node1="48" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047dcb11-c766-11e1-8775-005056c00008" p1="23.268648188151474" q1="9.354159975079968" p2="-22.994432143905403" q2="-11.632214529328236">
+    <iidm:line id="_04784cd5-c766-11e1-8775-005056c00008" name="70-74" r="6.9870239999999999" x="23.051952400000001" g1="0" b1="9.6648299999999994e-05" g2="0" b2="9.6648299999999994e-05" node1="48" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047dcb11-c766-11e1-8775-005056c00008" p1="22.997812842181219" q1="9.5052340296647113" p2="-22.72746487641264" q2="-11.796507092652121">
         <iidm:alias>_045e5c33-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046ab84b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9683,7 +9806,7 @@
             <iidm:temporaryLimit name="_37a5cc00-bd7f-4ec7-a77c-e140e23450d2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04747c40-c766-11e1-8775-005056c00008" name="77-82" r="5.1923519999999996" x="14.8626719" g1="0" b1="0.0002345615" g2="0" b2="0.0002345615" node1="69" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_046512f8-c766-11e1-8775-005056c00008" p1="-27.724314086194941" q1="30.645801112652631" p2="28.310190393141148" q2="-37.01817238158911">
+    <iidm:line id="_04747c40-c766-11e1-8775-005056c00008" name="77-82" r="5.1923519999999996" x="14.8626719" g1="0" b1="0.0002345615" g2="0" b2="0.0002345615" node1="69" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_046512f8-c766-11e1-8775-005056c00008" p1="-27.520598188106259" q1="31.334822061965362" p2="28.117621310154721" q2="-37.667775942922241">
         <iidm:alias>_0451b202-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0452ea84-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9691,7 +9814,7 @@
             <iidm:temporaryLimit name="_e9798d58-b518-4fab-984c-c72076dfc2ae" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045e3524-c766-11e1-8775-005056c00008" name="23-24" r="2.3522400000000001" x="8.5726080000000007" g1="0" b1="0.00014290635" g2="0" b2="0.00014290635" node1="39" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_048c22fa-c766-11e1-8775-005056c00008" p1="54.6614930117046" q1="-10.120877812538412" p2="-54.250490024320555" q2="6.6521833389095244">
+    <iidm:line id="_045e3524-c766-11e1-8775-005056c00008" name="23-24" r="2.3522400000000001" x="8.5726080000000007" g1="0" b1="0.00014290635" g2="0" b2="0.00014290635" node1="39" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_048c22fa-c766-11e1-8775-005056c00008" p1="53.234798869723306" q1="-9.7416701139184436" p2="-52.846137506815928" q2="6.1813853727448649">
         <iidm:alias>_046cb413-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f9fd3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9699,7 +9822,7 @@
             <iidm:temporaryLimit name="_e8ec73b8-1ecf-4d18-9ef9-80eabf3a4969" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0474f177-c766-11e1-8775-005056c00008" name="15-17" r="2.2999679999999998" x="7.6142880000000002" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="48" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-150.90522652139532" q1="-19.120654982163945" p2="154.28572123547502" q2="26.1797369362971">
+    <iidm:line id="_0474f177-c766-11e1-8775-005056c00008" name="15-17" r="2.2999679999999998" x="7.6142880000000002" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="48" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-159.93859138685463" q1="-15.581020937915035" p2="163.71836655340309" q2="23.966009589253371">
         <iidm:alias>_044c5ad2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046931a7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9707,7 +9830,7 @@
             <iidm:temporaryLimit name="_2ceac3d1-f73d-43db-8d37-9e329f1787bb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0483be84-c766-11e1-8775-005056c00008" name="8-30" r="2.0860400000000001" x="24.393599999999999" g1="0" b1="0.00053099175999999997" g2="0" b2="0.00053099175999999997" node1="30" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="38" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="87.821113766322782" q1="26.508995417759685" p2="-87.374332138246118" q2="-71.682501432317025">
+    <iidm:line id="_0483be84-c766-11e1-8775-005056c00008" name="8-30" r="2.0860400000000001" x="24.393599999999999" g1="0" b1="0.00053099175999999997" g2="0" b2="0.00053099175999999997" node1="30" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="38" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="103.80077871087474" q1="20.898749575670799" p2="-103.24889905924964" q2="-65.182119199007502">
         <iidm:alias>_0454e651-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04801506-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9715,7 +9838,7 @@
             <iidm:temporaryLimit name="_ca795ad3-97e5-4416-aaba-53cce27f6434" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0488eea6-c766-11e1-8775-005056c00008" name="49-69" r="17.16264" x="56.453762099999999" g1="0" b1="0.00023760329999999999" g2="0" b2="0.00023760329999999999" node1="115" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-75.48731888055481" q1="26.636234564007168" p2="81.729868240449633" q2="-14.886828490748419">
+    <iidm:line id="_0488eea6-c766-11e1-8775-005056c00008" name="49-69" r="17.16264" x="56.453762099999999" g1="0" b1="0.00023760329999999999" g2="0" b2="0.00023760329999999999" node1="115" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-75.303084945949323" q1="26.521510178949935" p2="81.512936545227817" q2="-14.879655986142842">
         <iidm:alias>_04492681-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046735d6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9723,7 +9846,7 @@
             <iidm:temporaryLimit name="_c42dc3ef-3a2e-4070-8efb-78e5c0cd5554" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047566a0-c766-11e1-8775-005056c00008" name="13-15" r="12.9634562" x="42.584255200000001" g1="0" b1="0.00017986685000000001" g2="0" b2="0.00017986685000000001" node1="21" voltageLevelId1="_04851e1b-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="15.043056789653519" q1="-1.222197049513055" p2="-14.85967298123572" q2="-3.9117047759987278">
+    <iidm:line id="_047566a0-c766-11e1-8775-005056c00008" name="13-15" r="12.9634562" x="42.584255200000001" g1="0" b1="0.00017986685000000001" g2="0" b2="0.00017986685000000001" node1="21" voltageLevelId1="_04851e1b-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="10.923848826898285" q1="0.22496740858836475" p2="-10.820544703202236" q2="-5.6216539052134475">
         <iidm:alias>_04662461-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04865694-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9731,7 +9854,7 @@
             <iidm:temporaryLimit name="_ad988fd9-9270-4230-95a2-1858f32259df" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0476c63a-c766-11e1-8775-005056c00008" name="69-70" r="5.2271999999999998" x="22.12848" g1="0" b1="0.00035009184999999998" g2="0" b2="0.00035009184999999998" node1="59" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="76.824315884620972" q1="20.009928874709036" p2="-74.974122922196287" q2="-24.618008103267638">
+    <iidm:line id="_0476c63a-c766-11e1-8775-005056c00008" name="69-70" r="5.2271999999999998" x="22.12848" g1="0" b1="0.00035009184999999998" g2="0" b2="0.00035009184999999998" node1="59" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="77.629285120139613" q1="19.797254463212504" p2="-75.747421753829443" q2="-24.272703487181658">
         <iidm:alias>_047e193a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b1184-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9739,7 +9862,7 @@
             <iidm:temporaryLimit name="_519e3ecb-3561-4d11-ac6b-172a0b4b09b2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04520028-c766-11e1-8775-005056c00008" name="19-20" r="4.3908480000000001" x="20.38608" g1="0" b1="8.5514249999999999e-05" g2="0" b2="8.5514249999999999e-05" node1="39" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b2d70-c766-11e1-8775-005056c00008" p1="-14.775264596080993" q1="2.2311123196940583" p2="14.841076396523048" q2="-4.5595759294343186">
+    <iidm:line id="_04520028-c766-11e1-8775-005056c00008" name="19-20" r="4.3908480000000001" x="20.38608" g1="0" b1="8.5514249999999999e-05" g2="0" b2="8.5514249999999999e-05" node1="39" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b2d70-c766-11e1-8775-005056c00008" p1="-12.812058275459085" q1="1.1718729017677441" p2="12.860651686867108" q2="-3.5800349127163305">
         <iidm:alias>_0472f5a9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04745537-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9747,7 +9870,7 @@
             <iidm:temporaryLimit name="_b88528bf-cb1c-4c00-ad79-d5937197d40c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04862f83-c766-11e1-8775-005056c00008" name="94-95" r="2.2999679999999998" x="7.5620159999999998" g1="0" b1="3.1852600000000001e-05" g2="0" b2="3.1852600000000001e-05" node1="51" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f4108-c766-11e1-8775-005056c00008" p1="57.130256058905516" q1="6.3243897763954005" p2="-56.681692300354911" q2="-5.9197883256615045">
+    <iidm:line id="_04862f83-c766-11e1-8775-005056c00008" name="94-95" r="2.2999679999999998" x="7.5620159999999998" g1="0" b1="3.1852600000000001e-05" g2="0" b2="3.1852600000000001e-05" node1="51" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f4108-c766-11e1-8775-005056c00008" p1="57.189602796366344" q1="6.5036823983040222" p2="-56.739626833737724" q2="-6.0939701688591947">
         <iidm:alias>_044ca8f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04837060-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9755,7 +9878,7 @@
             <iidm:temporaryLimit name="_b70e76a1-6e79-4fb6-b487-dffa9bfeab7b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047b0bf6-c766-11e1-8775-005056c00008" name="12-16" r="3.6938879999999998" x="14.5316162" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="68" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046f7338-c766-11e1-8775-005056c00008" p1="16.370478413576116" q1="7.7077938708199536" p2="-16.295925010439372" q2="-9.48914132732755">
+    <iidm:line id="_047b0bf6-c766-11e1-8775-005056c00008" name="12-16" r="3.6938879999999998" x="14.5316162" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="68" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046f7338-c766-11e1-8775-005056c00008" p1="9.7888642719580439" q1="9.5631623449443843" p2="-9.7437791523917703" q2="-11.460001290894265">
         <iidm:alias>_0450798a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045c8772-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9763,7 +9886,7 @@
             <iidm:temporaryLimit name="_af73f526-c58b-40e7-8e1c-14f05a39f6a2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04524e47-c766-11e1-8775-005056c00008" name="100-103" r="2.7878400000000001" x="9.1476000000000006" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="78" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0475b4c0-c766-11e1-8775-005056c00008" p1="115.37736849783204" q1="-20.640390621020977" p2="-113.26868088465005" q2="22.053751386355046">
+    <iidm:line id="_04524e47-c766-11e1-8775-005056c00008" name="100-103" r="2.7878400000000001" x="9.1476000000000006" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="78" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0475b4c0-c766-11e1-8775-005056c00008" p1="115.38827346623424" q1="-20.642984193784347" p2="-113.2791810228893" q2="22.057676449241168">
         <iidm:alias>_04684744-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048aea71-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9771,7 +9894,7 @@
             <iidm:temporaryLimit name="_1631e50b-21a3-470b-803b-f9665b6fcd60" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04682038-c766-11e1-8775-005056c00008" name="27-32" r="3.9900959999999999" x="13.1551189" g1="0" b1="5.5268600000000001e-05" g2="0" b2="5.5268600000000001e-05" node1="40" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="17.919587454633966" q1="-3.4785222188396503" p2="-17.839415963520587" q2="1.9436979943836554">
+    <iidm:line id="_04682038-c766-11e1-8775-005056c00008" name="27-32" r="3.9900959999999999" x="13.1551189" g1="0" b1="5.5268600000000001e-05" g2="0" b2="5.5268600000000001e-05" node1="40" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="15.978013064744841" q1="-2.2619494629168782" p2="-15.915302841261672" q2="0.66508961430670244">
         <iidm:alias>_0455347a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479ac63-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9779,7 +9902,7 @@
             <iidm:temporaryLimit name="_52eb4b09-42bb-4106-ac26-fe1059639d3a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0482fb31-c766-11e1-8775-005056c00008" name="59-61" r="5.7150720000000002" x="26.1360016" g1="0" b1="0.0001113407" g2="0" b2="0.0001113407" node1="68" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-100.77149571953805" q1="22.250063250143626" p2="104.40139657720484" q2="-9.4527932228603611">
+    <iidm:line id="_0482fb31-c766-11e1-8775-005056c00008" name="59-61" r="5.7150720000000002" x="26.1360016" g1="0" b1="0.0001113407" g2="0" b2="0.0001113407" node1="68" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-100.756036810757" q1="22.243927903952486" p2="104.38478527580119" q2="-9.4519269793003424">
         <iidm:alias>_044a10e9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0473b8f5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9787,7 +9910,7 @@
             <iidm:temporaryLimit name="_b5a7dea0-bfce-4548-a04d-7bb7b6d9f80a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047d55e3-c766-11e1-8775-005056c00008" name="100-104" r="7.8582239999999999" x="35.544960000000003" g1="0" b1="0.00015524565000000001" g2="0" b2="0.00015524565000000001" node1="79" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="54.998828257512791" q1="10.980765831930785" p2="-53.597057298540939" q2="-9.9861135542452111">
+    <iidm:line id="_047d55e3-c766-11e1-8775-005056c00008" name="100-104" r="7.8582239999999999" x="35.544960000000003" g1="0" b1="0.00015524565000000001" g2="0" b2="0.00015524565000000001" node1="79" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="55.0011637206375" q1="10.980556766004216" p2="-53.59928247915682" q2="-9.9854019995909962">
         <iidm:alias>_04636547-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048aea76-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9795,7 +9918,7 @@
             <iidm:temporaryLimit name="_17a10cd0-b653-4dcf-bdc3-4d5005ea9591" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04653a02-c766-11e1-8775-005056c00008" name="75-77" r="10.4718237" x="34.830577900000002" g1="0" b1="0.00014284895" g2="0" b2="0.00014284895" node1="49" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-36.467205577842059" q1="-7.0443140927521508" p2="37.335025661782183" q2="5.0978903033215071">
+    <iidm:line id="_04653a02-c766-11e1-8775-005056c00008" name="75-77" r="10.4718237" x="34.830577900000002" g1="0" b1="0.00014284895" g2="0" b2="0.00014284895" node1="49" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-36.619286321417356" q1="-6.9224138148545098" p2="37.493539985835305" q2="4.9981746861446785">
         <iidm:alias>_04642894-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04720b47-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9803,7 +9926,7 @@
             <iidm:temporaryLimit name="_6f81df11-7e71-4b6e-a6ee-a8c5f72f4ba5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04483c2a-c766-11e1-8775-005056c00008" name="23-32" r="5.5234079999999999" x="20.089872400000001" g1="0" b1="0.00033660465000000001" g2="0" b2="0.00033660465000000001" node1="40" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="84.173770323896363" q1="5.1375551589593753" p2="-81.890574452997868" q2="-8.1678714105738841">
+    <iidm:line id="_04483c2a-c766-11e1-8775-005056c00008" name="23-32" r="5.5234079999999999" x="20.089872400000001" g1="0" b1="0.00033660465000000001" g2="0" b2="0.00033660465000000001" node1="40" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="80.519861498063236" q1="5.8632207329596646" p2="-78.426319217401769" q2="-9.6061012915451212">
         <iidm:alias>_044b978a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0461dea6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9811,7 +9934,7 @@
             <iidm:temporaryLimit name="_a8f6a7d2-e58d-4671-a776-97be7291355e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048719e5-c766-11e1-8775-005056c00008" name="96-97" r="3.0143520000000001" x="15.42024" g1="0" b1="6.8870549999999994e-05" g2="0" b2="6.8870549999999994e-05" node1="50" voltageLevelId1="_045a1672-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="3.1221333822606181" q1="-25.298474860999161" p2="-3.0172118785962971" q2="23.442464182056792">
+    <iidm:line id="_048719e5-c766-11e1-8775-005056c00008" name="96-97" r="3.0143520000000001" x="15.42024" g1="0" b1="6.8870549999999994e-05" g2="0" b2="6.8870549999999994e-05" node1="50" voltageLevelId1="_045a1672-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="3.0825471867312064" q1="-25.477059088422383" p2="-2.9760501769600296" q2="23.63042473306303">
         <iidm:alias>_0451b207-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04828601-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9819,7 +9942,7 @@
             <iidm:temporaryLimit name="_ea6d39aa-df95-4d3e-b7b6-a800e552e72a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048481d0-c766-11e1-8775-005056c00008" name="25-27" r="5.5408330000000001" x="28.401121100000001" g1="0" b1="0.000506198385" g2="0" b2="0.000506198385" node1="30" voltageLevelId1="_04728079-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0476c639-c766-11e1-8775-005056c00008" p1="154.53299301868819" q1="30.725386743658252" p2="-147.17310126924849" q2="-10.981359815697697">
+    <iidm:line id="_048481d0-c766-11e1-8775-005056c00008" name="25-27" r="5.5408330000000001" x="28.401121100000001" g1="0" b1="0.000506198385" g2="0" b2="0.000506198385" node1="30" voltageLevelId1="_04728079-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0476c639-c766-11e1-8775-005056c00008" p1="149.1704178552547" q1="29.587444887243951" p2="-142.30645978547057" q2="-12.410328909194867">
         <iidm:alias>_046d2947-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04725960-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9827,7 +9950,7 @@
             <iidm:temporaryLimit name="_d9d53af2-5ffa-4f2a-a4e6-ed22371332d6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04885268-c766-11e1-8775-005056c00008" name="110-112" r="4.3037280000000004" x="11.1513615" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="41" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="13" voltageLevelId2="_04784cd1-c766-11e1-8775-005056c00008" p1="69.35450823948328" q1="11.007395721331104" p2="-68.000114548689169" q2="-13.000023200821706">
+    <iidm:line id="_04885268-c766-11e1-8775-005056c00008" name="110-112" r="4.3037280000000004" x="11.1513615" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="41" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="13" voltageLevelId2="_04784cd1-c766-11e1-8775-005056c00008" p1="69.354467841511365" q1="11.007391880299638" p2="-68.000074500951058" q2="-13.000015279315114">
         <iidm:alias>_04611b55-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0481c2ba-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9835,7 +9958,7 @@
             <iidm:temporaryLimit name="_d50299b9-a055-408a-aa1e-2e93a715120f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0484a8e4-c766-11e1-8775-005056c00008" name="89-92" r="1.7249760000000001" x="8.7991200000000003" g1="0" b1="0.00015725434999999999" g2="0" b2="0.00015725434999999999" node1="57" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="68" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="228.3385895581275" q1="-3.2753855219762706" p2="-223.22809329542434" q2="23.894147266656518">
+    <iidm:line id="_0484a8e4-c766-11e1-8775-005056c00008" name="89-92" r="1.7249760000000001" x="8.7991200000000003" g1="0" b1="0.00015725434999999999" g2="0" b2="0.00015725434999999999" node1="57" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="68" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="228.46770189756859" q1="-3.185601700819285" p2="-223.35142947021853" q2="23.834107489263936">
         <iidm:alias>_04481517-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04808a3c-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9843,7 +9966,7 @@
             <iidm:temporaryLimit name="_eee9ca2b-764f-4ab8-a745-405338044743" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04689568-c766-11e1-8775-005056c00008" name="49-54" r="15.1414566" x="50.703842199999997" g1="0" b1="0.00020948120000000001" g2="0" b2="0.00020948120000000001" node1="116" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="46.51102456294894" q1="9.626659704043794" p2="-44.571838005485844" q2="-10.296626079185794">
+    <iidm:line id="_04689568-c766-11e1-8775-005056c00008" name="49-54" r="15.1414566" x="50.703842199999997" g1="0" b1="0.00020948120000000001" g2="0" b2="0.00020948120000000001" node1="116" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="46.528628155985139" q1="9.6237624198155665" p2="-44.588151131923532" q2="-10.289406146778203">
         <iidm:alias>_046030f0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04605808-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9851,7 +9974,7 @@
             <iidm:temporaryLimit name="_690202a4-aad2-4ad3-8842-961b39e37709" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046c8d04-c766-11e1-8775-005056c00008" name="40-41" r="2.5264799999999998" x="8.4854880000000001" g1="0" b1="3.5066600000000001e-05" g2="0" b2="3.5066600000000001e-05" node1="40" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048c4a08-c766-11e1-8775-005056c00008" p1="26.457164545692397" q1="-1.677632643589289" p2="-26.330907022612365" q2="1.1212007293999182">
+    <iidm:line id="_046c8d04-c766-11e1-8775-005056c00008" name="40-41" r="2.5264799999999998" x="8.4854880000000001" g1="0" b1="3.5066600000000001e-05" g2="0" b2="3.5066600000000001e-05" node1="40" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048c4a08-c766-11e1-8775-005056c00008" p1="26.647857576119122" q1="-1.8101078938517006" p2="-26.519594196732072" q2="1.2613093378608233">
         <iidm:alias>_045cae80-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a2194-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9859,7 +9982,7 @@
             <iidm:temporaryLimit name="_34f2ef7c-32da-4444-b989-d02f5f931c50" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046735d5-c766-11e1-8775-005056c00008" name="39-40" r="3.206016" x="10.54152" g1="0" b1="4.4536249999999999e-05" g2="0" b2="4.4536249999999999e-05" node1="22" voltageLevelId1="_046bf0c7-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="38.082866149407515" q1="3.7853563625201168" p2="-37.754703521342655" q2="-3.9709635467573099">
+    <iidm:line id="_046735d5-c766-11e1-8775-005056c00008" name="39-40" r="3.206016" x="10.54152" g1="0" b1="4.4536249999999999e-05" g2="0" b2="4.4536249999999999e-05" node1="22" voltageLevelId1="_046bf0c7-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="38.282887827720366" q1="3.6677549984856976" p2="-37.951203594080809" q2="-3.8405242552376291">
         <iidm:alias>_045115c1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048badc2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9867,7 +9990,7 @@
             <iidm:temporaryLimit name="_38d58455-5205-46bb-8e44-c66873f62938" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0470d2c4-c766-11e1-8775-005056c00008" name="89-92" r="6.8476319999999999" x="27.5473423" g1="0" b1="0.00011880164999999999" g2="0" b2="0.00011880164999999999" node1="58" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="72.030379379500204" q1="-5.8598349975598207" p2="-70.006062263058283" q2="9.8861772845099729">
+    <iidm:line id="_0470d2c4-c766-11e1-8775-005056c00008" name="89-92" r="6.8476319999999999" x="27.5473423" g1="0" b1="0.00011880164999999999" g2="0" b2="0.00011880164999999999" node1="58" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="72.072531939357603" q1="-5.8335489521191137" p2="-70.045926828098601" q2="9.8693069733603256">
         <iidm:alias>_04690a97-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04690a98-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9875,7 +9998,7 @@
             <iidm:temporaryLimit name="_0cce41c7-b99f-4fec-93d2-73ea24433fa1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0479ac60-c766-11e1-8775-005056c00008" name="33-37" r="7.2309599999999996" x="24.742080000000001" g1="0" b1="0.00010502754999999999" g2="0" b2="0.00010502754999999999" node1="21" voltageLevelId1="_0456bb11-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="38.75168667728942" q1="-19.979716438088893" p2="-37.881187631760262" q2="19.703867651386879">
+    <iidm:line id="_0479ac60-c766-11e1-8775-005056c00008" name="33-37" r="7.2309599999999996" x="24.742080000000001" g1="0" b1="0.00010502754999999999" g2="0" b2="0.00010502754999999999" node1="21" voltageLevelId1="_0456bb11-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="39.738613794293279" q1="-20.270243522253811" p2="-38.825107752449725" q2="20.145382589239912">
         <iidm:alias>_04716f08-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0483be89-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9883,7 +10006,7 @@
             <iidm:temporaryLimit name="_343677c6-7477-4bf6-a12c-2c7e4a684d6f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048c4a00-c766-11e1-8775-005056c00008" name="105-108" r="4.5476640000000002" x="12.249072099999999" g1="0" b1="5.2915499999999998e-05" g2="0" b2="5.2915499999999998e-05" node1="50" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_046c65f4-c766-11e1-8775-005056c00008" p1="22.930935534014786" q1="-0.8417102865993592" p2="-22.783657781414377" q2="-0.46916803252774819">
+    <iidm:line id="_048c4a00-c766-11e1-8775-005056c00008" name="105-108" r="4.5476640000000002" x="12.249072099999999" g1="0" b1="5.2915499999999998e-05" g2="0" b2="5.2915499999999998e-05" node1="50" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_046c65f4-c766-11e1-8775-005056c00008" p1="22.934315922718056" q1="-0.84277720499801745" p2="-22.786994639134384" q2="-0.46798235788446474">
         <iidm:alias>_046adf53-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04795e46-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9891,7 +10014,7 @@
             <iidm:temporaryLimit name="_74cf84b9-e14f-4f81-9e8b-3a791cd474a0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04631724-c766-11e1-8775-005056c00008" name="34-37" r="0.44605400000000001" x="1.637856" g1="0" b1="2.8236900000000001e-05" g2="0" b2="2.8236900000000001e-05" node1="41" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-57.122927232225273" q1="-35.115254778821601" p2="57.251084205911553" q2="34.703432856537255">
+    <iidm:line id="_04631724-c766-11e1-8775-005056c00008" name="34-37" r="0.44605400000000001" x="1.637856" g1="0" b1="2.8236900000000001e-05" g2="0" b2="2.8236900000000001e-05" node1="41" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-56.385264589594918" q1="-35.455168629129766" p2="56.511834586176576" q2="35.038444710453909">
         <iidm:alias>_04592c19-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04719611-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9899,7 +10022,7 @@
             <iidm:temporaryLimit name="_8e90bf2e-3be4-41be-a84e-c1d4e709f8a1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04814d85-c766-11e1-8775-005056c00008" name="61-62" r="1.435738" x="6.5514239999999999" g1="0" b1="2.812215e-05" g2="0" b2="2.812215e-05" node1="40" voltageLevelId1="_0448d867-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="60.12136910567515" q1="-18.209732278229612" p2="-59.7943791648878" q2="18.729631918916148">
+    <iidm:line id="_04814d85-c766-11e1-8775-005056c00008" name="61-62" r="1.435738" x="6.5514239999999999" g1="0" b1="2.812215e-05" g2="0" b2="2.812215e-05" node1="40" voltageLevelId1="_0448d867-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="60.101680141214111" q1="-18.205970576338498" p2="-59.774898222452762" q2="18.724921227190784">
         <iidm:alias>_045a3d85-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047abdd8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9907,7 +10030,7 @@
             <iidm:temporaryLimit name="_39a23399-348e-44d9-8032-8fc62e6c7d63" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046a4318-c766-11e1-8775-005056c00008" name="101-102" r="4.2863040000000003" x="19.5148811" g1="0" b1="8.4366399999999999e-05" g2="0" b2="8.4366399999999999e-05" node1="22" voltageLevelId1="_046ed6f7-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="-44.087960214642074" q1="11.599158207450778" p2="44.617733538423927" q2="-12.066079163504975">
+    <iidm:line id="_046a4318-c766-11e1-8775-005056c00008" name="101-102" r="4.2863040000000003" x="19.5148811" g1="0" b1="8.4366399999999999e-05" g2="0" b2="8.4366399999999999e-05" node1="22" voltageLevelId1="_046ed6f7-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="-44.122763000796319" q1="11.625156170285722" p2="44.653503487126791" q2="-12.087468200759259">
         <iidm:alias>_04878f1b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04885261-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9915,7 +10038,7 @@
             <iidm:temporaryLimit name="_0501dacc-29fc-44a2-8cad-31a20b011d25" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c81e3-c766-11e1-8775-005056c00008" name="26-30" r="3.8671600000000002" x="41.624000000000002" g1="0" b1="0.00093801650000000002" g2="0" b2="0.00093801650000000002" node1="21" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="225.56381600925391" q1="0.32961639395655551" p2="-221.44578467406654" q2="-45.980818611472394">
+    <iidm:line id="_044c81e3-c766-11e1-8775-005056c00008" name="26-30" r="3.8671600000000002" x="41.624000000000002" g1="0" b1="0.00093801650000000002" g2="0" b2="0.00093801650000000002" node1="21" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="238.5005098888017" q1="-3.724980265529676" p2="-233.9452226779398" q2="-37.62792827564126">
         <iidm:alias>_0463654b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04747c4a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9923,7 +10046,7 @@
             <iidm:temporaryLimit name="_c95a66fd-913c-48c7-b8ef-cf3007c60af6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048915b9-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="41" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="117" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-53.764396359400024" q1="-18.767940594353604" p2="56.437593857578797" q2="22.736854434801991">
+    <iidm:line id="_048915b9-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="41" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="117" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-53.573597451264007" q1="-18.910093626721363" p2="56.234520857061398" q2="22.825584738655479">
         <iidm:alias>_044bbe98-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0456e224-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9931,7 +10054,7 @@
             <iidm:temporaryLimit name="_6cd83bc2-204f-44d5-afd4-fbfef8d2146f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c5ad6-c766-11e1-8775-005056c00008" name="105-106" r="2.4393600000000002" x="9.5309279999999994" g1="0" b1="4.1150150000000001e-05" g2="0" b2="4.1150150000000001e-05" node1="51" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="9.6391674694995118" q1="6.137963398597396" p2="-9.6182487932390792" q2="-7.3852682731713539">
+    <iidm:line id="_044c5ad6-c766-11e1-8775-005056c00008" name="105-106" r="2.4393600000000002" x="9.5309279999999994" g1="0" b1="4.1150150000000001e-05" g2="0" b2="4.1150150000000001e-05" node1="51" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="9.6375701074925413" q1="6.1385330649233172" p2="-9.616654876947921" q2="-7.3858502214823094">
         <iidm:alias>_04505270-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04531190-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9939,7 +10062,7 @@
             <iidm:temporaryLimit name="_487e1317-48f9-4747-b931-f3f79e95f55a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048badc5-c766-11e1-8775-005056c00008" name="60-61" r="0.45999400000000001" x="2.3522400000000001" g1="0" b1="4.1781450000000003e-05" g2="0" b2="4.1781450000000003e-05" node1="30" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-169.31158386609923" q1="15.894528233970984" p2="170.08728674019829" q2="-13.365698633058166">
+    <iidm:line id="_048badc5-c766-11e1-8775-005056c00008" name="60-61" r="0.45999400000000001" x="2.3522400000000001" g1="0" b1="4.1781450000000003e-05" g2="0" b2="4.1781450000000003e-05" node1="30" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-169.2889488399199" q1="15.89121434476229" p2="170.06444320202925" q2="-13.363450942799457">
         <iidm:alias>_04793734-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048a4e31-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9947,7 +10070,7 @@
             <iidm:temporaryLimit name="_3c55a929-a755-409b-af5f-bae188892af1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044cd003-c766-11e1-8775-005056c00008" name="23-25" r="2.7181440000000001" x="13.9391994" g1="0" b1="0.00024793390000000002" g2="0" b2="0.00024793390000000002" node1="41" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="-204.6783587938406" q1="-10.737229144915899" p2="211.21663834183099" q2="35.181763530200257">
+    <iidm:line id="_044cd003-c766-11e1-8775-005056c00008" name="23-25" r="2.7181440000000001" x="13.9391994" g1="0" b1="0.00024793390000000002" g2="0" b2="0.00024793390000000002" node1="41" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="-197.46418392366459" q1="-12.094786335255096" p2="203.54060134620889" q2="34.161899911088518">
         <iidm:alias>_045ed161-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0473b8f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9955,7 +10078,7 @@
             <iidm:temporaryLimit name="_9658628a-596f-41a9-96a7-c5a8aaf5400c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0457a574-c766-11e1-8775-005056c00008" name="19-34" r="13.102848099999999" x="43.037277199999998" g1="0" b1="0.00018135905000000001" g2="0" b2="0.00018135905000000001" node1="40" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0483be8b-c766-11e1-8775-005056c00008" p1="51.299705245755987" q1="-15.731445360005555" p2="-48.918998026441386" q2="17.938447989758703">
+    <iidm:line id="_0457a574-c766-11e1-8775-005056c00008" name="19-34" r="13.102848099999999" x="43.037277199999998" g1="0" b1="0.00018135905000000001" g2="0" b2="0.00018135905000000001" node1="40" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0483be8b-c766-11e1-8775-005056c00008" p1="52.487625575995345" q1="-15.858156335887177" p2="-49.997002618520682" q2="18.431658409677816">
         <iidm:alias>_04502b61-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04686e5b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9963,7 +10086,7 @@
             <iidm:temporaryLimit name="_b69ab61b-751d-487a-a538-2d47eea7572e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04595326-c766-11e1-8775-005056c00008" name="59-60" r="5.5234079999999999" x="25.264800000000001" g1="0" b1="0.00010789715" g2="0" b2="0.00010789715" node1="69" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_045cfca4-c766-11e1-8775-005056c00008" p1="-89.12379965349659" q1="19.123114548571589" p2="91.862381271900134" q2="-10.272331131510496">
+    <iidm:line id="_04595326-c766-11e1-8775-005056c00008" name="59-60" r="5.5234079999999999" x="25.264800000000001" g1="0" b1="0.00010789715" g2="0" b2="0.00010789715" node1="69" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_045cfca4-c766-11e1-8775-005056c00008" p1="-89.109724815911889" q1="19.117750148039065" p2="91.847414069754564" q2="-10.271048415046479">
         <iidm:alias>_04611b57-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0463b366-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9971,7 +10094,7 @@
             <iidm:temporaryLimit name="_a38d4859-b54a-482f-a2ad-0b4ce4c4da2a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045a8ba1-c766-11e1-8775-005056c00008" name="15-19" r="2.0908799999999998" x="6.865056" g1="0" b1="2.8983e-05" g2="0" b2="2.8983e-05" node1="50" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="33.144735385667744" q1="10.696933919546112" p2="-32.98179537216533" q2="-11.063267056272018">
+    <iidm:line id="_045a8ba1-c766-11e1-8775-005056c00008" name="15-19" r="2.0908799999999998" x="6.865056" g1="0" b1="2.8983e-05" g2="0" b2="2.8983e-05" node1="50" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="32.523639708648815" q1="10.758050044861738" p2="-32.365800154508229" q2="-11.140295487054757">
         <iidm:alias>_047629f1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0481e9c1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9979,7 +10102,7 @@
             <iidm:temporaryLimit name="_15d16bd2-d87c-4584-93d2-b294dc1be116" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04513cd6-c766-11e1-8775-005056c00008" name="90-91" r="4.4256960000000003" x="14.566463499999999" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="31" voltageLevelId1="_047d07c3-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044f8f29-c766-11e1-8775-005056c00008" p1="4.3750957649295543" q1="-16.350290569623876" p2="-4.304392514762462" q2="14.594619193886798">
+    <iidm:line id="_04513cd6-c766-11e1-8775-005056c00008" name="90-91" r="4.4256960000000003" x="14.566463499999999" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="31" voltageLevelId1="_047d07c3-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044f8f29-c766-11e1-8775-005056c00008" p1="4.3991739581056466" q1="-16.340056273666434" p2="-4.328496991271523" q2="14.58438679551637">
         <iidm:alias>_045f94b9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04627ae1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9987,7 +10110,7 @@
             <iidm:temporaryLimit name="_7d2a67fb-9d8c-4745-a67e-ce6ade5e520e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0487b623-c766-11e1-8775-005056c00008" name="22-23" r="5.9590079999999999" x="27.704158799999998" g1="0" b1="0.00011593205" g2="0" b2="0.00011593205" node1="21" voltageLevelId1="_04773b6a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_047f9fdb-c766-11e1-8775-005056c00008" p1="-57.585417105334734" q1="-10.758628494933694" p2="58.843254697996159" q2="12.720663355124916">
+    <iidm:line id="_0487b623-c766-11e1-8775-005056c00008" name="22-23" r="5.9590079999999999" x="27.704158799999998" g1="0" b1="0.00011593205" g2="0" b2="0.00011593205" node1="21" voltageLevelId1="_04773b6a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_047f9fdb-c766-11e1-8775-005056c00008" p1="-55.535906754542374" q1="-11.410496442073098" p2="56.709666393110801" q2="12.973336857628064">
         <iidm:alias>_045e0e18-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0477b095-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9995,7 +10118,7 @@
             <iidm:temporaryLimit name="_6477d99a-dd64-4083-8f56-1396610879f0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048b1189-c766-11e1-8775-005056c00008" name="83-85" r="7.4923200000000003" x="25.787520000000001" g1="0" b1="9.9862250000000004e-05" g2="0" b2="9.9862250000000004e-05" node1="32" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-54.887609763053078" q1="18.457820185817425" p2="56.433129336845077" q2="-16.440303188354932">
+    <iidm:line id="_048b1189-c766-11e1-8775-005056c00008" name="83-85" r="7.4923200000000003" x="25.787520000000001" g1="0" b1="9.9862250000000004e-05" g2="0" b2="9.9862250000000004e-05" node1="32" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-54.713942435447137" q1="19.2171858993811" p2="56.26910423649695" q2="-17.153361916459808">
         <iidm:alias>_0455d0b1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0462c906-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10003,7 +10126,7 @@
             <iidm:temporaryLimit name="_38cb3e5b-af1a-4684-aa2f-242826ed460c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045868c5-c766-11e1-8775-005056c00008" name="17-31" r="8.2589760000000005" x="27.233711199999998" g1="0" b1="0.00011449725" g2="0" b2="0.00011449725" node1="60" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="12.907586416602662" q1="2.5568189135667945" p2="-12.815519279686837" q2="-6.0355127472480463">
+    <iidm:line id="_045868c5-c766-11e1-8775-005056c00008" name="17-31" r="8.2589760000000005" x="27.233711199999998" g1="0" b1="0.00011449725" g2="0" b2="0.00011449725" node1="60" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="17.216785870562525" q1="1.0537000442247721" p2="-17.066053644841514" q2="-4.3370528123669736">
         <iidm:alias>_04544a16-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0467f924-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10011,7 +10134,7 @@
             <iidm:temporaryLimit name="_9066b19a-f404-42c3-88ce-51d375f6fdb5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0488c796-c766-11e1-8775-005056c00008" name="89-90" r="9.0256319999999999" x="32.75712" g1="0" b1="0.00015151515000000001" g2="0" b2="0.00015151515000000001" node1="59" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="59.703592472319166" q1="9.2545708709129535" p2="-57.802618715379275" q2="-7.443442738968395">
+    <iidm:line id="_0488c796-c766-11e1-8775-005056c00008" name="89-90" r="9.0256319999999999" x="32.75712" g1="0" b1="0.00015151515000000001" g2="0" b2="0.00015151515000000001" node1="59" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="59.712550063190321" q1="9.2602189181464905" p2="-57.810957419058852" q2="-7.4467726133773668">
         <iidm:alias>_0459ef61-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04837069-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10019,7 +10142,7 @@
             <iidm:temporaryLimit name="_924b4a0b-bef5-432a-ad87-ab5c10d9c019" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0462c907-c766-11e1-8775-005056c00008" name="70-75" r="7.4574720000000001" x="24.56784" g1="0" b1="0.0001033058" g2="0" b2="0.0001033058" node1="50" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="8.5910764634699301" q1="7.0620259682649511" p2="-8.5241801222600628" q2="-10.269882574250699">
+    <iidm:line id="_0462c907-c766-11e1-8775-005056c00008" name="70-75" r="7.4574720000000001" x="24.56784" g1="0" b1="0.0001033058" g2="0" b2="0.0001033058" node1="50" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="8.2549521881726768" q1="7.2560566823416428" p2="-8.1890445760507031" q2="-10.467544203663765">
         <iidm:alias>_04649dc9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04784cdb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10027,7 +10150,7 @@
             <iidm:temporaryLimit name="_d432d118-553c-4f4c-a734-e98e0762ec40" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045fbbc3-c766-11e1-8775-005056c00008" name="50-57" r="8.2589760000000005" x="23.34816" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="22" voltageLevelId1="_044d1e26-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="44.112401524825593" q1="6.7443523458377452" p2="-43.157320689557494" q2="-7.2669495506046164">
+    <iidm:line id="_045fbbc3-c766-11e1-8775-005056c00008" name="50-57" r="8.2589760000000005" x="23.34816" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="22" voltageLevelId1="_044d1e26-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="44.128539032905621" q1="6.7397783879879718" p2="-43.172817253310377" q2="-7.2605528398604191">
         <iidm:alias>_04500455-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0468e383-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10035,7 +10158,7 @@
             <iidm:temporaryLimit name="_2f32bda4-7275-4485-9901-12f8cff9e4a1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044b9789-c766-11e1-8775-005056c00008" name="5-6" r="2.0734560000000002" x="9.4089600000000004" g1="0" b1="4.0920549999999999e-05" g2="0" b2="4.0920549999999999e-05" node1="49" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f6818-c766-11e1-8775-005056c00008" p1="95.829421653668462" q1="17.679365268526247" p2="-94.716530049259745" q2="-14.052794760627133">
+    <iidm:line id="_044b9789-c766-11e1-8775-005056c00008" name="5-6" r="2.0734560000000002" x="9.4089600000000004" g1="0" b1="4.0920549999999999e-05" g2="0" b2="4.0920549999999999e-05" node1="49" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f6818-c766-11e1-8775-005056c00008" p1="91.566788030158818" q1="19.187926914984907" p2="-90.54244318178597" q2="-15.965326385968531">
         <iidm:alias>_044a5f01-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0455d0b2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10043,7 +10166,7 @@
             <iidm:temporaryLimit name="_b3b0e81b-a434-4e9c-ad94-1161ff47b077" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04720b41-c766-11e1-8775-005056c00008" name="55-59" r="8.2572340000000004" x="37.600994100000001" g1="0" b1="0.00016201790000000001" g2="0" b2="0.00016201790000000001" node1="30" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-24.192541330018447" q1="-11.535506911702544" p2="24.541278046143304" q2="7.8299528717243065">
+    <iidm:line id="_04720b41-c766-11e1-8775-005056c00008" name="55-59" r="8.2572340000000004" x="37.600994100000001" g1="0" b1="0.00016201790000000001" g2="0" b2="0.00016201790000000001" node1="30" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-24.177310293772113" q1="-11.539774415884084" p2="24.525701632754046" q2="7.8326502412600334">
         <iidm:alias>_04656113-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04675ce4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10051,7 +10174,7 @@
             <iidm:temporaryLimit name="_6db0d250-4a2e-4169-abf0-f842aeca485d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048963d9-c766-11e1-8775-005056c00008" name="1-2" r="5.2794720000000002" x="17.4065762" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="22" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_045d4ac5-c766-11e1-8775-005056c00008" p1="-10.484629710296666" q1="-10.853306043547969" p2="10.551620255118975" q2="8.7011094553182886">
+    <iidm:line id="_048963d9-c766-11e1-8775-005056c00008" name="1-2" r="5.2794720000000002" x="17.4065762" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="22" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_045d4ac5-c766-11e1-8775-005056c00008" p1="-11.423008900398866" q1="-10.337574625861487" p2="11.493503891186865" q2="8.1957180827369953">
         <iidm:alias>_044b9786-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04845acb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10059,7 +10182,7 @@
             <iidm:temporaryLimit name="_9f39cb45-314c-445e-b177-909854a9ce45" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0484f709-c766-11e1-8775-005056c00008" name="11-12" r="1.0367280000000001" x="3.4151039999999999" g1="0" b1="1.4405399999999999e-05" g2="0" b2="1.4405399999999999e-05" node1="40" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="39.703161953803829" q1="-28.922460195061007" p2="-39.55654651528031" q2="28.91508078534611">
+    <iidm:line id="_0484f709-c766-11e1-8775-005056c00008" name="11-12" r="1.0367280000000001" x="3.4151039999999999" g1="0" b1="1.4405399999999999e-05" g2="0" b2="1.4405399999999999e-05" node1="40" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="34.702210601488474" q1="-25.298793615560516" p2="-34.590337246299342" q2="25.176756371902421">
         <iidm:alias>_0456e227-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04880440-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10067,7 +10190,7 @@
             <iidm:temporaryLimit name="_70fad3e1-4529-4a7f-9e6c-8ab249d65460" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044bbe91-c766-11e1-8775-005056c00008" name="8-9" r="1.18096" x="14.762" g1="0" b1="0.001200413215" g2="0" b2="0.001200413215" node1="31" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_045c8779-c766-11e1-8775-005056c00008" p1="-486.69731390675952" q1="-86.188781504969569" p2="492.44155555956502" q2="37.062842879663059">
+    <iidm:line id="_044bbe91-c766-11e1-8775-005056c00008" name="8-9" r="1.18096" x="14.762" g1="0" b1="0.001200413215" g2="0" b2="0.001200413215" node1="31" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_045c8779-c766-11e1-8775-005056c00008" p1="-486.6491870572184" q1="-83.534042311162708" p2="492.36488023425204" q2="33.672900675234516">
         <iidm:alias>_04745535-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048a7548-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="2000">
@@ -10075,7 +10198,7 @@
             <iidm:temporaryLimit name="_205e5d8a-f05a-479d-adaa-3514f48f6857" acceptableDuration="60" value="2400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04566cf8-c766-11e1-8775-005056c00008" name="64-65" r="1.30196" x="14.6168" g1="0" b1="0.000392562" g2="0" b2="0.000392562" node1="35" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-157.43737986738793" q1="-33.951628321506497" p2="158.1170401583787" q2="3.5798554979112218">
+    <iidm:line id="_04566cf8-c766-11e1-8775-005056c00008" name="64-65" r="1.30196" x="14.6168" g1="0" b1="0.000392562" g2="0" b2="0.000392562" node1="35" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-157.40882128360056" q1="-33.953430656899833" p2="158.08823804466269" q2="3.5789094312952456">
         <iidm:alias>_044a10e2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04793738-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10083,7 +10206,7 @@
             <iidm:temporaryLimit name="_8cee2b62-2953-439b-ba4b-4a48d55116c0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046783f3-c766-11e1-8775-005056c00008" name="54-56" r="0.47915999999999997" x="1.6639919999999999" g1="0" b1="2.1005500000000001e-05" g2="0" b2="2.1005500000000001e-05" node1="60" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="29.565694135054756" q1="2.6944810994670712" p2="-29.539060256239893" q2="-3.268787754746695">
+    <iidm:line id="_046783f3-c766-11e1-8775-005056c00008" name="54-56" r="0.47915999999999997" x="1.6639919999999999" g1="0" b1="2.1005500000000001e-05" g2="0" b2="2.1005500000000001e-05" node1="60" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="29.576224396728932" q1="2.6939343940465763" p2="-29.54957183362491" q2="-3.2681758509204242">
         <iidm:alias>_0460f444-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d2949-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10091,7 +10214,7 @@
             <iidm:temporaryLimit name="_640627c7-0672-413e-8dc8-c9965709a5cb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04670ec6-c766-11e1-8775-005056c00008" name="84-85" r="5.2620480000000001" x="11.1687832" g1="0" b1="3.541095e-05" g2="0" b2="3.541095e-05" node1="21" voltageLevelId1="_047b0bf4-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-44.538458894964947" q1="13.851145939334955" p2="45.244641340203792" q2="-13.514877431841493">
+    <iidm:line id="_04670ec6-c766-11e1-8775-005056c00008" name="84-85" r="5.2620480000000001" x="11.1687832" g1="0" b1="3.541095e-05" g2="0" b2="3.541095e-05" node1="21" voltageLevelId1="_047b0bf4-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-44.336621887731859" q1="14.340499635035853" p2="45.044794670992999" q2="-13.99437470407964">
         <iidm:alias>_0453fbf5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046512f7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10099,7 +10222,7 @@
             <iidm:temporaryLimit name="_8b888209-5038-4b98-80fc-062b5ea55747" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0460cd36-c766-11e1-8775-005056c00008" name="34-36" r="1.51763" x="4.669632" g1="0" b1="1.6299349999999998e-05" g2="0" b2="1.6299349999999998e-05" node1="43" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="34.474041324264903" q1="11.251331547309263" p2="-34.345069442923744" q2="-11.35772807284212">
+    <iidm:line id="_0460cd36-c766-11e1-8775-005056c00008" name="34-36" r="1.51763" x="4.669632" g1="0" b1="1.6299349999999998e-05" g2="0" b2="1.6299349999999998e-05" node1="43" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="34.55452221699457" q1="11.218342513197706" p2="-34.424944039331677" q2="-11.322333415944847">
         <iidm:alias>_046a6a26-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0487b620-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10107,7 +10230,7 @@
             <iidm:temporaryLimit name="_c0a08025-3a61-4d24-9944-f3ef0b079f64" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04549836-c766-11e1-8775-005056c00008" name="24-70" r="0.38507000000000002" x="71.699759999999998" g1="0" b1="0.00029264234999999998" g2="0" b2="0.00029264234999999998" node1="32" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="17.207103629653488" q1="-1.3775616380928188" p2="-17.200218254398667" q2="-7.346077389587756">
+    <iidm:line id="_04549836-c766-11e1-8775-005056c00008" name="24-70" r="0.38507000000000002" x="71.699759999999998" g1="0" b1="0.00029264234999999998" g2="0" b2="0.00029264234999999998" node1="32" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="16.464854573082498" q1="-1.2170230790261825" p2="-16.458509061402843" q2="-7.6186631957757145">
         <iidm:alias>_04549834-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04854522-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10115,7 +10238,7 @@
             <iidm:temporaryLimit name="_32793450-bbfd-4dcd-a911-89e199600780" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0452273a-c766-11e1-8775-005056c00008" name="85-86" r="6.0983999999999998" x="21.431519999999999" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="50" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0484f70a-c766-11e1-8775-005056c00008" p1="21.232962447900487" q1="12.279407090539777" p2="-20.998102595697489" q2="-14.002476497851868">
+    <iidm:line id="_0452273a-c766-11e1-8775-005056c00008" name="85-86" r="6.0983999999999998" x="21.431519999999999" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="50" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0484f70a-c766-11e1-8775-005056c00008" p1="21.281694964869676" q1="16.35173429138154" p2="-20.997648939494169" q2="-17.874796606713904">
         <iidm:alias>_044afb43-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479fa85-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10123,7 +10246,7 @@
             <iidm:temporaryLimit name="_2ec4bef5-7abb-4f52-bb62-49ee474d672b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0450eeb5-c766-11e1-8775-005056c00008" name="16-17" r="7.9104960000000002" x="31.380622899999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="22" voltageLevelId1="_046f7338-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-8.7036073131196101" q1="-0.5105486271287546" p2="8.7408828861729155" q2="-3.814261178632488">
+    <iidm:line id="_0450eeb5-c766-11e1-8775-005056c00008" name="16-17" r="7.9104960000000002" x="31.380622899999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="22" voltageLevelId1="_046f7338-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-15.255769571543224" q1="1.4603029925570339" p2="15.372480332827507" q2="-5.4668351093823668">
         <iidm:alias>_044ef2ea-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04837066-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10131,7 +10254,7 @@
             <iidm:temporaryLimit name="_9280074c-8555-49ff-9e62-8ed8f7d95060" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048a4e33-c766-11e1-8775-005056c00008" name="62-66" r="8.3983679999999996" x="37.984317799999999" g1="0" b1="0.00016586315" g2="0" b2="0.00016586315" node1="41" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-15.275091353917183" q1="-21.571892602388633" p2="15.557777028395986" q2="16.818290833830936">
+    <iidm:line id="_048a4e33-c766-11e1-8775-005056c00008" name="62-66" r="8.3983679999999996" x="37.984317799999999" g1="0" b1="0.00016586315" g2="0" b2="0.00016586315" node1="41" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-15.288674381073319" q1="-21.568399977530582" p2="15.571498102431539" q2="16.81542587734975">
         <iidm:alias>_046e13a9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a96c7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10139,7 +10262,7 @@
             <iidm:temporaryLimit name="_ace48562-0a49-4b76-ae82-c896a00b04f9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0478e913-c766-11e1-8775-005056c00008" name="76-77" r="7.736256" x="25.787520000000001" g1="0" b1="0.00010560145" g2="0" b2="0.00010560145" node1="21" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-62.368056732890466" q1="-21.280243196644328" p2="64.525266099759165" q2="25.00163002688592">
+    <iidm:line id="_0478e913-c766-11e1-8775-005056c00008" name="76-77" r="7.736256" x="25.787520000000001" g1="0" b1="0.00010560145" g2="0" b2="0.00010560145" node1="21" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-62.481229243853619" q1="-21.188678469339585" p2="64.644122071936323" q2="24.929809016204011">
         <iidm:alias>_044b9785-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04725965-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10147,7 +10270,7 @@
             <iidm:temporaryLimit name="_3f744dba-88dc-4d89-90d4-a6f196054b28" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048badc1-c766-11e1-8775-005056c00008" name="60-62" r="2.1431520000000002" x="9.7748640000000009" g1="0" b1="4.2125800000000002e-05" g2="0" b2="4.2125800000000002e-05" node1="32" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="-0.5507528628289885" q1="-8.6221963369152697" p2="0.55858236424052476" q2="7.2052844584337858">
+    <iidm:line id="_048badc1-c766-11e1-8775-005056c00008" name="60-62" r="2.1431520000000002" x="9.7748640000000009" g1="0" b1="4.2125800000000002e-05" g2="0" b2="4.2125800000000002e-05" node1="32" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="-0.55840034445381659" q1="-8.6201632845332963" p2="0.56622689307448903" q2="7.2032379626921061">
         <iidm:alias>_045b7600-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04720b44-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10155,7 +10278,7 @@
             <iidm:temporaryLimit name="_43f91aaf-c5f4-4995-85a2-37afac616331" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0472a780-c766-11e1-8775-005056c00008" name="27-28" r="3.3332109999999999" x="14.89752" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="42" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04819ba0-c766-11e1-8775-005056c00008" p1="34.509246723019608" q1="-1.0891888758789117" p2="-34.265899330861664" q2="0.16771185383888318">
+    <iidm:line id="_0472a780-c766-11e1-8775-005056c00008" name="27-28" r="3.3332109999999999" x="14.89752" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="42" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04819ba0-c766-11e1-8775-005056c00008" p1="32.649147855987735" q1="-1.4222221024175457" p2="-32.431948093572274" q2="0.37652680930398402">
         <iidm:alias>_04531198-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0475188b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10163,7 +10286,7 @@
             <iidm:temporaryLimit name="_2c20e8bd-84e6-4a1e-b88e-071f631327cb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c81e1-c766-11e1-8775-005056c00008" name="45-46" r="6.9695999999999998" x="23.626943600000001" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="31" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="34" voltageLevelId2="_048a7544-c766-11e1-8775-005056c00008" p1="-33.818260099518284" q1="-6.951394170783125" p2="34.303652388504425" q2="5.3166022985383217">
+    <iidm:line id="_044c81e1-c766-11e1-8775-005056c00008" name="45-46" r="6.9695999999999998" x="23.626943600000001" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="31" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="34" voltageLevelId2="_048a7544-c766-11e1-8775-005056c00008" p1="-33.687417010368009" q1="-7.0236673559709608" p2="34.169512423981757" q2="5.3778242984282727">
         <iidm:alias>_04561ed6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045c877a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10171,7 +10294,7 @@
             <iidm:temporaryLimit name="_6ad31f7e-233f-4801-898f-9ffc883ec724" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c1249-c766-11e1-8775-005056c00008" name="18-19" r="1.949746" x="8.5900320000000008" g1="0" b1="3.2770900000000002e-05" g2="0" b2="3.2770900000000002e-05" node1="22" voltageLevelId1="_04689563-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="48.835677111222267" q1="0.72902670410045844" p2="-48.537506332994717" q2="-0.43160850125639749">
+    <iidm:line id="_045c1249-c766-11e1-8775-005056c00008" name="18-19" r="1.949746" x="8.5900320000000008" g1="0" b1="3.2770900000000002e-05" g2="0" b2="3.2770900000000002e-05" node1="22" voltageLevelId1="_04689563-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="52.651471471441461" q1="-0.31871392503115892" p2="-52.304689623193021" q2="0.83135435156413628">
         <iidm:alias>_046b066b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047ae4e0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10179,7 +10302,7 @@
             <iidm:temporaryLimit name="_a025c9d8-58f9-4320-a1fe-73ecc68d4147" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044a5f09-c766-11e1-8775-005056c00008" name="9-10" r="1.2487200000000001" x="15.584800700000001" g1="0" b1="0.0012706611300000001" g2="0" b2="0.0012706611300000001" node1="21" voltageLevelId1="_045c8779-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_044f4102-c766-11e1-8775-005056c00008" p1="-492.44155555956473" q1="-37.062842879663485" p2="498.29790331186547" q2="-23.577607519666177">
+    <iidm:line id="_044a5f09-c766-11e1-8775-005056c00008" name="9-10" r="1.2487200000000001" x="15.584800700000001" g1="0" b1="0.0012706611300000001" g2="0" b2="0.0012706611300000001" node1="21" voltageLevelId1="_045c8779-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_044f4102-c766-11e1-8775-005056c00008" p1="-492.36488023425187" q1="-33.672900675235297" p2="498.21198633483357" q2="-27.225314504536403">
         <iidm:alias>_04614262-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04834957-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="2000">
@@ -10187,7 +10310,7 @@
             <iidm:temporaryLimit name="_b7fac0a3-c5af-48b9-af49-261fd8d46e00" acceptableDuration="60" value="2400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0480b14b-c766-11e1-8775-005056c00008" name="85-88" r="3.4847999999999999" x="17.772480000000002" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="51" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0470f9d2-c766-11e1-8775-005056c00008" p1="-63.091792462894936" q1="5.015680348912877" p2="63.940959197372614" q2="-3.3218410613823854">
+    <iidm:line id="_0480b14b-c766-11e1-8775-005056c00008" name="85-88" r="3.4847999999999999" x="17.772480000000002" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="51" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0470f9d2-c766-11e1-8775-005056c00008" p1="-62.991098351629837" q1="3.5774000799814645" p2="63.838582225846586" q2="-1.8825221760294053">
         <iidm:alias>_047602e2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04765105-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10195,7 +10318,7 @@
             <iidm:temporaryLimit name="_51646744-d343-42b5-8ba7-fcedc7cc3a98" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04486330-c766-11e1-8775-005056c00008" name="69-77" r="5.3840159999999999" x="17.598240000000001" g1="0" b1="0.00029786500000000002" g2="0" b2="0.00029786500000000002" node1="60" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="32.452580160128811" q1="17.958014107589737" p2="-31.989249649836943" q2="-27.220928629641605">
+    <iidm:line id="_04486330-c766-11e1-8775-005056c00008" name="69-77" r="5.3840159999999999" x="17.598240000000001" g1="0" b1="0.00029786500000000002" g2="0" b2="0.00029786500000000002" node1="60" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="32.558691831069716" q1="18.073650878551717" p2="-32.091798529794232" q2="-27.32343035695386">
         <iidm:alias>_046205b9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479d379-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10203,7 +10326,7 @@
             <iidm:temporaryLimit name="_76311a15-b79a-4439-a7ce-47afa8fa6fe2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04553477-c766-11e1-8775-005056c00008" name="11-13" r="3.8768400000000001" x="12.7369442" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="41" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04851e1b-c766-11e1-8775-005056c00008" p1="49.663800664508919" q1="15.034850947991199" p2="-49.041923339903995" q2="-14.776917538538029">
+    <iidm:line id="_04553477-c766-11e1-8775-005056c00008" name="11-13" r="3.8768400000000001" x="12.7369442" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="41" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04851e1b-c766-11e1-8775-005056c00008" p1="45.461680556845103" q1="16.207954014563015" p2="-44.922763434239549" q2="-16.224111922879096">
         <iidm:alias>_0479fa89-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0485452a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10211,7 +10334,7 @@
             <iidm:temporaryLimit name="_efbf8de7-4b84-4834-bb7c-6250b6072211" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04488a45-c766-11e1-8775-005056c00008" name="103-105" r="9.3218399999999999" x="28.314" g1="0" b1="0.0001170799" g2="0" b2="0.0001170799" node1="42" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="43.796718699648103" q1="12.535287175237963" p2="-42.678685846314266" q2="-13.121379288697366">
+    <iidm:line id="_04488a45-c766-11e1-8775-005056c00008" name="103-105" r="9.3218399999999999" x="28.314" g1="0" b1="0.0001170799" g2="0" b2="0.0001170799" node1="42" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="43.796566988351081" q1="12.535374384238764" p2="-42.678539142135627" q2="-13.121479015057226">
         <iidm:alias>_044f8f24-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04611b58-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10219,7 +10342,7 @@
             <iidm:temporaryLimit name="_22b6919a-a7a0-49fc-9e90-329069c55055" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046009e6-c766-11e1-8775-005056c00008" name="45-49" r="11.918016400000001" x="32.408639999999998" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="32" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="118" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-40.859546077777338" q1="-7.9943105353247219" p2="42.06585550093299" q2="6.7976250611905753">
+    <iidm:line id="_046009e6-c766-11e1-8775-005056c00008" name="45-49" r="11.918016400000001" x="32.408639999999998" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="32" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="118" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-40.73195716273159" q1="-8.071503009847838" p2="41.931634319067392" q2="6.8569499812349832">
         <iidm:alias>_044ca8f9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047dcb1b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10227,7 +10350,7 @@
             <iidm:temporaryLimit name="_8b91f4fd-4038-45b7-870c-fbc08592b95a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046a6a27-c766-11e1-8775-005056c00008" name="88-89" r="2.4219360000000001" x="12.4058876" g1="0" b1="5.549815e-05" g2="0" b2="5.549815e-05" node1="22" voltageLevelId1="_0470f9d2-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-111.94020761748935" q1="-6.6779304531562778" p2="113.7520202133049" q2="14.049828206328213">
+    <iidm:line id="_046a6a27-c766-11e1-8775-005056c00008" name="88-89" r="2.4219360000000001" x="12.4058876" g1="0" b1="5.549815e-05" g2="0" b2="5.549815e-05" node1="22" voltageLevelId1="_0470f9d2-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-111.83766968257804" q1="-8.1171936450887152" p2="113.65269639058812" q2="15.507525111881321">
         <iidm:alias>_045ef879-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04649dc1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10235,7 +10358,7 @@
             <iidm:temporaryLimit name="_970bc323-73bf-440d-a3c5-00aebc3a1992" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048a7540-c766-11e1-8775-005056c00008" name="80-98" r="4.1469120000000004" x="18.817920000000001" g1="0" b1="8.20707e-05" g2="0" b2="8.20707e-05" node1="79" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04773b62-c766-11e1-8775-005056c00008" p1="11.391946496978317" q1="11.979904116544128" p2="-11.32312874609897" q2="-14.711971141066371">
+    <iidm:line id="_048a7540-c766-11e1-8775-005056c00008" name="80-98" r="4.1469120000000004" x="18.817920000000001" g1="0" b1="8.20707e-05" g2="0" b2="8.20707e-05" node1="79" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04773b62-c766-11e1-8775-005056c00008" p1="11.399711615384867" q1="11.978094851658753" p2="-11.330865664860116" q2="-14.71003308067791">
         <iidm:alias>_045338a2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04887972-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10243,7 +10366,7 @@
             <iidm:temporaryLimit name="_cb084dc7-1b26-415f-9495-4695df661912" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04640183-c766-11e1-8775-005056c00008" name="91-92" r="6.7430880000000002" x="22.163329999999998" g1="0" b1="9.3778700000000004e-05" g2="0" b2="9.3778700000000004e-05" node1="22" voltageLevelId1="_044f8f29-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="-5.6955872163822248" q1="-14.594621033075777" p2="5.7790441413152847" q2="11.731661959427559">
+    <iidm:line id="_04640183-c766-11e1-8775-005056c00008" name="91-92" r="6.7430880000000002" x="22.163329999999998" g1="0" b1="9.3778700000000004e-05" g2="0" b2="9.3778700000000004e-05" node1="22" voltageLevelId1="_044f8f29-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="-5.6714758891670494" q1="-14.584388271559229" p2="5.7547161758582828" q2="11.720974415580004">
         <iidm:alias>_04492680-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_044c5ad5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10251,7 +10374,7 @@
             <iidm:temporaryLimit name="_3a165a76-f6ba-461b-84d6-159a5e0b5077" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0474a358-c766-11e1-8775-005056c00008" name="7-12" r="1.501949" x="5.9241599999999996" g1="0" b1="2.5080350000000001e-05" g2="0" b2="2.5080350000000001e-05" node1="22" voltageLevelId1="_047eb571-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="23.628706744840112" q1="-9.8094316301421642" p2="-23.57172210649777" q2="9.1786328219031219">
+    <iidm:line id="_0474a358-c766-11e1-8775-005056c00008" name="7-12" r="1.501949" x="5.9241599999999996" g1="0" b1="2.5080350000000001e-05" g2="0" b2="2.5080350000000001e-05" node1="22" voltageLevelId1="_047eb571-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="19.471767616582078" q1="-7.8185049518218115" p2="-19.433549727075608" q2="7.1133939589466362">
         <iidm:alias>_046ab848-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0477feb7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10259,7 +10382,7 @@
             <iidm:temporaryLimit name="_b19bc945-cc51-4d77-8eaa-3f6afe2d9316" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04765108-c766-11e1-8775-005056c00008" name="99-100" r="3.13632" x="14.165711399999999" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_04644fa4-c766-11e1-8775-005056c00008" node2="80" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-40.053801967418607" q1="12.29195768316607" p2="40.362473851591233" q2="-13.13855988330514">
+    <iidm:line id="_04765108-c766-11e1-8775-005056c00008" name="99-100" r="3.13632" x="14.165711399999999" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_04644fa4-c766-11e1-8775-005056c00008" node2="80" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-40.045972980118933" q1="12.290177505758301" p2="40.354528178735229" q2="-13.137305875352146">
         <iidm:alias>_0471e436-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047e4040-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10267,7 +10390,7 @@
             <iidm:temporaryLimit name="_a9e283ed-fcad-4f4c-ab57-8531875bb098" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047b8128-c766-11e1-8775-005056c00008" name="114-115" r="0.400752" x="1.8120959999999999" g1="0" b1="7.9201000000000006e-06" g2="0" b2="7.9201000000000006e-06" node1="22" voltageLevelId1="_04791027-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="-1.6445806635733324" q1="2.8187714630332197" p2="1.6448640217510704" q2="-3.07247870596504">
+    <iidm:line id="_047b8128-c766-11e1-8775-005056c00008" name="114-115" r="0.400752" x="1.8120959999999999" g1="0" b1="7.9201000000000006e-06" g2="0" b2="7.9201000000000006e-06" node1="22" voltageLevelId1="_04791027-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="-0.58763017647224214" q1="2.2299784620843011" p2="0.5877767732418866" q2="-2.4849362039500003">
         <iidm:alias>_046c17d3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d0233-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10275,7 +10398,7 @@
             <iidm:temporaryLimit name="_c59e4022-b1c0-4811-a32e-f54656bff32d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046931a5-c766-11e1-8775-005056c00008" name="83-84" r="10.890000000000001" x="22.999680000000001" g1="0" b1="7.4035799999999993e-05" g2="0" b2="7.4035799999999993e-05" node1="33" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b0bf4-c766-11e1-8775-005056c00008" p1="-32.531601006821923" q1="20.542419770883644" p2="33.538845083174451" q2="-20.850760429436693">
+    <iidm:line id="_046931a5-c766-11e1-8775-005056c00008" name="83-84" r="10.890000000000001" x="22.999680000000001" g1="0" b1="7.4035799999999993e-05" g2="0" b2="7.4035799999999993e-05" node1="33" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b0bf4-c766-11e1-8775-005056c00008" p1="-32.321166251732109" q1="21.058771809357623" p2="33.337077650322414" q2="-21.340038346999613">
         <iidm:alias>_0465d645-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479102b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10283,7 +10406,7 @@
             <iidm:temporaryLimit name="_1268eb09-e233-44ce-b8af-22dc30eb16ad" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047ae4ea-c766-11e1-8775-005056c00008" name="14-15" r="10.367279999999999" x="33.976799999999997" g1="0" b1="0.0001440542" g2="0" b2="0.0001440542" node1="21" voltageLevelId1="_047b8129-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="21.157917254616692" q1="5.8573751012279738" p2="-20.836803484272455" q2="-9.4646467734257769">
+    <iidm:line id="_047ae4ea-c766-11e1-8775-005056c00008" name="14-15" r="10.367279999999999" x="33.976799999999997" g1="0" b1="0.0001440542" g2="0" b2="0.0001440542" node1="21" voltageLevelId1="_047b8129-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="16.495796328812094" q1="7.3519279545171319" p2="-16.267221744087259" q2="-11.26042587295137">
         <iidm:alias>_0449e9d9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046ed6fa-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10291,7 +10414,7 @@
             <iidm:temporaryLimit name="_9c0c454b-ecc3-40f6-b505-f32fec412522" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046e3ab2-c766-11e1-8775-005056c00008" name="80-96" r="6.2029439999999996" x="31.711680000000001" g1="0" b1="0.0001417585" g2="0" b2="0.0001417585" node1="80" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="4.6718713683062143" q1="26.195192635364002" p2="-4.3904172119784146" q2="-29.838371825201826">
+    <iidm:line id="_046e3ab2-c766-11e1-8775-005056c00008" name="80-96" r="6.2029439999999996" x="31.711680000000001" g1="0" b1="0.0001417585" g2="0" b2="0.0001417585" node1="80" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="4.7139737044660253" q1="26.394504753816793" p2="-4.428588877029223" q2="-30.015814403582151">
         <iidm:alias>_045338a4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04865695-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10299,7 +10422,7 @@
             <iidm:temporaryLimit name="_1432f4d6-9299-4b0d-bd7f-16e059f9de66" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04893cc4-c766-11e1-8775-005056c00008" name="56-59" r="13.9914722" x="41.643360000000001" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="59" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-20.146387592934637" q1="-7.6711537309296656" p2="20.528774440228474" q2="3.7707166347410088">
+    <iidm:line id="_04893cc4-c766-11e1-8775-005056c00008" name="56-59" r="13.9914722" x="41.643360000000001" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="59" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-20.132744023714181" q1="-7.6765432586027389" p2="20.514695948562711" q2="3.7748141175022827">
         <iidm:alias>_046b5484-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04798557-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10307,7 +10430,7 @@
             <iidm:temporaryLimit name="_193f6952-4267-4cc8-a541-726c095028ba" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c1243-c766-11e1-8775-005056c00008" name="92-100" r="11.290752400000001" x="51.400799999999997" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="71" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="36.825265655728224" q1="-17.27542978887449" p2="-35.779429252268237" q2="17.285204280369637">
+    <iidm:line id="_045c1243-c766-11e1-8775-005056c00008" name="92-100" r="11.290752400000001" x="51.400799999999997" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="71" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="36.86219025839501" q1="-17.294907936791081" p2="-35.814053414385853" q2="17.315395912738776">
         <iidm:alias>_045e8348-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045ed164-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10315,7 +10438,7 @@
             <iidm:temporaryLimit name="_579249ce-1c81-4d29-8d3f-5fc627a18f99" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0474a356-c766-11e1-8775-005056c00008" name="43-44" r="10.593792000000001" x="42.7584953" g1="0" b1="0.00017412765" g2="0" b2="0.00017412765" node1="22" voltageLevelId1="_045e8349-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04544a15-c766-11e1-8775-005056c00008" p1="-5.5010925233017245" q1="-11.149860682370806" p2="5.5692675692174047" q2="5.807538027558576">
+    <iidm:line id="_0474a356-c766-11e1-8775-005056c00008" name="43-44" r="10.593792000000001" x="42.7584953" g1="0" b1="0.00017412765" g2="0" b2="0.00017412765" node1="22" voltageLevelId1="_045e8349-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04544a15-c766-11e1-8775-005056c00008" p1="-5.2450198479219248" q1="-11.302540476274443" p2="5.3131634460548263" q2="5.962883544613538">
         <iidm:alias>_04642899-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047b0bf2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10323,7 +10446,7 @@
             <iidm:temporaryLimit name="_3d2cb4b5-ee82-4866-9855-4a5f4803cd3b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04627ae6-c766-11e1-8775-005056c00008" name="109-110" r="4.8438720000000002" x="13.2770882" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="22" voltageLevelId1="_046b7b99-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="12.734346191604844" q1="-2.9683151434893089" p2="-12.683861379993949" q2="1.2603430429312383">
+    <iidm:line id="_04627ae6-c766-11e1-8775-005056c00008" name="109-110" r="4.8438720000000002" x="13.2770882" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="22" voltageLevelId1="_046b7b99-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="12.737672961757379" q1="-2.9695428459067821" p2="-12.68716085691354" q2="1.2616472973300294">
         <iidm:alias>_0466e7b5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a6fbb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10331,7 +10454,7 @@
             <iidm:temporaryLimit name="_6fc48d8d-05f8-4104-a6a2-3686d430a091" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0478c207-c766-11e1-8775-005056c00008" name="68-81" r="0.84699999999999998" x="9.7767990000000005" g1="0" b1="0.00083471078000000004" g2="0" b2="0.00083471078000000004" node1="38" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_048a272b-c766-11e1-8775-005056c00008" p1="-150.67785139656104" q1="-3.8506603052204795" p2="151.09953176946269" q2="-71.524927125576156">
+    <iidm:line id="_0478c207-c766-11e1-8775-005056c00008" name="68-81" r="0.84699999999999998" x="9.7767990000000005" g1="0" b1="0.00083471078000000004" g2="0" b2="0.00083471078000000004" node1="38" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_048a272b-c766-11e1-8775-005056c00008" p1="-150.09276547037464" q1="-3.9115444591882764" p2="150.51127776143517" q2="-71.501014040253523">
         <iidm:alias>_044a37f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045b4ef6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10339,7 +10462,7 @@
             <iidm:temporaryLimit name="_191836a1-39cd-402b-8dcf-4f3867c45bd0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0467d215-c766-11e1-8775-005056c00008" name="85-89" r="4.1643359999999996" x="30.143518400000001" g1="0" b1="0.00013487144999999999" g2="0" b2="0.00013487144999999999" node1="52" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-83.818096137363511" q1="-2.3390823086154811" p2="85.591272931767577" q2="10.575339573707993">
+    <iidm:line id="_0467d215-c766-11e1-8775-005056c00008" name="85-89" r="4.1643359999999996" x="30.143518400000001" g1="0" b1="0.00013487144999999999" g2="0" b2="0.00013487144999999999" node1="52" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-83.603480764573618" q1="-3.7803924508227089" p2="85.377450588374259" q2="12.033989439444268">
         <iidm:alias>_047629f9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0478e915-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10347,7 +10470,7 @@
             <iidm:temporaryLimit name="_66cbdeeb-a4e4-4bfc-aec1-9fb7a2d2b6bc" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044a37f2-c766-11e1-8775-005056c00008" name="89-90" r="4.1469120000000004" x="17.371727" g1="0" b1="0.00030417815" g2="0" b2="0.00030417815" node1="62" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="112.73361109569694" q1="21.234040609131625" p2="-109.57236091780491" q2="-18.206189939994033">
+    <iidm:line id="_044a37f2-c766-11e1-8775-005056c00008" name="89-90" r="4.1469120000000004" x="17.371727" g1="0" b1="0.00030417815" g2="0" b2="0.00030417815" node1="62" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="112.75027163843386" q1="21.245367954169961" p2="-109.58799227366465" q2="-18.213061360938799">
         <iidm:alias>_045386c2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048719e9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10355,7 +10478,7 @@
             <iidm:temporaryLimit name="_8489e809-6588-4ed2-a9a4-43c44a0d47da" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04658820-c766-11e1-8775-005056c00008" name="98-100" r="6.9173280000000004" x="31.188960999999999" g1="0" b1="0.0001365932" g2="0" b2="0.0001365932" node1="22" voltageLevelId1="_04773b62-c766-11e1-8775-005056c00008" node2="82" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-22.676893025656732" q1="6.7119679430040131" p2="22.903939766858276" q2="-10.642475703238455">
+    <iidm:line id="_04658820-c766-11e1-8775-005056c00008" name="98-100" r="6.9173280000000004" x="31.188960999999999" g1="0" b1="0.0001365932" g2="0" b2="0.0001365932" node1="22" voltageLevelId1="_04773b62-c766-11e1-8775-005056c00008" node2="82" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-22.669140066665971" q1="6.7100338475233317" p2="22.896040068718499" q2="-10.641201570804924">
         <iidm:alias>_046f4c22-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046fe865-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10363,7 +10486,7 @@
             <iidm:temporaryLimit name="_620beaaf-63c8-4020-bea5-c3609c0eaadf" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c5ada-c766-11e1-8775-005056c00008" name="28-29" r="4.1294880000000003" x="16.430831900000001" g1="0" b1="6.8296599999999999e-05" g2="0" b2="6.8296599999999999e-05" node1="22" voltageLevelId1="_04819ba0-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04588fd5-c766-11e1-8775-005056c00008" p1="17.266063208332096" q1="-7.1676004357754595" p2="-17.180162595161221" q2="5.3057663206824461">
+    <iidm:line id="_044c5ada-c766-11e1-8775-005056c00008" name="28-29" r="4.1294880000000003" x="16.430831900000001" g1="0" b1="6.8296599999999999e-05" g2="0" b2="6.8296599999999999e-05" node1="22" voltageLevelId1="_04819ba0-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04588fd5-c766-11e1-8775-005056c00008" p1="15.431726587374373" q1="-5.1663908564799854" p2="-15.366700850560497" q2="3.2155680760187613">
         <iidm:alias>_0461697a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04697fc1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10371,7 +10494,13 @@
             <iidm:temporaryLimit name="_6748d0d0-aec8-4b7b-a9ab-be6aecda7c5d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0468e382-c766-11e1-8775-005056c00008" name="3-5" r="4.1991839999999998" x="18.817920000000001" g1="0" b1="8.1496799999999995e-05" g2="0" b2="8.1496799999999995e-05" node1="31" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-72.361137042554759" q1="-15.612373437356396" p2="73.747786670422627" q2="19.038077930711992">
+    <iidm:line id="_044c5ada-c766-11e1-8775-005056c00008-1" name="28-29-open-ended" r="4.1294880000000003" x="16.430831900000001" g1="0" b1="6.8296599999999999e-05" g2="0" b2="6.8296599999999999e-05" node1="25" voltageLevelId1="_04819ba0-c766-11e1-8775-005056c00008" node2="25" voltageLevelId2="_04588fd5-c766-11e1-8775-005056c00008" p1="0.00031217881517489696" q1="-2.210073811390159" p2="0" q2="0">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_accb8136-1faf-4399-9787-3cd567284fd2-1" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_6748d0d0-aec8-4b7b-a9ab-be6aecda7c5d-1" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0468e382-c766-11e1-8775-005056c00008" name="3-5" r="4.1991839999999998" x="18.817920000000001" g1="0" b1="8.1496799999999995e-05" g2="0" b2="8.1496799999999995e-05" node1="31" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-70.18144228166345" q1="-16.755827430812879" p2="71.496301965763436" q2="19.855808904132004">
         <iidm:alias>_046b0668-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04742e24-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10379,7 +10508,7 @@
             <iidm:temporaryLimit name="_828ca44c-560b-4f94-b825-21e237285fae" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0447c6f1-c766-11e1-8775-005056c00008" name="82-96" r="2.8226879999999999" x="9.2347199999999994" g1="0" b1="0.00015610649999999999" g2="0" b2="0.00015610649999999999" node1="33" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="-15.592230815492428" q1="-8.8513461353024923" p2="15.639598084034038" q2="3.7292602596144753">
+    <iidm:line id="_0447c6f1-c766-11e1-8775-005056c00008" name="82-96" r="2.8226879999999999" x="9.2347199999999994" g1="0" b1="0.00015610649999999999" g2="0" b2="0.00015610649999999999" node1="33" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="-15.791208696737623" q1="-9.5673250408141222" p2="15.841300366194686" q2="4.4603239421008896">
         <iidm:alias>_0478e91a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0480d856-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10387,7 +10516,7 @@
             <iidm:temporaryLimit name="_233b7735-85f4-4a6f-9d87-15129fe42ef5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0483e594-c766-11e1-8775-005056c00008" name="38-65" r="4.3608399999999996" x="47.7224" g1="0" b1="0.0010805785" g2="0" b2="0.0010805785" node1="29" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-162.04611005596766" q1="-97.45523026232479" p2="165.16343607894285" q2="34.733754118980158">
+    <iidm:line id="_0483e594-c766-11e1-8775-005056c00008" name="38-65" r="4.3608399999999996" x="47.7224" g1="0" b1="0.0010805785" g2="0" b2="0.0010805785" node1="29" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-160.69674152343191" q1="-97.983252373054185" p2="163.77530194535689" q2="34.859523549709472">
         <iidm:alias>_04638c56-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d5054-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10395,7 +10524,7 @@
             <iidm:temporaryLimit name="_990ce3c5-c90c-41b9-abee-fb803d9df3a5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04784cd4-c766-11e1-8775-005056c00008" name="106-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_04479fe8-c766-11e1-8775-005056c00008" node2="24" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="23.852677428575007" q1="-0.69449673144674895" p2="-23.524275877990576" q2="-2.4551199981766976">
+    <iidm:line id="_04784cd4-c766-11e1-8775-005056c00008" name="106-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_04479fe8-c766-11e1-8775-005056c00008" node2="24" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="23.852893759222127" q1="-0.6945749012715845" p2="-23.524486085386414" q2="-2.4550166180564923">
         <iidm:alias>_04483c21-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f0395-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10403,7 +10532,7 @@
             <iidm:temporaryLimit name="_1372c3b0-62d7-47d7-a8c0-ed8e10bc1f1a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046f9a43-c766-11e1-8775-005056c00008" name="27-115" r="2.8575360000000001" x="12.9111843" g1="0" b1="5.6588600000000002e-05" g2="0" b2="5.6588600000000002e-05" node1="43" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="23.745359074475889" q1="2.5493967815970016" p2="-23.644473374161628" q2="-3.9273167415321755">
+    <iidm:line id="_046f9a43-c766-11e1-8775-005056c00008" name="27-115" r="2.8575360000000001" x="12.9111843" g1="0" b1="5.6588600000000002e-05" g2="0" b2="5.6588600000000002e-05" node1="43" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="22.680126327490324" q1="3.0947512730464384" p2="-22.587463441803159" q2="-4.5148982436550691">
         <iidm:alias>_046d0238-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048c22f4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10411,7 +10540,7 @@
             <iidm:temporaryLimit name="_64cfd0fb-1d8e-45d2-a52f-469238dfc0c6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04529c61-c766-11e1-8775-005056c00008" name="12-14" r="3.7461600000000002" x="12.3187675" g1="0" b1="5.2112050000000002e-05" g2="0" b2="5.2112050000000002e-05" node1="71" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b8129-c766-11e1-8775-005056c00008" p1="35.443668311605876" q1="6.0403979683005895" p2="-35.157553810832262" q2="-6.8573329071313749">
+    <iidm:line id="_04529c61-c766-11e1-8775-005056c00008" name="12-14" r="3.7461600000000002" x="12.3187675" g1="0" b1="5.2112050000000002e-05" g2="0" b2="5.2112050000000002e-05" node1="71" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b8129-c766-11e1-8775-005056c00008" p1="30.717220429172983" q1="7.3233430279179359" p2="-30.495440858883459" q2="-8.3518849406058422">
         <iidm:alias>_045fbbc1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047bf65b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10419,7 +10548,7 @@
             <iidm:temporaryLimit name="_efe2501d-bcee-42ff-a037-3d8a280487b0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0463da77-c766-11e1-8775-005056c00008" name="76-118" r="2.8575360000000001" x="9.4786560000000009" g1="0" b1="3.8911849999999999e-05" g2="0" b2="3.8911849999999999e-05" node1="22" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="-5.6320040829837854" q1="-14.719783837493452" p2="5.6750798054584219" q2="13.657446231383222">
+    <iidm:line id="_0463da77-c766-11e1-8775-005056c00008" name="76-118" r="2.8575360000000001" x="9.4786560000000009" g1="0" b1="3.8911849999999999e-05" g2="0" b2="3.8911849999999999e-05" node1="22" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="-5.5187899251476251" q1="-14.811323480374369" p2="5.562121553439658" q2="13.74999196947955">
         <iidm:alias>_046931a0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04806320-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10427,7 +10556,7 @@
             <iidm:temporaryLimit name="_2ae204bf-78cc-49cb-b886-a933b33057e4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046931a3-c766-11e1-8775-005056c00008" name="74-75" r="2.1431520000000002" x="7.0741440000000004" g1="0" b1="2.9671699999999999e-05" g2="0" b2="2.9671699999999999e-05" node1="23" voltageLevelId1="_047dcb11-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="-45.005820631056359" q1="-4.301699039270634" p2="45.278050663401338" q2="4.2396127095609746">
+    <iidm:line id="_046931a3-c766-11e1-8775-005056c00008" name="74-75" r="2.1431520000000002" x="7.0741440000000004" g1="0" b1="2.9671699999999999e-05" g2="0" b2="2.9671699999999999e-05" node1="23" voltageLevelId1="_047dcb11-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="-45.27276934106095" q1="-4.136989607511822" p2="45.548040276870665" q2="4.0849378549128366">
         <iidm:alias>_044f4103-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04638c58-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10435,7 +10564,7 @@
             <iidm:temporaryLimit name="_e822432e-79af-4bba-8f40-5250468f81a0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045ed162-c766-11e1-8775-005056c00008" name="3-12" r="8.4332159999999998" x="27.878398900000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="32" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-7.4176562913597515" q1="-10.392066312643877" p2="7.4825751329904655" q2="6.6978444723992672">
+    <iidm:line id="_045ed162-c766-11e1-8775-005056c00008" name="3-12" r="8.4332159999999998" x="27.878398900000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="32" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-8.6506158577155077" q1="-9.7358416000212866" p2="8.720125066243984" q2="6.0549967217033194">
         <iidm:alias>_047a48a1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047b5a14-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10443,7 +10572,7 @@
             <iidm:temporaryLimit name="_c437e52c-43d7-4ae9-87ad-dc19396dc6ff" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04499bb6-c766-11e1-8775-005056c00008" name="49-51" r="8.468064" x="23.8708782" g1="0" b1="9.81405e-05" g2="0" b2="9.81405e-05" node1="119" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04542300-c766-11e1-8775-005056c00008" p1="76.822391246448674" q1="18.66849471227091" p2="-73.898644192307259" q2="-13.817958186511897">
+    <iidm:line id="_04499bb6-c766-11e1-8775-005056c00008" name="49-51" r="8.468064" x="23.8708782" g1="0" b1="9.81405e-05" g2="0" b2="9.81405e-05" node1="119" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04542300-c766-11e1-8775-005056c00008" p1="76.842553985178853" q1="18.665291141069087" p2="-73.917433919349776" q2="-13.810875348959959">
         <iidm:alias>_0487dd38-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b1180-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10451,7 +10580,7 @@
             <iidm:temporaryLimit name="_90dcdbe1-437b-443f-b0b5-c2353f7c6954" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04839779-c766-11e1-8775-005056c00008" name="40-42" r="9.6703209999999995" x="31.885919999999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="42" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="-0.74454786046971377" q1="-9.573316660499442" p2="0.78574389202298378" q2="5.8873054676908971">
+    <iidm:line id="_04839779-c766-11e1-8775-005056c00008" name="40-42" r="9.6703209999999995" x="31.885919999999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="42" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="-0.5510250366848799" q1="-9.7101888801019918" p2="0.59357311218210407" q2="6.031532674485474">
         <iidm:alias>_044974a9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04616975-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10459,7 +10588,7 @@
             <iidm:temporaryLimit name="_9b8510fa-bd0e-4e63-8f4c-0e5443a3eb63" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0484a8e1-c766-11e1-8775-005056c00008" name="32-113" r="10.71576" x="35.370719999999999" g1="0" b1="0.00014864555000000001" g2="0" b2="0.00014864555000000001" node1="52" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="4.7873532670554937" q1="-10.045195113608631" p2="-4.7338081624868078" q2="5.3277220968122867">
+    <iidm:line id="_0484a8e1-c766-11e1-8775-005056c00008" name="32-113" r="10.71576" x="35.370719999999999" g1="0" b1="0.00014864555000000001" g2="0" b2="0.00014864555000000001" node1="52" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="0.83174736664933424" q1="-8.3182666615530199" p2="-0.80837283161100026" q2="3.4979601577141208">
         <iidm:alias>_04723258-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0482860a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10467,7 +10596,7 @@
             <iidm:temporaryLimit name="_336bfd86-a922-4154-9e06-cd87382cdc5f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04898ae4-c766-11e1-8775-005056c00008" name="51-58" r="4.4431200000000004" x="12.5278568" g1="0" b1="5.1308550000000002e-05" g2="0" b2="5.1308550000000002e-05" node1="31" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="25.291769389590392" q1="0.49598963742439917" p2="-25.11637899077413" q2="-1.6560488406678766">
+    <iidm:line id="_04898ae4-c766-11e1-8775-005056c00008" name="51-58" r="4.4431200000000004" x="12.5278568" g1="0" b1="5.1308550000000002e-05" g2="0" b2="5.1308550000000002e-05" node1="31" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="25.304357465847815" q1="0.49077915435671304" p2="-25.128795757866847" q2="-1.650347688396353">
         <iidm:alias>_044778d4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04789af1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10475,7 +10604,7 @@
             <iidm:temporaryLimit name="_2be10dec-f0ac-470d-83f7-a2a4e70f3491" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046efe04-c766-11e1-8775-005056c00008" name="29-31" r="1.8817919999999999" x="5.7673439999999996" g1="0" b1="2.3817700000000001e-05" g2="0" b2="2.3817700000000001e-05" node1="22" voltageLevelId1="_04588fd5-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="-6.8197796743834136" q1="-9.3057504914732849" p2="6.8344587032620794" q2="8.5776848013670062">
+    <iidm:line id="_046efe04-c766-11e1-8775-005056c00008" name="29-31" r="1.8817919999999999" x="5.7673439999999996" g1="0" b1="2.3817700000000001e-05" g2="0" b2="2.3817700000000001e-05" node1="22" voltageLevelId1="_04588fd5-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="-8.6332670715654007" q1="-7.215559173779809" p2="8.6473599876115337" q2="6.4852851173684156">
         <iidm:alias>_04492688-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047cb9a5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10483,7 +10612,7 @@
             <iidm:temporaryLimit name="_f0e21213-6535-44a7-89b6-3063f8738d6b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044a10e4-c766-11e1-8775-005056c00008" name="65-68" r="0.66791999999999996" x="7.7439999999999998" g1="0" b1="0.00065909092999999995" g2="0" b2="0.00065909092999999995" node1="41" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0449e9d2-c766-11e1-8775-005056c00008" p1="-163.64096148536882" q1="23.939568534661593" p2="164.04992634459097" q2="-83.232755338440583">
+    <iidm:line id="_044a10e4-c766-11e1-8775-005056c00008" name="65-68" r="0.66791999999999996" x="7.7439999999999998" g1="0" b1="0.00065909092999999995" g2="0" b2="0.00065909092999999995" node1="41" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0449e9d2-c766-11e1-8775-005056c00008" p1="-162.13456638551236" q1="23.747005905609331" p2="162.53653125340767" q2="-83.121557067917379">
         <iidm:alias>_0461dea7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047629f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10491,7 +10620,7 @@
             <iidm:temporaryLimit name="_ab31cd46-6d0c-4d9c-95f1-396a45a237e1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046b7b92-c766-11e1-8775-005056c00008" name="49-54" r="12.719519999999999" x="50.355361899999998" g1="0" b1="0.00021177684999999999" g2="0" b2="0.00021177684999999999" node1="120" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="46.758267564660223" q1="11.852377691380827" p2="-45.067243720561358" q2="-12.399956170706732">
+    <iidm:line id="_046b7b92-c766-11e1-8775-005056c00008" name="49-54" r="12.719519999999999" x="50.355361899999998" g1="0" b1="0.00021177684999999999" g2="0" b2="0.00021177684999999999" node1="120" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="46.776312972028109" q1="11.850195437120556" p2="-45.08416380567509" q2="-12.393317566403979">
         <iidm:alias>_0462f017-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047120e1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10499,7 +10628,7 @@
             <iidm:temporaryLimit name="_1bf78539-b6fa-4d8b-ba8e-9b5970019be6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04607f15-c766-11e1-8775-005056c00008" name="70-71" r="1.536797" x="6.1855200000000004" g1="0" b1="2.5195149999999999e-05" g2="0" b2="2.5195149999999999e-05" node1="52" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04664b78-c766-11e1-8775-005056c00008" p1="-5.6855860436676613" q1="-4.4521779926832643" p2="5.690008174364845" q2="3.618188835516261">
+    <iidm:line id="_04607f15-c766-11e1-8775-005056c00008" name="70-71" r="1.536797" x="6.1855200000000004" g1="0" b1="2.5195149999999999e-05" g2="0" b2="2.5195149999999999e-05" node1="52" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04664b78-c766-11e1-8775-005056c00008" p1="-5.0470388264267232" q1="-4.870010905929484" p2="5.0511580322945466" q2="4.0345141868487184">
         <iidm:alias>_04486336-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f51b4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10507,7 +10636,7 @@
             <iidm:temporaryLimit name="_08ff3ae4-d1dd-49f7-9eda-32ffc8eb0010" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c5ad7-c766-11e1-8775-005056c00008" name="55-56" r="0.85029100000000002" x="2.631024" g1="0" b1="1.0732300000000001e-05" g2="0" b2="1.0732300000000001e-05" node1="31" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="-28.675217632281079" q1="-7.0082261643596935" p2="28.722081565461941" q2="6.8138737933864686">
+    <iidm:line id="_044c5ad7-c766-11e1-8775-005056c00008" name="55-56" r="0.85029100000000002" x="2.631024" g1="0" b1="1.0732300000000001e-05" g2="0" b2="1.0732300000000001e-05" node1="31" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="-28.6864845460439" q1="-7.0045873433254577" p2="28.733380683075673" q2="6.8103348702091022">
         <iidm:alias>_04558294-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045868c2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10515,7 +10644,7 @@
             <iidm:temporaryLimit name="_94316214-afd8-4c0d-bca4-916acb92af85" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048a2725-c766-11e1-8775-005056c00008" name="35-37" r="1.9166399999999999" x="8.6597279999999994" g1="0" b1="3.7821399999999997e-05" g2="0" b2="3.7821399999999997e-05" node1="21" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-29.638134877560013" q1="-14.398597357975746" p2="29.771664621701088" q2="13.82729702952342">
+    <iidm:line id="_048a2725-c766-11e1-8775-005056c00008" name="35-37" r="1.9166399999999999" x="8.6597279999999994" g1="0" b1="3.7821399999999997e-05" g2="0" b2="3.7821399999999997e-05" node1="21" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-29.558192214087935" q1="-14.434159796702916" p2="29.691398975508999" q2="13.862634120847162">
         <iidm:alias>_0471bd29-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04808a30-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10523,7 +10652,7 @@
             <iidm:temporaryLimit name="_4ea6b532-d914-4b0c-97ee-9f02a14a40b3" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04614263-c766-11e1-8775-005056c00008" name="4-5" r="0.30666199999999999" x="1.3904350000000001" g1="0" b1="6.0261499999999999e-06" g2="0" b2="6.0261499999999999e-06" node1="22" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-113.00889095238789" q1="-18.127334235193011" p2="113.23681488534312" q2="18.947675323388395">
+    <iidm:line id="_04614263-c766-11e1-8775-005056c00008" name="4-5" r="0.30666199999999999" x="1.3904350000000001" g1="0" b1="6.0261499999999999e-06" g2="0" b2="6.0261499999999999e-06" node1="22" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-108.5493947894178" q1="-19.947860656901117" p2="108.7609434100879" q2="20.693561017967458">
         <iidm:alias>_04529c66-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04753f92-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10531,7 +10660,7 @@
             <iidm:temporaryLimit name="_2a95fb2b-6661-46e7-a9f6-fe63c1b7433c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0451b208-c766-11e1-8775-005056c00008" name="20-21" r="3.1885919999999999" x="14.7929754" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_046b2d70-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0460f448-c766-11e1-8775-005056c00008" p1="-32.839244946290883" q1="1.5600854414896066" p2="33.063887605446915" q2="-2.4359611541232873">
+    <iidm:line id="_0451b208-c766-11e1-8775-005056c00008" name="20-21" r="3.1885919999999999" x="14.7929754" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_046b2d70-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0460f448-c766-11e1-8775-005056c00008" p1="-30.858868993348736" q1="0.58053926602714823" p2="31.056429015890956" q2="-1.5842809828432951">
         <iidm:alias>_046c65f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048c22f6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10539,7 +10668,7 @@
             <iidm:temporaryLimit name="_4b67f5f5-f0e1-4bfb-9d57-4d3474720a45" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047d55e4-c766-11e1-8775-005056c00008" name="104-105" r="1.731946" x="6.5862720000000001" g1="0" b1="2.8294300000000001e-05" g2="0" b2="2.8294300000000001e-05" node1="32" voltageLevelId1="_0483977a-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="48.029324763978536" q1="0.86591976177679975" p2="-47.785730628144691" q2="-0.86340093082424296">
+    <iidm:line id="_047d55e4-c766-11e1-8775-005056c00008" name="104-105" r="1.731946" x="6.5862720000000001" g1="0" b1="2.8294300000000001e-05" g2="0" b2="2.8294300000000001e-05" node1="32" voltageLevelId1="_0483977a-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="48.031007798211498" q1="0.86546920910184721" p2="-47.787396532073004" q2="-0.86288449700458369">
         <iidm:alias>_0451d910-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046c65f2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10547,7 +10676,7 @@
             <iidm:temporaryLimit name="_1ca40dc7-6736-4fa8-b4cb-ca696949e421" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046dc589-c766-11e1-8775-005056c00008" name="44-45" r="3.9029759999999998" x="15.699023199999999" g1="0" b1="6.4279149999999996e-05" g2="0" b2="6.4279149999999996e-05" node1="23" voltageLevelId1="_04544a15-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_045d23b4-c766-11e1-8775-005056c00008" p1="-21.567892423528335" q1="-4.3039883742849216" p2="21.680037613139831" q2="2.6089825900313448">
+    <iidm:line id="_046dc589-c766-11e1-8775-005056c00008" name="44-45" r="3.9029759999999998" x="15.699023199999999" g1="0" b1="6.4279149999999996e-05" g2="0" b2="6.4279149999999996e-05" node1="23" voltageLevelId1="_04544a15-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_045d23b4-c766-11e1-8775-005056c00008" p1="-21.311784297348062" q1="-4.4616824791887746" p2="21.421614894975981" q2="2.7577156868252262">
         <iidm:alias>_04518afa-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04667287-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10555,7 +10684,7 @@
             <iidm:temporaryLimit name="_ba738481-ddba-4ebe-a218-8aad0b537f5b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04642896-c766-11e1-8775-005056c00008" name="4-11" r="3.641616" x="11.9877129" g1="0" b1="5.0160700000000002e-05" g2="0" b2="5.0160700000000002e-05" node1="23" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="74.0094741320314" q1="6.1276294360795287" p2="-72.867258418886109" q2="-4.1022510676013164">
+    <iidm:line id="_04642896-c766-11e1-8775-005056c00008" name="4-11" r="3.641616" x="11.9877129" g1="0" b1="5.0160700000000002e-05" g2="0" b2="5.0160700000000002e-05" node1="23" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="69.549931798999097" q1="7.9481357566423343" p2="-68.535881019580017" q2="-6.3469840548208287">
         <iidm:alias>_0455f7c5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04803c17-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10563,7 +10692,7 @@
             <iidm:temporaryLimit name="_b1d87c24-e527-4174-aa04-cd0b9de271ea" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047d07c0-c766-11e1-8775-005056c00008" name="92-93" r="4.4953919999999998" x="14.775551800000001" g1="0" b1="6.2557400000000005e-05" g2="0" b2="6.2557400000000005e-05" node1="72" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04789af0-c766-11e1-8775-005056c00008" p1="70.560842138043483" q1="-12.787157181377177" p2="-69.212549630263226" q2="15.098080000773519">
+    <iidm:line id="_047d07c0-c766-11e1-8775-005056c00008" name="92-93" r="4.4953919999999998" x="14.775551800000001" g1="0" b1="6.2557400000000005e-05" g2="0" b2="6.2557400000000005e-05" node1="72" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04789af0-c766-11e1-8775-005056c00008" p1="70.618135449683919" q1="-12.723915454670726" p2="-69.267960330130478" q2="15.041389924471172">
         <iidm:alias>_044a5f07-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047602e5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10571,7 +10700,7 @@
             <iidm:temporaryLimit name="_4e1daf8e-7708-4b96-8d3f-67f58f2505f9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044f4109-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="43" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="121" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-53.764396359400024" q1="-18.767940594353604" p2="56.437593857578797" q2="22.736854434801991">
+    <iidm:line id="_044f4109-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="43" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="121" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-53.573597451264007" q1="-18.910093626721363" p2="56.234520857061398" q2="22.825584738655479">
         <iidm:alias>_046958b0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04758db0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10579,7 +10708,7 @@
             <iidm:temporaryLimit name="_c58940cb-bd36-4dfc-9615-11716dd652a7" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046e61c8-c766-11e1-8775-005056c00008" name="69-75" r="7.0567200000000003" x="21.257280000000002" g1="0" b1="0.00035583104999999999" g2="0" b2="0.00035583104999999999" node1="61" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="89.744045339482" q1="24.542976488073347" p2="-86.331393040879007" q2="-26.709960442251241">
+    <iidm:line id="_046e61c8-c766-11e1-8775-005056c00008" name="69-75" r="7.0567200000000003" x="21.257280000000002" g1="0" b1="0.00035583104999999999" g2="0" b2="0.00035583104999999999" node1="61" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="90.1065652471558" q1="24.472843407056686" p2="-86.670913657934193" q2="-26.570363245301198">
         <iidm:alias>_046d294a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048ac362-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10587,7 +10716,7 @@
             <iidm:temporaryLimit name="_3c9a454c-10ee-4c72-a059-77f723f5b7c7" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0463da71-c766-11e1-8775-005056c00008" name="79-80" r="2.7181440000000001" x="12.2664957" g1="0" b1="5.3661600000000001e-05" g2="0" b2="5.3661600000000001e-05" node1="23" voltageLevelId1="_04481510-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-66.439747440747155" q1="-32.255825127375203" p2="67.269637022224643" q2="34.04155840788988">
+    <iidm:line id="_0463da71-c766-11e1-8775-005056c00008" name="79-80" r="2.7181440000000001" x="12.2664957" g1="0" b1="5.3661600000000001e-05" g2="0" b2="5.3661600000000001e-05" node1="23" voltageLevelId1="_04481510-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-66.525654476557733" q1="-32.366509061502121" p2="67.358529975074944" q2="34.165898444556674">
         <iidm:alias>_0464ebe9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04662468-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10595,7 +10724,7 @@
             <iidm:temporaryLimit name="_270a7d04-9ff9-4178-8b72-b610735a72ac" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044fdd41-c766-11e1-8775-005056c00008" name="51-52" r="3.5370720000000002" x="10.2453117" g1="0" b1="4.0059699999999999e-05" g2="0" b2="4.0059699999999999e-05" node1="32" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04806326-c766-11e1-8775-005056c00008" p1="31.606890071744896" q1="5.3219806371915706" p2="-31.381670112577581" q2="-5.9579577508203529">
+    <iidm:line id="_044fdd41-c766-11e1-8775-005056c00008" name="51-52" r="3.5370720000000002" x="10.2453117" g1="0" b1="4.0059699999999999e-05" g2="0" b2="4.0059699999999999e-05" node1="32" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04806326-c766-11e1-8775-005056c00008" p1="31.613094570042797" q1="5.3201101357621683" p2="-31.387792890736726" q2="-5.9558434367908211">
         <iidm:alias>_045115c2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0464ebe5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10603,7 +10732,7 @@
             <iidm:temporaryLimit name="_9d1eb182-ceb5-426e-9440-5f4d426a31cb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c3958-c766-11e1-8775-005056c00008" name="53-54" r="4.5825120000000004" x="21.257280000000002" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="22" voltageLevelId1="_04876804-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="-9.70122534360355" q1="-6.7106309472099879" p2="9.7372664669849307" q2="4.0789206244051703">
+    <iidm:line id="_045c3958-c766-11e1-8775-005056c00008" name="53-54" r="4.5825120000000004" x="21.257280000000002" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="22" voltageLevelId1="_04876804-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="-9.6951628296978836" q1="-6.713031514469181" p2="9.7311769969857345" q2="4.0812006527842257">
         <iidm:alias>_044f6817-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0455f7c6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10611,7 +10740,7 @@
             <iidm:temporaryLimit name="_735ac8df-6a6a-43f0-86f2-49d3280c9a3b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044ef2e1-c766-11e1-8775-005056c00008" name="54-55" r="2.9446560000000002" x="12.3187675" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="63" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04767817-c766-11e1-8775-005056c00008" p1="10.15264038151204" q1="1.7063939841937499" p2="-10.132260868064279" q2="-3.456273959848132">
+    <iidm:line id="_044ef2e1-c766-11e1-8775-005056c00008" name="54-55" r="2.9446560000000002" x="12.3187675" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="63" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04767817-c766-11e1-8775-005056c00008" p1="10.15660533269928" q1="1.7058214597974175" p2="-10.136211451098928" q2="-3.4556404460656402">
         <iidm:alias>_04640181-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047dcb17-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10619,7 +10748,7 @@
             <iidm:temporaryLimit name="_52aadf8d-53f2-4827-8c70-421bdf1ba822" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0456e226-c766-11e1-8775-005056c00008" name="80-97" r="3.1885919999999999" x="16.2740154" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="82" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="12.182925736957975" q1="30.797761295689085" p2="-11.982698234015666" q2="-32.44237482802216">
+    <iidm:line id="_0456e226-c766-11e1-8775-005056c00008" name="80-97" r="3.1885919999999999" x="16.2740154" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="82" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="12.226442673097461" q1="30.998285175386865" p2="-12.023845583439543" q2="-32.630322514776985">
         <iidm:alias>_04479fe9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047df222-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10627,7 +10756,7 @@
             <iidm:temporaryLimit name="_fece5807-6af8-4161-8de8-8f8473d92f11" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0487b624-c766-11e1-8775-005056c00008" name="103-110" r="6.8058139999999998" x="31.5897121" g1="0" b1="0.00013228879999999999" g2="0" b2="0.00013228879999999999" node1="43" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="57.716058795244884" q1="18.4977906835494" p2="-56.274111118002665" q2="-16.258631525539347">
+    <iidm:line id="_0487b624-c766-11e1-8775-005056c00008" name="103-110" r="6.8058139999999998" x="31.5897121" g1="0" b1="0.00013228879999999999" g2="0" b2="0.00013228879999999999" node1="43" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="57.719639307825275" q1="18.497457717424208" p2="-56.277537877053533" q2="-16.257581660742957">
         <iidm:alias>_046a9139-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b3895-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10635,7 +10764,7 @@
             <iidm:temporaryLimit name="_3eacc034-737e-41de-a7b6-b610d3bd0921" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045338a8-c766-11e1-8775-005056c00008" name="56-58" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="61" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="-13.0520963516403" q1="-0.68688888910047319" p2="13.116384509844004" q2="-1.3439487539281698">
+    <iidm:line id="_045338a8-c766-11e1-8775-005056c00008" name="56-58" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="61" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="-13.064392391642679" q1="-0.68083697587682723" p2="13.128803563019197" q2="-1.3496491375483488">
         <iidm:alias>_0451d915-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04817494-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10643,7 +10772,7 @@
             <iidm:temporaryLimit name="_0d0c3ec5-798a-48a4-9bc8-d19c57128a13" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04854529-c766-11e1-8775-005056c00008" name="15-33" r="6.6211200000000003" x="21.675455100000001" g1="0" b1="9.1655200000000003e-05" g2="0" b2="9.1655200000000003e-05" node1="52" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456bb11-c766-11e1-8775-005056c00008" p1="63.465855570461983" q1="-8.1949656244779483" p2="-61.747150100487616" q2="10.982744194916656">
+    <iidm:line id="_04854529-c766-11e1-8775-005056c00008" name="15-33" r="6.6211200000000003" x="21.675455100000001" g1="0" b1="9.1655200000000003e-05" g2="0" b2="9.1655200000000003e-05" node1="52" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456bb11-c766-11e1-8775-005056c00008" p1="64.51150322600347" q1="-8.2899928043017308" p2="-62.734060737549392" q2="11.273314418991777">
         <iidm:alias>_0448d862-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047d2ed5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10651,7 +10780,7 @@
             <iidm:temporaryLimit name="_5b0395f4-534d-4975-a1af-e0b6ef439193" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04649dc2-c766-11e1-8775-005056c00008" name="35-36" r="0.39029799999999998" x="1.7772479999999999" g1="0" b1="7.6905500000000004e-06" g2="0" b2="7.6905500000000004e-06" node1="22" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="-3.3526456827650417" q1="5.4029691908474211" p2="3.3537065813200204" q2="-5.6340951388262557">
+    <iidm:line id="_04649dc2-c766-11e1-8775-005056c00008" name="35-36" r="0.39029799999999998" x="1.7772479999999999" g1="0" b1="7.6905500000000004e-06" g2="0" b2="7.6905500000000004e-06" node1="22" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="-3.4325316597157096" q1="5.4386164195306748" p2="3.4336175115077605" q2="-5.6693749813263601">
         <iidm:alias>_044c0cb5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0456e225-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10659,7 +10788,7 @@
             <iidm:temporaryLimit name="_74c4b341-7b99-4a81-b88a-2ed3b0c4b1de" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0470d2c9-c766-11e1-8775-005056c00008" name="37-40" r="10.3324327" x="29.272320000000001" g1="0" b1="0.0001205234" g2="0" b2="0.0001205234" node1="61" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="56.106265547844814" q1="10.325497997713642" p2="-53.937369212709918" q2="-7.7655972256317458">
+    <iidm:line id="_0470d2c9-c766-11e1-8775-005056c00008" name="37-40" r="10.3324327" x="29.272320000000001" g1="0" b1="0.0001205234" g2="0" b2="0.0001205234" node1="61" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="56.309653479892205" q1="10.234713032549514" p2="-54.124954702258577" q2="-7.6264733540590903">
         <iidm:alias>_045b9d10-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046a4317-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10667,7 +10796,7 @@
             <iidm:temporaryLimit name="_e98d56fe-a54b-45e4-acff-0ac310beb3dd" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044e56a2-c766-11e1-8775-005056c00008" name="48-49" r="3.1188959999999999" x="8.7991200000000003" g1="0" b1="3.6099649999999999e-05" g2="0" b2="3.6099649999999999e-05" node1="23" voltageLevelId1="_044778d3-c766-11e1-8775-005056c00008" node2="122" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-28.876453440258075" q1="1.3282034704302961" p2="29.020363964113599" q2="-2.2384986275255647">
+    <iidm:line id="_044e56a2-c766-11e1-8775-005056c00008" name="48-49" r="3.1188959999999999" x="8.7991200000000003" g1="0" b1="3.6099649999999999e-05" g2="0" b2="3.6099649999999999e-05" node1="23" voltageLevelId1="_044778d3-c766-11e1-8775-005056c00008" node2="122" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-28.845815352149462" q1="1.3184915158090651" p2="28.98941528359676" q2="-2.2296637662654772">
         <iidm:alias>_0454bf49-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0460a623-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10675,7 +10804,7 @@
             <iidm:temporaryLimit name="_f2e58700-2366-46e0-8408-9472d85acd23" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047eb573-c766-11e1-8775-005056c00008" name="56-59" r="14.3748007" x="43.734237700000001" g1="0" b1="0.0001632805" g2="0" b2="0.0001632805" node1="62" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-19.191925931111577" q1="-7.7082365442985417" p2="19.549681882498572" q2="3.4479242911167356">
+    <iidm:line id="_047eb573-c766-11e1-8775-005056c00008" name="56-59" r="14.3748007" x="43.734237700000001" g1="0" b1="0.0001632805" g2="0" b2="0.0001632805" node1="62" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-19.178872707388546" q1="-7.7132937590090265" p2="19.536221751230741" q2="3.4517461018672">
         <iidm:alias>_0468bc78-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048915b0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10683,7 +10812,7 @@
             <iidm:temporaryLimit name="_89654167-95a6-4c76-aad7-63a881116e17" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046f9a4b-c766-11e1-8775-005056c00008" name="94-100" r="3.1014719999999998" x="10.105919999999999" g1="0" b1="0.00017332415000000001" g2="0" b2="0.00017332415000000001" node1="52" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-6.1109078736458518" q1="-51.957830805615366" p2="6.5566401284610887" q2="47.344167270844061">
+    <iidm:line id="_046f9a4b-c766-11e1-8775-005056c00008" name="94-100" r="3.1014719999999998" x="10.105919999999999" g1="0" b1="0.00017332415000000001" g2="0" b2="0.00017332415000000001" node1="52" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-6.1268498386341372" q1="-52.232605602098523" p2="6.5777266774478784" q2="47.636724272586974">
         <iidm:alias>_04812676-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048a2722-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10691,7 +10820,7 @@
             <iidm:temporaryLimit name="_216c0f3b-03e8-4b7d-96fc-a5f891331f7f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046735d0-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="123" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-92.486694760975197" q1="-2.4723953394523481" p2="93.952420318999827" q2="7.2973814268894248">
+    <iidm:line id="_046735d0-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="123" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-92.393956693688949" q1="-2.4979024760235808" p2="93.856755334442283" q2="7.3079463701532639">
         <iidm:alias>_04570934-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b3894-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10699,7 +10828,7 @@
             <iidm:temporaryLimit name="_32655e4f-e7da-46b0-a908-b601224ddb73" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046d294b-c766-11e1-8775-005056c00008" name="21-22" r="3.641616" x="16.901281399999998" g1="0" b1="7.0592299999999998e-05" g2="0" b2="7.0592299999999998e-05" node1="22" voltageLevelId1="_0460f448-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04773b6a-c766-11e1-8775-005056c00008" p1="-47.06264543206116" q1="-5.5628560572512793" p2="47.586082104748627" q2="5.7591792930526884">
+    <iidm:line id="_046d294b-c766-11e1-8775-005056c00008" name="21-22" r="3.641616" x="16.901281399999998" g1="0" b1="7.0592299999999998e-05" g2="0" b2="7.0592299999999998e-05" node1="22" voltageLevelId1="_0460f448-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04773b6a-c766-11e1-8775-005056c00008" p1="-45.055238742971881" q1="-6.4145766872792525" p2="45.536534292289069" q2="6.4110205090249712">
         <iidm:alias>_044a37f0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_044be5a2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10707,7 +10836,7 @@
             <iidm:temporaryLimit name="_bafaeace-e459-4dc2-87a0-467a9ea25f8d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_6a131803-f462-47e2-bc21-bda919364fe9" name="reactor1" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="36" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="37" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="-4.163336342344337e-15" q1="-83.151416571290355" p2="4.163336342344337e-15" q2="92.151059484793663">
+    <iidm:line id="_6a131803-f462-47e2-bc21-bda919364fe9" name="reactor1" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="36" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="37" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="5.5511151231257827e-14" q1="-83.151395509477183" p2="-5.5511151231257827e-14" q2="92.151036143418636">
         <iidm:alias>_04531196-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_ca0adad2-ffe3-4efa-b56b-7d333b8ae18f</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10715,7 +10844,7 @@
             <iidm:temporaryLimit name="_ae4eadea-f3fc-4ac6-8899-c1698ece7a89" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_9803b364-2a93-4f21-94b7-8bdbe27a16f2" name="reactor2" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="38" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="-2.0380162835120785e-09" q1="27.474152264622987" p2="2.0380162835120785e-09" q2="-26.588965493470678">
+    <iidm:line id="_9803b364-2a93-4f21-94b7-8bdbe27a16f2" name="reactor2" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="38" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="7.2349789353998162e-09" q1="27.473608925270675" p2="-7.234978588455121e-09" q2="-26.588456930479094">
         <iidm:alias>_0461b792-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_afe0e60b-3870-44fb-ba93-a056228f9636</iidm:alias>
     </iidm:line>

--- a/tests/main_sa/reference/launch/branch_contingency/outputIIDM.xml
+++ b/tests/main_sa/reference/launch/branch_contingency/outputIIDM.xml
@@ -31,8 +31,8 @@
                     <iidm:alias>_bea273f1-1e21-476d-b0d0-92dd6cb9a2d4</iidm:alias>
                     <iidm:alias>_c94e6b68-da6c-43d1-94fd-09ad60c74134</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_047abdd7-c766-11e1-8775-005056c00008-BREAKER" name="BREAKER-Jay LD" kind="BREAKER" retained="true" open="false" node1="0" node2="8"/>
                 <iidm:internalConnection node1="7" node2="0"/>
-                <iidm:internalConnection node1="8" node2="0"/>
                 <iidm:internalConnection node1="9" node2="1"/>
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="4"/>
@@ -47,9 +47,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="124.57600856510108" angle="7.4304451985468569" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.70914608999902" angle="-3.5675439636302397" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047abdd7-c766-11e1-8775-005056c00008" name="Jay LD" loadType="UNDEFINED" p0="14" q0="8" node="8" p="13.993798525258441" q="7.9940947056924392">
+            <iidm:load id="_047abdd7-c766-11e1-8775-005056c00008" name="Jay LD" loadType="UNDEFINED" p0="14" q0="8" node="8" p="13.995266389630132" q="7.995492307763592">
                 <iidm:alias>_04590500-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -139,12 +139,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="127.49597014122573" angle="11.095707282791558" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="127.75235590874658" angle="-0.1232104078812096" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045b00d5-c766-11e1-8775-005056c00008" name="Madison LD" loadType="UNDEFINED" p0="62" q0="13" node="14" p="61.957252264812709" q="12.985064708916161">
+            <iidm:load id="_045b00d5-c766-11e1-8775-005056c00008" name="Madison LD" loadType="UNDEFINED" p0="62" q0="13" node="14" p="61.969623710328882" q="12.989386363680049">
                 <iidm:alias>_045b27e3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_04689566-c766-11e1-8775-005056c00008" name="Madison NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="15" p="8.9937946836018448" q="0">
+            <iidm:load id="_04689566-c766-11e1-8775-005056c00008" name="Madison NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="15" p="8.9955905385961277" q="0">
                 <iidm:alias>_04765100-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -272,16 +272,16 @@
                 <iidm:internalConnection node1="61" node2="12"/>
                 <iidm:internalConnection node1="62" node2="15"/>
                 <iidm:internalConnection node1="63" node2="18"/>
-                <iidm:bus v="126.06000135163058" angle="-7.4893933373947288" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63"/>
+                <iidm:bus v="126.06000481388762" angle="-18.509689787413215" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_046c3ee7-c766-11e1-8775-005056c00008" name="Torrey SM" energySource="THERMAL" minP="20" maxP="80" ratedS="100" voltageRegulatorOn="true" targetP="48" targetV="126.06" targetQ="0" node="21" p="-53.150167420159946" q="-7.265047684684613">
+            <iidm:generator id="_046c3ee7-c766-11e1-8775-005056c00008" name="Torrey SM" energySource="THERMAL" minP="20" maxP="80" ratedS="100" voltageRegulatorOn="true" targetP="48" targetV="126.06" targetQ="0" node="21" p="-53.141574262000368" q="-7.2761333028638369">
                 <iidm:alias>_047147f3-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_b97aee41-3115-4cfd-9071-b52fb44d0b66"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_5005c073-28d1-4a7d-b257-649dec43ec73"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-30" maxQ="85"/>
             </iidm:generator>
-            <iidm:load id="_044afb44-c766-11e1-8775-005056c00008" name="Torrey LD" loadType="UNDEFINED" p0="113" q0="32" node="20" p="113.00000181739949" q="32.000000857769685">
+            <iidm:load id="_044afb44-c766-11e1-8775-005056c00008" name="Torrey LD" loadType="UNDEFINED" p0="113" q0="32" node="20" p="113.00000647274277" q="32.000003054981903">
                 <iidm:alias>_04522737-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -332,9 +332,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="123.83963003533923" angle="8.3388106744659627" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="123.83062324401473" angle="-2.7414838967402688" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04481515-c766-11e1-8775-005056c00008" name="Darrah LD" loadType="UNDEFINED" p0="68" q0="36" node="8" p="68.000244243684691" q="36.00021550939158">
+            <iidm:load id="_04481515-c766-11e1-8775-005056c00008" name="Darrah LD" loadType="UNDEFINED" p0="68" q0="36" node="8" p="68.000558799436433" q="36.000493059676856">
                 <iidm:alias>_044e7db8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -385,9 +385,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.46450027382099" angle="22.729420310095936" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.45866113421161" angle="11.674189164424398" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044c0cb3-c766-11e1-8775-005056c00008" name="Smythe LD" loadType="UNDEFINED" p0="5" q0="3" node="8" p="4.9999728063874951" q="2.9999728064367939">
+            <iidm:load id="_044c0cb3-c766-11e1-8775-005056c00008" name="Smythe LD" loadType="UNDEFINED" p0="5" q0="3" node="8" p="4.9999729989465687" q="2.999972998995172">
                 <iidm:alias>_045163e8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -514,9 +514,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="125.90823055546622" angle="-7.6616941203619646" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="125.90820051282051" angle="-18.682061954607828" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0450a093-c766-11e1-8775-005056c00008" name="Sunnysde LD" loadType="UNDEFINED" p0="84" q0="18" node="20" p="84.000006004154827" q="18.00000214434106">
+            <iidm:load id="_0450a093-c766-11e1-8775-005056c00008" name="Sunnysde LD" loadType="UNDEFINED" p0="84" q0="18" node="20" p="84.000008850757297" q="18.000003160984861">
                 <iidm:alias>_045f4695-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -568,12 +568,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="126.73071638558821" angle="8.2171700731285231" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="126.73637158113587" angle="-2.8826773381458834" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044b2251-c766-11e1-8775-005056c00008" name="Bellefnt LD" loadType="UNDEFINED" p0="68" q0="27" node="8" p="67.999595210909618" q="26.999732125398186">
+            <iidm:load id="_044b2251-c766-11e1-8775-005056c00008" name="Bellefnt LD" loadType="UNDEFINED" p0="68" q0="27" node="8" p="68.000323383699453" q="27.000214004257984">
                 <iidm:alias>_04622cc1-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0449e9d5-c766-11e1-8775-005056c00008" name="Bellefnt SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.40300000000001" targetDeadband="1" node="9" q="-11.065804713691426">
+            <iidm:shunt id="_0449e9d5-c766-11e1-8775-005056c00008" name="Bellefnt SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.40300000000001" targetDeadband="1" node="9" q="-11.066792330389148">
                 <iidm:alias>_047bcf48-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_6cc38790-c6a6-4309-99f4-a3258e24e785"/>
                 <iidm:shuntLinearModel bPerSection="0.00013779999999999999" gPerSection="0" maximumSectionCount="10"/>
@@ -665,12 +665,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="126.06592828572953" angle="8.389810385827408" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="126.06591415470838" angle="-2.672005001269619" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04682035-c766-11e1-8775-005056c00008" name="Fieldale LD" loadType="UNDEFINED" p0="39" q0="30" node="14" p="39.000005990161959" q="30.000007679695205">
+            <iidm:load id="_04682035-c766-11e1-8775-005056c00008" name="Fieldale LD" loadType="UNDEFINED" p0="39" q0="30" node="14" p="39.000007909650684" q="30.000010140578485">
                 <iidm:alias>_0478c20a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_045c6067-c766-11e1-8775-005056c00008" name="Fieldale SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.066" targetDeadband="1" node="15" q="-5.4670606864426894">
+            <iidm:shunt id="_045c6067-c766-11e1-8775-005056c00008" name="Fieldale SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.066" targetDeadband="1" node="15" q="-5.467059460811833">
                 <iidm:alias>_0451b209-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_2d222dd9-7306-4afd-baa5-fd303b0eeb40"/>
                 <iidm:shuntLinearModel bPerSection="6.8800000000000005e-05" gPerSection="0" maximumSectionCount="10"/>
@@ -780,7 +780,7 @@
                 <iidm:internalConnection node1="51" node2="9"/>
                 <iidm:internalConnection node1="52" node2="12"/>
                 <iidm:internalConnection node1="53" node2="15"/>
-                <iidm:bus v="138.01493830412369" angle="4.3075426818691387" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
+                <iidm:bus v="138.01489050681408" angle="-6.7147626951016344" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="_047f0391-c766-11e1-8775-005056c00008" name="Muskngum SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="392" targetV="138.59999099999999" targetQ="0" node="18" p="-0" q="-0">
                 <iidm:alias>_047eb572-c766-11e1-8775-005056c00008</iidm:alias>
@@ -789,7 +789,7 @@
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
-            <iidm:load id="_047e1936-c766-11e1-8775-005056c00008" name="Muskngum LD" loadType="UNDEFINED" p0="39" q0="18" node="17" p="38.999756308012302" q="17.999812545015281">
+            <iidm:load id="_047e1936-c766-11e1-8775-005056c00008" name="Muskngum LD" loadType="UNDEFINED" p0="39" q0="18" node="17" p="38.999757139875605" q="17.99981318490747">
                 <iidm:alias>_046e88d5-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -876,9 +876,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="221.10000254423986" angle="9.4732734557703662" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="221.10000883871095" angle="-1.5525109454899984" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0458ddf1-c766-11e1-8775-005056c00008" name="Muskngum SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="391" targetV="221.09999999999999" targetQ="0" node="14" p="-432.95240544338623" q="-159.96732070663109">
+            <iidm:generator id="_0458ddf1-c766-11e1-8775-005056c00008" name="Muskngum SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="391" targetV="221.09999999999999" targetQ="0" node="14" p="-432.88240700921136" q="-159.82014129430189">
                 <iidm:alias>_04522732-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_5036c3a5-56f9-489c-9ecb-8c15aa7c70c5"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_12b01822-ca11-4cf8-a6b4-2f8ff805ca20"/>
@@ -886,7 +886,7 @@
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045cae83-c766-11e1-8775-005056c00008" name="65-66" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="42" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="273.47995590504064" q1="97.450447980841687" p2="-273.47995590504064" q2="-70.457027313696827">
+        <iidm:twoWindingsTransformer id="_045cae83-c766-11e1-8775-005056c00008" name="65-66" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="42" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="273.29618415851996" q1="97.434987058538738" p2="-273.29618415851991" q2="-70.474712517344543">
             <iidm:alias>_044b2254-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_044b4964-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_045645e1-c766-11e1-8775-005056c00008</iidm:alias>
@@ -961,9 +961,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="123.99683216158495" angle="5.5007188177673809" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.06707014193688" angle="-5.3638882179032752" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0453d4e2-c766-11e1-8775-005056c00008" name="Adams LD" loadType="UNDEFINED" p0="18" q0="3" node="8" p="17.993360446727088" q="2.9981559064235466">
+            <iidm:load id="_0453d4e2-c766-11e1-8775-005056c00008" name="Adams LD" loadType="UNDEFINED" p0="18" q0="3" node="8" p="17.9949359788619" q="2.9985934593809382">
                 <iidm:alias>_0448ff77-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1053,16 +1053,16 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="133.31999748744235" angle="14.131192266882017" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="133.32000192565815" angle="3.0697517046132798" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_046bf0c4-c766-11e1-8775-005056c00008" name="Claytor SM" energySource="THERMAL" minP="0" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="40" targetV="133.31999200000001" targetQ="0" node="15" p="-44.291806183466626" q="-83.07077631023661">
+            <iidm:generator id="_046bf0c4-c766-11e1-8775-005056c00008" name="Claytor SM" energySource="THERMAL" minP="0" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="40" targetV="133.31999200000001" targetQ="0" node="15" p="-44.284645218333637" q="-83.074459291546603">
                 <iidm:alias>_0460a627-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e56da2eb-bb6a-4133-953c-40073c5bc5f4"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_d41be6b4-155e-4c8f-b46b-16b50c49f0f4"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-60" maxQ="170"/>
             </iidm:generator>
-            <iidm:load id="_048433b6-c766-11e1-8775-005056c00008" name="Claytor LD" loadType="UNDEFINED" p0="23" q0="16" node="14" p="23.00000142001781" q="16.000001646397497">
+            <iidm:load id="_048433b6-c766-11e1-8775-005056c00008" name="Claytor LD" loadType="UNDEFINED" p0="23" q0="16" node="14" p="23.000002568521101" q="16.000002977995589">
                 <iidm:alias>_0480ff6b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1133,12 +1133,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="129.73718464034962" angle="-4.3434119671908222" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="129.73333741072872" angle="-15.342878188874449" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0449e9d7-c766-11e1-8775-005056c00008" name="N.Newark LD" loadType="UNDEFINED" p0="53" q0="22" node="11" p="52.997455168194975" q="21.998239452715968">
+            <iidm:load id="_0449e9d7-c766-11e1-8775-005056c00008" name="N.Newark LD" loadType="UNDEFINED" p0="53" q0="22" node="11" p="52.997651366236632" q="21.998375183032731">
                 <iidm:alias>_04531191-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_04684741-c766-11e1-8775-005056c00008" name="N.Newark SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.32300000000001" targetDeadband="1" node="12" q="-9.6614170830039949">
+            <iidm:shunt id="_04684741-c766-11e1-8775-005056c00008" name="N.Newark SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.32300000000001" targetDeadband="1" node="12" q="-9.6608440917067142">
                 <iidm:alias>_04607f19-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_eae61817-d3cb-488f-a1f3-13bc8e31431b"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -1191,9 +1191,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.88981903093941" angle="11.271623327911563" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.9953564209452" angle="0.035040799403042971" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0448d86a-c766-11e1-8775-005056c00008" name="Hillsbro NegG LD" loadType="UNDEFINED" p0="12" q0="0" node="8" p="11.997709991140461" q="0">
+            <iidm:load id="_0448d86a-c766-11e1-8775-005056c00008" name="Hillsbro NegG LD" loadType="UNDEFINED" p0="12" q0="0" node="8" p="11.998408635219917" q="0">
                 <iidm:alias>_044ef2e8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1244,9 +1244,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="125.32853991547648" angle="-6.0227450473020063" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="125.2852737536024" angle="-16.957777970218562" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047dcb12-c766-11e1-8775-005056c00008" name="S.Kenton LD" loadType="UNDEFINED" p0="18" q0="7" node="8" p="17.996889423165292" q="6.9979840015219468">
+            <iidm:load id="_047dcb12-c766-11e1-8775-005056c00008" name="S.Kenton LD" loadType="UNDEFINED" p0="18" q0="7" node="8" p="17.99711373827774" q="6.9981293748003646">
                 <iidm:alias>_0451b205-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1281,6 +1281,9 @@
                     <iidm:alias>_8ef85f09-3622-4a12-87bf-fefcecc01e4a</iidm:alias>
                     <iidm:alias>_a0244ab3-80e5-4c20-b201-a142d50e6ec1</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_dffdb415-95a8-496a-ad1a-93cdeb444fae-1" name="DISCONNECTOR723-1" kind="DISCONNECTOR" retained="false" open="false" node1="24" node2="25"/>
+                <iidm:switch id="_aa063f2e-1205-4d1a-a549-3ccc5b31e65d-1" name="BREAKER362-1" kind="BREAKER" retained="false" open="false" node1="23" node2="24"/>
+                <iidm:switch id="_28b3e895-483c-478d-a5a3-7b9d7c9e11f3-1" name="DISCONNECTOR724-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="23"/>
                 <iidm:internalConnection node1="7" node2="0"/>
                 <iidm:internalConnection node1="8" node2="0"/>
                 <iidm:internalConnection node1="9" node2="1"/>
@@ -1297,9 +1300,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="125.2092118824993" angle="21.236712790955366" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.1793127816079" angle="10.277719229224795" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044afb49-c766-11e1-8775-005056c00008" name="Hazard LD" loadType="UNDEFINED" p0="21" q0="10" node="8" p="20.998299625577875" q="9.9986505329138993">
+            <iidm:load id="_044afb49-c766-11e1-8775-005056c00008" name="Hazard LD" loadType="UNDEFINED" p0="21" q0="10" node="8" p="20.997925521896271" q="9.9983536430205575">
                 <iidm:alias>_045e5c31-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1320,6 +1323,9 @@
                     <iidm:alias>_2a61ce12-8d9c-4aae-8bc7-c8f820ecae6c</iidm:alias>
                     <iidm:alias>_a3d5e8cc-be34-4d4a-a586-ce582737826b</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_83a05cd7-017e-4e7a-bc5e-a01ee9681f9f-1" name="DISCONNECTOR725-1" kind="DISCONNECTOR" retained="false" open="false" node1="14" node2="15"/>
+                <iidm:switch id="_cf4393c0-21c2-4e35-b330-c1acda2647ba-1" name="BREAKER363-1" kind="BREAKER" retained="false" open="true" node1="13" node2="14"/>
+                <iidm:switch id="_b9ab29b9-3d90-4536-8d1a-7757d8c22ae4-1" name="DISCONNECTOR726-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="13"/>
                 <iidm:internalConnection node1="4" node2="0"/>
                 <iidm:internalConnection node1="5" node2="0"/>
                 <iidm:internalConnection node1="6" node2="1"/>
@@ -1329,14 +1335,14 @@
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="3"/>
-                <iidm:bus v="31.302302970624826" angle="21.236712790955366" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="31.044828195401973" angle="10.2777192292248" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13"/>
             </iidm:nodeBreakerTopology>
             <iidm:staticVarCompensator id="_047fc6e6-c766-11e1-8775-005056c00008" name="Pinevlle SVC" bMin="-10" bMax="10" voltageSetpoint="33.494999999999997" regulationMode="VOLTAGE" node="5" p="0" q="0">
                 <iidm:alias>_046ab846-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_98f667da-02d1-4a31-b826-44314a1fbbfe"/>
             </iidm:staticVarCompensator>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045e3525-c766-11e1-8775-005056c00008" name="86-87" r="0.30796918750000002" x="2.2585859312499998" g="0" b="-0.0040863184000000004" ratedU1="132" ratedU2="33" node1="22" voltageLevelId1="_0484f70a-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_04555b88-c766-11e1-8775-005056c00008" p1="0" q1="4.0039144029879719" p2="-2.7261023256703831e-14" q2="1.2002684062935592e-14">
+        <iidm:twoWindingsTransformer id="_045e3525-c766-11e1-8775-005056c00008" name="86-87" r="0.30796918750000002" x="2.2585859312499998" g="0" b="-0.0040863184000000004" ratedU1="132" ratedU2="33" node1="22" voltageLevelId1="_0484f70a-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_04555b88-c766-11e1-8775-005056c00008" p1="-2.9577035265404561e-14" q1="3.9383174954730844" p2="2.7048312894766807e-14" q2="-9.0628272064390434e-14">
             <iidm:alias>_0452755a-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04682034-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_048c7110-c766-11e1-8775-005056c00008</iidm:alias>
@@ -1412,6 +1418,82 @@
                 <iidm:temporaryLimit name="_257d56c1-d70a-4a96-b85c-d928ade03ad4" acceptableDuration="60" value="12246"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
+        <iidm:twoWindingsTransformer id="_045e3525-c766-11e1-8775-005056c00008-1" name="86-87-open-ended" r="0.30796918750000002" x="2.2585859312499998" g="0" b="-0.0040863184000000004" ratedU1="132" ratedU2="33" node1="25" voltageLevelId1="_0484f70a-c766-11e1-8775-005056c00008" node2="15" voltageLevelId2="_04555b88-c766-11e1-8775-005056c00008" p1="0" q1="3.9383174954730418" p2="0" q2="0">
+            <iidm:alias>_0452755a-c766-11e1-8775-005056c00008-1</iidm:alias>
+            <iidm:alias>_04682034-c766-11e1-8775-005056c00008-1</iidm:alias>
+            <iidm:alias>_048c7110-c766-11e1-8775-005056c00008-1</iidm:alias>
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="31" loadTapChangingCapabilities="false">
+                <iidm:step r="-78.460970487743992" x="-78.460970487743992" g="364.27347129590328" b="364.27347129590328" rho="0.4641016"/>
+                <iidm:step r="-76.770985444658564" x="-76.770985444658564" g="330.49609255595948" b="330.49609255595948" rho="0.48196488000000004"/>
+                <iidm:step r="-75.017181047101431" x="-75.017181047101431" g="300.27508580410921" b="300.27508580410921" rho="0.49982816000000002"/>
+                <iidm:step r="-73.199557295072623" x="-73.199557295072623" g="273.1281647135425" b="273.1281647135425" rho="0.51769144000000011"/>
+                <iidm:step r="-71.318114188572153" x="-71.318114188572153" g="248.65210975826625" b="248.65210975826625" rho="0.53555472000000004"/>
+                <iidm:step r="-69.372851727600008" x="-69.372851727600008" g="226.50770848984379" b="226.50770848984379" rho="0.55341799999999997"/>
+                <iidm:step r="-67.363769912156158" x="-67.363769912156158" g="206.40793906293555" b="206.40793906293555" rho="0.57128128"/>
+                <iidm:step r="-65.290868742240633" x="-65.290868742240633" g="188.10862264852744" b="188.10862264852744" rho="0.58914456000000004"/>
+                <iidm:step r="-63.154148217853432" x="-63.154148217853432" g="171.40097232995538" b="171.40097232995538" rho="0.60700784000000008"/>
+                <iidm:step r="-60.953608338994556" x="-60.953608338994556" g="156.10561116167679" b="156.10561116167679" rho="0.62487112"/>
+                <iidm:step r="-58.689249105663997" x="-58.689249105663997" g="142.06773741726079" b="142.06773741726079" rho="0.64273440000000004"/>
+                <iidm:step r="-56.361070517861769" x="-56.361070517861769" g="129.15319231405709" b="129.15319231405709" rho="0.66059767999999996"/>
+                <iidm:step r="-53.969072575587838" x="-53.969072575587838" g="117.24524269951107" b="117.24524269951107" rho="0.67846096"/>
+                <iidm:step r="-51.51325527884223" x="-51.51325527884223" g="106.24193390397649" b="106.24193390397649" rho="0.69632424000000004"/>
+                <iidm:step r="-48.993618627624947" x="-48.993618627624947" g="96.053900138385018" b="96.053900138385018" rho="0.71418752000000008"/>
+                <iidm:step r="-46.410162621936003" x="-46.410162621936003" g="86.602544237115268" b="86.602544237115268" rho="0.7320508"/>
+                <iidm:step r="-43.762887261775354" x="-43.762887261775354" g="77.81851722275475" b="77.81851722275475" rho="0.74991407999999993"/>
+                <iidm:step r="-41.051792547143037" x="-41.051792547143037" g="69.640442552852292" b="69.640442552852292" rho="0.76777735999999996"/>
+                <iidm:step r="-38.276878478039045" x="-38.276878478039045" g="62.013841060226049" b="62.013841060226049" rho="0.78564064"/>
+                <iidm:step r="-35.438145054463355" x="-35.438145054463355" g="54.890221299184191" b="54.890221299184191" rho="0.80350392000000004"/>
+                <iidm:step r="-32.53559227641599" x="-32.53559227641599" g="48.2263068397802" b="48.2263068397802" rho="0.82136720000000008"/>
+                <iidm:step r="-29.569220143896956" x="-29.569220143896956" g="41.983377444222199" b="41.983377444222199" rho="0.83923048"/>
+                <iidm:step r="-26.53902865690624" x="-26.53902865690624" g="36.126705339843348" b="36.126705339843348" rho="0.85709376000000004"/>
+                <iidm:step r="-23.445017815443848" x="-23.445017815443848" g="30.625071218648301" b="30.625071218648301" rho="0.87495704000000007"/>
+                <iidm:step r="-20.287187619509762" x="-20.287187619509762" g="25.450347332714429" b="25.450347332714429" rho="0.89282032000000011"/>
+                <iidm:step r="-17.06553806910399" x="-17.06553806910399" g="20.577137262099331" b="20.577137262099331" rho="0.91068360000000004"/>
+                <iidm:step r="-13.780069164226571" x="-13.780069164226571" g="15.982463718828566" b="15.982463718828566" rho="0.92854687999999996"/>
+                <iidm:step r="-10.430780904877434" x="-10.430780904877434" g="11.645497203453271" b="11.645497203453271" rho="0.94641016"/>
+                <iidm:step r="-7.0176732910566368" x="-7.0176732910566368" g="7.5473195169912355" b="7.5473195169912355" rho="0.96427344000000004"/>
+                <iidm:step r="-3.5407463227641656" x="-3.5407463227641656" g="3.6707171036300279" b="3.6707171036300279" rho="0.98213671999999985"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1"/>
+                <iidm:step r="3.6045656772358381" x="3.6045656772358381" g="-3.4791571719583358" b="-3.4791571719583358" rho="1.01786328"/>
+                <iidm:step r="7.272950708943382" x="7.272950708943382" g="-6.7798551833225922" b="-6.7798551833225922" rho="1.0357265600000001"/>
+                <iidm:step r="11.005155095122543" x="11.005155095122543" g="-9.9140937064517427" b="-9.9140937064517427" rho="1.0535898399999999"/>
+                <iidm:step r="14.801178835773431" x="14.801178835773431" g="-12.892880531259154" b="-12.892880531259154" rho="1.0714531199999999"/>
+                <iidm:step r="18.661021930895984" x="18.661021930895984" g="-15.726328348801433" b="-15.726328348801433" rho="1.0893164"/>
+                <iidm:step r="22.584684380490238" x="22.584684380490238" g="-18.423740693731116" b="-18.423740693731116" rho="1.10717968"/>
+                <iidm:step r="26.572166184556178" x="26.572166184556178" g="-20.993688411566747" b="-20.993688411566747" rho="1.12504296"/>
+                <iidm:step r="30.623467343093779" x="30.623467343093779" g="-23.444077826121855" b="-23.444077826121855" rho="1.1429062400000001"/>
+                <iidm:step r="34.738587856103067" x="34.738587856103067" g="-25.782211620922489" b="-25.782211620922489" rho="1.1607695200000001"/>
+                <iidm:step r="38.917527723583987" x="38.917527723583987" g="-28.014843311220961" b="-28.014843311220961" rho="1.1786327999999999"/>
+                <iidm:step r="43.16028694553664" x="43.16028694553664" g="-30.148226066322692" b="-30.148226066322692" rho="1.19649608"/>
+                <iidm:step r="47.466865521960955" x="47.466865521960955" g="-32.188156542116317" b="-32.188156542116317" rho="1.21435936"/>
+                <iidm:step r="51.837263452856973" x="51.837263452856973" g="-34.140014298236885" b="-34.140014298236885" rho="1.23222264"/>
+                <iidm:step r="56.271480738224653" x="56.271480738224653" g="-36.0087973009527" b="-36.0087973009527" rho="1.2500859200000001"/>
+                <iidm:step r="60.769517378063973" x="60.769517378063973" g="-37.799153949786998" b="-37.799153949786998" rho="1.2679491999999999"/>
+                <iidm:step r="65.331373372375026" x="65.331373372375026" g="-39.515412011505823" b="-39.515412011505823" rho="1.2858124799999999"/>
+                <iidm:step r="69.957048721157761" x="69.957048721157761" g="-41.161604798123854" b="-41.161604798123854" rho="1.30367576"/>
+                <iidm:step r="74.646543424412172" x="74.646543424412172" g="-42.741494884907091" b="-42.741494884907091" rho="1.32153904"/>
+                <iidm:step r="79.399857482138245" x="79.399857482138245" g="-44.258595629064871" b="-44.258595629064871" rho="1.33940232"/>
+                <iidm:step r="84.216990894335964" x="84.216990894335964" g="-45.716190719151165" b="-45.716190719151165" rho="1.3572655999999998"/>
+                <iidm:step r="89.097943661005473" x="89.097943661005473" g="-47.11735195848069" b="-47.11735195848069" rho="1.3751288800000001"/>
+                <iidm:step r="94.04271578214653" x="94.04271578214653" g="-48.464955462553469" b="-48.464955462553469" rho="1.3929921599999999"/>
+                <iidm:step r="99.051307257759348" x="99.051307257759348" g="-49.761696430103783" b="-49.761696430103783" rho="1.41085544"/>
+                <iidm:step r="104.12371808784383" x="104.12371808784383" g="-51.010102629540867" b="-51.010102629540867" rho="1.42871872"/>
+                <iidm:step r="109.25994827240002" x="109.25994827240002" g="-52.212546726893493" b="-52.212546726893493" rho="1.446582"/>
+                <iidm:step r="114.45999781142788" x="114.45999781142788" g="-53.371257567609966" b="-53.371257567609966" rho="1.4644452800000001"/>
+                <iidm:step r="119.72386670492732" x="119.72386670492732" g="-54.488330512455207" b="-54.488330512455207" rho="1.4823085599999999"/>
+                <iidm:step r="125.05155495289854" x="125.05155495289854" g="-55.565736917068101" b="-55.565736917068101" rho="1.5001718399999999"/>
+                <iidm:step r="130.44306255534144" x="130.44306255534144" g="-56.605332835313817" b="-56.605332835313817" rho="1.51803512"/>
+                <iidm:step r="135.89838951225599" x="135.89838951225599" g="-57.608867018227542" b="-57.608867018227542" rho="1.5358984"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="2186">
+                <iidm:temporaryLimit name="_580d3b53-5508-4d8d-97cc-4ea463e0cdb9-1" acceptableDuration="900" value="2514"/>
+                <iidm:temporaryLimit name="_a867e68a-58d1-49cb-955f-bb8e59cf2a11-1" acceptableDuration="60" value="3061"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="8747">
+                <iidm:temporaryLimit name="_1a7f23f9-e2c0-46a6-a93c-687f2209e33d-1" acceptableDuration="900" value="10059"/>
+                <iidm:temporaryLimit name="_257d56c1-d70a-4a96-b85c-d928ade03ad4-1" acceptableDuration="60" value="12246"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
     </iidm:substation>
     <iidm:substation id="_045beb3a-c766-11e1-8775-005056c00008" name="Minas Tirith" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
         <iidm:voltageLevel id="_048a9c58-c766-11e1-8775-005056c00008" name="MNT132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -1460,12 +1542,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="132.72377843871442" angle="11.982139196869833" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="132.84755644910246" angle="0.16373978788277363" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0447ee05-c766-11e1-8775-005056c00008" name="NwCarlsl NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="8" p="8.9994557546352905" q="0">
+            <iidm:load id="_0447ee05-c766-11e1-8775-005056c00008" name="NwCarlsl NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="8" p="8.9995978213897541" q="0">
                 <iidm:alias>_04731cb7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_047a48a8-c766-11e1-8775-005056c00008" name="NwCarlsl LD" loadType="UNDEFINED" p0="30" q0="12" node="9" p="29.998185848784303" q="11.998790590235215">
+            <iidm:load id="_047a48a8-c766-11e1-8775-005056c00008" name="NwCarlsl LD" loadType="UNDEFINED" p0="30" q0="12" node="9" p="29.998659404632516" q="11.999106283067638">
                 <iidm:alias>_044c0cb9-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1516,9 +1598,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.62191576110305" angle="9.4084896980614463" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.62189619960881" angle="-1.6530920509393685" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044ecbd1-c766-11e1-8775-005056c00008" name="Blaine LD" loadType="UNDEFINED" p0="2" q0="1" node="8" p="2.0000004918415137" q="1.0000004098679616">
+            <iidm:load id="_044ecbd1-c766-11e1-8775-005056c00008" name="Blaine LD" loadType="UNDEFINED" p0="2" q0="1" node="8" p="2.0000005897263589" q="1.0000004914386806">
                 <iidm:alias>_04700f74-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1569,9 +1651,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="133.18520318042516" angle="15.424801642820443" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="133.16042577404045" angle="4.3644943309549271" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046b7b95-c766-11e1-8775-005056c00008" name="Sundial LD" loadType="UNDEFINED" p0="15" q0="9" node="8" p="14.999900907917899" q="8.9999009081361034">
+            <iidm:load id="_046b7b95-c766-11e1-8775-005056c00008" name="Sundial LD" loadType="UNDEFINED" p0="15" q0="9" node="8" p="14.999895331036015" q="8.9998953312794718">
                 <iidm:alias>_046efe07-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1622,9 +1704,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.69359721723532" angle="7.1682122815302591" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.74396681294921" angle="-4.4803151535545203" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045645e2-c766-11e1-8775-005056c00008" name="Riversde LD" loadType="UNDEFINED" p0="51" q0="27" node="8" p="50.99864406688949" q="26.998803599034904">
+            <iidm:load id="_045645e2-c766-11e1-8775-005056c00008" name="Riversde LD" loadType="UNDEFINED" p0="51" q0="27" node="8" p="50.998996282224198" q="26.999114372478399">
                 <iidm:alias>_0476ed4b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1675,9 +1757,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.69878109967132" angle="10.369131842918332" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.87481388481633" angle="-0.78154116769440329" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04887973-c766-11e1-8775-005056c00008" name="Randolph LD" loadType="UNDEFINED" p0="10" q0="5" node="8" p="9.9955148752032414" q="4.9962629548178983">
+            <iidm:load id="_04887973-c766-11e1-8775-005056c00008" name="Randolph LD" loadType="UNDEFINED" p0="10" q0="5" node="8" p="9.9966258213014143" q="4.9971885006819763">
                 <iidm:alias>_0462f018-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1728,9 +1810,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.48483419456981" angle="-6.8628366988268876" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.48459517694907" angle="-17.882283283606657" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0477627b-c766-11e1-8775-005056c00008" name="WNwPhil2 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="11.999996257614381" q="2.9999984406728206">
+            <iidm:load id="_0477627b-c766-11e1-8775-005056c00008" name="WNwPhil2 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="11.999996045589462" q="2.9999983523291234">
                 <iidm:alias>_045841b6-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1800,9 +1882,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="126.73057812823774" angle="10.138690137737646" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="126.73055737160007" angle="-0.9226815883720485" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0476781a-c766-11e1-8775-005056c00008" name="Cloverdl LD" loadType="UNDEFINED" p0="43" q0="16" node="11" p="43.000011853105256" q="16.000007350763624">
+            <iidm:load id="_0476781a-c766-11e1-8775-005056c00008" name="Cloverdl LD" loadType="UNDEFINED" p0="43" q0="16" node="11" p="43.000013953892697" q="16.000008653577801">
                 <iidm:alias>_0481749a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1872,9 +1954,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="128.11690924187963" angle="11.507959278986943" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="128.11689919132772" angle="0.44657238631376828" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046b0665-c766-11e1-8775-005056c00008" name="Hancock LD" loadType="UNDEFINED" p0="38" q0="25" node="11" p="38.000006739252846" q="25.000007389532058">
+            <iidm:load id="_046b0665-c766-11e1-8775-005056c00008" name="Hancock LD" loadType="UNDEFINED" p0="38" q0="25" node="11" p="38.000008613736" q="25.000009444886679">
                 <iidm:alias>_0464c4d5-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1926,12 +2008,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="128.66422164944049" angle="-5.4731313081459412" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="128.65035859553441" angle="-16.45574855284498" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044bbe92-c766-11e1-8775-005056c00008" name="WMVernon LD" loadType="UNDEFINED" p0="16" q0="8" node="8" p="15.998630237326045" q="7.9988585636791303">
+            <iidm:load id="_044bbe92-c766-11e1-8775-005056c00008" name="WMVernon LD" loadType="UNDEFINED" p0="16" q0="8" node="8" p="15.998731756931761" q="7.9989431587010271">
                 <iidm:alias>_04500452-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_047825c8-c766-11e1-8775-005056c00008" name="WMVernon SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.21199999999999" targetDeadband="1" node="9" q="-9.5022726293447484">
+            <iidm:shunt id="_047825c8-c766-11e1-8775-005056c00008" name="WMVernon SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.21199999999999" targetDeadband="1" node="9" q="-9.5002250761200102">
                 <iidm:alias>_047084aa-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_2a6c1dcd-201b-4911-83b2-c16acc50a0f4"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -1965,9 +2047,9 @@
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="3"/>
-                <iidm:bus v="230.99998883776559" angle="34.601350442797219" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="230.99998532353558" angle="22.470243549919616" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_045868c0-c766-11e1-8775-005056c00008" name="Breed SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="450" targetV="230.99998500000001" targetQ="0" node="5" p="-498.28281956399945" q="23.169859165286198">
+            <iidm:generator id="_045868c0-c766-11e1-8775-005056c00008" name="Breed SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="450" targetV="230.99998500000001" targetQ="0" node="5" p="-498.20225870625342" q="26.946318694000563">
                 <iidm:alias>_045b7606-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_f26d4eb3-ebdb-4025-8080-f856ce656b42"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_7566f2a7-61eb-42fe-a59a-8276257fdbc6"/>
@@ -2041,9 +2123,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="127.47359674514624" angle="-5.7581410987812882" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="127.47325352657461" angle="-16.776906763744385" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044d1e22-c766-11e1-8775-005056c00008" name="Newcmrst LD" loadType="UNDEFINED" p0="17" q0="8" node="11" p="16.999990961345361" q="7.9999929108603638">
+            <iidm:load id="_044d1e22-c766-11e1-8775-005056c00008" name="Newcmrst LD" loadType="UNDEFINED" p0="17" q0="8" node="11" p="16.999990230106697" q="7.9999923373400534">
                 <iidm:alias>_048a754b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2113,9 +2195,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="138.5999951231409" angle="24.582756818535753" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="138.59999100630455" angle="12.862662547319658" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_045ab2b0-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="220" targetV="138.59999099999999" targetQ="0" node="11" p="-243.60493400906643" q="-50.208263608390212">
+            <iidm:generator id="_045ab2b0-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="220" targetV="138.59999099999999" targetQ="0" node="11" p="-243.56554870083502" q="-46.987975234464599">
                 <iidm:alias>_046ba2a5-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_56975783-9739-40fc-8ec1-e1de8cb06c9a"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b8449cd9-5a17-497e-bf04-70f728b0f9f2"/>
@@ -2168,9 +2250,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="223.30000593950282" angle="26.893708525919031" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="223.30000003796977" angle="14.922491153199275" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0483224a-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="314" targetV="223.30000000000001" targetQ="0" node="8" p="-347.69067854021296" q="-24.05998588597167">
+            <iidm:generator id="_0483224a-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="314" targetV="223.30000000000001" targetQ="0" node="8" p="-347.63446496391907" q="-19.34234670114645">
                 <iidm:alias>_045cd594-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_05df66ba-3f64-40cb-8b18-c66d26c4e2c1"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_c1d29442-5f57-41d1-bb60-4b74b4994c20"/>
@@ -2178,7 +2260,7 @@
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045b7604-c766-11e1-8775-005056c00008" name="26-25" r="0" x="6.6559680000000006" g="0" b="0" ratedU1="220" ratedU2="132" node1="22" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="117.18478553837576" q1="22.54553495578126" p2="-117.18478553837568" q2="-17.679208590268576">
+        <iidm:twoWindingsTransformer id="_045b7604-c766-11e1-8775-005056c00008" name="26-25" r="0" x="6.6559680000000006" g="0" b="0" ratedU1="220" ratedU2="132" node1="22" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="104.45653697208657" q1="22.059823867739503" p2="-104.45653697208657" q2="-18.164936452132867">
             <iidm:alias>_0447c6f3-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0463b364-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04803c1c-c766-11e1-8775-005056c00008</iidm:alias>
@@ -2321,9 +2403,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="136.62000190944167" angle="14.828929619551399" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="136.62000602133594" angle="3.7684852155647932" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_048aea70-c766-11e1-8775-005056c00008" name="Sporn SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="513.43743900000004" targetV="136.62" targetQ="-62.132553100000003" node="20" p="-568.52678838808663" q="50.154163766504169">
+            <iidm:generator id="_048aea70-c766-11e1-8775-005056c00008" name="Sporn SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="513.43743900000004" targetV="136.62" targetQ="-62.132553100000003" node="20" p="-568.43487069812056" q="50.466572349993363">
                 <iidm:alias>_04555b84-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_27799004-aa1e-4889-ba95-ee6fdae64895"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_827a9c80-183d-4e33-9e73-ef0aab3dfb13"/>
@@ -2413,9 +2495,9 @@
                 <iidm:internalConnection node1="39" node2="9"/>
                 <iidm:internalConnection node1="40" node2="12"/>
                 <iidm:internalConnection node1="41" node2="3"/>
-                <iidm:bus v="219.70611649454597" angle="11.023127228217485" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41"/>
+                <iidm:bus v="219.70695623216679" angle="-0.017712193280935366" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41"/>
             </iidm:nodeBreakerTopology>
-            <iidm:danglingLine id="_0482fb33-c766-11e1-8775-005056c00008" name="68-116" p0="184" q0="0" r="0.16456000000000001" x="1.9601999999999999" g="0" b="0.00033884300000000002" ucteXnodeCode="XWE_BR21" node="41" p="184.11557519154462" q="-14.979571767632343">
+            <iidm:danglingLine id="_0482fb33-c766-11e1-8775-005056c00008" name="68-116" p0="184" q0="0" r="0.16456000000000001" x="1.9601999999999999" g="0" b="0.00033884300000000002" ucteXnodeCode="XWE_BR21" node="41" p="184.11558522837132" q="-14.979707159080263">
                 <iidm:alias>_0459c855-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_04684742-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_5631ccc0-d9d2-11e2-bb49-005056c00008</iidm:alias>
@@ -2428,7 +2510,7 @@
                 </iidm:currentLimits>
             </iidm:danglingLine>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_044f6815-c766-11e1-8775-005056c00008" name="68-69" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-198.31277111166526" q1="102.11066045084101" p2="198.31277111166523" q2="-85.973811027797396">
+        <iidm:twoWindingsTransformer id="_044f6815-c766-11e1-8775-005056c00008" name="68-69" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-197.29344588166086" q1="102.05506294662831" p2="197.29344588166089" q2="-86.052803534231899">
             <iidm:alias>_047e8e67-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04840ca7-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0487dd39-c766-11e1-8775-005056c00008</iidm:alias>
@@ -2535,9 +2617,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="131.60564554681798" angle="2.9732524130737317" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="131.6056522580397" angle="-8.0508317349378782" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04547126-c766-11e1-8775-005056c00008" name="Natrium LD" loadType="UNDEFINED" p0="77" q0="14" node="14" p="76.999906514104737" q="13.999971670952293">
+            <iidm:load id="_04547126-c766-11e1-8775-005056c00008" name="Natrium LD" loadType="UNDEFINED" p0="77" q0="14" node="14" p="76.999909962302965" q="13.999972715860022">
                 <iidm:alias>_047b3307-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2588,9 +2670,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="123.83127953636935" angle="-5.0741477638175265" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="123.77017966158465" angle="-15.976401909242512" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045d4ac9-c766-11e1-8775-005056c00008" name="Sterling LD" loadType="UNDEFINED" p0="31" q0="17" node="8" p="30.992972659626165" q="16.993577647363761">
+            <iidm:load id="_045d4ac9-c766-11e1-8775-005056c00008" name="Sterling LD" loadType="UNDEFINED" p0="31" q0="17" node="8" p="30.993480414098912" q="16.9940416564298">
                 <iidm:alias>_0477b094-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2698,9 +2780,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="130.29520502752601" angle="17.967825550103331" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="130.27270209889906" angle="6.9089616194231382" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0466246a-c766-11e1-8775-005056c00008" name="Switchbk LD" loadType="UNDEFINED" p0="30" q0="16" node="17" p="29.99972090775238" q="15.999751918771427">
+            <iidm:load id="_0466246a-c766-11e1-8775-005056c00008" name="Switchbk LD" loadType="UNDEFINED" p0="30" q0="16" node="17" p="29.999711430009938" q="15.999743494164619">
                 <iidm:alias>_04882b59-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2751,9 +2833,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="135.08660293618402" angle="15.235160137897299" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="135.08662889394787" angle="4.1747280816033632" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046adf5a-c766-11e1-8775-005056c00008" name="Bradley LD" loadType="UNDEFINED" p0="34" q0="8" node="8" p="33.999982154624881" q="7.9999930018149019">
+            <iidm:load id="_046adf5a-c766-11e1-8775-005056c00008" name="Bradley LD" loadType="UNDEFINED" p0="34" q0="8" node="8" p="33.999984542274611" q="7.999993938147826">
                 <iidm:alias>_04555b85-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2788,6 +2870,9 @@
                     <iidm:alias>_7f359893-b7c5-41b0-ada8-8df06cf7a8e6</iidm:alias>
                     <iidm:alias>_a4edf081-2fb2-4da4-94db-98a2a596247f</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_312f25f3-55bc-4417-848c-236d31d823f4-1" name="DISCONNECTOR524-1" kind="DISCONNECTOR" retained="false" open="false" node1="24" node2="25"/>
+                <iidm:switch id="_686e884a-a0b1-454e-b7d1-33c7ad46f89f-1" name="BREAKER262-1" kind="BREAKER" retained="false" open="false" node1="23" node2="24"/>
+                <iidm:switch id="_346a5319-3ec2-40a2-aefd-38dfacbbe97c-1" name="DISCONNECTOR523-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="23"/>
                 <iidm:internalConnection node1="7" node2="0"/>
                 <iidm:internalConnection node1="8" node2="0"/>
                 <iidm:internalConnection node1="9" node2="1"/>
@@ -2804,9 +2889,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.72323755132612" angle="8.4357179302141532" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.04546597044323" angle="-2.6049998289062315" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047a48a2-c766-11e1-8775-005056c00008" name="Mullin LD" loadType="UNDEFINED" p0="17" q0="7" node="8" p="16.991167637523528" q="6.9939396245709666">
+            <iidm:load id="_047a48a2-c766-11e1-8775-005056c00008" name="Mullin LD" loadType="UNDEFINED" p0="17" q0="7" node="8" p="16.993768365688261" q="6.9957239107932434">
                 <iidm:alias>_0474553a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2972,16 +3057,16 @@
                 <iidm:internalConnection node1="81" node2="18"/>
                 <iidm:internalConnection node1="82" node2="21"/>
                 <iidm:internalConnection node1="83" node2="24"/>
-                <iidm:bus v="134.24399334969962" angle="17.671756752059252" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
+                <iidm:bus v="134.24399781186858" angle="6.6106399961761948" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_044cd00a-c766-11e1-8775-005056c00008" name="Glen Lyn SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="252" targetV="134.243988" targetQ="0" node="27" p="-279.03837895583973" q="-83.970974255995884">
+            <iidm:generator id="_044cd00a-c766-11e1-8775-005056c00008" name="Glen Lyn SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="252" targetV="134.243988" targetQ="0" node="27" p="-278.99326487550195" q="-84.322872647594181">
                 <iidm:alias>_045e5c30-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e54b499b-436c-4b89-9803-b1d75e2fa364"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_32c8ab65-80f7-4c17-b3f5-ff075cce0ba5"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
-            <iidm:load id="_04566cf5-c766-11e1-8775-005056c00008" name="Glen Lyn LD" loadType="UNDEFINED" p0="37" q0="18" node="26" p="37.000002211706729" q="18.000001793275761">
+            <iidm:load id="_04566cf5-c766-11e1-8775-005056c00008" name="Glen Lyn LD" loadType="UNDEFINED" p0="37" q0="18" node="26" p="37.00000405648494" q="18.000003289041956">
                 <iidm:alias>_04577e64-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3032,9 +3117,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.55453610253718" angle="9.6218305517830309" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.63038124880953" angle="-2.0700931471381478" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044ea4c0-c766-11e1-8775-005056c00008" name="Kankakee LD" loadType="UNDEFINED" p0="52" q0="22" node="8" p="51.998189451766997" q="21.998723346191333">
+            <iidm:load id="_044ea4c0-c766-11e1-8775-005056c00008" name="Kankakee LD" loadType="UNDEFINED" p0="52" q0="22" node="8" p="51.998675563350197" q="21.999066110291114">
                 <iidm:alias>_047e6758-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3143,12 +3228,12 @@
                 <iidm:internalConnection node1="51" node2="9"/>
                 <iidm:internalConnection node1="52" node2="12"/>
                 <iidm:internalConnection node1="53" node2="15"/>
-                <iidm:bus v="127.42281329861309" angle="10.405736502639101" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
+                <iidm:bus v="127.42280493467807" angle="-0.65569028845281097" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0484cffb-c766-11e1-8775-005056c00008" name="Roanoke LD" loadType="UNDEFINED" p0="31" q0="26" node="17" p="31.000004104579581" q="26.000005737584615">
+            <iidm:load id="_0484cffb-c766-11e1-8775-005056c00008" name="Roanoke LD" loadType="UNDEFINED" p0="31" q0="26" node="17" p="31.000005636785122" q="26.000007879377534">
                 <iidm:alias>_0454983a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0489d903-c766-11e1-8775-005056c00008" name="Roanoke SC" sectionCount="5" voltageRegulatorOn="true" targetV="127.423" targetDeadband="1" node="18" q="-18.639586204575327">
+            <iidm:shunt id="_0489d903-c766-11e1-8775-005056c00008" name="Roanoke SC" sectionCount="5" voltageRegulatorOn="true" targetV="127.423" targetDeadband="1" node="18" q="-18.639583757599326">
                 <iidm:alias>_0476c638-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_5be38d1a-9d01-42d8-b8bb-e9a26cfbcf1a"/>
                 <iidm:shuntLinearModel bPerSection="0.0002296" gPerSection="0" maximumSectionCount="10"/>
@@ -3240,12 +3325,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="120.60503981105656" angle="-10.277216215524184" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="120.57411386654368" angle="-21.24884371884577" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047a219a-c766-11e1-8775-005056c00008" name="Howard LD" loadType="UNDEFINED" p0="37" q0="23" node="14" p="36.992319323884651" q="22.992043093394567">
+            <iidm:load id="_047a219a-c766-11e1-8775-005056c00008" name="Howard LD" loadType="UNDEFINED" p0="37" q0="23" node="14" p="36.992652810655294" q="22.992388550928396">
                 <iidm:alias>_04882b51-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_04488a49-c766-11e1-8775-005056c00008" name="Howard NegG LD" loadType="UNDEFINED" p0="59" q0="0" node="15" p="58.987752435383634" q="0">
+            <iidm:load id="_04488a49-c766-11e1-8775-005056c00008" name="Howard NegG LD" loadType="UNDEFINED" p0="59" q0="0" node="15" p="58.988284211585466" q="0">
                 <iidm:alias>_046d9e74-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3295,7 +3380,7 @@
                 <iidm:internalConnection node1="19" node2="6"/>
                 <iidm:internalConnection node1="20" node2="3"/>
                 <iidm:internalConnection node1="21" node2="6"/>
-                <iidm:bus v="218.77271736335075" angle="12.820289680075486" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
+                <iidm:bus v="218.7731610320763" angle="1.7721774383127251" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_046efe09-c766-11e1-8775-005056c00008" name="CRI132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -3458,20 +3543,20 @@
                 <iidm:internalConnection node1="81" node2="18"/>
                 <iidm:internalConnection node1="82" node2="21"/>
                 <iidm:internalConnection node1="83" node2="24"/>
-                <iidm:bus v="137.28000328724508" angle="15.724128590908563" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
+                <iidm:bus v="137.28000770489527" angle="4.6640997728942146" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_045868c1-c766-11e1-8775-005056c00008" name="CabinCrk SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="477" targetV="137.28" targetQ="0" node="27" p="-528.17978873783943" q="-140.06720280116738">
+            <iidm:generator id="_045868c1-c766-11e1-8775-005056c00008" name="CabinCrk SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="477" targetV="137.28" targetQ="0" node="27" p="-528.09439422862863" q="-140.88967769334911">
                 <iidm:alias>_0487dd36-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_a6ec9760-88da-48df-a23f-7877e7c85ccd"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_e6131af8-c298-413b-84e3-4e21c3b6b06f"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-225" maxQ="640"/>
             </iidm:generator>
-            <iidm:load id="_04747c44-c766-11e1-8775-005056c00008" name="CabinCrk LD" loadType="UNDEFINED" p0="130" q0="26" node="26" p="130.00000466938221" q="26.000001556460759">
+            <iidm:load id="_04747c44-c766-11e1-8775-005056c00008" name="CabinCrk LD" loadType="UNDEFINED" p0="130" q0="26" node="26" p="130.00001094445363" q="26.000003648151321">
                 <iidm:alias>_046a9138-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_0488c79b-c766-11e1-8775-005056c00008" name="81-80" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="21" voltageLevelId1="_048a272b-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-151.44482730418096" q1="71.53888949222879" p2="151.44482730418099" q2="-62.362566517011246">
+        <iidm:twoWindingsTransformer id="_0488c79b-c766-11e1-8775-005056c00008" name="81-80" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="21" voltageLevelId1="_048a272b-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-150.82417800716468" q1="71.513704851256747" p2="150.82417800716468" q2="-62.399962745397715">
             <iidm:alias>_044974a0-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_045a3d83-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_046adf57-c766-11e1-8775-005056c00008</iidm:alias>
@@ -3551,12 +3636,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="134.74729435113386" angle="-1.052774590816276" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="134.74741245021903" angle="-12.068729104733748" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04524e4a-c766-11e1-8775-005056c00008" name="Zanesvll LD" loadType="UNDEFINED" p0="20" q0="11" node="8" p="19.999999343330053" q="10.999999398052559">
+            <iidm:load id="_04524e4a-c766-11e1-8775-005056c00008" name="Zanesvll LD" loadType="UNDEFINED" p0="20" q0="11" node="8" p="20.000000695337018" q="11.000000637392276">
                 <iidm:alias>_045c1240-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_048b5fa9-c766-11e1-8775-005056c00008" name="Zanesvll SC" sectionCount="5" voltageRegulatorOn="true" targetV="134.72300000000001" targetDeadband="1" node="9" q="-15.633033501392903">
+            <iidm:shunt id="_048b5fa9-c766-11e1-8775-005056c00008" name="Zanesvll SC" sectionCount="5" voltageRegulatorOn="true" targetV="134.72300000000001" targetDeadband="1" node="9" q="-15.633060904507346">
                 <iidm:alias>_04736ad5-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_99c6c4ad-5247-4058-96d4-ee8495103e85"/>
                 <iidm:shuntLinearModel bPerSection="0.00017220000000000001" gPerSection="0" maximumSectionCount="10"/>
@@ -3609,9 +3694,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.77511164357267" angle="20.720365037384148" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.7595261069095" angle="9.664021395290403" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044ca8f2-c766-11e1-8775-005056c00008" name="Tazewell LD" loadType="UNDEFINED" p0="12" q0="7" node="8" p="11.999889738359323" q="6.9998928015110078">
+            <iidm:load id="_044ca8f2-c766-11e1-8775-005056c00008" name="Tazewell LD" loadType="UNDEFINED" p0="12" q0="7" node="8" p="11.999887917600759" q="6.9998910313400025">
                 <iidm:alias>_04542305-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3662,9 +3747,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="119.84272160173786" angle="-8.5389017089252288" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="119.78557193882278" angle="-19.465883812970926" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04778989-c766-11e1-8775-005056c00008" name="NwLibrty LD" loadType="UNDEFINED" p0="27" q0="11" node="8" p="26.993129400784397" q="10.995335174036009">
+            <iidm:load id="_04778989-c766-11e1-8775-005056c00008" name="NwLibrty LD" loadType="UNDEFINED" p0="27" q0="11" node="8" p="26.993488959697693" q="10.995579278641397">
                 <iidm:alias>_0483e592-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3697,12 +3782,12 @@
                 <iidm:internalConnection node1="11" node2="2"/>
                 <iidm:internalConnection node1="12" node2="3"/>
                 <iidm:internalConnection node1="13" node2="3"/>
-                <iidm:bus v="122.60530117687317" angle="5.7426530804054963" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13"/>
+                <iidm:bus v="122.6052862844908" angle="-5.3191630866698869" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0463da70-c766-11e1-8775-005056c00008" name="Danville LD" loadType="UNDEFINED" p0="25" q0="13" node="5" p="25.000004067259106" q="13.000003524958084">
+            <iidm:load id="_0463da70-c766-11e1-8775-005056c00008" name="Danville LD" loadType="UNDEFINED" p0="25" q0="13" node="5" p="25.000005295447203" q="13.000004589387897">
                 <iidm:alias>_0488eeab-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_0448b150-c766-11e1-8775-005056c00008" name="Danville NegG LD" loadType="UNDEFINED" p0="43" q0="0" node="6" p="43.000006995685666" q="0">
+            <iidm:load id="_0448b150-c766-11e1-8775-005056c00008" name="Danville NegG LD" loadType="UNDEFINED" p0="43" q0="0" node="6" p="43.000009108169188" q="0">
                 <iidm:alias>_0457cc88-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3753,9 +3838,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.59331661436823" angle="26.500699852241997" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.45634525438791" angle="15.461644860783593" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045cae82-c766-11e1-8775-005056c00008" name="Fremont LD" loadType="UNDEFINED" p0="48" q0="10" node="8" p="47.999218645754873" q="9.9997286979147795">
+            <iidm:load id="_045cae82-c766-11e1-8775-005056c00008" name="Fremont LD" loadType="UNDEFINED" p0="48" q0="10" node="8" p="47.99909541881938" q="9.9996859112853507">
                 <iidm:alias>_045f4693-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3901,9 +3986,9 @@
                 <iidm:internalConnection node1="70" node2="15"/>
                 <iidm:internalConnection node1="71" node2="18"/>
                 <iidm:internalConnection node1="72" node2="21"/>
-                <iidm:bus v="132.3528904172999" angle="13.420146651337891" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
+                <iidm:bus v="132.33422806669151" angle="2.3556761273344105" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0448d863-c766-11e1-8775-005056c00008" name="Turner LD" loadType="UNDEFINED" p0="61" q0="28" node="23" p="60.999956613673014" q="27.999966808282313">
+            <iidm:load id="_0448d863-c766-11e1-8775-005056c00008" name="Turner LD" loadType="UNDEFINED" p0="61" q0="28" node="23" p="60.999980712093915" q="27.999985244226412">
                 <iidm:alias>_046e3ab3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3938,6 +4023,9 @@
                     <iidm:alias>_0b877750-4384-4ec3-bb38-08ee5ccf16d3</iidm:alias>
                     <iidm:alias>_1ed822d3-f3ab-4432-80f0-4c55ae3b4b78</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_3be2355e-0065-43df-a264-57a295042faa-1" name="DISCONNECTOR526-1" kind="DISCONNECTOR" retained="false" open="false" node1="24" node2="25"/>
+                <iidm:switch id="_2463ff2c-7690-4dd6-bf44-039f9f475bb1-1" name="BREAKER263-1" kind="BREAKER" retained="false" open="true" node1="23" node2="24"/>
+                <iidm:switch id="_ddcf7aac-e7c3-45e9-bd81-6146e951addd-1" name="DISCONNECTOR525-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="23"/>
                 <iidm:internalConnection node1="7" node2="0"/>
                 <iidm:internalConnection node1="8" node2="0"/>
                 <iidm:internalConnection node1="9" node2="1"/>
@@ -3954,9 +4042,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.11595653458853" angle="6.4058243786538229" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.1970059254987" angle="-4.4114289475570674" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047d7cf6-c766-11e1-8775-005056c00008" name="Grant LD" loadType="UNDEFINED" p0="24" q0="4" node="8" p="23.998276745942011" q="3.9995213297741259">
+            <iidm:load id="_047d7cf6-c766-11e1-8775-005056c00008" name="Grant LD" loadType="UNDEFINED" p0="24" q0="4" node="8" p="23.999252196741665" q="3.9997922790301379">
                 <iidm:alias>_0481e9c0-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4026,9 +4114,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="220.97968056993693" angle="18.005575471556888" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="221.45504142395154" angle="5.903603533560573" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04867dab-c766-11e1-8775-005056c00008" name="Olive NegG LD" loadType="UNDEFINED" p0="28" q0="0" node="11" p="27.996826771584004" q="0">
+            <iidm:load id="_04867dab-c766-11e1-8775-005056c00008" name="Olive NegG LD" loadType="UNDEFINED" p0="28" q0="0" node="11" p="27.997696831797487" q="0">
                 <iidm:alias>_048433b8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4134,15 +4222,15 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="133.17751778771219" angle="12.474343410056361" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="133.30949113992591" angle="0.63272597847398382" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:shunt id="_0447c6f6-c766-11e1-8775-005056c00008" name="Olive SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.67599999999999" targetDeadband="1" node="17" q="-40.72243285644533">
+            <iidm:shunt id="_0447c6f6-c766-11e1-8775-005056c00008" name="Olive SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.67599999999999" targetDeadband="1" node="17" q="-40.803181302655815">
                 <iidm:alias>_045e8340-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_c701959a-91c1-4a35-9a37-71fb790426ca"/>
                 <iidm:shuntLinearModel bPerSection="0.00045919999999999999" gPerSection="0" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_04575750-c766-11e1-8775-005056c00008" name="8-5" r="0" x="4.6522079999999999" g="0" b="0" ratedU1="220" ratedU2="132" node1="32" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="371.41856666589757" q1="59.300008562448426" p2="-371.41856666589752" q2="-22.976869896773387">
+        <iidm:twoWindingsTransformer id="_04575750-c766-11e1-8775-005056c00008" name="8-5" r="0" x="4.6522079999999999" g="0" b="0" ratedU1="220" ratedU2="132" node1="32" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="355.09952298588985" q1="62.361484109259166" p2="-355.09952298588985" q2="-29.129984587217635">
             <iidm:alias>_045eaa55-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_046b2d74-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04745533-c766-11e1-8775-005056c00008</iidm:alias>
@@ -4213,9 +4301,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.77736755971966" angle="19.650928815952494" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.77393078788666" angle="8.592798555015067" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047b0bf0-c766-11e1-8775-005056c00008" name="Wythe LD" loadType="UNDEFINED" p0="22" q0="15" node="8" p="21.999916521495404" q="14.999905138182942">
+            <iidm:load id="_047b0bf0-c766-11e1-8775-005056c00008" name="Wythe LD" loadType="UNDEFINED" p0="22" q0="15" node="8" p="21.999917805669469" q="14.999906597467991">
                 <iidm:alias>_0479d376-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4266,9 +4354,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="123.89985758235315" angle="-5.1041378270431839" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="123.83903280502389" angle="-16.007035620364334" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0458ddf5-c766-11e1-8775-005056c00008" name="WestLima LD" loadType="UNDEFINED" p0="33" q0="9" node="8" p="32.992524060568385" q="8.9966021023294189">
+            <iidm:load id="_0458ddf5-c766-11e1-8775-005056c00008" name="WestLima LD" loadType="UNDEFINED" p0="33" q0="9" node="8" p="32.99306255469488" q="8.9968468367496079">
                 <iidm:alias>_04492686-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4376,9 +4464,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="128.45057874647472" angle="22.56279524925316" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="128.11542495217742" angle="11.532753276020602" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044b2257-c766-11e1-8775-005056c00008" name="BeaverCk LD" loadType="UNDEFINED" p0="24" q0="15" node="17" p="23.999203839945412" q="14.999170675780421">
+            <iidm:load id="_044b2257-c766-11e1-8775-005056c00008" name="BeaverCk LD" loadType="UNDEFINED" p0="24" q0="15" node="17" p="23.999059381409911" q="14.999020201769111">
                 <iidm:alias>_045868c4-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4437,6 +4525,9 @@
                     <iidm:alias>_2b636cdd-aa2f-4a65-92fc-12b4fc392e5f</iidm:alias>
                     <iidm:alias>_c96e50b9-ea15-4421-b6c8-bd9c9158a69a</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_e5318967-afcc-4fcc-b0de-d5f2522a95a6-1" name="DISCONNECTOR699-1" kind="DISCONNECTOR" retained="false" open="false" node1="43" node2="44"/>
+                <iidm:switch id="_e9f91b69-a29b-44ea-aa0f-cff86ee80320-1" name="BREAKER350-1" kind="BREAKER" retained="true" open="true" node1="42" node2="43"/>
+                <iidm:switch id="_ad86e83d-6334-4dd8-b642-b4c16d65329a-1" name="DISCONNECTOR700-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="42"/>
                 <iidm:internalConnection node1="13" node2="0"/>
                 <iidm:internalConnection node1="14" node2="1"/>
                 <iidm:internalConnection node1="15" node2="2"/>
@@ -4466,7 +4557,7 @@
                 <iidm:internalConnection node1="39" node2="9"/>
                 <iidm:internalConnection node1="40" node2="12"/>
                 <iidm:internalConnection node1="41" node2="3"/>
-                <iidm:bus v="214.48577908368662" angle="15.565564274449294" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41"/>
+                <iidm:bus v="215.53446964248138" angle="2.9892736081597655" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_047bcf46-c766-11e1-8775-005056c00008" name="STN132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -4546,6 +4637,9 @@
                     <iidm:alias>_4aab41d6-d1b6-4dbe-a6aa-cb7ccd941912</iidm:alias>
                     <iidm:alias>_e9315b98-af75-40bb-bf8e-05bd03d43db5</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_b8b0b9a9-af8b-41d2-a4f8-940637e63f70-1" name="DISCONNECTOR701-1" kind="DISCONNECTOR" retained="false" open="false" node1="64" node2="65"/>
+                <iidm:switch id="_0b78ffaa-9859-4658-af17-c8d355633556-1" name="BREAKER351-1" kind="BREAKER" retained="true" open="false" node1="63" node2="64"/>
+                <iidm:switch id="_9dfeeaef-5c49-4c2c-97b1-03876970bee4-1" name="DISCONNECTOR702-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="63"/>
                 <iidm:internalConnection node1="19" node2="0"/>
                 <iidm:internalConnection node1="20" node2="0"/>
                 <iidm:internalConnection node1="21" node2="1"/>
@@ -4590,9 +4684,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="129.34019354949271" angle="8.7801230012761735" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="129.29355833649743" angle="-1.6327052438698282" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045dbff4-c766-11e1-8775-005056c00008" name="Sorenson LD" loadType="UNDEFINED" p0="11" q0="3" node="20" p="10.99787199418056" q="2.9990327870036442">
+            <iidm:load id="_045dbff4-c766-11e1-8775-005056c00008" name="Sorenson LD" loadType="UNDEFINED" p0="11" q0="3" node="20" p="10.99846803310818" q="2.9993036837400662">
                 <iidm:alias>_044d4536-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4613,6 +4707,9 @@
                     <iidm:alias>_340082f1-db9c-446d-97df-80e45aa0058b</iidm:alias>
                     <iidm:alias>_90c04b95-703a-4bae-82b8-7edf3075aa24</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_4d08a684-cdcb-484a-a767-03b10f4ada7f-1" name="DISCONNECTOR735-1" kind="DISCONNECTOR" retained="false" open="false" node1="14" node2="15"/>
+                <iidm:switch id="_f468d841-1bf6-470e-85d4-55d34fab8bff-1" name="BREAKER368-1" kind="BREAKER" retained="true" open="false" node1="13" node2="14"/>
+                <iidm:switch id="_f193bd8f-badf-4600-82ac-f212d1f33534-1" name="DISCONNECTOR736-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="13"/>
                 <iidm:internalConnection node1="4" node2="0"/>
                 <iidm:internalConnection node1="5" node2="1"/>
                 <iidm:internalConnection node1="6" node2="2"/>
@@ -4622,13 +4719,13 @@
                 <iidm:internalConnection node1="10" node2="3"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="0"/>
-                <iidm:bus v="384.14206312091778" angle="15.342577280566902" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="389.08870131716668" angle="0" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15"/>
             </iidm:nodeBreakerTopology>
             <iidm:lccConverterStation id="_7393a68e-c4e6-48dd-9347-543858363fdb" name="Conv1" lossFactor="0" powerFactor="0.80000000000000004" node="12" p="10" q="6">
                 <iidm:alias>_739658a7-e08b-4395-8d79-93e87b7855e3</iidm:alias>
             </iidm:lccConverterStation>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_047120e9-c766-11e1-8775-005056c00008" name="30-17" r="0" x="6.7605125399999997" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_047b8123-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="303.02064577919799" q1="111.42612765917472" p2="-303.02064577919811" q2="-72.211717068720105">
+        <iidm:twoWindingsTransformer id="_047120e9-c766-11e1-8775-005056c00008" name="30-17" r="0" x="6.7605125399999997" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_047b8123-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="207.60041701300773" q1="116.2862483380552" p2="-207.6004170130077" q2="-95.192234716457691">
             <iidm:alias>_044f6811-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0463b36a-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_047d2ed8-c766-11e1-8775-005056c00008</iidm:alias>
@@ -4647,7 +4744,7 @@
                 <iidm:temporaryLimit name="_f62f2fc6-4b6c-4571-a8c5-40d6a89ac703" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_b08e9e50-4e0c-4ac0-9f21-4a27429caeb2" name="PowTrans1" r="0.4840000000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_3bbfa58a-a1ad-4b23-a526-3d76b096c1f4" node2="41" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="-10.000000654676242" q1="-6.0000001980284416" p2="10.001438623333261" q2="6.0539240226691371">
+        <iidm:twoWindingsTransformer id="_b08e9e50-4e0c-4ac0-9f21-4a27429caeb2" name="PowTrans1" r="0.4840000000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_3bbfa58a-a1ad-4b23-a526-3d76b096c1f4" node2="41" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="-133.64046748341337" q1="21.072719045582268" p2="133.82910975672479" q2="-13.998633796403192">
             <iidm:alias>_046ba2aa-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_a5bf9702-545a-437d-9663-773550202828</iidm:alias>
             <iidm:alias>_ee9505e1-96d7-49b3-9d1a-924397ffb27e</iidm:alias>
@@ -4667,6 +4764,32 @@
                 <iidm:temporaryLimit name="_611bb05e-9b9a-469c-b1d1-80a944c3ce2f" acceptableDuration="60" value="1400"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
+        <iidm:threeWindingsTransformer id="_86d83c7d-7826-4c16-b161-4ce17174e77f-1" name="T422" r1="-1.5199999809265099" x1="23.199999999999999" g1="0" b1="0" ratedU1="400" r2="2.0000000630528461" x2="19.999999999999996" g2="0" b2="0" ratedU2="220" r3="1.2000000564689806" x3="12" g3="0" b3="0" ratedU3="132" ratedU0="400" node1="15" voltageLevelId1="_3bbfa58a-a1ad-4b23-a526-3d76b096c1f4" node2="44" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" node3="65" voltageLevelId3="_047bcf46-c766-11e1-8775-005056c00008" p1="123.64046749295264" q1="-27.07271903985977" p2="0" q2="0" p3="-123.67432947418831" q3="30.797537855101847">
+            <iidm:alias>_1b2d419c-ac88-4dae-8dfe-2eb92d18c40a-1</iidm:alias>
+            <iidm:alias>_206474da-93c8-46b1-863f-9a308bfc2117-1</iidm:alias>
+            <iidm:alias>_9ac069ea-557b-4b8c-b12e-f9f2aecc3bf5-1</iidm:alias>
+            <iidm:alias>_ae46e10e-1fbe-4139-b493-ed8e2844ee8d-1</iidm:alias>
+            <iidm:ratioTapChanger1 lowTapPosition="1" tapPosition="11" targetDeadband="0" loadTapChangingCapabilities="true" regulating="false" targetV="220">
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.95238095238095233"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.96385542168674687"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.97560975609756106"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.98765432098765438"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0126582278481011"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0256410256410258"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0389610389610389"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0526315789473684"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0666666666666667"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0810810810810809"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.095890410958904"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.1111111111111112"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.1267605633802817"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.1428571428571428"/>
+            </iidm:ratioTapChanger1>
+            <iidm:currentLimits1 permanentLimit="500">
+                <iidm:temporaryLimit name="_3fd18f6e-749a-4fa7-af1b-b0c2d3952638-1" acceptableDuration="1800" value="533"/>
+            </iidm:currentLimits1>
+        </iidm:threeWindingsTransformer>
     </iidm:substation>
     <iidm:substation id="_04642898-c766-11e1-8775-005056c00008" name="Rómenna" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
         <iidm:voltageLevel id="_0457f394-c766-11e1-8775-005056c00008" name="RÓM132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -4905,16 +5028,16 @@
                 <iidm:internalConnection node1="121" node2="30"/>
                 <iidm:internalConnection node1="122" node2="33"/>
                 <iidm:internalConnection node1="123" node2="36"/>
-                <iidm:bus v="135.30000104182696" angle="-0.23413993373961983" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123"/>
+                <iidm:bus v="135.300004517801" angle="-11.251107811568632" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04859346-c766-11e1-8775-005056c00008" name="Philo SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="204" targetV="135.30000000000001" targetQ="0" node="39" p="-225.88821153567977" q="-175.32503599605801">
+            <iidm:generator id="_04859346-c766-11e1-8775-005056c00008" name="Philo SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="204" targetV="135.30000000000001" targetQ="0" node="39" p="-225.85169061350157" q="-175.28770826063101">
                 <iidm:alias>_048719e2-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e3753d6d-b894-4cce-b6fa-307c50dc107f"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_dff93c01-9c84-4c1f-8529-66c054ed9e37"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
-            <iidm:load id="_045163e2-c766-11e1-8775-005056c00008" name="Philo LD" loadType="UNDEFINED" p0="87" q0="30" node="38" p="87.000001004866348" q="30.000000577509393">
+            <iidm:load id="_045163e2-c766-11e1-8775-005056c00008" name="Philo LD" loadType="UNDEFINED" p0="87" q0="30" node="38" p="87.00000435752429" q="30.000002504324343">
                 <iidm:alias>_04513cd3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4965,9 +5088,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.79954675918205" angle="20.561453087370456" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.51342180477654" angle="9.5205228460694507" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04524e46-c766-11e1-8775-005056c00008" name="BetsyLne LD" loadType="UNDEFINED" p0="11" q0="7" node="8" p="10.999637996987209" q="6.9996160616224614">
+            <iidm:load id="_04524e46-c766-11e1-8775-005056c00008" name="BetsyLne LD" loadType="UNDEFINED" p0="11" q0="7" node="8" p="10.999579517566765" q="6.9995540394654112">
                 <iidm:alias>_04549830-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5020,15 +5143,15 @@
                 <iidm:internalConnection node1="22" node2="6"/>
                 <iidm:internalConnection node1="23" node2="3"/>
                 <iidm:internalConnection node1="24" node2="6"/>
-                <iidm:bus v="124.75915657857517" angle="7.4310750484254227" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24"/>
+                <iidm:bus v="124.75914130405346" angle="-3.6303250867601498" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04566cf3-c766-11e1-8775-005056c00008" name="Reusens NegG LD" loadType="UNDEFINED" p0="22" q0="0" node="8" p="22.000002599265908" q="0">
+            <iidm:load id="_04566cf3-c766-11e1-8775-005056c00008" name="Reusens NegG LD" loadType="UNDEFINED" p0="22" q0="0" node="8" p="22.000003678462747" q="0">
                 <iidm:alias>_0483be81-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_0482fb36-c766-11e1-8775-005056c00008" name="Reusens LD" loadType="UNDEFINED" p0="28" q0="12" node="9" p="28.000003308156611" q="12.0000023629691">
+            <iidm:load id="_0482fb36-c766-11e1-8775-005056c00008" name="Reusens LD" loadType="UNDEFINED" p0="28" q0="12" node="9" p="28.000004681679862" q="12.00000334405723">
                 <iidm:alias>_0486cbc1-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_04558293-c766-11e1-8775-005056c00008" name="Reusens SC" sectionCount="5" voltageRegulatorOn="true" targetV="124.76300000000001" targetDeadband="1" node="10" q="-5.3543074196679186">
+            <iidm:shunt id="_04558293-c766-11e1-8775-005056c00008" name="Reusens SC" sectionCount="5" voltageRegulatorOn="true" targetV="124.76300000000001" targetDeadband="1" node="10" q="-5.3543061085901229">
                 <iidm:alias>_04893ccc-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_99303cd3-6b53-4ee2-a5ce-fe8d5feeb304"/>
                 <iidm:shuntLinearModel bPerSection="6.8800000000000005e-05" gPerSection="0" maximumSectionCount="10"/>
@@ -5101,12 +5224,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="126.42436552290128" angle="24.760615680032192" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="126.42256813241863" angle="13.709622691746295" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045c8777-c766-11e1-8775-005056c00008" name="Holston NegG LD" loadType="UNDEFINED" p0="85" q0="0" node="11" p="84.999799174534346" q="0">
+            <iidm:load id="_045c8777-c766-11e1-8775-005056c00008" name="Holston NegG LD" loadType="UNDEFINED" p0="85" q0="0" node="11" p="84.999801995256249" q="0">
                 <iidm:alias>_0487dd31-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_0451d918-c766-11e1-8775-005056c00008" name="Holston LD" loadType="UNDEFINED" p0="78" q0="42" node="12" p="77.999815713102123" q="41.999834614452659">
+            <iidm:load id="_0451d918-c766-11e1-8775-005056c00008" name="Holston LD" loadType="UNDEFINED" p0="78" q0="42" node="12" p="77.999818301529274" q="41.999836937396466">
                 <iidm:alias>_0485ba54-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5214,9 +5337,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="127.73086993011438" angle="9.3063130529952378" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="127.73125284183358" angle="-1.7845501220960833" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04742e27-c766-11e1-8775-005056c00008" name="SthPoint LD" loadType="UNDEFINED" p0="47" q0="11" node="17" p="47.000002055456456" q="11.000000801773806">
+            <iidm:load id="_04742e27-c766-11e1-8775-005056c00008" name="SthPoint LD" loadType="UNDEFINED" p0="47" q0="11" node="17" p="47.000363905926498" q="11.000141949486622">
                 <iidm:alias>_047b3303-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5268,12 +5391,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="132.92316312887144" angle="13.434977248514613" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="132.91063499890603" angle="2.3719609339565055" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04716f06-c766-11e1-8775-005056c00008" name="CapitlHl LD" loadType="UNDEFINED" p0="39" q0="32" node="8" p="38.999980043970311" q="31.999972709707642">
+            <iidm:load id="_04716f06-c766-11e1-8775-005056c00008" name="CapitlHl LD" loadType="UNDEFINED" p0="39" q0="32" node="8" p="38.999989275997471" q="31.999985334698742">
                 <iidm:alias>_04700f70-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0466c0a0-c766-11e1-8775-005056c00008" name="CapitlHl SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.00200000000001" targetDeadband="1" node="9" q="-20.283515256019882">
+            <iidm:shunt id="_0466c0a0-c766-11e1-8775-005056c00008" name="CapitlHl SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.00200000000001" targetDeadband="1" node="9" q="-20.279691956392668">
                 <iidm:alias>_045e8346-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_99931a87-ee15-4fd0-b251-9556df7fe598"/>
                 <iidm:shuntLinearModel bPerSection="0.0002296" gPerSection="0" maximumSectionCount="10"/>
@@ -5326,9 +5449,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="132.06149730490742" angle="13.120161731803508" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="132.044919204438" angle="2.0560689903143698" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046efe03-c766-11e1-8775-005056c00008" name="Chemical LD" loadType="UNDEFINED" p0="71" q0="26" node="8" p="70.999940814416036" q="25.999963877353167">
+            <iidm:load id="_046efe03-c766-11e1-8775-005056c00008" name="Chemical LD" loadType="UNDEFINED" p0="71" q0="26" node="8" p="70.99996606251753" q="25.99997928698583">
                 <iidm:alias>_045d71d5-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5379,9 +5502,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.51522828304931" angle="9.0782935335837021" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.56133250829484" angle="-2.5560615242914011" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046a4319-c766-11e1-8775-005056c00008" name="JacksnRd LD" loadType="UNDEFINED" p0="19" q0="2" node="8" p="18.999590979053878" q="1.9999282424541995">
+            <iidm:load id="_046a4319-c766-11e1-8775-005056c00008" name="JacksnRd LD" loadType="UNDEFINED" p0="19" q0="2" node="8" p="18.999700257890691" q="1.9999474139415667">
                 <iidm:alias>_046c8d06-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5527,9 +5650,9 @@
                 <iidm:internalConnection node1="70" node2="15"/>
                 <iidm:internalConnection node1="71" node2="18"/>
                 <iidm:internalConnection node1="72" node2="21"/>
-                <iidm:bus v="130.60656056239606" angle="24.425207683004405" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
+                <iidm:bus v="130.59981768573152" angle="13.371477087487202" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0458ddf4-c766-11e1-8775-005056c00008" name="Saltvlle LD" loadType="UNDEFINED" p0="65" q0="10" node="23" p="64.999638636428941" q="9.999907342845793">
+            <iidm:load id="_0458ddf4-c766-11e1-8775-005056c00008" name="Saltvlle LD" loadType="UNDEFINED" p0="65" q0="10" node="23" p="64.999639450977824" q="9.9999075517037088">
                 <iidm:alias>_045645e4-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5599,9 +5722,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="131.51507232396369" angle="14.178418680486839" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="131.67777158950102" angle="2.8408543928907353" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0476ed42-c766-11e1-8775-005056c00008" name="Trenton NegG LD" loadType="UNDEFINED" p0="13" q0="0" node="11" p="12.996212936218196" q="0">
+            <iidm:load id="_0476ed42-c766-11e1-8775-005056c00008" name="Trenton NegG LD" loadType="UNDEFINED" p0="13" q0="0" node="11" p="12.997328301823682" q="0">
                 <iidm:alias>_0471e432-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5671,9 +5794,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="128.34011133793575" angle="8.100201739513869" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="128.40272041598669" angle="-3.5781959440323523" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044a5f08-c766-11e1-8775-005056c00008" name="HickryCk LD" loadType="UNDEFINED" p0="39" q0="10" node="11" p="38.998749041764697" q="9.9994654081794554">
+            <iidm:load id="_044a5f08-c766-11e1-8775-005056c00008" name="HickryCk LD" loadType="UNDEFINED" p0="39" q0="10" node="11" p="38.999075317203626" q="9.9996048395349">
                 <iidm:alias>_047d7cf3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5802,9 +5925,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="125.33784794768792" angle="-4.2533412930916832" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="125.27889038313039" angle="-15.158368459543526" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:shunt id="_0450eeb7-c766-11e1-8775-005056c00008" name="EastLima SC" sectionCount="5" voltageRegulatorOn="true" targetV="131.565" targetDeadband="1" node="20" q="-22.54324174390635">
+            <iidm:shunt id="_0450eeb7-c766-11e1-8775-005056c00008" name="EastLima SC" sectionCount="5" voltageRegulatorOn="true" targetV="131.565" targetDeadband="1" node="20" q="-22.522038539026756">
                 <iidm:alias>_044aad27-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_6c36f421-303e-4932-93a9-5b0ff86cb7d4"/>
                 <iidm:shuntLinearModel bPerSection="0.00028699999999999998" gPerSection="0" maximumSectionCount="10"/>
@@ -5892,16 +6015,16 @@
                 <iidm:internalConnection node1="41" node2="7"/>
                 <iidm:internalConnection node1="42" node2="12"/>
                 <iidm:internalConnection node1="43" node2="11"/>
-                <iidm:bus v="218.90662875289041" angle="6.7703702508309416" nodes="0,1,2,3,8,9,10,13,17,18,21,22,23,24,25,26,31,32,33,34,35,39,40"/>
-                <iidm:bus v="237.93768605998153" angle="-4.9792777497258172" nodes="11,15,37,43"/>
-                <iidm:bus v="226.19467473625627" angle="6.7703702533857228" nodes="12,16,38,42"/>
-                <iidm:bus v="214.70025154563999" angle="-4.9792777497258172" nodes="4,5,6,7,14,19,20,27,28,29,30,36,41"/>
+                <iidm:bus v="218.90682234415274" angle="-4.2547575167269125" nodes="0,1,2,3,8,9,10,13,17,18,21,22,23,24,25,26,31,32,33,34,35,39,40"/>
+                <iidm:bus v="237.93769285011385" angle="-16.002050465734069" nodes="11,15,37,43"/>
+                <iidm:bus v="226.19468120327809" angle="-4.2547575136702278" nodes="12,16,38,42"/>
+                <iidm:bus v="214.70025767263536" angle="-16.002050465734069" nodes="4,5,6,7,14,19,20,27,28,29,30,36,41"/>
             </iidm:nodeBreakerTopology>
-            <iidm:vscConverterStation id="_b46bfb8e-7af6-459e-acf3-53a42c943a7c" name="VSC2" voltageRegulatorOn="true" lossFactor="0.32362458" voltageSetpoint="218.47" reactivePowerSetpoint="0" node="42" p="-0" q="-27.475285846435249">
+            <iidm:vscConverterStation id="_b46bfb8e-7af6-459e-acf3-53a42c943a7c" name="VSC2" voltageRegulatorOn="true" lossFactor="0.32362458" voltageSetpoint="218.47" reactivePowerSetpoint="0" node="42" p="-0" q="-27.474579619155886">
                 <iidm:alias>_a168e701-bd48-4f66-8f0b-0f69b2545530</iidm:alias>
                 <iidm:minMaxReactiveLimits minQ="-1.7976931348623157e+308" maxQ="1.7976931348623157e+308"/>
             </iidm:vscConverterStation>
-            <iidm:vscConverterStation id="_b48ce7cf-abf5-413f-bc51-9e1d3103c9bd" name="VSC1" voltageRegulatorOn="true" lossFactor="0.32467531999999999" voltageSetpoint="213.53999999999999" reactivePowerSetpoint="0" node="43" p="-0" q="-92.151020935009058">
+            <iidm:vscConverterStation id="_b48ce7cf-abf5-413f-bc51-9e1d3103c9bd" name="VSC1" voltageRegulatorOn="true" lossFactor="0.32467531999999999" voltageSetpoint="213.53999999999999" reactivePowerSetpoint="0" node="43" p="-0" q="-92.151020935009171">
                 <iidm:alias>_071bb138-ff00-4874-8acc-a884aa5cf4a9</iidm:alias>
                 <iidm:minMaxReactiveLimits minQ="-1.7976931348623157e+308" maxQ="1.7976931348623157e+308"/>
             </iidm:vscConverterStation>
@@ -5969,7 +6092,7 @@
                 <iidm:internalConnection node1="29" node2="6"/>
                 <iidm:internalConnection node1="30" node2="9"/>
                 <iidm:internalConnection node1="31" node2="3"/>
-                <iidm:bus v="201.80615428769744" angle="-0.2611014590114174" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
+                <iidm:bus v="201.76431916855847" angle="-11.196617155351635" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_0448d867-c766-11e1-8775-005056c00008" name="EDO132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -6055,9 +6178,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="131.34000165839387" angle="4.3635821936351036" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="131.3400054265789" angle="-6.6609691598260268" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0472a789-c766-11e1-8775-005056c00008" name="W.Kammer SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="160" targetV="131.34" targetQ="0" node="14" p="-177.1672247338665" q="94.093551060428453">
+            <iidm:generator id="_0472a789-c766-11e1-8775-005056c00008" name="W.Kammer SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="160" targetV="131.34" targetQ="0" node="14" p="-177.13858087333455" q="94.090935625558856">
                 <iidm:alias>_04697fc0-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_17852426-f663-4add-9a2b-0a635d51f101"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b512ea0a-96d0-4a48-9de1-a5cf499bf0dd"/>
@@ -6206,16 +6329,16 @@
                 <iidm:internalConnection node1="71" node2="15"/>
                 <iidm:internalConnection node1="72" node2="18"/>
                 <iidm:internalConnection node1="73" node2="21"/>
-                <iidm:bus v="130.02000167211349" angle="-4.9792777497258163" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
+                <iidm:bus v="130.0200053825514" angle="-16.002050465734072" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04839777-c766-11e1-8775-005056c00008" name="Tidd SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="155" targetV="130.02000000000001" targetQ="0" node="24" p="-171.63074896093318" q="-94.87226968678182">
+            <iidm:generator id="_04839777-c766-11e1-8775-005056c00008" name="Tidd SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="155" targetV="130.02000000000001" targetQ="0" node="24" p="-171.60300022104283" q="-94.872818467466487">
                 <iidm:alias>_045fe2d8-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_d2a96d8d-65be-4fd6-a012-ceeeabd2bee6"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_29df1e0b-36ca-4536-97b4-6f98b84d49d8"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-90" maxQ="255"/>
             </iidm:generator>
-            <iidm:load id="_04798556-c766-11e1-8775-005056c00008" name="Tidd LD" loadType="UNDEFINED" p0="277" q0="113" node="23" p="277.00000534350988" q="113.00000363307234">
+            <iidm:load id="_04798556-c766-11e1-8775-005056c00008" name="Tidd LD" loadType="UNDEFINED" p0="277" q0="113" node="23" p="277.00001720081616" q="113.00001169489933">
                 <iidm:alias>_04502b62-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6245,13 +6368,13 @@
                 <iidm:internalConnection node1="10" node2="3"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="0"/>
-                <iidm:bus v="360.96780424394734" angle="0" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="360.89240423392255" angle="-10.935406982142585" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
             </iidm:nodeBreakerTopology>
             <iidm:lccConverterStation id="_9793118d-5ba1-4a9c-b2e0-db1d15be5913" name="Conv2" lossFactor="0" powerFactor="-0.75741000000000003" node="12" p="-10" q="8.6206896551724146">
                 <iidm:alias>_453bdc57-5855-4eb5-8712-d6a0255e0da8</iidm:alias>
             </iidm:lccConverterStation>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045c1248-c766-11e1-8775-005056c00008" name="38-37" r="0" x="6.5340005399999992" g="0" b="0" ratedU1="220" ratedU2="132" node1="30" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="172.94962799018055" q1="88.545274910198515" p2="-172.94962799018055" q2="-73.836747553150303">
+        <iidm:twoWindingsTransformer id="_045c1248-c766-11e1-8775-005056c00008" name="38-37" r="0" x="6.5340005399999992" g="0" b="0" ratedU1="220" ratedU2="132" node1="30" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="171.51463807739651" q1="89.068771570707696" p2="-171.51463807739646" q2="-74.510568474464023">
             <iidm:alias>_0453d4e8-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0477d7aa-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_047df228-c766-11e1-8775-005056c00008</iidm:alias>
@@ -6275,7 +6398,7 @@
                 <iidm:temporaryLimit name="_c97df399-5a91-4c8b-b72c-496cade334b5" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_0485ba57-c766-11e1-8775-005056c00008" name="64-61" r="0" x="4.669632" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="157.49826563586814" q1="60.53776518147135" p2="-157.49826563586811" q2="-53.060715419662664">
+        <iidm:twoWindingsTransformer id="_0485ba57-c766-11e1-8775-005056c00008" name="64-61" r="0" x="4.669632" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="157.46071151263499" q1="60.539494297327003" p2="-157.46071151263502" q2="-53.065509094337585">
             <iidm:alias>_04549831-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0472ce92-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0489d905-c766-11e1-8775-005056c00008</iidm:alias>
@@ -6301,7 +6424,7 @@
                 <iidm:temporaryLimit name="_f6b1a81c-eda7-4a08-b290-bd29a5ed9fa4" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_044cd007-c766-11e1-8775-005056c00008" name="63-59" r="0" x="6.7256646120000001" g="0" b="0" ratedU1="220" ratedU2="132" node1="41" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="73" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-4.163336342344337e-15" q1="83.15138392507447" p2="-1.1102230246251565e-14" q2="-80.568832305757681">
+        <iidm:twoWindingsTransformer id="_044cd007-c766-11e1-8775-005056c00008" name="63-59" r="0" x="6.7256646120000001" g="0" b="0" ratedU1="220" ratedU2="132" node1="41" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="73" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="7.4940054162198066e-14" q1="83.151388670929634" p2="-4.4408920985006262e-14" q2="-80.568836904213882">
             <iidm:alias>_044e7db4-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_046eafe5-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0488797a-c766-11e1-8775-005056c00008</iidm:alias>
@@ -6347,7 +6470,7 @@
                 <iidm:temporaryLimit name="_f2daef4d-6f1a-44d1-9c9b-228acff12575" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_ffd940c8-03c8-4dcf-ad46-62018a0d813d" name="PowTrans2" r="0.3932500000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_04f97116-552a-4a34-afd9-4862f62ac7aa" node2="31" voltageLevelId2="_04742e21-c766-11e1-8775-005056c00008" p1="9.9999999384673917" q1="-8.6206896021271398" p2="-9.9983039667921538" q2="8.6989652179079755">
+        <iidm:twoWindingsTransformer id="_ffd940c8-03c8-4dcf-ad46-62018a0d813d" name="PowTrans2" r="0.3932500000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_04f97116-552a-4a34-afd9-4862f62ac7aa" node2="31" voltageLevelId2="_04742e21-c766-11e1-8775-005056c00008" p1="10.000000431046647" q1="-8.6206896140425737" p2="-9.9983037505322123" q2="8.6989979454695074">
             <iidm:alias>_04479fea-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_c089eb25-9f67-4d82-88a8-635dd4808bae</iidm:alias>
             <iidm:alias>_ea8cd467-31f0-40dc-95d7-4064463724c4</iidm:alias>
@@ -6414,9 +6537,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="124.78825680218249" angle="-8.1518912326789383" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.78807504729548" angle="-19.171654590421777" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0481c2b3-c766-11e1-8775-005056c00008" name="Wooster LD" loadType="UNDEFINED" p0="23" q0="11" node="8" p="22.999991165743268" q="10.999992958202059">
+            <iidm:load id="_0481c2b3-c766-11e1-8775-005056c00008" name="Wooster LD" loadType="UNDEFINED" p0="23" q0="11" node="8" p="22.99999107000794" q="10.999992881891311">
                 <iidm:alias>_04614268-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6486,9 +6609,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="125.56954166440585" angle="-7.9139621527171755" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="125.56951015545829" angle="-18.934456301916395" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044974a8-c766-11e1-8775-005056c00008" name="Wagenhls LD" loadType="UNDEFINED" p0="63" q0="22" node="11" p="63.000004082833939" q="22.00000237625261">
+            <iidm:load id="_044974a8-c766-11e1-8775-005056c00008" name="Wagenhls LD" loadType="UNDEFINED" p0="63" q0="22" node="11" p="63.000006181419522" q="22.000003597651691">
                 <iidm:alias>_048481d4-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6539,9 +6662,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.26375327546405" angle="7.1415379741402631" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.32323235398036" angle="-4.2645189402215404" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047fedf2-c766-11e1-8775-005056c00008" name="Concord LD" loadType="UNDEFINED" p0="34" q0="16" node="8" p="33.997686891444346" q="15.998185838353205">
+            <iidm:load id="_047fedf2-c766-11e1-8775-005056c00008" name="Concord LD" loadType="UNDEFINED" p0="34" q0="16" node="8" p="33.998325705762241" q="15.998686849604194">
                 <iidm:alias>_046d9e75-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6649,9 +6772,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="127.18220950751869" angle="10.765888728861032" nodes="0,1,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,20,21,22,23,24,25,26,27,28,29,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,49,50,51,52"/>
+                <iidm:bus v="127.39225245204395" angle="-0.39122050190788232" nodes="0,1,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,20,21,22,23,24,25,26,27,28,29,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045f94ba-c766-11e1-8775-005056c00008" name="Delaware LD" loadType="UNDEFINED" p0="59" q0="23" node="17" p="58.953035050188952" q="22.969494146806028">
+            <iidm:load id="_045f94ba-c766-11e1-8775-005056c00008" name="Delaware LD" loadType="UNDEFINED" p0="59" q0="23" node="17" p="58.968550444241032" q="22.979570303643214">
                 <iidm:alias>_0463654a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6759,9 +6882,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="125.24713569432676" angle="4.908803713286674" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="125.20036406463868" angle="-5.7883164607265707" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04697fc9-c766-11e1-8775-005056c00008" name="FtWayne LD" loadType="UNDEFINED" p0="90" q0="30" node="17" p="89.984653092761278" q="29.991474425056726">
+            <iidm:load id="_04697fc9-c766-11e1-8775-005056c00008" name="FtWayne LD" loadType="UNDEFINED" p0="90" q0="30" node="17" p="89.988667356136702" q="29.993704351003132">
                 <iidm:alias>_044d1e25-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6812,9 +6935,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.01487873841117" angle="-5.9125895730185904" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.01465252112749" angle="-16.931836023858985" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0474f170-c766-11e1-8775-005056c00008" name="WNwPhil1 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="11.999998196551527" q="2.9999992485631748">
+            <iidm:load id="_0474f170-c766-11e1-8775-005056c00008" name="WNwPhil1 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="11.999998022356934" q="2.9999991759821012">
                 <iidm:alias>_0466c0a7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6885,12 +7008,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="129.61455407256651" angle="15.396768045202151" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="129.51031934961014" angle="4.3364454230457294" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044a5f05-c766-11e1-8775-005056c00008" name="Logan LD" loadType="UNDEFINED" p0="54" q0="27" node="11" p="53.999063971579439" q="26.999219980823145">
+            <iidm:load id="_044a5f05-c766-11e1-8775-005056c00008" name="Logan LD" loadType="UNDEFINED" p0="54" q0="27" node="11" p="53.99896969315445" q="26.99914141642261">
                 <iidm:alias>_04767811-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0475dbd6-c766-11e1-8775-005056c00008" name="Logan SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.41900000000001" targetDeadband="1" node="12" q="-19.286322656289951">
+            <iidm:shunt id="_0475dbd6-c766-11e1-8775-005056c00008" name="Logan SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.41900000000001" targetDeadband="1" node="12" q="-19.25531539510763">
                 <iidm:alias>_04577e67-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_a7768441-642e-48a2-b4a8-0ae06bebf676"/>
                 <iidm:shuntLinearModel bPerSection="0.0002296" gPerSection="0" maximumSectionCount="10"/>
@@ -6964,19 +7087,19 @@
                 <iidm:internalConnection node1="32" node2="3"/>
                 <iidm:internalConnection node1="33" node2="6"/>
                 <iidm:internalConnection node1="34" node2="9"/>
-                <iidm:bus v="132.66000080579317" angle="-1.798680563937588" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34"/>
+                <iidm:bus v="132.6600040635401" angle="-12.81080818786875" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04633e31-c766-11e1-8775-005056c00008" name="W.Lancst SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="19" targetV="132.66" targetQ="0" node="13" p="-21.038607937146644" q="1.4502044669335754">
+            <iidm:generator id="_04633e31-c766-11e1-8775-005056c00008" name="W.Lancst SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="19" targetV="132.66" targetQ="0" node="13" p="-21.035206478708478" q="1.4624064965852381">
                 <iidm:alias>_047bcf42-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_83fae784-1da1-4055-8108-ba978276d1b6"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_5f711f63-f631-45d3-b26c-33821ab2ee56"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-15" maxQ="45"/>
             </iidm:generator>
-            <iidm:load id="_048a9c51-c766-11e1-8775-005056c00008" name="W.Lancst LD" loadType="UNDEFINED" p0="28" q0="10" node="11" p="28.000000255113179" q="10.000000151853081">
+            <iidm:load id="_048a9c51-c766-11e1-8775-005056c00008" name="W.Lancst LD" loadType="UNDEFINED" p0="28" q0="10" node="11" p="28.000001286512031" q="10.000000765780984">
                 <iidm:alias>_044e7db6-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_045b00d9-c766-11e1-8775-005056c00008" name="W.Lancst SC" sectionCount="5" voltageRegulatorOn="true" targetV="132.66" targetDeadband="1" node="12" q="-10.101639917117208">
+            <iidm:shunt id="_045b00d9-c766-11e1-8775-005056c00008" name="W.Lancst SC" sectionCount="5" voltageRegulatorOn="true" targetV="132.66" targetDeadband="1" node="12" q="-10.101640413251488">
                 <iidm:alias>_04758db6-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_be267a3c-f7a7-4bdf-bb17-71b773247fbf"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -7086,9 +7209,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="129.87639697929788" angle="9.8455985453320025" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="129.89824791671973" angle="-1.2834827282677637" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045dbff2-c766-11e1-8775-005056c00008" name="Portsmth LD" loadType="UNDEFINED" p0="66" q0="20" node="17" p="65.998353365770299" q="19.999168373466816">
+            <iidm:load id="_045dbff2-c766-11e1-8775-005056c00008" name="Portsmth LD" loadType="UNDEFINED" p0="66" q0="20" node="17" p="65.999588785740826" q="19.999792316462049">
                 <iidm:alias>_0454bf45-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7159,16 +7282,16 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="127.64400767097132" angle="6.1528799191220456" nodes="0,1,4,5,6,7,8,9,10,11,12,13,15,16,17,18,19,20,23,24,25,26,27,28,29,30,32,33"/>
+                <iidm:bus v="127.64400024746938" angle="-4.584203351642075" nodes="0,1,4,5,6,7,8,9,10,11,12,13,15,16,17,18,19,20,23,24,25,26,27,28,29,30,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04856c34-c766-11e1-8775-005056c00008" name="DeerCrk SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="7" targetV="127.64400000000001" targetQ="0" node="12" p="-7.7510660821066599" q="-40.016561325359334">
+            <iidm:generator id="_04856c34-c766-11e1-8775-005056c00008" name="DeerCrk SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="7" targetV="127.64400000000001" targetQ="0" node="12" p="-7.7498129132083875" q="-38.524065293232077">
                 <iidm:alias>_0477d7a5-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e5a479a8-ab8d-4a54-bb52-376874ae2784"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b55d80d5-720f-46f9-897f-ff8c5eaf8b44"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-15" maxQ="45"/>
             </iidm:generator>
-            <iidm:load id="_04791028-c766-11e1-8775-005056c00008" name="DeerCrk LD" loadType="UNDEFINED" p0="43" q0="27" node="11" p="43.000003876231212" q="27.00000405652116">
+            <iidm:load id="_04791028-c766-11e1-8775-005056c00008" name="DeerCrk LD" loadType="UNDEFINED" p0="43" q0="27" node="11" p="43.000000125049148" q="27.000000130865391">
                 <iidm:alias>_04486337-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7219,9 +7342,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.6203154957187" angle="10.317160417177853" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.85475958822097" angle="-0.8682635546209152" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0462c904-c766-11e1-8775-005056c00008" name="Medford LD" loadType="UNDEFINED" p0="22" q0="7" node="8" p="21.98365806288589" q="6.9913359671946438">
+            <iidm:load id="_0462c904-c766-11e1-8775-005056c00008" name="Medford LD" loadType="UNDEFINED" p0="22" q0="7" node="8" p="21.988776816157184" q="6.994049323730021">
                 <iidm:alias>_0489b1f7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7310,9 +7433,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="131.95003791757267" angle="15.831626695985017" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="132.11606334282769" angle="4.440981381864427" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046205b5-c766-11e1-8775-005056c00008" name="CollCrnr LD" loadType="UNDEFINED" p0="7" q0="3" node="14" p="6.9981017144083726" q="2.9986442042915842">
+            <iidm:load id="_046205b5-c766-11e1-8775-005056c00008" name="CollCrnr LD" loadType="UNDEFINED" p0="7" q0="3" node="14" p="6.9987357999652486" q="2.9990970543368705">
                 <iidm:alias>_04486334-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7363,9 +7486,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.9279557415108" angle="16.548245488262197" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.89379808172308" angle="5.4885744312227533" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0483be82-c766-11e1-8775-005056c00008" name="Caldwell LD" loadType="UNDEFINED" p0="42" q0="31" node="8" p="41.999491921971" q="30.999374985897322">
+            <iidm:load id="_0483be82-c766-11e1-8775-005056c00008" name="Caldwell LD" loadType="UNDEFINED" p0="42" q0="31" node="8" p="41.999467856583642" q="30.999345381895381">
                 <iidm:alias>_045841b9-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7416,9 +7539,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.33150110400933" angle="9.0337250221990821" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.33148118916897" angle="-2.0279206418131959" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045f94b4-c766-11e1-8775-005056c00008" name="Franklin LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="8.0000019455914835" q="3.000001215994776">
+            <iidm:load id="_045f94b4-c766-11e1-8775-005056c00008" name="Franklin LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="8.00000233708497" q="3.0000014606782486">
                 <iidm:alias>_047da403-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7469,9 +7592,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="124.88629211271304" angle="5.6842518261876744" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.82817102543304" angle="-4.8639742195214142" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045f6da2-c766-11e1-8775-005056c00008" name="McKinley LD" loadType="UNDEFINED" p0="60" q0="34" node="8" p="59.988158131518219" q="33.988816748890585">
+            <iidm:load id="_045f6da2-c766-11e1-8775-005056c00008" name="McKinley LD" loadType="UNDEFINED" p0="60" q0="34" node="8" p="59.991351902298305" q="33.991832744591441">
                 <iidm:alias>_0465d641-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7618,19 +7741,19 @@
                 <iidm:internalConnection node1="71" node2="18"/>
                 <iidm:internalConnection node1="72" node2="21"/>
                 <iidm:internalConnection node1="73" node2="12"/>
-                <iidm:bus v="130.68001196535675" angle="8.5568285672591973" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
+                <iidm:bus v="130.68000800113376" angle="-2.9827615227320896" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_044ca8f0-c766-11e1-8775-005056c00008" name="TwinBrch SM" energySource="THERMAL" minP="50" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="85" targetV="130.68000799999999" targetQ="0" node="24" p="-94.120088139866581" q="-91.38693097671154">
+            <iidm:generator id="_044ca8f0-c766-11e1-8775-005056c00008" name="TwinBrch SM" energySource="THERMAL" minP="50" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="85" targetV="130.68000799999999" targetQ="0" node="24" p="-94.104871088958973" q="-87.33224594130354">
                 <iidm:alias>_04633e38-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_0f6ab5a4-6b72-42f4-92bc-1993e1ae58a3"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_668eb671-5c36-4351-a95d-53ca850581db"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-60" maxQ="170"/>
             </iidm:generator>
-            <iidm:load id="_048740f1-c766-11e1-8775-005056c00008" name="TwinBrch LD" loadType="UNDEFINED" p0="47" q0="10" node="23" p="47.000002139253425" q="10.000000758600516">
+            <iidm:load id="_048740f1-c766-11e1-8775-005056c00008" name="TwinBrch LD" loadType="UNDEFINED" p0="47" q0="10" node="23" p="47.000000000611657" q="10.0000000002169">
                 <iidm:alias>_044ecbda-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:danglingLine id="_045338a1-c766-11e1-8775-005056c00008" name="12-117" p0="20" q0="8" r="5.7324960000000003" x="24.393599999999999" g="0" b="0.00020546369999999999" ucteXnodeCode="XMO_TE32" node="73" p="20.161794839601875" q="5.1797258380355728">
+            <iidm:danglingLine id="_045338a1-c766-11e1-8775-005056c00008" name="12-117" p0="20" q0="8" r="5.7324960000000003" x="24.393599999999999" g="0" b="0.00020546369999999999" ucteXnodeCode="XMO_TE32" node="73" p="20.161793616287486" q="5.1797255239899158">
                 <iidm:alias>_044afb42-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_0457f391-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_5631f3d0-d9d2-11e2-bb49-005056c00008</iidm:alias>
@@ -7728,9 +7851,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="124.08689539928865" angle="4.1853240764946955" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="124.04838815238988" angle="-6.4984348152394151" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0479fa87-c766-11e1-8775-005056c00008" name="Lincoln LD" loadType="UNDEFINED" p0="45" q0="25" node="14" p="44.990703493838019" q="24.991392716701942">
+            <iidm:load id="_0479fa87-c766-11e1-8775-005056c00008" name="Lincoln LD" loadType="UNDEFINED" p0="45" q0="25" node="14" p="44.993051859300479" q="24.993566867510651">
                 <iidm:alias>_047fc6e2-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7781,9 +7904,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="134.64611575084473" angle="15.739452452455302" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="134.64613869115536" angle="4.6786488538719668" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044c81e4-c766-11e1-8775-005056c00008" name="Hinton NegG LD" loadType="UNDEFINED" p0="42" q0="0" node="8" p="41.999982207454316" q="0">
+            <iidm:load id="_044c81e4-c766-11e1-8775-005056c00008" name="Hinton NegG LD" loadType="UNDEFINED" p0="42" q0="0" node="8" p="41.999985059415849" q="0">
                 <iidm:alias>_04494d96-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7834,9 +7957,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.2384746112015" angle="7.8399490782527268" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.21693443320163" angle="-3.3457634173136888" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_048bfbe0-c766-11e1-8775-005056c00008" name="N. E. LD" loadType="UNDEFINED" p0="25" q0="10" node="8" p="24.998444893507642" q="9.9989632838350779">
+            <iidm:load id="_048bfbe0-c766-11e1-8775-005056c00008" name="N. E. LD" loadType="UNDEFINED" p0="25" q0="10" node="8" p="24.998904211521374" q="9.9992694850209887">
                 <iidm:alias>_0480b140-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7887,9 +8010,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.13888580587883" angle="-6.8366787788639272" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.13852750236174" angle="-17.855712882949302" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04854525-c766-11e1-8775-005056c00008" name="SCoshoct LD" loadType="UNDEFINED" p0="18" q0="5" node="8" p="17.999988706876746" q="4.9999947717032924">
+            <iidm:load id="_04854525-c766-11e1-8775-005056c00008" name="SCoshoct LD" loadType="UNDEFINED" p0="18" q0="5" node="8" p="17.999987858405827" q="4.9999943788928514">
                 <iidm:alias>_04747c42-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7940,9 +8063,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="125.04956025615419" angle="8.3931489881511574" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="125.04559610258441" angle="-2.692849706755045" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044aad24-c766-11e1-8775-005056c00008" name="WHuntngd LD" loadType="UNDEFINED" p0="33" q0="15" node="8" p="33.000053804061267" q="15.000040760674624">
+            <iidm:load id="_044aad24-c766-11e1-8775-005056c00008" name="WHuntngd LD" loadType="UNDEFINED" p0="33" q0="15" node="8" p="33.000264685952466" q="15.000200520197065">
                 <iidm:alias>_04784cd2-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7974,9 +8097,9 @@
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="3"/>
-                <iidm:bus v="129.36000569864166" angle="9.9464349271755061" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="129.3600100152853" angle="-1.1157033908521812" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0452ea80-c766-11e1-8775-005056c00008" name="DanRiver SM" energySource="THERMAL" minP="20" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="36" targetV="129.36000000000001" targetQ="0" node="5" p="-39.862625565119956" q="-20.273567340220033">
+            <iidm:generator id="_0452ea80-c766-11e1-8775-005056c00008" name="DanRiver SM" energySource="THERMAL" minP="20" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="36" targetV="129.36000000000001" targetQ="0" node="5" p="-39.856180696500267" q="-20.275435758011369">
                 <iidm:alias>_046a4316-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_fec62959-21c5-4921-90b2-7c85e9f3bfab"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_9db08c95-4586-4a2b-87e3-5a17c944b43a"/>
@@ -8049,9 +8172,9 @@
                 <iidm:internalConnection node1="29" node2="3"/>
                 <iidm:internalConnection node1="30" node2="9"/>
                 <iidm:internalConnection node1="31" node2="6"/>
-                <iidm:bus v="130.12605134801575" angle="9.9608653422854641" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
+                <iidm:bus v="130.16253270312438" angle="-1.1858679501090876" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
             </iidm:nodeBreakerTopology>
-            <iidm:danglingLine id="_044ef2e7-c766-11e1-8775-005056c00008" name="71-73" p0="6" q0="0" r="1.508918" x="7.9104960000000002" g="0" b="6.76079e-05" ucteXnodeCode="XMO_TE31" node="31" p="6.0032115209724433" q="-1.1279540366953051">
+            <iidm:danglingLine id="_044ef2e7-c766-11e1-8775-005056c00008" name="71-73" p0="6" q0="0" r="1.508918" x="7.9104960000000002" g="0" b="6.76079e-05" ucteXnodeCode="XMO_TE31" node="31" p="6.0032100014023779" q="-1.128605446732986">
                 <iidm:alias>_04670ec2-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_046b2d7a-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_26a070b9-db0c-47cd-9991-0a461576aec2</iidm:alias>
@@ -8111,9 +8234,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="134.29666110577247" angle="2.8922125244604957" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="134.29661380000971" angle="-8.1308988694422109" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0453add4-c766-11e1-8775-005056c00008" name="Summerfl LD" loadType="UNDEFINED" p0="28" q0="7" node="8" p="27.999908238138211" q="6.9999617659326869">
+            <iidm:load id="_0453add4-c766-11e1-8775-005056c00008" name="Summerfl LD" loadType="UNDEFINED" p0="28" q0="7" node="8" p="27.999908988690787" q="6.9999620786622456">
                 <iidm:alias>_04851e16-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8240,9 +8363,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="132.66000680180292" angle="31.087115659572454" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="132.66001115632471" angle="20.037065634704" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0489b1fa-c766-11e1-8775-005056c00008" name="ClinchRv SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="607" targetV="132.66" targetQ="0" node="20" p="-672.12815883410599" q="-45.97388601470027">
+            <iidm:generator id="_0489b1fa-c766-11e1-8775-005056c00008" name="ClinchRv SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="607" targetV="132.66" targetQ="0" node="20" p="-672.0194911882129" q="-49.02380614296343">
                 <iidm:alias>_04840caa-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_2621b09a-22e3-4630-b3bd-32c102e36741"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b0d662e5-64c9-4d59-b8e0-9b1ed175769b"/>
@@ -8297,9 +8420,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.4689355962395" angle="7.6279012517623599" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.48680202911549" angle="-3.9524788818472989" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0485e168-c766-11e1-8775-005056c00008" name="Pokagon LD" loadType="UNDEFINED" p0="20" q0="9" node="8" p="19.99980240823184" q="8.999851806661912">
+            <iidm:load id="_0485e168-c766-11e1-8775-005056c00008" name="Pokagon LD" loadType="UNDEFINED" p0="20" q0="9" node="8" p="19.999852526431898" q="8.9998893950957797">
                 <iidm:alias>_0462c902-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8350,9 +8473,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.04221261632642" angle="7.1596058140729903" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.04993799201702" angle="-4.1626526306423086" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04812679-c766-11e1-8775-005056c00008" name="GoshenJt LD" loadType="UNDEFINED" p0="14" q0="1" node="8" p="13.999360103212624" q="0.99992382297165583">
+            <iidm:load id="_04812679-c766-11e1-8775-005056c00008" name="GoshenJt LD" loadType="UNDEFINED" p0="14" q0="1" node="8" p="13.999537929952796" q="0.99994499226623268">
                 <iidm:alias>_045b9d17-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8403,9 +8526,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="118.01251613502941" angle="-11.021626153462767" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="117.96515580379237" angle="-21.970221976193894" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0489b1f2-c766-11e1-8775-005056c00008" name="S.Tiffin LD" loadType="UNDEFINED" p0="37" q0="10" node="8" p="36.990452896431918" q="9.9956998727933737">
+            <iidm:load id="_0489b1f2-c766-11e1-8775-005056c00008" name="S.Tiffin LD" loadType="UNDEFINED" p0="37" q0="10" node="8" p="36.990875476737088" q="9.9958901922612746">
                 <iidm:alias>_046476b8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8456,9 +8579,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="123.61139506260467" angle="-0.28857691758919463" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="123.53834276421082" angle="-11.083753326697874" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045cfca7-c766-11e1-8775-005056c00008" name="Haviland LD" loadType="UNDEFINED" p0="23" q0="9" node="8" p="22.996113146993665" q="8.9974652386623131">
+            <iidm:load id="_045cfca7-c766-11e1-8775-005056c00008" name="Haviland LD" loadType="UNDEFINED" p0="23" q0="9" node="8" p="22.996758614407849" q="8.9978861521822946">
                 <iidm:alias>_0482ad17-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8528,9 +8651,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="131.00718338176839" angle="3.0116631259553528" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="131.00722279412551" angle="-8.0126821774124402" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04555b82-c766-11e1-8775-005056c00008" name="SWKammer LD" loadType="UNDEFINED" p0="78" q0="3" node="11" p="77.999913802648692" q="2.9999944745307974">
+            <iidm:load id="_04555b82-c766-11e1-8775-005056c00008" name="SWKammer LD" loadType="UNDEFINED" p0="78" q0="3" node="11" p="77.999918394474108" q="2.999994768878369">
                 <iidm:alias>_0474ca6b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8638,9 +8761,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="130.40115920260018" angle="15.824083739656121" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="130.35321470498738" angle="4.7637614202385299" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04817492-c766-11e1-8775-005056c00008" name="Baileysv LD" loadType="UNDEFINED" p0="38" q0="15" node="17" p="37.999508148258471" q="14.999676414724055">
+            <iidm:load id="_04817492-c766-11e1-8775-005056c00008" name="Baileysv LD" loadType="UNDEFINED" p0="38" q0="15" node="17" p="37.999479593733597" q="14.999657629019236">
                 <iidm:alias>_0474f17b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8691,9 +8814,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.04623612312028" angle="24.294335688712124" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.04245799307543" angle="13.242220443029186" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0461b790-c766-11e1-8775-005056c00008" name="HolstonT NegG LD" loadType="UNDEFINED" p0="10" q0="0" node="8" p="9.9999629885090222" q="0">
+            <iidm:load id="_0461b790-c766-11e1-8775-005056c00008" name="HolstonT NegG LD" loadType="UNDEFINED" p0="10" q0="0" node="8" p="9.999963235333226" q="0">
                 <iidm:alias>_0464ebe7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8744,9 +8867,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.65395358474463" angle="10.34095845846168" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.8848993906568" angle="-0.84020955144925336" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044c81e5-c766-11e1-8775-005056c00008" name="WMedford LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="7.9939812098086458" q="2.9962391995904132">
+            <iidm:load id="_044c81e5-c766-11e1-8775-005056c00008" name="WMedford LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="7.9958793582376311" q="2.9974250411032188">
                 <iidm:alias>_04570939-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8836,12 +8959,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="124.67645167952151" angle="-4.5423212939052222" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="124.61555042095254" angle="-15.442380575423002" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04854520-c766-11e1-8775-005056c00008" name="Rockhill LD" loadType="UNDEFINED" p0="59" q0="26" node="14" p="58.987261529906512" q="25.990644734864681">
+            <iidm:load id="_04854520-c766-11e1-8775-005056c00008" name="Rockhill LD" loadType="UNDEFINED" p0="59" q0="26" node="14" p="58.988232710134369" q="25.991357932317516">
                 <iidm:alias>_0461b799-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0460cd38-c766-11e1-8775-005056c00008" name="Rockhill SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.81399999999999" targetDeadband="1" node="15" q="-12.482006735527039">
+            <iidm:shunt id="_0460cd38-c766-11e1-8775-005056c00008" name="Rockhill SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.81399999999999" targetDeadband="1" node="15" q="-12.469815431593728">
                 <iidm:alias>_048b86b4-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_069d84c6-bd26-4c26-ac6c-e801a0202a00"/>
                 <iidm:shuntLinearModel bPerSection="0.0001606" gPerSection="0" maximumSectionCount="10"/>
@@ -8914,12 +9037,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="128.70776515859029" angle="17.127949998875639" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="128.53134522342103" angle="6.0718221919305115" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047a48a5-c766-11e1-8775-005056c00008" name="Sprigg LD" loadType="UNDEFINED" p0="20" q0="10" node="11" p="19.999493136055275" q="9.9995776169476134">
+            <iidm:load id="_047a48a5-c766-11e1-8775-005056c00008" name="Sprigg LD" loadType="UNDEFINED" p0="20" q0="10" node="11" p="19.999430623409054" q="9.9995255240101937">
                 <iidm:alias>_0472ce97-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_04553478-c766-11e1-8775-005056c00008" name="Sprigg SC" sectionCount="5" voltageRegulatorOn="true" targetV="129.935" targetDeadband="1" node="12" q="-9.5087053781562076">
+            <iidm:shunt id="_04553478-c766-11e1-8775-005056c00008" name="Sprigg SC" sectionCount="5" voltageRegulatorOn="true" targetV="129.935" targetDeadband="1" node="12" q="-9.4826560486368425">
                 <iidm:alias>_045bc428-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_f4cdc674-4a66-4ab8-8d4f-552cb066e259"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -9011,12 +9134,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="118.47775537192862" angle="-10.094895983300827" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="118.42514778466283" angle="-21.034100642920581" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04819ba4-c766-11e1-8775-005056c00008" name="West End NegG LD" loadType="UNDEFINED" p0="46" q0="0" node="14" p="45.988056276590477" q="0">
+            <iidm:load id="_04819ba4-c766-11e1-8775-005056c00008" name="West End NegG LD" loadType="UNDEFINED" p0="46" q0="0" node="14" p="45.988614316427515" q="0">
                 <iidm:alias>_04627ae0-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_04555b89-c766-11e1-8775-005056c00008" name="West End LD" loadType="UNDEFINED" p0="20" q0="23" node="15" p="19.994807076778468" q="22.990047758611897">
+            <iidm:load id="_04555b89-c766-11e1-8775-005056c00008" name="West End LD" loadType="UNDEFINED" p0="20" q0="23" node="15" p="19.995049702794571" q="22.990512713190533">
                 <iidm:alias>_04592c18-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9067,9 +9190,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.08911214814981" angle="8.9250626552501444" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.08078438327146" angle="-1.5822062025367944" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046d0232-c766-11e1-8775-005056c00008" name="Deer Crk NegG LD" loadType="UNDEFINED" p0="6" q0="0" node="8" p="5.9982580690323442" q="0">
+            <iidm:load id="_046d0232-c766-11e1-8775-005056c00008" name="Deer Crk NegG LD" loadType="UNDEFINED" p0="6" q0="0" node="8" p="5.9988068303057727" q="0">
                 <iidm:alias>_0480150a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9139,9 +9262,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="133.91909820351538" angle="0.58510157683111497" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="133.92248232788629" angle="-10.436102098003371" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046c3ee3-c766-11e1-8775-005056c00008" name="Crooksvl LD" loadType="UNDEFINED" p0="34" q0="0" node="11" p="33.999556506124136" q="0">
+            <iidm:load id="_046c3ee3-c766-11e1-8775-005056c00008" name="Crooksvl LD" loadType="UNDEFINED" p0="34" q0="0" node="11" p="33.999588793581218" q="0">
                 <iidm:alias>_047e4047-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9192,9 +9315,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="132.05317286050845" angle="-2.6560350848857013" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="132.05297284881576" angle="-13.673791598680463" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046dc585-c766-11e1-8775-005056c00008" name="WCambrdg LD" loadType="UNDEFINED" p0="17" q0="4" node="8" p="16.999996977047253" q="3.999998814528404">
+            <iidm:load id="_046dc585-c766-11e1-8775-005056c00008" name="WCambrdg LD" loadType="UNDEFINED" p0="17" q0="4" node="8" p="16.999996836028345" q="3.9999987592268784">
                 <iidm:alias>_045dbff8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9283,9 +9406,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="130.23072722752147" angle="9.1173303370478678" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="130.29023186497389" angle="-2.4941780611949667" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_048b5fa5-c766-11e1-8775-005056c00008" name="SouthBnd LD" loadType="UNDEFINED" p0="70" q0="23" node="14" p="69.997815789256578" q="22.998803897033735">
+            <iidm:load id="_048b5fa5-c766-11e1-8775-005056c00008" name="SouthBnd LD" loadType="UNDEFINED" p0="70" q0="23" node="14" p="69.998419734987678" q="22.999134623291059">
                 <iidm:alias>_04522734-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9335,11 +9458,11 @@
                 <iidm:internalConnection node1="19" node2="6"/>
                 <iidm:internalConnection node1="20" node2="3"/>
                 <iidm:internalConnection node1="21" node2="6"/>
-                <iidm:bus v="227.75394666401951" angle="26.174592044980798" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
+                <iidm:bus v="228.00860371599541" angle="14.049160326907414" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:line id="_044cd006-c766-11e1-8775-005056c00008" name="31-32" r="5.1923519999999996" x="17.16264" g1="0" b1="7.20271e-05" g2="0" b2="7.20271e-05" node1="31" voltageLevelId1="_04636548-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="0" q1="0" p2="0" q2="0">
+    <iidm:line id="_044cd006-c766-11e1-8775-005056c00008" name="31-32" r="5.1923519999999996" x="17.16264" g1="0" b1="7.20271e-05" g2="0" b2="7.20271e-05" node1="31" voltageLevelId1="_04636548-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="0" q1="-0" p2="0" q2="-0">
         <iidm:alias>_04682030-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0471bd25-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9347,7 +9470,7 @@
             <iidm:temporaryLimit name="_de6da3cb-8cb5-4900-9c33-8ad45632b535" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045a3d89-c766-11e1-8775-005056c00008" name="2-12" r="3.2582879999999999" x="10.7331839" g1="0" b1="4.5110200000000001e-05" g2="0" b2="4.5110200000000001e-05" node1="21" voltageLevelId1="_045d4ac5-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-30.517501666656393" q1="-17.739785558307787" p2="30.758386263214138" q2="17.018418084088232">
+    <iidm:line id="_045a3d89-c766-11e1-8775-005056c00008" name="2-12" r="3.2582879999999999" x="10.7331839" g1="0" b1="4.5110200000000001e-05" g2="0" b2="4.5110200000000001e-05" node1="21" voltageLevelId1="_045d4ac5-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-31.476746297867781" q1="-17.220067140389517" p2="31.725866192826942" q2="16.525620658823115">
         <iidm:alias>_046adf51-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046fe868-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9355,7 +9478,7 @@
             <iidm:temporaryLimit name="_6bd63dd1-1344-4183-b7bd-af326919f4eb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04513cd7-c766-11e1-8775-005056c00008" name="32-114" r="2.3522400000000001" x="10.6634884" g1="0" b1="4.6717149999999997e-05" g2="0" b2="4.6717149999999997e-05" node1="49" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04791027-c766-11e1-8775-005056c00008" p1="12.017283145563026" q1="2.9354559262055888" p2="-11.994300794723374" q2="-4.336334120849628">
+    <iidm:line id="_04513cd7-c766-11e1-8775-005056c00008" name="32-114" r="2.3522400000000001" x="10.6634884" g1="0" b1="4.6717149999999997e-05" g2="0" b2="4.6717149999999997e-05" node1="49" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04791027-c766-11e1-8775-005056c00008" p1="12.612107060170269" q1="2.5674329281424115" p2="-12.587448750471781" q2="-3.9659469452876266">
         <iidm:alias>_046d0237-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0470d2c7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9363,7 +9486,7 @@
             <iidm:temporaryLimit name="_5f05650a-c63d-46e5-a426-2db4f036929f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045d71d4-c766-11e1-8775-005056c00008" name="24-72" r="8.5029120000000002" x="34.151040000000002" g1="0" b1="0.00014003675" g2="0" b2="0.00014003675" node1="30" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="24.785786797631648" q1="-5.5368791629526708" p2="-24.479006830003126" q2="1.9477927146655596">
+    <iidm:line id="_045d71d4-c766-11e1-8775-005056c00008" name="24-72" r="8.5029120000000002" x="34.151040000000002" g1="0" b1="0.00014003675" g2="0" b2="0.00014003675" node1="30" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="24.040086034831749" q1="-5.1768645460772929" p2="-23.752971040614092" q2="1.4989288436880732">
         <iidm:alias>_04667281-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d0234-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9371,7 +9494,7 @@
             <iidm:temporaryLimit name="_d2074163-ab09-4251-a1d7-6983091dc4f1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045f94b8-c766-11e1-8775-005056c00008" name="17-18" r="2.1431520000000002" x="8.7991200000000003" g1="0" b1="3.7247499999999999e-05" g2="0" b2="3.7247499999999999e-05" node1="57" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04689563-c766-11e1-8775-005056c00008" p1="109.2588565628414" q1="40.913331736970619" p2="-107.50850682178412" q2="-34.930979463000931">
+    <iidm:line id="_045f94b8-c766-11e1-8775-005056c00008" name="17-18" r="2.1431520000000002" x="8.7991200000000003" g1="0" b1="3.7247499999999999e-05" g2="0" b2="3.7247499999999999e-05" node1="57" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04689563-c766-11e1-8775-005056c00008" p1="113.35496690727737" q1="40.298275677582431" p2="-111.49295868056829" q2="-33.856498301003136">
         <iidm:alias>_045e0e17-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0485ba59-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9379,7 +9502,7 @@
             <iidm:temporaryLimit name="_2b6693c7-4e29-4c2c-91d0-3485bbe8fe87" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048963d8-c766-11e1-8775-005056c00008" name="17-113" r="1.590811" x="5.244624" g1="0" b1="2.2038549999999999e-05" g2="0" b2="2.2038549999999999e-05" node1="58" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="-5.6520001817389751" q1="7.5479220928223869" p2="5.6609977254037558" q2="-8.2541895299090093">
+    <iidm:line id="_048963d8-c766-11e1-8775-005056c00008" name="17-113" r="1.590811" x="5.244624" g1="0" b1="2.2038549999999999e-05" g2="0" b2="2.2038549999999999e-05" node1="58" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="-1.1110377610222684" q1="5.2152526192081066" p2="1.1141221362852212" q2="-5.9407015331759228">
         <iidm:alias>_045841b5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046958b4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9387,7 +9510,7 @@
             <iidm:temporaryLimit name="_786432da-fa4d-4751-a275-87d0e20529f1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0458ddf0-c766-11e1-8775-005056c00008" name="49-50" r="4.6522079999999999" x="13.102848099999999" g1="0" b1="5.3776400000000002e-05" g2="0" b2="5.3776400000000002e-05" node1="112" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044d1e26-c766-11e1-8775-005056c00008" p1="62.125935612982062" q1="11.702310856345335" p2="-61.104166391282774" q2="-10.74670954171237">
+    <iidm:line id="_0458ddf0-c766-11e1-8775-005056c00008" name="49-50" r="4.6522079999999999" x="13.102848099999999" g1="0" b1="5.3776400000000002e-05" g2="0" b2="5.3776400000000002e-05" node1="112" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044d1e26-c766-11e1-8775-005056c00008" p1="62.143424412245473" q1="11.698994859852609" p2="-61.121124306480176" q2="-10.741895531052556">
         <iidm:alias>_0464ebe8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f9fd8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9395,7 +9518,7 @@
             <iidm:temporaryLimit name="_1f0844a5-ea5c-42b2-abcb-6fac2c426092" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04535fb7-c766-11e1-8775-005056c00008" name="1-3" r="2.2476959999999999" x="7.3877759999999997" g1="0" b1="3.1049149999999997e-05" g2="0" b2="3.1049149999999997e-05" node1="21" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_047eb579-c766-11e1-8775-005056c00008" p1="-40.547957004925344" q1="-16.106897956310494" p2="40.812304768285678" q2="15.965967439824755">
+    <iidm:line id="_04535fb7-c766-11e1-8775-005056c00008" name="1-3" r="2.2476959999999999" x="7.3877759999999997" g1="0" b1="3.1049149999999997e-05" g2="0" b2="3.1049149999999997e-05" node1="21" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_047eb579-c766-11e1-8775-005056c00008" p1="-39.592624219197447" q1="-16.637277720847781" p2="39.848403657689587" q2="16.467289191352506">
         <iidm:alias>_044ef2e9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047c4474-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9403,7 +9526,7 @@
             <iidm:temporaryLimit name="_4ea43e34-67a3-42b8-9601-2189db7790d4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0478e912-c766-11e1-8775-005056c00008" name="92-102" r="2.1431520000000002" x="9.7400160000000007" g1="0" b1="4.2011000000000001e-05" g2="0" b2="4.2011000000000001e-05" node1="66" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="49.940417832519387" q1="-9.0341950892799279" p2="-49.618377620166868" q2="9.066080848576302">
+    <iidm:line id="_0478e912-c766-11e1-8775-005056c00008" name="92-102" r="2.1431520000000002" x="9.7400160000000007" g1="0" b1="4.2011000000000001e-05" g2="0" b2="4.2011000000000001e-05" node1="66" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="49.977041517058865" q1="-9.0531133265160317" p2="-49.65446850405408" q2="9.08755851296457">
         <iidm:alias>_045a1673-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0468bc79-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9411,7 +9534,7 @@
             <iidm:temporaryLimit name="_23cc194e-9273-46e9-a793-84a9c2911737" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04547127-c766-11e1-8775-005056c00008" name="93-94" r="3.8855520000000001" x="12.7543688" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="21" voltageLevelId1="_04789af0-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="57.209845611852941" q1="-22.097684244305686" p2="-56.351129983137227" q2="23.095854037652934">
+    <iidm:line id="_04547127-c766-11e1-8775-005056c00008" name="93-94" r="3.8855520000000001" x="12.7543688" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="21" voltageLevelId1="_04789af0-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="57.266526697769336" q1="-22.041369744963003" p2="-56.406655329633828" q2="23.043866679844381">
         <iidm:alias>_04500450-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047b0bfb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9419,7 +9542,7 @@
             <iidm:temporaryLimit name="_1a9fe09e-3f63-4904-8e36-aa38c5e16c59" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04791021-c766-11e1-8775-005056c00008" name="46-48" r="10.4718237" x="32.931359999999998" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044778d3-c766-11e1-8775-005056c00008" p1="-8.8324655915759323" q1="-7.9374400775750598" p2="8.897239250816936" q2="3.2982201630553201">
+    <iidm:line id="_04791021-c766-11e1-8775-005056c00008" name="46-48" r="10.4718237" x="32.931359999999998" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044778d3-c766-11e1-8775-005056c00008" p1="-8.799817630819188" q1="-7.9487554588822107" p2="8.864323613454026" q2="3.308689338091618">
         <iidm:alias>_0459ef69-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04640186-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9427,7 +9550,7 @@
             <iidm:temporaryLimit name="_467ba04d-dbad-4fe1-81c8-3bc87b41fcd1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046958b6-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="113" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-92.566894200537547" q1="-2.4504235348212626" p2="94.035153985074487" q2="7.2883476799120741">
+    <iidm:line id="_046958b6-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="113" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-92.464111321841088" q1="-2.4787209656408402" p2="93.929124003714733" q2="7.3000677204051252">
         <iidm:alias>_04776270-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a96c8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9435,7 +9558,7 @@
             <iidm:temporaryLimit name="_d0737ab4-5a3a-46c8-8aeb-789313f0f332" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046f4c26-c766-11e1-8775-005056c00008" name="75-118" r="2.5264799999999998" x="8.3809430000000003" g1="0" b1="3.4377849999999998e-05" g2="0" b2="3.4377849999999998e-05" node1="48" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="39.202703960259441" q1="28.728155848911218" p2="-38.831873690975726" q2="-28.596483059622081">
+    <iidm:line id="_046f4c26-c766-11e1-8775-005056c00008" name="75-118" r="2.5264799999999998" x="8.3809430000000003" g1="0" b1="3.4377849999999998e-05" g2="0" b2="3.4377849999999998e-05" node1="48" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="39.071229085571623" q1="28.831582274537805" p2="-38.701054776122213" q2="-28.70205474217925">
         <iidm:alias>_04619088-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04814d8a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9443,7 +9566,7 @@
             <iidm:temporaryLimit name="_173dc7ff-ae18-4410-b2e1-a4c2abac8ff6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c3954-c766-11e1-8775-005056c00008" name="94-96" r="4.6870560000000001" x="15.1414566" g1="0" b1="6.60009e-05" g2="0" b2="6.60009e-05" node1="49" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="38.268875230212068" q1="-13.09307290696764" p2="-37.824971591049504" q2="12.284299677917458">
+    <iidm:line id="_045c3954-c766-11e1-8775-005056c00008" name="94-96" r="4.6870560000000001" x="15.1414566" g1="0" b1="6.60009e-05" g2="0" b2="6.60009e-05" node1="49" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="38.336270772837182" q1="-12.893855058031656" p2="-37.89209187355825" q2="12.087183177126345">
         <iidm:alias>_046ba2a0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0472ce94-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9451,7 +9574,7 @@
             <iidm:temporaryLimit name="_efde58bf-c92e-496d-b558-d0095a271083" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04518af7-c766-11e1-8775-005056c00008" name="62-67" r="4.4953919999999998" x="20.38608" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="39" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="-2.4835951814313928" q1="-18.364507875626156" p2="2.5586584244085397" q2="15.559752847964784">
+    <iidm:line id="_04518af7-c766-11e1-8775-005056c00008" name="62-67" r="4.4953919999999998" x="20.38608" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="39" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="-2.4975634507838613" q1="-18.361100715204103" p2="2.5726149913751826" q2="15.556293591740539">
         <iidm:alias>_04544a10-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04814d86-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9459,7 +9582,7 @@
             <iidm:temporaryLimit name="_8a81d4ae-2bc8-4038-8650-27a6150946b1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0452c375-c766-11e1-8775-005056c00008" name="47-49" r="3.3279839999999998" x="10.890000000000001" g1="0" b1="4.6028449999999998e-05" g2="0" b2="4.6028449999999998e-05" node1="30" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="114" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="17.0588503301332" q1="-22.850160501376973" p2="-16.914835048927795" q2="21.653324557296074">
+    <iidm:line id="_0452c375-c766-11e1-8775-005056c00008" name="47-49" r="3.3279839999999998" x="10.890000000000001" g1="0" b1="4.6028449999999998e-05" g2="0" b2="4.6028449999999998e-05" node1="30" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="114" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="16.957921017102951" q1="-22.779962909495289" p2="-16.815123273456429" q2="21.579101112637971">
         <iidm:alias>_0465fd54-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0471e431-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9467,7 +9590,7 @@
             <iidm:temporaryLimit name="_8d6a074c-900d-4a37-830c-5da4c1de1ab5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046c17d9-c766-11e1-8775-005056c00008" name="100-106" r="10.54152" x="39.900959999999998" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="76" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="59.401672017691411" q1="10.058507120863283" p2="-57.234742888300481" q2="-7.920143676612752">
+    <iidm:line id="_046c17d9-c766-11e1-8775-005056c00008" name="100-106" r="10.54152" x="39.900959999999998" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="76" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="59.403505971317529" q1="10.058356349006042" p2="-57.236451873157421" q2="-7.9195191596082735">
         <iidm:alias>_045d98e5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0480d851-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9475,7 +9598,7 @@
             <iidm:temporaryLimit name="_3154dc30-b0e5-4570-8e52-9333bae20ef2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046b2d77-c766-11e1-8775-005056c00008" name="77-78" r="0.655142" x="2.1605759999999998" g1="0" b1="3.6271800000000001e-05" g2="0" b2="3.6271800000000001e-05" node1="66" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044fb634-c766-11e1-8775-005056c00008" p1="43.777135323365876" q1="4.0513530292375632" p2="-43.704639552475236" q2="-5.0802435015976082">
+    <iidm:line id="_046b2d77-c766-11e1-8775-005056c00008" name="77-78" r="0.655142" x="2.1605759999999998" g1="0" b1="3.6271800000000001e-05" g2="0" b2="3.6271800000000001e-05" node1="66" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044fb634-c766-11e1-8775-005056c00008" p1="43.681726835970835" q1="3.9499776549809464" p2="-43.609558005371341" q2="-4.9796083522970171">
         <iidm:alias>_046ed6fb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04893cc3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9483,7 +9606,7 @@
             <iidm:temporaryLimit name="_cce754c5-b9d5-4105-a431-32da96e4a6cf" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c8776-c766-11e1-8775-005056c00008" name="6-7" r="0.79976199999999997" x="3.6241919999999999" g1="0" b1="1.5782850000000001e-05" g2="0" b2="1.5782850000000001e-05" node1="21" voltageLevelId1="_044f6818-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047eb571-c766-11e1-8775-005056c00008" p1="42.872151553654525" q1="-8.1022022044255557" p2="-42.783028767349968" q2="7.968210771388887">
+    <iidm:line id="_045c8776-c766-11e1-8775-005056c00008" name="6-7" r="0.79976199999999997" x="3.6241919999999999" g1="0" b1="1.5782850000000001e-05" g2="0" b2="1.5782850000000001e-05" node1="21" voltageLevelId1="_044f6818-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047eb571-c766-11e1-8775-005056c00008" p1="38.620121610189038" q1="-6.1336834326637248" p2="-38.548606183499807" q2="5.9194000714671704">
         <iidm:alias>_046efe08-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04720b4a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9491,7 +9614,7 @@
             <iidm:temporaryLimit name="_361a9cc3-fb33-4037-9b9a-c20adb90b66b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047ba839-c766-11e1-8775-005056c00008" name="77-80" r="5.1226560000000001" x="18.295200000000001" g1="0" b1="6.5426999999999995e-05" g2="0" b2="6.5426999999999995e-05" node1="67" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="76" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-46.068617043910429" q1="-23.088245279316705" p2="46.830050219591683" q2="23.428521791286865">
+    <iidm:line id="_047ba839-c766-11e1-8775-005056c00008" name="77-80" r="5.1226560000000001" x="18.295200000000001" g1="0" b1="6.5426999999999995e-05" g2="0" b2="6.5426999999999995e-05" node1="67" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="76" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-46.167700014057878" q1="-23.187190317358315" p2="46.933298469149229" q2="23.542665936557228">
         <iidm:alias>_047c6b85-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0480b148-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9499,7 +9622,7 @@
             <iidm:temporaryLimit name="_da00c66f-a882-4938-923b-f2455f7f9a81" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04592c16-c766-11e1-8775-005056c00008" name="78-79" r="0.95135000000000003" x="4.2514560000000001" g1="0" b1="1.8595050000000001e-05" g2="0" b2="1.8595050000000001e-05" node1="22" voltageLevelId1="_044fb634-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04481510-c766-11e1-8775-005056c00008" p1="-27.295302031701716" q1="-20.919720131312133" p2="27.359081142772567" q2="20.551890444644116">
+    <iidm:line id="_04592c16-c766-11e1-8775-005056c00008" name="78-79" r="0.95135000000000003" x="4.2514560000000001" g1="0" b1="1.8595050000000001e-05" g2="0" b2="1.8595050000000001e-05" node1="22" voltageLevelId1="_044fb634-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04481510-c766-11e1-8775-005056c00008" p1="-27.390409961130818" q1="-21.02037027696478" p2="27.454715818461274" q2="20.655037894136655">
         <iidm:alias>_0453add6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045b7605-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9507,7 +9630,7 @@
             <iidm:temporaryLimit name="_ba4abe9d-8490-4c19-b19b-c9d2c3597fc9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047b3301-c766-11e1-8775-005056c00008" name="103-104" r="8.1195839999999997" x="27.599615100000001" g1="0" b1="0.00011679295" g2="0" b2="0.00011679295" node1="40" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="33.048952178294485" q1="13.983406639398371" p2="-32.432186380848812" q2="-15.87986895691682">
+    <iidm:line id="_047b3301-c766-11e1-8775-005056c00008" name="103-104" r="8.1195839999999997" x="27.599615100000001" g1="0" b1="0.00011679295" g2="0" b2="0.00011679295" node1="40" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="33.048430019550082" q1="13.983604379966033" p2="-32.431677126108227" q2="-15.880110397457308">
         <iidm:alias>_0459a142-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045d98e6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9515,7 +9638,7 @@
             <iidm:temporaryLimit name="_2320da74-eda7-4f7f-ade9-1ed0e994f3af" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045e5c32-c766-11e1-8775-005056c00008" name="95-96" r="2.9795039999999999" x="9.5309279999999994" g1="0" b1="4.2298000000000001e-05" g2="0" b2="4.2298000000000001e-05" node1="21" voltageLevelId1="_044f4108-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="14.674365699348185" q1="-25.078121178106151" p2="-14.529269740440864" q2="24.119908769557348">
+    <iidm:line id="_045e5c32-c766-11e1-8775-005056c00008" name="95-96" r="2.9795039999999999" x="9.5309279999999994" g1="0" b1="4.2298000000000001e-05" g2="0" b2="4.2298000000000001e-05" node1="21" voltageLevelId1="_044f4108-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="14.734420326945679" q1="-24.904628962093792" p2="-14.59043890644906" q2="23.943752633724095">
         <iidm:alias>_04597a34-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04801509-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9523,7 +9646,7 @@
             <iidm:temporaryLimit name="_3bc03415-e95f-47a7-8e92-01089d304a9c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045ed169-c766-11e1-8775-005056c00008" name="77-80" r="2.9620799999999998" x="8.4506409999999992" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="68" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="77" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-100.52396338010048" q1="-42.567163228642301" p2="102.50586577208958" q2="43.296203806744671">
+    <iidm:line id="_045ed169-c766-11e1-8775-005056c00008" name="77-80" r="2.9620799999999998" x="8.4506409999999992" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="68" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="77" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-100.74724736792136" q1="-42.763202917986867" p2="102.73999139052232" q2="43.523842927059896">
         <iidm:alias>_0464289a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04828605-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9531,7 +9654,7 @@
             <iidm:temporaryLimit name="_f93b6d4c-39fa-4f6f-a42d-c63a4cf21a67" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047f78c2-c766-11e1-8775-005056c00008" name="5-11" r="3.5370720000000002" x="11.8831682" g1="0" b1="4.987375e-05" g2="0" b2="4.987375e-05" node1="48" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="88.225172748336803" q1="8.3847306404291313" p2="-86.655768631875958" q2="-4.8425854756149382">
+    <iidm:line id="_047f78c2-c766-11e1-8775-005056c00008" name="5-11" r="3.5370720000000002" x="11.8831682" g1="0" b1="4.987375e-05" g2="0" b2="4.987375e-05" node1="48" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="83.096549224054144" q1="10.426890579528186" p2="-81.696755814429409" q2="-7.4570977298083774">
         <iidm:alias>_045bc426-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0476c633-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9539,7 +9662,7 @@
             <iidm:temporaryLimit name="_3bc4ab96-7a0d-4e18-b9f5-d89f63a82f0a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04845ac7-c766-11e1-8775-005056c00008" name="71-72" r="7.7711040000000002" x="31.363201100000001" g1="0" b1="0.00012752525" g2="0" b2="0.00012752525" node1="29" voltageLevelId1="_04664b78-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="-12.410610313236555" q1="-2.1110580058260475" p2="12.48129853793834" q2="-1.9477924050914346">
+    <iidm:line id="_04845ac7-c766-11e1-8775-005056c00008" name="71-72" r="7.7711040000000002" x="31.363201100000001" g1="0" b1="0.00012752525" g2="0" b2="0.00012752525" node1="29" voltageLevelId1="_04664b78-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="-11.691775396028925" q1="-2.5965418480329694" p2="11.754563174344664" q2="-1.4989293419411551">
         <iidm:alias>_04642891-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046b0661-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9547,7 +9670,7 @@
             <iidm:temporaryLimit name="_bcb69c6e-125e-449c-acb3-a4deb151668d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047343c2-c766-11e1-8775-005056c00008" name="66-67" r="3.9029759999999998" x="17.685359999999999" g1="0" b1="7.6962800000000001e-05" g2="0" b2="7.6962800000000001e-05" node1="50" voltageLevelId1="_047147f4-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="30.857651213741299" q1="21.060874197791364" p2="-30.558566802303815" q2="-22.559714605418247">
+    <iidm:line id="_047343c2-c766-11e1-8775-005056c00008" name="66-67" r="3.9029759999999998" x="17.685359999999999" g1="0" b1="7.6962800000000001e-05" g2="0" b2="7.6962800000000001e-05" node1="50" voltageLevelId1="_047147f4-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="30.871762083828742" q1="21.058111243057802" p2="-30.572524499255948" q2="-22.556255591617628">
         <iidm:alias>_0465af34-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04860874-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9555,7 +9678,7 @@
             <iidm:temporaryLimit name="_b4b8a31d-dc3c-4b51-88ad-a22e070eb96c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04569409-c766-11e1-8775-005056c00008" name="34-43" r="7.1961120000000003" x="29.289743399999999" g1="0" b1="0.0001212695" g2="0" b2="0.0001212695" node1="40" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_045e8349-c766-11e1-8775-005056c00008" p1="12.396217614035178" q1="-7.5282771936933859" p2="-12.310335671918892" q2="4.0879864145190412">
+    <iidm:line id="_04569409-c766-11e1-8775-005056c00008" name="34-43" r="7.1961120000000003" x="29.289743399999999" g1="0" b1="0.0001212695" g2="0" b2="0.0001212695" node1="40" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_045e8349-c766-11e1-8775-005056c00008" p1="12.676990578465292" q1="-7.6607355547063296" p2="-12.587051651456369" q2="4.2401136622480573">
         <iidm:alias>_04500454-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04505274-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9563,7 +9686,7 @@
             <iidm:temporaryLimit name="_5585c67a-0839-48e6-8847-4393e1e9b9c7" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04817498-c766-11e1-8775-005056c00008" name="52-53" r="7.0567200000000003" x="28.488240000000001" g1="0" b1="0.00011644859999999999" g2="0" b2="0.00011644859999999999" node1="21" voltageLevelId1="_04806326-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04876804-c766-11e1-8775-005056c00008" p1="13.378641682839355" q1="0.95902432714088448" p2="-13.295751819857561" q2="-4.2905610068833795">
+    <iidm:line id="_04817498-c766-11e1-8775-005056c00008" name="52-53" r="7.0567200000000003" x="28.488240000000001" g1="0" b1="0.00011644859999999999" g2="0" b2="0.00011644859999999999" node1="21" voltageLevelId1="_04806326-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04876804-c766-11e1-8775-005056c00008" p1="13.385065687109845" q1="0.95680572252687945" p2="-13.302104657428268" q2="-4.2880392913495236">
         <iidm:alias>_045115c7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0472a784-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9571,7 +9694,7 @@
             <iidm:temporaryLimit name="_e7c9dfab-fb45-4470-964f-4ba9e391f60b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044b7078-c766-11e1-8775-005056c00008" name="105-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="49" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="23" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="26.894184299442479" q1="1.3281092341895209" p2="-26.475725182430033" q2="-4.1905954922427071">
+    <iidm:line id="_044b7078-c766-11e1-8775-005056c00008" name="105-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="49" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="23" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="26.8939700423023" q1="1.3281863298664371" p2="-26.475517116853105" q2="-4.1906931614136553">
         <iidm:alias>_0452c378-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0481c2b7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9579,7 +9702,7 @@
             <iidm:temporaryLimit name="_fff133bf-25fd-46b2-b144-a227c31ee882" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048ac367-c766-11e1-8775-005056c00008" name="100-101" r="4.8264480000000001" x="21.9890881" g1="0" b1="9.4123049999999997e-05" g2="0" b2="9.4123049999999997e-05" node1="77" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046ed6f7-c766-11e1-8775-005056c00008" p1="-21.774781958859247" q1="24.723309390959415" p2="22.088699038054312" q2="-26.599110743944308">
+    <iidm:line id="_048ac367-c766-11e1-8775-005056c00008" name="100-101" r="4.8264480000000001" x="21.9890881" g1="0" b1="9.4123049999999997e-05" g2="0" b2="9.4123049999999997e-05" node1="77" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046ed6f7-c766-11e1-8775-005056c00008" p1="-21.809071822358881" q1="24.753270992714977" p2="22.123813363315541" q2="-26.625231639907149">
         <iidm:alias>_044afb45-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b5fa2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9587,7 +9710,7 @@
             <iidm:temporaryLimit name="_217e3c95-24b5-438f-a721-d2257e1a43b4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0481c2b1-c766-11e1-8775-005056c00008" name="56-57" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="57" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="-30.784898301168294" q1="-5.4825701685802342" p2="31.149416623898684" q2="4.2702357439461842">
+    <iidm:line id="_0481c2b1-c766-11e1-8775-005056c00008" name="56-57" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="57" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="-30.800838205764137" q1="-5.4748672292363993" p2="31.165701361711967" q2="4.2635085150613916">
         <iidm:alias>_045e0e12-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0487dd35-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9595,7 +9718,7 @@
             <iidm:temporaryLimit name="_f5547027-3d48-4a53-937b-bd5ba63ef70d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047a6fb7-c766-11e1-8775-005056c00008" name="47-69" r="14.705855400000001" x="48.403869999999998" g1="0" b1="0.00020351240000000001" g2="0" b2="0.00020351240000000001" node1="31" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="57" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-83.990460262720006" q1="26.015457765675325" p2="90.496562767592593" q2="-12.04924332022069">
+    <iidm:line id="_047a6fb7-c766-11e1-8775-005056c00008" name="47-69" r="14.705855400000001" x="48.403869999999998" g1="0" b1="0.00020351240000000001" g2="0" b2="0.00020351240000000001" node1="31" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="57" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-83.777937755102045" q1="25.896550774846695" p2="90.248712751251787" q2="-12.046800430173565">
         <iidm:alias>_04758db9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0485ba56-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9603,7 +9726,7 @@
             <iidm:temporaryLimit name="_e9fec217-cf6f-4d39-9495-26ed10c05100" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0453fbf0-c766-11e1-8775-005056c00008" name="110-111" r="3.8332799999999998" x="13.1551189" g1="0" b1="5.7392100000000002e-05" g2="0" b2="5.7392100000000002e-05" node1="40" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_046a1c00-c766-11e1-8775-005056c00008" p1="-39.395344725627311" q1="-20.542445109826925" p2="39.862629528272912" q2="20.273570683286295">
+    <iidm:line id="_0453fbf0-c766-11e1-8775-005056c00008" name="110-111" r="3.8332799999999998" x="13.1551189" g1="0" b1="5.7392100000000002e-05" g2="0" b2="5.7392100000000002e-05" node1="40" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_046a1c00-c766-11e1-8775-005056c00008" p1="-39.389002009436162" q1="-20.544656177303693" p2="39.856187329258717" q2="20.275440484216482">
         <iidm:alias>_0447c6f5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04812675-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9611,7 +9734,7 @@
             <iidm:temporaryLimit name="_ea48fee0-31b6-4990-a332-25d08b7d731f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04778984-c766-11e1-8775-005056c00008" name="41-42" r="7.14384" x="23.522401800000001" g1="0" b1="9.8714400000000005e-05" g2="0" b2="9.8714400000000005e-05" node1="21" voltageLevelId1="_048c4a08-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="-10.799770353472422" q1="-11.050552509027806" p2="10.907620997418837" q2="8.595021834981468">
+    <iidm:line id="_04778984-c766-11e1-8775-005056c00008" name="41-42" r="7.14384" x="23.522401800000001" g1="0" b1="9.8714400000000005e-05" g2="0" b2="9.8714400000000005e-05" node1="21" voltageLevelId1="_048c4a08-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="-10.594852468437074" q1="-11.192025131289132" p2="10.701965908725239" q2="8.7359065898043742">
         <iidm:alias>_044d1e2a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046512f1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9619,7 +9742,7 @@
             <iidm:temporaryLimit name="_063af52c-fe10-4c1e-85d4-dd80dcc1d2f9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04653a08-c766-11e1-8775-005056c00008" name="80-99" r="7.9104960000000002" x="35.893439999999998" g1="0" b1="0.00015668044999999999" g2="0" b2="0.00015668044999999999" node1="78" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04644fa4-c766-11e1-8775-005056c00008" p1="1.9859420702832999" q1="6.6832811673764345" p2="-1.9453115002477213" q2="-12.292240710798836">
+    <iidm:line id="_04653a08-c766-11e1-8775-005056c00008" name="80-99" r="7.9104960000000002" x="35.893439999999998" g1="0" b1="0.00015668044999999999" g2="0" b2="0.00015668044999999999" node1="78" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04644fa4-c766-11e1-8775-005056c00008" p1="1.9925680065471578" q1="6.6817483641969098" p2="-1.9519387709755156" q2="-12.290715120631615">
         <iidm:alias>_04773b69-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0477b092-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9627,7 +9750,7 @@
             <iidm:temporaryLimit name="_c05229ce-6abb-4209-ad4f-0dcd4a070f28" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04581aa5-c766-11e1-8775-005056c00008" name="54-59" r="8.7642720000000001" x="39.953229999999998" g1="0" b1="0.0001716024" g2="0" b2="0.0001716024" node1="58" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-19.674436773670479" q1="-10.512035180282005" p2="19.921347259469989" q2="6.0096851010246057">
+    <iidm:line id="_04581aa5-c766-11e1-8775-005056c00008" name="54-59" r="8.7642720000000001" x="39.953229999999998" g1="0" b1="0.0001716024" g2="0" b2="0.0001716024" node1="58" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-19.657700557751063" q1="-10.516483864594163" p2="19.904286191943712" q2="6.0126525858815842">
         <iidm:alias>_0457cc82-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045cae81-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9635,7 +9758,7 @@
             <iidm:temporaryLimit name="_ac528cbe-6fc1-41dd-ba9d-d8b7a4c77576" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04690a93-c766-11e1-8775-005056c00008" name="92-94" r="8.3809430000000003" x="27.529920000000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="67" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="65.126597183350967" q1="-16.415128040677722" p2="-62.940410793222725" q2="19.631094854638974">
+    <iidm:line id="_04690a93-c766-11e1-8775-005056c00008" name="92-94" r="8.3809430000000003" x="27.529920000000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="67" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="65.184975550941758" q1="-16.352656987202892" p2="-62.995706324345612" q2="19.57963871268025">
         <iidm:alias>_044c33c1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0483706b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9643,7 +9766,7 @@
             <iidm:temporaryLimit name="_6ac84228-6b04-4b10-b560-29655c8e93b4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046009e3-c766-11e1-8775-005056c00008" name="37-39" r="5.5931040000000003" x="18.469439999999999" g1="0" b1="7.7479350000000006e-05" g2="0" b2="7.7479350000000006e-05" node1="57" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046bf0c7-c766-11e1-8775-005056c00008" p1="66.644158150873253" q1="18.166087634214396" p2="-64.929099428065342" q2="-14.832601550519575">
+    <iidm:line id="_046009e3-c766-11e1-8775-005056c00008" name="37-39" r="5.5931040000000003" x="18.469439999999999" g1="0" b1="7.7479350000000006e-05" g2="0" b2="7.7479350000000006e-05" node1="57" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046bf0c7-c766-11e1-8775-005056c00008" p1="66.873430157311887" q1="18.08916932949904" p2="-65.146924041016007" q2="-14.715676013818294">
         <iidm:alias>_044c33c9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04789afa-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9651,7 +9774,7 @@
             <iidm:temporaryLimit name="_2ccdc288-c132-40d1-a928-3887bec4ff67" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0458b6e8-c766-11e1-8775-005056c00008" name="46-47" r="6.6211200000000003" x="22.12848" g1="0" b1="9.0679499999999998e-05" g2="0" b2="9.0679499999999998e-05" node1="33" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_0457f396-c766-11e1-8775-005056c00008" p1="-32.530788103399125" q1="1.2842532315641975" p2="32.932053315235585" q2="-3.1652973900930559">
+    <iidm:line id="_0458b6e8-c766-11e1-8775-005056c00008" name="46-47" r="6.6211200000000003" x="22.12848" g1="0" b1="9.0679499999999998e-05" g2="0" b2="9.0679499999999998e-05" node1="33" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_0457f396-c766-11e1-8775-005056c00008" p1="-32.421946598597522" q1="1.2261558500102328" p2="32.820427389392847" q2="-3.1165881078687687">
         <iidm:alias>_04507980-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0464c4da-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9659,7 +9782,7 @@
             <iidm:temporaryLimit name="_06ca3245-2668-448f-a5c6-961924217a5c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044f8f22-c766-11e1-8775-005056c00008" name="82-83" r="1.9514879999999999" x="6.3858959999999998" g1="0" b1="0.0001089302" g2="0" b2="0.0001089302" node1="31" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728074-c766-11e1-8775-005056c00008" p1="-66.702613702741516" q1="38.151337378532816" p2="67.405122882870955" q2="-39.487025351161883">
+    <iidm:line id="_044f8f22-c766-11e1-8775-005056c00008" name="82-83" r="1.9514879999999999" x="6.3858959999999998" g1="0" b1="0.0001089302" g2="0" b2="0.0001089302" node1="31" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728074-c766-11e1-8775-005056c00008" p1="-66.314255698011593" q1="39.487944452279656" p2="67.02450049045467" q2="-40.790433349020979">
         <iidm:alias>_047a48a6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b3891-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9667,7 +9790,7 @@
             <iidm:temporaryLimit name="_dfbd2f07-76ab-41e3-910f-dc706979ea4b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045cfca6-c766-11e1-8775-005056c00008" name="108-109" r="1.82952" x="5.0181120000000004" g1="0" b1="2.1809000000000001e-05" g2="0" b2="2.1809000000000001e-05" node1="21" voltageLevelId1="_046c65f4-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b7b99-c766-11e1-8775-005056c00008" p1="20.784216745157373" q1="-0.53102810599199302" p2="-20.734919824277565" q2="-0.031487535614895673">
+    <iidm:line id="_045cfca6-c766-11e1-8775-005056c00008" name="108-109" r="1.82952" x="5.0181120000000004" g1="0" b1="2.1809000000000001e-05" g2="0" b2="2.1809000000000001e-05" node1="21" voltageLevelId1="_046c65f4-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b7b99-c766-11e1-8775-005056c00008" p1="20.787359695719008" q1="-0.53214284164396797" p2="-20.738047804148493" q2="-0.030331519722000527">
         <iidm:alias>_04481514-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04716f00-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9675,7 +9798,7 @@
             <iidm:temporaryLimit name="_11451cec-81c7-4f83-a7db-df7dcaffa94e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04784cd5-c766-11e1-8775-005056c00008" name="70-74" r="6.9870239999999999" x="23.051952400000001" g1="0" b1="9.6648299999999994e-05" g2="0" b2="9.6648299999999994e-05" node1="48" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047dcb11-c766-11e1-8775-005056c00008" p1="23.58313043879604" q1="9.2330822474685519" p2="-23.303872773641132" q2="-11.494229523227117">
+    <iidm:line id="_04784cd5-c766-11e1-8775-005056c00008" name="70-74" r="6.9870239999999999" x="23.051952400000001" g1="0" b1="9.6648299999999994e-05" g2="0" b2="9.6648299999999994e-05" node1="48" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047dcb11-c766-11e1-8775-005056c00008" p1="23.276823316082659" q1="9.409419528387085" p2="-23.001998797104619" q2="-11.685880013093591">
         <iidm:alias>_045e5c33-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046ab84b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9683,7 +9806,7 @@
             <iidm:temporaryLimit name="_37a5cc00-bd7f-4ec7-a77c-e140e23450d2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04747c40-c766-11e1-8775-005056c00008" name="77-82" r="5.1923519999999996" x="14.8626719" g1="0" b1="0.0002345615" g2="0" b2="0.0002345615" node1="69" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_046512f8-c766-11e1-8775-005056c00008" p1="-27.674554451264893" q1="30.631182886687636" p2="28.259304118301355" q2="-37.006884685039417">
+    <iidm:line id="_04747c40-c766-11e1-8775-005056c00008" name="77-82" r="5.1923519999999996" x="14.8626719" g1="0" b1="0.0002345615" g2="0" b2="0.0002345615" node1="69" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_046512f8-c766-11e1-8775-005056c00008" p1="-27.478526123334696" q1="31.324572087711584" p2="28.074637593873465" q2="-37.660257555879106">
         <iidm:alias>_0451b202-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0452ea84-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9691,7 +9814,7 @@
             <iidm:temporaryLimit name="_e9798d58-b518-4fab-984c-c72076dfc2ae" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045e3524-c766-11e1-8775-005056c00008" name="23-24" r="2.3522400000000001" x="8.5726080000000007" g1="0" b1="0.00014290635" g2="0" b2="0.00014290635" node1="39" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_048c22fa-c766-11e1-8775-005056c00008" p1="56.234842674324767" q1="-10.380793864029897" p2="-55.799184936821156" q2="7.0086697722691769">
+    <iidm:line id="_045e3524-c766-11e1-8775-005056c00008" name="23-24" r="2.3522400000000001" x="8.5726080000000007" g1="0" b1="0.00014290635" g2="0" b2="0.00014290635" node1="39" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_048c22fa-c766-11e1-8775-005056c00008" p1="54.624885134294487" q1="-9.9368828316268232" p2="-54.21530441025466" q2="6.4573378244182553">
         <iidm:alias>_046cb413-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f9fd3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9699,7 +9822,7 @@
             <iidm:temporaryLimit name="_e8ec73b8-1ecf-4d18-9ef9-80eabf3a4969" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0474f177-c766-11e1-8775-005056c00008" name="15-17" r="2.2999679999999998" x="7.6142880000000002" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="48" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-148.92332294340946" q1="-19.486962238923685" p2="152.21987317924385" q2="26.27043859740094">
+    <iidm:line id="_0474f177-c766-11e1-8775-005056c00008" name="15-17" r="2.2999679999999998" x="7.6142880000000002" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="48" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-158.25991360902529" q1="-15.907621664048616" p2="161.96326406239058" q2="24.040882506986165">
         <iidm:alias>_044c5ad2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046931a7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9707,7 +9830,7 @@
             <iidm:temporaryLimit name="_2ceac3d1-f73d-43db-8d37-9e329f1787bb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0483be84-c766-11e1-8775-005056c00008" name="8-30" r="2.0860400000000001" x="24.393599999999999" g1="0" b1="0.00053099175999999997" g2="0" b2="0.00053099175999999997" node1="30" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="38" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="87.26364102623296" q1="27.197552472766652" p2="-86.817768259956779" q2="-72.340858383003976">
+    <iidm:line id="_0483be84-c766-11e1-8775-005056c00008" name="8-30" r="2.0860400000000001" x="24.393599999999999" g1="0" b1="0.00053099175999999997" g2="0" b2="0.00053099175999999997" node1="30" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="38" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="103.5401016747965" q1="21.384631819505707" p2="-102.98842692379971" q2="-65.641848521365148">
         <iidm:alias>_0454e651-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04801506-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9715,7 +9838,7 @@
             <iidm:temporaryLimit name="_ca795ad3-97e5-4416-aaba-53cce27f6434" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0488eea6-c766-11e1-8775-005056c00008" name="49-69" r="17.16264" x="56.453762099999999" g1="0" b1="0.00023760329999999999" g2="0" b2="0.00023760329999999999" node1="115" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-75.643615292312049" q1="26.733824579380773" p2="81.913990460936418" q2="-14.892886295464372">
+    <iidm:line id="_0488eea6-c766-11e1-8775-005056c00008" name="49-69" r="17.16264" x="56.453762099999999" g1="0" b1="0.00023760329999999999" g2="0" b2="0.00023760329999999999" node1="115" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-75.441919368319716" q1="26.608026794594785" p2="81.676407219269592" q2="-14.885134598677082">
         <iidm:alias>_04492681-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046735d6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9723,7 +9846,7 @@
             <iidm:temporaryLimit name="_c42dc3ef-3a2e-4070-8efb-78e5c0cd5554" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047566a0-c766-11e1-8775-005056c00008" name="13-15" r="12.9634562" x="42.584255200000001" g1="0" b1="0.00017986685000000001" g2="0" b2="0.00017986685000000001" node1="21" voltageLevelId1="_04851e1b-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="15.103824401207817" q1="-1.2001678991608928" p2="-14.91888234519152" q2="-3.9269856230768054">
+    <iidm:line id="_047566a0-c766-11e1-8775-005056c00008" name="13-15" r="12.9634562" x="42.584255200000001" g1="0" b1="0.00017986685000000001" g2="0" b2="0.00017986685000000001" node1="21" voltageLevelId1="_04851e1b-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="10.915420449805586" q1="0.24085102450197224" p2="-10.812175344120851" q2="-5.6369913476346598">
         <iidm:alias>_04662461-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04865694-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9731,7 +9854,7 @@
             <iidm:temporaryLimit name="_ad988fd9-9270-4230-95a2-1858f32259df" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0476c63a-c766-11e1-8775-005056c00008" name="69-70" r="5.2271999999999998" x="22.12848" g1="0" b1="0.00035009184999999998" g2="0" b2="0.00035009184999999998" node1="59" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="75.965458497384034" q1="20.186553337058061" p2="-74.14937953425958" q2="-24.938265618597164">
+    <iidm:line id="_0476c63a-c766-11e1-8775-005056c00008" name="69-70" r="5.2271999999999998" x="22.12848" g1="0" b1="0.00035009184999999998" g2="0" b2="0.00035009184999999998" node1="59" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="76.871762807739529" q1="19.922123362342052" p2="-75.020829851906285" q2="-24.528274701285934">
         <iidm:alias>_047e193a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b1184-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9739,7 +9862,7 @@
             <iidm:temporaryLimit name="_519e3ecb-3561-4d11-ac6b-172a0b4b09b2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04520028-c766-11e1-8775-005056c00008" name="19-20" r="4.3908480000000001" x="20.38608" g1="0" b1="8.5514249999999999e-05" g2="0" b2="8.5514249999999999e-05" node1="39" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b2d70-c766-11e1-8775-005056c00008" p1="-16.404084839073562" q1="2.9635713485112727" p2="16.486045549227534" q2="-5.21454999759308">
+    <iidm:line id="_04520028-c766-11e1-8775-005056c00008" name="19-20" r="4.3908480000000001" x="20.38608" g1="0" b1="8.5514249999999999e-05" g2="0" b2="8.5514249999999999e-05" node1="39" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b2d70-c766-11e1-8775-005056c00008" p1="-14.278303569223736" q1="1.7937568815509224" p2="14.339235528479321" q2="-4.1430418858970963">
         <iidm:alias>_0472f5a9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04745537-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9747,7 +9870,7 @@
             <iidm:temporaryLimit name="_b88528bf-cb1c-4c00-ad79-d5937197d40c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04862f83-c766-11e1-8775-005056c00008" name="94-95" r="2.2999679999999998" x="7.5620159999999998" g1="0" b1="3.1852600000000001e-05" g2="0" b2="3.1852600000000001e-05" node1="51" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f4108-c766-11e1-8775-005056c00008" p1="57.122300036270993" q1="6.3254528362475346" p2="-56.673858014341818" q2="-5.9212535572862173">
+    <iidm:line id="_04862f83-c766-11e1-8775-005056c00008" name="94-95" r="2.2999679999999998" x="7.5620159999999998" g1="0" b1="3.1852600000000001e-05" g2="0" b2="3.1852600000000001e-05" node1="51" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f4108-c766-11e1-8775-005056c00008" p1="57.183774877762794" q1="6.5041292466780947" p2="-56.733889101239221" q2="-6.0947157958674749">
         <iidm:alias>_044ca8f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04837060-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9755,7 +9878,7 @@
             <iidm:temporaryLimit name="_b70e76a1-6e79-4fb6-b487-dffa9bfeab7b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047b0bf6-c766-11e1-8775-005056c00008" name="12-16" r="3.6938879999999998" x="14.5316162" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="68" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046f7338-c766-11e1-8775-005056c00008" p1="16.775590437489303" q1="7.7414305769330172" p2="-16.698004863716147" q2="-9.5106171700342834">
+    <iidm:line id="_047b0bf6-c766-11e1-8775-005056c00008" name="12-16" r="3.6938879999999998" x="14.5316162" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="68" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046f7338-c766-11e1-8775-005056c00008" p1="10.062281954338431" q1="9.5739531038782797" p2="-10.015973245748535" q2="-11.465839764675653">
         <iidm:alias>_0450798a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045c8772-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9763,7 +9886,7 @@
             <iidm:temporaryLimit name="_af73f526-c58b-40e7-8e1c-14f05a39f6a2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04524e47-c766-11e1-8775-005056c00008" name="100-103" r="2.7878400000000001" x="9.1476000000000006" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="78" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0475b4c0-c766-11e1-8775-005056c00008" p1="115.37914342705307" q1="-20.640777475819512" p2="-113.27038735331318" q2="22.054370686037831">
+    <iidm:line id="_04524e47-c766-11e1-8775-005056c00008" name="100-103" r="2.7878400000000001" x="9.1476000000000006" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="78" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0475b4c0-c766-11e1-8775-005056c00008" p1="115.38943969318045" q1="-20.643231647441031" p2="-113.28030262655957" q2="22.05807462425836">
         <iidm:alias>_04684744-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048aea71-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9771,7 +9894,7 @@
             <iidm:temporaryLimit name="_1631e50b-21a3-470b-803b-f9665b6fcd60" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04682038-c766-11e1-8775-005056c00008" name="27-32" r="3.9900959999999999" x="13.1551189" g1="0" b1="5.5268600000000001e-05" g2="0" b2="5.5268600000000001e-05" node1="40" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="7.347954014414702" q1="-0.065812623798844339" p2="-7.3345305785268797" q2="-1.6823214409586014">
+    <iidm:line id="_04682038-c766-11e1-8775-005056c00008" name="27-32" r="3.9900959999999999" x="13.1551189" g1="0" b1="5.5268600000000001e-05" g2="0" b2="5.5268600000000001e-05" node1="40" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="6.2744395407858642" q1="0.70545263803758484" p2="-6.264182927440487" q2="-2.4705997246800342">
         <iidm:alias>_0455347a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479ac63-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9779,7 +9902,7 @@
             <iidm:temporaryLimit name="_52eb4b09-42bb-4106-ac26-fe1059639d3a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0482fb31-c766-11e1-8775-005056c00008" name="59-61" r="5.7150720000000002" x="26.1360016" g1="0" b1="0.0001113407" g2="0" b2="0.0001113407" node1="68" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-100.79276521750675" q1="22.25853511659259" p2="104.42425509092776" q2="-9.4539966946279197">
+    <iidm:line id="_0482fb31-c766-11e1-8775-005056c00008" name="59-61" r="5.7150720000000002" x="26.1360016" g1="0" b1="0.0001113407" g2="0" b2="0.0001113407" node1="68" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-100.77435739117273" q1="22.251217375694853" p2="104.40447327059343" q2="-9.45296268089891">
         <iidm:alias>_044a10e9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0473b8f5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9787,7 +9910,7 @@
             <iidm:temporaryLimit name="_b5a7dea0-bfce-4548-a04d-7bb7b6d9f80a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047d55e3-c766-11e1-8775-005056c00008" name="100-104" r="7.8582239999999999" x="35.544960000000003" g1="0" b1="0.00015524565000000001" g2="0" b2="0.00015524565000000001" node1="79" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="54.999167674356094" q1="10.980723711450288" p2="-53.597379033534999" q2="-9.9859837929442978">
+    <iidm:line id="_047d55e3-c766-11e1-8775-005056c00008" name="100-104" r="7.8582239999999999" x="35.544960000000003" g1="0" b1="0.00015524565000000001" g2="0" b2="0.00015524565000000001" node1="79" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="55.001391184796212" q1="10.980532361034733" p2="-53.599498282281957" q2="-9.9853206237180281">
         <iidm:alias>_04636547-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048aea76-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9795,7 +9918,7 @@
             <iidm:temporaryLimit name="_17a10cd0-b653-4dcf-bdc3-4d5005ea9591" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04653a02-c766-11e1-8775-005056c00008" name="75-77" r="10.4718237" x="34.830577900000002" g1="0" b1="0.00014284895" g2="0" b2="0.00014284895" node1="49" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-36.261565941264401" q1="-7.1279040832242293" p2="37.120300976103017" q2="5.1512310035656812">
+    <iidm:line id="_04653a02-c766-11e1-8775-005056c00008" name="75-77" r="10.4718237" x="34.830577900000002" g1="0" b1="0.00014284895" g2="0" b2="0.00014284895" node1="49" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-36.438010987184413" q1="-6.9891618703535192" p2="37.304131953424942" q2="5.0377469652382887">
         <iidm:alias>_04642894-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04720b47-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9803,7 +9926,7 @@
             <iidm:temporaryLimit name="_6f81df11-7e71-4b6e-a6ee-a8c5f72f4ba5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04483c2a-c766-11e1-8775-005056c00008" name="23-32" r="5.5234079999999999" x="20.089872400000001" g1="0" b1="0.00033660465000000001" g2="0" b2="0.00033660465000000001" node1="40" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="77.413638966579597" q1="7.4335301960297864" p2="-75.456393032267371" q2="-11.619834714820913">
+    <iidm:line id="_04483c2a-c766-11e1-8775-005056c00008" name="23-32" r="5.5234079999999999" x="20.089872400000001" g1="0" b1="0.00033660465000000001" g2="0" b2="0.00033660465000000001" node1="40" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="74.313638028325997" q1="7.7359229200366908" p2="-72.507448566603642" q2="-12.504409768007982">
         <iidm:alias>_044b978a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0461dea6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9811,7 +9934,7 @@
             <iidm:temporaryLimit name="_a8f6a7d2-e58d-4671-a776-97be7291355e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048719e5-c766-11e1-8775-005056c00008" name="96-97" r="3.0143520000000001" x="15.42024" g1="0" b1="6.8870549999999994e-05" g2="0" b2="6.8870549999999994e-05" node1="50" voltageLevelId1="_045a1672-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="3.1321593412489421" q1="-25.29928345486578" p2="-3.0272201750080336" q2="23.443357945894">
+    <iidm:line id="_048719e5-c766-11e1-8775-005056c00008" name="96-97" r="3.0143520000000001" x="15.42024" g1="0" b1="6.8870549999999994e-05" g2="0" b2="6.8870549999999994e-05" node1="50" voltageLevelId1="_045a1672-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="3.0924426466412669" q1="-25.477860016596519" p2="-2.9859283208461664" q2="23.631307907432486">
         <iidm:alias>_0451b207-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04828601-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9819,7 +9942,7 @@
             <iidm:temporaryLimit name="_ea6d39aa-df95-4d3e-b7b6-a800e552e72a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048481d0-c766-11e1-8775-005056c00008" name="25-27" r="5.5408330000000001" x="28.401121100000001" g1="0" b1="0.000506198385" g2="0" b2="0.000506198385" node1="30" voltageLevelId1="_04728079-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0476c639-c766-11e1-8775-005056c00008" p1="153.19933919489944" q1="31.73499586744817" p2="-145.93397045572794" q2="-12.446691961532633">
+    <iidm:line id="_048481d0-c766-11e1-8775-005056c00008" name="25-27" r="5.5408330000000001" x="28.401121100000001" g1="0" b1="0.000506198385" g2="0" b2="0.000506198385" node1="30" voltageLevelId1="_04728079-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0476c639-c766-11e1-8775-005056c00008" p1="147.90327136466038" q1="30.302858380779575" p2="-141.13151881630907" q2="-13.577851233486712">
         <iidm:alias>_046d2947-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04725960-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9827,7 +9950,7 @@
             <iidm:temporaryLimit name="_d9d53af2-5ffa-4f2a-a4e6-ed22371332d6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04885268-c766-11e1-8775-005056c00008" name="110-112" r="4.3037280000000004" x="11.1513615" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="41" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="13" voltageLevelId2="_04784cd1-c766-11e1-8775-005056c00008" p1="69.35440424601677" q1="11.007379229592734" p2="-68.000012515848368" q2="-13.000003242837337">
+    <iidm:line id="_04885268-c766-11e1-8775-005056c00008" name="110-112" r="4.3037280000000004" x="11.1513615" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="41" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="13" voltageLevelId2="_04784cd1-c766-11e1-8775-005056c00008" p1="69.354409232817872" q1="11.007382686753617" p2="-68.000016990544594" q2="-13.000004089488376">
         <iidm:alias>_04611b55-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0481c2ba-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9835,7 +9958,7 @@
             <iidm:temporaryLimit name="_d50299b9-a055-408a-aa1e-2e93a715120f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0484a8e4-c766-11e1-8775-005056c00008" name="89-92" r="1.7249760000000001" x="8.7991200000000003" g1="0" b1="0.00015725434999999999" g2="0" b2="0.00015725434999999999" node1="57" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="68" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="228.33534655026173" q1="-3.276131023861617" p2="-223.22498680307223" q2="23.894202851980818">
+    <iidm:line id="_0484a8e4-c766-11e1-8775-005056c00008" name="89-92" r="1.7249760000000001" x="8.7991200000000003" g1="0" b1="0.00015725434999999999" g2="0" b2="0.00015725434999999999" node1="57" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="68" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="228.46682247691686" q1="-3.1861884454857936" p2="-223.35058446653068" q2="23.834522141183083">
         <iidm:alias>_04481517-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04808a3c-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9843,7 +9966,7 @@
             <iidm:temporaryLimit name="_eee9ca2b-764f-4ab8-a745-405338044743" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04689568-c766-11e1-8775-005056c00008" name="49-54" r="15.1414566" x="50.703842199999997" g1="0" b1="0.00020948120000000001" g2="0" b2="0.00020948120000000001" node1="116" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="46.502172848647504" q1="9.6281365877933442" p2="-44.563634069678614" q2="-10.300270510882362">
+    <iidm:line id="_04689568-c766-11e1-8775-005056c00008" name="49-54" r="15.1414566" x="50.703842199999997" g1="0" b1="0.00020948120000000001" g2="0" b2="0.00020948120000000001" node1="116" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="46.520650242102604" q1="9.6250879086400083" p2="-44.580757766719145" q2="-10.292689120045868">
         <iidm:alias>_046030f0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04605808-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9851,7 +9974,7 @@
             <iidm:temporaryLimit name="_690202a4-aad2-4ad3-8842-961b39e37709" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046c8d04-c766-11e1-8775-005056c00008" name="40-41" r="2.5264799999999998" x="8.4854880000000001" g1="0" b1="3.5066600000000001e-05" g2="0" b2="3.5066600000000001e-05" node1="40" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048c4a08-c766-11e1-8775-005056c00008" p1="26.31554563337447" q1="-1.6160669734211783" p2="-26.190675567041261" q2="1.0548581269361277">
+    <iidm:line id="_046c8d04-c766-11e1-8775-005056c00008" name="40-41" r="2.5264799999999998" x="8.4854880000000001" g1="0" b1="3.5066600000000001e-05" g2="0" b2="3.5066600000000001e-05" node1="40" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048c4a08-c766-11e1-8775-005056c00008" p1="26.523028719775965" q1="-1.7493179121054303" p2="-26.396015360122512" q2="1.1961365097388821">
         <iidm:alias>_045cae80-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a2194-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9859,7 +9982,7 @@
             <iidm:temporaryLimit name="_34f2ef7c-32da-4444-b989-d02f5f931c50" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046735d5-c766-11e1-8775-005056c00008" name="39-40" r="3.206016" x="10.54152" g1="0" b1="4.4536249999999999e-05" g2="0" b2="4.4536249999999999e-05" node1="22" voltageLevelId1="_046bf0c7-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="37.935974783774547" q1="3.8372719771776551" p2="-37.61024947256135" q2="-4.0310693765149352">
+    <iidm:line id="_046735d5-c766-11e1-8775-005056c00008" name="39-40" r="3.206016" x="10.54152" g1="0" b1="4.4536249999999999e-05" g2="0" b2="4.4536249999999999e-05" node1="22" voltageLevelId1="_046bf0c7-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="38.153440793224554" q1="3.7200992114913403" p2="-37.823939945579497" q2="-3.9003175229723244">
         <iidm:alias>_045115c1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048badc2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9867,7 +9990,7 @@
             <iidm:temporaryLimit name="_38d58455-5205-46bb-8e44-c66873f62938" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0470d2c4-c766-11e1-8775-005056c00008" name="89-92" r="6.8476319999999999" x="27.5473423" g1="0" b1="0.00011880164999999999" g2="0" b2="0.00011880164999999999" node1="58" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="72.029344389002858" q1="-5.860016897843523" p2="-70.005081347679621" q2="9.8861465191256386">
+    <iidm:line id="_0470d2c4-c766-11e1-8775-005056c00008" name="89-92" r="6.8476319999999999" x="27.5473423" g1="0" b1="0.00011880164999999999" g2="0" b2="0.00011880164999999999" node1="58" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="72.072245176015301" q1="-5.833718993456527" p2="-70.045653697649499" q2="9.8694247913144402">
         <iidm:alias>_04690a97-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04690a98-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9875,7 +9998,7 @@
             <iidm:temporaryLimit name="_0cce41c7-b99f-4fec-93d2-73ea24433fa1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0479ac60-c766-11e1-8775-005056c00008" name="33-37" r="7.2309599999999996" x="24.742080000000001" g1="0" b1="0.00010502754999999999" g2="0" b2="0.00010502754999999999" node1="21" voltageLevelId1="_0456bb11-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="37.97052671980726" q1="-19.828556458358754" p2="-37.131067074162267" q2="19.446188568479521">
+    <iidm:line id="_0479ac60-c766-11e1-8775-005056c00008" name="33-37" r="7.2309599999999996" x="24.742080000000001" g1="0" b1="0.00010502754999999999" g2="0" b2="0.00010502754999999999" node1="21" voltageLevelId1="_0456bb11-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="39.035029335998175" q1="-20.120563930698044" p2="-38.150621936906369" q2="19.895441291514974">
         <iidm:alias>_04716f08-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0483be89-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9883,7 +10006,7 @@
             <iidm:temporaryLimit name="_343677c6-7477-4bf6-a12c-2c7e4a684d6f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048c4a00-c766-11e1-8775-005056c00008" name="105-108" r="4.5476640000000002" x="12.249072099999999" g1="0" b1="5.2915499999999998e-05" g2="0" b2="5.2915499999999998e-05" node1="50" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_046c65f4-c766-11e1-8775-005056c00008" p1="22.931502530546094" q1="-0.84188326924650236" p2="-22.784217278890313" q2="-0.46897228276187586">
+    <iidm:line id="_048c4a00-c766-11e1-8775-005056c00008" name="105-108" r="4.5476640000000002" x="12.249072099999999" g1="0" b1="5.2915499999999998e-05" g2="0" b2="5.2915499999999998e-05" node1="50" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_046c65f4-c766-11e1-8775-005056c00008" p1="22.934686525637058" q1="-0.84288736579403778" p2="-22.787360360715535" q2="-0.46785761195635106">
         <iidm:alias>_046adf53-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04795e46-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9891,7 +10014,7 @@
             <iidm:temporaryLimit name="_74cf84b9-e14f-4f81-9e8b-3a791cd474a0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04631724-c766-11e1-8775-005056c00008" name="34-37" r="0.44605400000000001" x="1.637856" g1="0" b1="2.8236900000000001e-05" g2="0" b2="2.8236900000000001e-05" node1="41" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-57.532204656628117" q1="-34.995872528655127" p2="57.661454555328731" q2="34.58795217781725">
+    <iidm:line id="_04631724-c766-11e1-8775-005056c00008" name="34-37" r="0.44605400000000001" x="1.637856" g1="0" b1="2.8236900000000001e-05" g2="0" b2="2.8236900000000001e-05" node1="41" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-56.75220802400824" q1="-35.33540918842931" p2="56.879702023602107" q2="34.921887309393263">
         <iidm:alias>_04592c19-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04719611-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9899,7 +10022,7 @@
             <iidm:temporaryLimit name="_8e90bf2e-3be4-41be-a84e-c1d4e709f8a1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04814d85-c766-11e1-8775-005056c00008" name="61-62" r="1.435738" x="6.5514239999999999" g1="0" b1="2.812215e-05" g2="0" b2="2.812215e-05" node1="40" voltageLevelId1="_0448d867-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="60.131241851283278" q1="-18.211584509523423" p2="-59.804147493056966" q2="18.731961052315942">
+    <iidm:line id="_04814d85-c766-11e1-8775-005056c00008" name="61-62" r="1.435738" x="6.5514239999999999" g1="0" b1="2.812215e-05" g2="0" b2="2.812215e-05" node1="40" voltageLevelId1="_0448d867-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="60.110603158088338" q1="-18.207642596171773" p2="-59.783726996081299" q2="18.72702340907713">
         <iidm:alias>_045a3d85-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047abdd8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9907,7 +10030,7 @@
             <iidm:temporaryLimit name="_39a23399-348e-44d9-8032-8fc62e6c7d63" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046a4318-c766-11e1-8775-005056c00008" name="101-102" r="4.2863040000000003" x="19.5148811" g1="0" b1="8.4366399999999999e-05" g2="0" b2="8.4366399999999999e-05" node1="22" voltageLevelId1="_046ed6f7-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="-44.08861597085459" q1="11.599205866695694" p2="44.618404717991034" q2="-12.066053606670618">
+    <iidm:line id="_046a4318-c766-11e1-8775-005056c00008" name="101-102" r="4.2863040000000003" x="19.5148811" g1="0" b1="8.4366399999999999e-05" g2="0" b2="8.4366399999999999e-05" node1="22" voltageLevelId1="_046ed6f7-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="-44.12373192471162" q1="11.625325533613687" p2="44.654495332477708" q2="-12.087531419912391">
         <iidm:alias>_04878f1b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04885261-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9915,7 +10038,7 @@
             <iidm:temporaryLimit name="_0501dacc-29fc-44a2-8cad-31a20b011d25" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c81e3-c766-11e1-8775-005056c00008" name="26-30" r="3.8671600000000002" x="41.624000000000002" g1="0" b1="0.00093801650000000002" g2="0" b2="0.00093801650000000002" node1="21" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="230.50591990892423" q1="1.51444165279363" p2="-226.20431614257458" q2="-45.13919329883943">
+    <iidm:line id="_044c81e3-c766-11e1-8775-005056c00008" name="26-30" r="3.8671600000000002" x="41.624000000000002" g1="0" b1="0.00093801650000000002" g2="0" b2="0.00093801650000000002" node1="21" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="243.17792753880249" q1="-2.7174765112424781" p2="-238.44109984593297" q2="-36.645766020286288">
         <iidm:alias>_0463654b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04747c4a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9923,7 +10046,7 @@
             <iidm:temporaryLimit name="_c95a66fd-913c-48c7-b8ef-cf3007c60af6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048915b9-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="41" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="117" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-53.908571119061286" q1="-18.704288616001364" p2="56.593317394426215" q2="22.725250522505089">
+    <iidm:line id="_048915b9-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="41" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="117" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-53.7018206911712" q1="-18.847455114101713" p2="56.372653283661613" q2="22.807402668631671">
         <iidm:alias>_044bbe98-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0456e224-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9931,7 +10054,7 @@
             <iidm:temporaryLimit name="_6cd83bc2-204f-44d5-afd4-fbfef8d2146f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c5ad6-c766-11e1-8775-005056c00008" name="105-106" r="2.4393600000000002" x="9.5309279999999994" g1="0" b1="4.1150150000000001e-05" g2="0" b2="4.1150150000000001e-05" node1="51" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="9.6388718179787745" q1="6.1380490229013391" p2="-9.6179537940450626" q2="-7.3853544656499501">
+    <iidm:line id="_044c5ad6-c766-11e1-8775-005056c00008" name="105-106" r="2.4393600000000002" x="9.5309279999999994" g1="0" b1="4.1150150000000001e-05" g2="0" b2="4.1150150000000001e-05" node1="51" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="9.6373797271412016" q1="6.1385884812618601" p2="-9.6164649184994122" q2="-7.3859061824122776">
         <iidm:alias>_04505270-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04531190-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9939,7 +10062,7 @@
             <iidm:temporaryLimit name="_487e1317-48f9-4747-b931-f3f79e95f55a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048badc5-c766-11e1-8775-005056c00008" name="60-61" r="0.45999400000000001" x="2.3522400000000001" g1="0" b1="4.1781450000000003e-05" g2="0" b2="4.1781450000000003e-05" node1="30" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-169.33408819248243" q1="15.897144408396379" p2="170.10999847850036" q2="-13.367253108505547">
+    <iidm:line id="_048badc5-c766-11e1-8775-005056c00008" name="60-61" r="0.45999400000000001" x="2.3522400000000001" g1="0" b1="4.1781450000000003e-05" g2="0" b2="4.1781450000000003e-05" node1="30" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-169.3085565122019" q1="15.893510790174236" p2="170.08423136583494" q2="-13.364823877656839">
         <iidm:alias>_04793734-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048a4e31-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9947,7 +10070,7 @@
             <iidm:temporaryLimit name="_3c55a929-a755-409b-af5f-bae188892af1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044cd003-c766-11e1-8775-005056c00008" name="23-25" r="2.7181440000000001" x="13.9391994" g1="0" b1="0.00024793390000000002" g2="0" b2="0.00024793390000000002" node1="41" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="-201.25593089954145" q1="-12.747396586289817" p2="207.59042924787065" q2="36.152471489165748">
+    <iidm:line id="_044cd003-c766-11e1-8775-005056c00008" name="23-25" r="2.7181440000000001" x="13.9391994" g1="0" b1="0.00024793390000000002" g2="0" b2="0.00024793390000000002" node1="41" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="-194.23018863778296" q1="-13.742379359350904" p2="200.11881339091735" q2="34.850053545797103">
         <iidm:alias>_045ed161-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0473b8f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9955,7 +10078,7 @@
             <iidm:temporaryLimit name="_9658628a-596f-41a9-96a7-c5a8aaf5400c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0457a574-c766-11e1-8775-005056c00008" name="19-34" r="13.102848099999999" x="43.037277199999998" g1="0" b1="0.00018135905000000001" g2="0" b2="0.00018135905000000001" node1="40" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0483be8b-c766-11e1-8775-005056c00008" p1="50.60463495894362" q1="-15.736669102185999" p2="-48.282866664110855" q2="17.751118451869115">
+    <iidm:line id="_0457a574-c766-11e1-8775-005056c00008" name="19-34" r="13.102848099999999" x="43.037277199999998" g1="0" b1="0.00018135905000000001" g2="0" b2="0.00018135905000000001" node1="40" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0483be8b-c766-11e1-8775-005056c00008" p1="51.86623214809709" q1="-15.849000592273782" p2="-49.430417650919964" q2="18.242529474820724">
         <iidm:alias>_04502b61-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04686e5b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9963,7 +10086,7 @@
             <iidm:temporaryLimit name="_b69ab61b-751d-487a-a538-2d47eea7572e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04595326-c766-11e1-8775-005056c00008" name="59-60" r="5.5234079999999999" x="25.264800000000001" g1="0" b1="0.00010789715" g2="0" b2="0.00010789715" node1="69" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_045cfca4-c766-11e1-8775-005056c00008" p1="-89.14392530275876" q1="19.130810249551672" p2="91.883785565791186" q2="-10.274175450938259">
+    <iidm:line id="_04595326-c766-11e1-8775-005056c00008" name="59-60" r="5.5234079999999999" x="25.264800000000001" g1="0" b1="0.00010789715" g2="0" b2="0.00010789715" node1="69" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_045cfca4-c766-11e1-8775-005056c00008" p1="-89.127040220548466" q1="19.124364790366101" p2="91.865828592661686" q2="-10.2726341811513">
         <iidm:alias>_04611b57-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0463b366-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9971,7 +10094,7 @@
             <iidm:temporaryLimit name="_a38d4859-b54a-482f-a2ad-0b4ce4c4da2a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045a8ba1-c766-11e1-8775-005056c00008" name="15-19" r="2.0908799999999998" x="6.865056" g1="0" b1="2.8983e-05" g2="0" b2="2.8983e-05" node1="50" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="32.108719832071223" q1="11.114121456483755" p2="-31.95346423955036" q2="-11.505284835203785">
+    <iidm:line id="_045a8ba1-c766-11e1-8775-005056c00008" name="15-19" r="2.0908799999999998" x="6.865056" g1="0" b1="2.8983e-05" g2="0" b2="2.8983e-05" node1="50" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="31.562005733173752" q1="11.115624440260854" p2="-31.411273735488127" q2="-11.521023853774407">
         <iidm:alias>_047629f1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0481e9c1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9979,7 +10102,7 @@
             <iidm:temporaryLimit name="_15d16bd2-d87c-4584-93d2-b294dc1be116" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04513cd6-c766-11e1-8775-005056c00008" name="90-91" r="4.4256960000000003" x="14.566463499999999" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="31" voltageLevelId1="_047d07c3-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044f8f29-c766-11e1-8775-005056c00008" p1="4.3745908150783563" q1="-16.350278207172188" p2="-4.3038887861642046" q2="14.594605226480162">
+    <iidm:line id="_04513cd6-c766-11e1-8775-005056c00008" name="90-91" r="4.4256960000000003" x="14.566463499999999" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="31" voltageLevelId1="_047d07c3-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044f8f29-c766-11e1-8775-005056c00008" p1="4.399041626407155" q1="-16.340112394465272" p2="-4.3283644438902966" q2="14.584444960315482">
         <iidm:alias>_045f94b9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04627ae1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9987,7 +10110,7 @@
             <iidm:temporaryLimit name="_7d2a67fb-9d8c-4745-a67e-ce6ade5e520e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0487b623-c766-11e1-8775-005056c00008" name="22-23" r="5.9590079999999999" x="27.704158799999998" g1="0" b1="0.00011593205" g2="0" b2="0.00011593205" node1="21" voltageLevelId1="_04773b6a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_047f9fdb-c766-11e1-8775-005056c00008" p1="-59.277957817892379" q1="-10.385699332286807" p2="60.609348695866416" q2="12.696018935542167">
+    <iidm:line id="_0487b623-c766-11e1-8775-005056c00008" name="22-23" r="5.9590079999999999" x="27.704158799999998" g1="0" b1="0.00011593205" g2="0" b2="0.00011593205" node1="21" voltageLevelId1="_04773b6a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_047f9fdb-c766-11e1-8775-005056c00008" p1="-57.056347646549654" q1="-11.084954803416721" p2="58.292930552969715" q2="12.944242976531543">
         <iidm:alias>_045e0e18-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0477b095-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9995,7 +10118,7 @@
             <iidm:temporaryLimit name="_6477d99a-dd64-4083-8f56-1396610879f0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048b1189-c766-11e1-8775-005056c00008" name="83-85" r="7.4923200000000003" x="25.787520000000001" g1="0" b1="9.9862250000000004e-05" g2="0" b2="9.9862250000000004e-05" node1="32" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-54.878910143401669" q1="18.455972151433052" p2="56.423949668115249" q2="-16.440130956712633">
+    <iidm:line id="_048b1189-c766-11e1-8775-005056c00008" name="83-85" r="7.4923200000000003" x="25.787520000000001" g1="0" b1="9.9862250000000004e-05" g2="0" b2="9.9862250000000004e-05" node1="32" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-54.707312702691013" q1="19.216198739786464" p2="56.262111711398546" q2="-17.153647741646871">
         <iidm:alias>_0455d0b1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0462c906-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10003,7 +10126,7 @@
             <iidm:temporaryLimit name="_38cb3e5b-af1a-4684-aa2f-242826ed460c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045868c5-c766-11e1-8775-005056c00008" name="17-31" r="8.2589760000000005" x="27.233711199999998" g1="0" b1="0.00011449725" g2="0" b2="0.00011449725" node1="60" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="27.861531516233757" q1="-1.6719399795520493" p2="-27.478263724107769" q2="-0.84516090401744592">
+    <iidm:line id="_045868c5-c766-11e1-8775-005056c00008" name="17-31" r="8.2589760000000005" x="27.233711199999998" g1="0" b1="0.00011449725" g2="0" b2="0.00011449725" node1="60" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="30.973316483350121" q1="-2.6718544619400615" p2="-30.499066030760364" q2="0.45614723194951218">
         <iidm:alias>_04544a16-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0467f924-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10011,7 +10134,7 @@
             <iidm:temporaryLimit name="_9066b19a-f404-42c3-88ce-51d375f6fdb5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0488c796-c766-11e1-8775-005056c00008" name="89-90" r="9.0256319999999999" x="32.75712" g1="0" b1="0.00015151515000000001" g2="0" b2="0.00015151515000000001" node1="59" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="59.703311834126119" q1="9.2545042658507324" p2="-57.802352943257475" q2="-7.4434223266482604">
+    <iidm:line id="_0488c796-c766-11e1-8775-005056c00008" name="89-90" r="9.0256319999999999" x="32.75712" g1="0" b1="0.00015151515000000001" g2="0" b2="0.00015151515000000001" node1="59" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="59.712447273524674" q1="9.2601688918310323" p2="-57.810859739142813" q2="-7.4467367060676946">
         <iidm:alias>_0459ef61-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04837069-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10019,7 +10142,7 @@
             <iidm:temporaryLimit name="_924b4a0b-bef5-432a-ad87-ab5c10d9c019" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0462c907-c766-11e1-8775-005056c00008" name="70-75" r="7.4574720000000001" x="24.56784" g1="0" b1="0.0001033058" g2="0" b2="0.0001033058" node1="50" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="8.9800244832784895" q1="6.9037077274706595" p2="-8.9113210739908304" q2="-10.105373630801681">
+    <iidm:line id="_0462c907-c766-11e1-8775-005056c00008" name="70-75" r="7.4574720000000001" x="24.56784" g1="0" b1="0.0001033058" g2="0" b2="0.0001033058" node1="50" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="8.5995025996695631" q1="7.1299593552020255" p2="-8.5320223795707513" q2="-10.336251425894826">
         <iidm:alias>_04649dc9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04784cdb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10027,7 +10150,7 @@
             <iidm:temporaryLimit name="_d432d118-553c-4f4c-a734-e98e0762ec40" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045fbbc3-c766-11e1-8775-005056c00008" name="50-57" r="8.2589760000000005" x="23.34816" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="22" voltageLevelId1="_044d1e26-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="44.104169343845342" q1="6.7467107431886166" p2="-43.149414878034342" q2="-7.270234978397963">
+    <iidm:line id="_045fbbc3-c766-11e1-8775-005056c00008" name="50-57" r="8.2589760000000005" x="23.34816" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="22" voltageLevelId1="_044d1e26-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="44.121127178773371" q1="6.7418968387300398" p2="-43.165699602568097" q2="-7.2635076374651577">
         <iidm:alias>_04500455-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0468e383-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10035,7 +10158,7 @@
             <iidm:temporaryLimit name="_2f32bda4-7275-4485-9901-12f8cff9e4a1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044b9789-c766-11e1-8775-005056c00008" name="5-6" r="2.0734560000000002" x="9.4089600000000004" g1="0" b1="4.0920549999999999e-05" g2="0" b2="4.0920549999999999e-05" node1="49" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f6818-c766-11e1-8775-005056c00008" p1="95.986428742863851" q1="17.537867122286311" p2="-94.870342187741883" q2="-13.896519604609377">
+    <iidm:line id="_044b9789-c766-11e1-8775-005056c00008" name="5-6" r="2.0734560000000002" x="9.4089600000000004" g1="0" b1="4.0920549999999999e-05" g2="0" b2="4.0920549999999999e-05" node1="49" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f6818-c766-11e1-8775-005056c00008" p1="91.644547856493659" q1="19.094553475566816" p2="-90.618797036546411" q2="-15.865382585801552">
         <iidm:alias>_044a5f01-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0455d0b2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10043,7 +10166,7 @@
             <iidm:temporaryLimit name="_b3b0e81b-a434-4e9c-ad94-1161ff47b077" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04720b41-c766-11e1-8775-005056c00008" name="55-59" r="8.2572340000000004" x="37.600994100000001" g1="0" b1="0.00016201790000000001" g2="0" b2="0.00016201790000000001" node1="30" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-24.201864754594087" q1="-11.532878316456092" p2="24.550813056262772" q2="7.8282889986404536">
+    <iidm:line id="_04720b41-c766-11e1-8775-005056c00008" name="55-59" r="8.2572340000000004" x="37.600994100000001" g1="0" b1="0.00016201790000000001" g2="0" b2="0.00016201790000000001" node1="30" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-24.185617381357542" q1="-11.537442714672192" p2="24.534197100738947" q2="7.8311761082045708">
         <iidm:alias>_04656113-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04675ce4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10051,7 +10174,7 @@
             <iidm:temporaryLimit name="_6db0d250-4a2e-4169-abf0-f842aeca485d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048963d9-c766-11e1-8775-005056c00008" name="1-2" r="5.2794720000000002" x="17.4065762" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="22" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_045d4ac5-c766-11e1-8775-005056c00008" p1="-10.450688306087569" q1="-10.891904332284497" p2="10.517698887674786" q2="8.7399340062228799">
+    <iidm:line id="_048963d9-c766-11e1-8775-005056c00008" name="1-2" r="5.2794720000000002" x="17.4065762" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="22" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_045d4ac5-c766-11e1-8775-005056c00008" p1="-11.406371985068253" q1="-10.361836586084237" p2="11.476893776100034" q2="8.2201777473798678">
         <iidm:alias>_044b9786-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04845acb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10059,7 +10182,7 @@
             <iidm:temporaryLimit name="_9f39cb45-314c-445e-b177-909854a9ce45" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0484f709-c766-11e1-8775-005056c00008" name="11-12" r="1.0367280000000001" x="3.4151039999999999" g1="0" b1="1.4405399999999999e-05" g2="0" b2="1.4405399999999999e-05" node1="40" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="39.939702188706292" q1="-29.263333035801548" p2="-39.790716729937074" q2="29.263787630307668">
+    <iidm:line id="_0484f709-c766-11e1-8775-005056c00008" name="11-12" r="1.0367280000000001" x="3.4151039999999999" g1="0" b1="1.4405399999999999e-05" g2="0" b2="1.4405399999999999e-05" node1="40" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="34.843385586294978" q1="-25.511147453681627" p2="-34.730252234085377" q2="25.393277690744227">
         <iidm:alias>_0456e227-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04880440-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10067,7 +10190,7 @@
             <iidm:temporaryLimit name="_70fad3e1-4529-4a7f-9e6c-8ab249d65460" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044bbe91-c766-11e1-8775-005056c00008" name="8-9" r="1.18096" x="14.762" g1="0" b1="0.001200413215" g2="0" b2="0.001200413215" node1="31" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_045c8779-c766-11e1-8775-005056c00008" p1="-486.67903344937946" q1="-86.497559415997245" p2="492.42599865702579" q2="37.448356823036399">
+    <iidm:line id="_044bbe91-c766-11e1-8775-005056c00008" name="8-9" r="1.18096" x="14.762" g1="0" b1="0.001200413215" g2="0" b2="0.001200413215" node1="31" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_045c8779-c766-11e1-8775-005056c00008" p1="-486.6373207822835" q1="-83.746116031846924" p2="492.35484671490599" q2="33.937132482543099">
         <iidm:alias>_04745535-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048a7548-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="2000">
@@ -10075,7 +10198,7 @@
             <iidm:temporaryLimit name="_205e5d8a-f05a-479d-adaa-3514f48f6857" acceptableDuration="60" value="2400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04566cf8-c766-11e1-8775-005056c00008" name="64-65" r="1.30196" x="14.6168" g1="0" b1="0.000392562" g2="0" b2="0.000392562" node1="35" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-157.49826559907035" q1="-33.947738907894539" p2="158.17844589224691" q2="3.581872460084945">
+    <iidm:line id="_04566cf8-c766-11e1-8775-005056c00008" name="64-65" r="1.30196" x="14.6168" g1="0" b1="0.000392562" g2="0" b2="0.000392562" node1="35" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-157.46071146860791" q1="-33.950127221596851" p2="158.14057113665231" q2="3.5806268255361693">
         <iidm:alias>_044a10e2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04793738-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10083,7 +10206,7 @@
             <iidm:temporaryLimit name="_8cee2b62-2953-439b-ba4b-4a48d55116c0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046783f3-c766-11e1-8775-005056c00008" name="54-56" r="0.47915999999999997" x="1.6639919999999999" g1="0" b1="2.1005500000000001e-05" g2="0" b2="2.1005500000000001e-05" node1="60" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="29.556752202927822" q1="2.696010017510448" p2="-29.530133977814732" q2="-3.2703709089543649">
+    <iidm:line id="_046783f3-c766-11e1-8775-005056c00008" name="54-56" r="0.47915999999999997" x="1.6639919999999999" g1="0" b1="2.1005500000000001e-05" g2="0" b2="2.1005500000000001e-05" node1="60" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="29.568405051431757" q1="2.6952287687341538" p2="-29.541766196016106" q2="-3.2695178761891057">
         <iidm:alias>_0460f444-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d2949-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10091,7 +10214,7 @@
             <iidm:temporaryLimit name="_640627c7-0672-413e-8dc8-c9965709a5cb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04670ec6-c766-11e1-8775-005056c00008" name="84-85" r="5.2620480000000001" x="11.1687832" g1="0" b1="3.541095e-05" g2="0" b2="3.541095e-05" node1="21" voltageLevelId1="_047b0bf4-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-44.532262457094099" q1="13.849613089975033" p2="45.238247959818445" q2="-13.513769339446863">
+    <iidm:line id="_04670ec6-c766-11e1-8775-005056c00008" name="84-85" r="5.2620480000000001" x="11.1687832" g1="0" b1="3.541095e-05" g2="0" b2="3.541095e-05" node1="21" voltageLevelId1="_047b0bf4-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-44.331864754803988" q1="14.339615124620607" p2="45.039887550312116" q2="-13.993815412213905">
         <iidm:alias>_0453fbf5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046512f7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10099,7 +10222,7 @@
             <iidm:temporaryLimit name="_8b888209-5038-4b98-80fc-062b5ea55747" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0460cd36-c766-11e1-8775-005056c00008" name="34-36" r="1.51763" x="4.669632" g1="0" b1="1.6299349999999998e-05" g2="0" b2="1.6299349999999998e-05" node1="43" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="34.431599638423101" q1="11.264403288077071" p2="-34.302900290559165" q2="-11.371703094653549">
+    <iidm:line id="_0460cd36-c766-11e1-8775-005056c00008" name="34-36" r="1.51763" x="4.669632" g1="0" b1="1.6299349999999998e-05" g2="0" b2="1.6299349999999998e-05" node1="43" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="34.517411628922687" q1="11.232076537337408" p2="-34.388081458720215" q2="-11.336941308271665">
         <iidm:alias>_046a6a26-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0487b620-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10107,7 +10230,7 @@
             <iidm:temporaryLimit name="_c0a08025-3a61-4d24-9944-f3ef0b079f64" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04549836-c766-11e1-8775-005056c00008" name="24-70" r="0.38507000000000002" x="71.699759999999998" g1="0" b1="0.00029264234999999998" g2="0" b2="0.00029264234999999998" node1="32" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="18.017189419622547" q1="-1.4717890606597048" p2="-18.009675440449012" q2="-7.1269737491261669">
+    <iidm:line id="_04549836-c766-11e1-8775-005056c00008" name="24-70" r="0.38507000000000002" x="71.699759999999998" g1="0" b1="0.00029264234999999998" g2="0" b2="0.00029264234999999998" node1="32" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="17.177892216624521" q1="-1.2804735987210347" p2="-17.171019381773895" q2="-7.4518622799689256">
         <iidm:alias>_04549834-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04854522-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10115,7 +10238,7 @@
             <iidm:temporaryLimit name="_32793450-bbfd-4dcd-a911-89e199600780" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0452273a-c766-11e1-8775-005056c00008" name="85-86" r="6.0983999999999998" x="21.431519999999999" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="50" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0484f70a-c766-11e1-8775-005056c00008" p1="21.233161541029475" q1="12.279494643934102" p2="-20.998298717082292" q2="-14.002565286814599">
+    <iidm:line id="_0452273a-c766-11e1-8775-005056c00008" name="85-86" r="6.0983999999999998" x="21.431519999999999" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="50" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0484f70a-c766-11e1-8775-005056c00008" p1="21.281975976190992" q1="16.351935598381644" p2="-20.997924160960284" q2="-17.874989235090055">
         <iidm:alias>_044afb43-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479fa85-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10123,7 +10246,7 @@
             <iidm:temporaryLimit name="_2ec4bef5-7abb-4f52-bb62-49ee474d672b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0450eeb5-c766-11e1-8775-005056c00008" name="16-17" r="7.9104960000000002" x="31.380622899999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="22" voltageLevelId1="_046f7338-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-8.3004406281531171" q1="-0.48834475934840993" p2="8.3345134827161509" q2="-3.8470659685076356">
+    <iidm:line id="_0450eeb5-c766-11e1-8775-005056c00008" name="16-17" r="7.9104960000000002" x="31.380622899999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="22" voltageLevelId1="_046f7338-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-14.982930795368517" q1="1.4665704246518851" p2="15.095769525364592" q2="-5.4871626965500218">
         <iidm:alias>_044ef2ea-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04837066-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10131,7 +10254,7 @@
             <iidm:temporaryLimit name="_9280074c-8555-49ff-9e62-8ed8f7d95060" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048a4e33-c766-11e1-8775-005056c00008" name="62-66" r="8.3983679999999996" x="37.984317799999999" g1="0" b1="0.00016586315" g2="0" b2="0.00016586315" node1="41" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-15.26960682672032" q1="-21.573483707522005" p2="15.552240281990956" q2="16.819645230852615">
+    <iidm:line id="_048a4e33-c766-11e1-8775-005056c00008" name="62-66" r="8.3983679999999996" x="37.984317799999999" g1="0" b1="0.00016586315" g2="0" b2="0.00016586315" node1="41" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-15.283640919170219" q1="-21.569847446082175" p2="15.56641631639093" q2="16.816652842810825">
         <iidm:alias>_046e13a9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a96c7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10139,7 +10262,7 @@
             <iidm:temporaryLimit name="_ace48562-0a49-4b76-ae82-c896a00b04f9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0478e913-c766-11e1-8775-005056c00008" name="76-77" r="7.736256" x="25.787520000000001" g1="0" b1="0.00010560145" g2="0" b2="0.00010560145" node1="21" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-62.211512853414618" q1="-21.341455691240675" p2="64.360047160627076" q2="25.033855087949629">
+    <iidm:line id="_0478e913-c766-11e1-8775-005056c00008" name="76-77" r="7.736256" x="25.787520000000001" g1="0" b1="0.00010560145" g2="0" b2="0.00010560145" node1="21" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-62.343134782096243" q1="-21.237359937731238" p2="64.49819135992675" q2="24.952257440936204">
         <iidm:alias>_044b9785-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04725965-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10147,7 +10270,7 @@
             <iidm:temporaryLimit name="_3f744dba-88dc-4d89-90d4-a6f196054b28" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048badc1-c766-11e1-8775-005056c00008" name="60-62" r="2.1431520000000002" x="9.7748640000000009" g1="0" b1="4.2125800000000002e-05" g2="0" b2="4.2125800000000002e-05" node1="32" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="-0.54961166290777408" q1="-8.6229634442459488" p2="0.5574425307847406" q2="7.2060589117178111">
+    <iidm:line id="_048badc1-c766-11e1-8775-005056c00008" name="60-62" r="2.1431520000000002" x="9.7748640000000009" g1="0" b1="4.2125800000000002e-05" g2="0" b2="4.2125800000000002e-05" node1="32" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="-0.55719207711203955" q1="-8.6208713719072083" p2="0.56501986007131877" q2="7.2039522597140984">
         <iidm:alias>_045b7600-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04720b44-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10155,7 +10278,7 @@
             <iidm:temporaryLimit name="_43f91aaf-c5f4-4995-85a2-37afac616331" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0472a780-c766-11e1-8775-005056c00008" name="27-28" r="3.3332109999999999" x="14.89752" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="42" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04819ba0-c766-11e1-8775-005056c00008" p1="49.590102207719184" q1="-4.3212324369466284" p2="-49.083584368846566" q2="4.5821385084811457">
+    <iidm:line id="_0472a780-c766-11e1-8775-005056c00008" name="27-28" r="3.3332109999999999" x="14.89752" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="42" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04819ba0-c766-11e1-8775-005056c00008" p1="46.436246465393673" q1="-4.3176281442661866" p2="-45.993622494443422" q2="4.2838408732623696">
         <iidm:alias>_04531198-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0475188b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10163,7 +10286,7 @@
             <iidm:temporaryLimit name="_2c20e8bd-84e6-4a1e-b88e-071f631327cb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c81e1-c766-11e1-8775-005056c00008" name="45-46" r="6.9695999999999998" x="23.626943600000001" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="31" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="34" voltageLevelId2="_048a7544-c766-11e1-8775-005056c00008" p1="-33.913861320195316" q1="-6.9305249912325673" p2="34.401859527385398" q2="5.3046224619883509">
+    <iidm:line id="_044c81e1-c766-11e1-8775-005056c00008" name="45-46" r="6.9695999999999998" x="23.626943600000001" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="31" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="34" voltageLevelId2="_048a7544-c766-11e1-8775-005056c00008" p1="-33.772590168652215" q1="-6.9999199812613915" p2="34.256966215301624" q2="5.3618333491237014">
         <iidm:alias>_04561ed6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045c877a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10171,7 +10294,7 @@
             <iidm:temporaryLimit name="_6ad31f7e-233f-4801-898f-9ffc883ec724" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c1249-c766-11e1-8775-005056c00008" name="18-19" r="1.949746" x="8.5900320000000008" g1="0" b1="3.2770900000000002e-05" g2="0" b2="3.2770900000000002e-05" node1="22" voltageLevelId1="_04689563-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="47.520349788594793" q1="0.94217968499072036" p2="-47.237787789093375" q2="-0.71299703908700784">
+    <iidm:line id="_045c1249-c766-11e1-8775-005056c00008" name="18-19" r="1.949746" x="8.5900320000000008" g1="0" b1="3.2770900000000002e-05" g2="0" b2="3.2770900000000002e-05" node1="22" voltageLevelId1="_04689563-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="51.501610907574701" q1="-0.13532944745948683" p2="-51.169703066053572" q2="0.58270473427293612">
         <iidm:alias>_046b066b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047ae4e0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10179,7 +10302,7 @@
             <iidm:temporaryLimit name="_a025c9d8-58f9-4320-a1fe-73ecc68d4147" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044a5f09-c766-11e1-8775-005056c00008" name="9-10" r="1.2487200000000001" x="15.584800700000001" g1="0" b1="0.0012706611300000001" g2="0" b2="0.0012706611300000001" node1="21" voltageLevelId1="_045c8779-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_044f4102-c766-11e1-8775-005056c00008" p1="-492.42599865702567" q1="-37.448356823035688" p2="498.28284436037507" q2="-23.169871892453298">
+    <iidm:line id="_044a5f09-c766-11e1-8775-005056c00008" name="9-10" r="1.2487200000000001" x="15.584800700000001" g1="0" b1="0.0012706611300000001" g2="0" b2="0.0012706611300000001" node1="21" voltageLevelId1="_045c8779-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_044f4102-c766-11e1-8775-005056c00008" p1="-492.35484671490622" q1="-33.937132482542907" p2="498.20225819178603" q2="-26.946316102370304">
         <iidm:alias>_04614262-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04834957-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="2000">
@@ -10187,7 +10310,7 @@
             <iidm:temporaryLimit name="_b7fac0a3-c5af-48b9-af49-261fd8d46e00" acceptableDuration="60" value="2400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0480b14b-c766-11e1-8775-005056c00008" name="85-88" r="3.4847999999999999" x="17.772480000000002" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="51" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0470f9d2-c766-11e1-8775-005056c00008" p1="-63.084191757268528" q1="5.0148664262107987" p2="63.933149828321298" q2="-3.3221000154193185">
+    <iidm:line id="_0480b14b-c766-11e1-8775-005056c00008" name="85-88" r="3.4847999999999999" x="17.772480000000002" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="51" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0470f9d2-c766-11e1-8775-005056c00008" p1="-62.985356073835732" q1="3.577050157820548" p2="63.83268154193" q2="-1.8829893493320538">
         <iidm:alias>_047602e2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04765105-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10195,7 +10318,7 @@
             <iidm:temporaryLimit name="_51646744-d343-42b5-8ba7-fcedc7cc3a98" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04486330-c766-11e1-8775-005056c00008" name="69-77" r="5.3840159999999999" x="17.598240000000001" g1="0" b1="0.00029786500000000002" g2="0" b2="0.00029786500000000002" node1="60" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="32.453529865430028" q1="17.948833410630254" p2="-31.990305856766067" q2="-27.212180038059863">
+    <iidm:line id="_04486330-c766-11e1-8775-005056c00008" name="69-77" r="5.3840159999999999" x="17.598240000000001" g1="0" b1="0.00029786500000000002" g2="0" b2="0.00029786500000000002" node1="60" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="32.557290921265611" q1="18.06373585827744" p2="-32.090558991092003" q2="-27.314145439689145">
         <iidm:alias>_046205b9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479d379-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10203,7 +10326,7 @@
             <iidm:temporaryLimit name="_76311a15-b79a-4439-a7ce-47afa8fa6fe2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04553477-c766-11e1-8775-005056c00008" name="11-13" r="3.8768400000000001" x="12.7369442" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="41" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04851e1b-c766-11e1-8775-005056c00008" p1="49.725044106224622" q1="15.061644359527074" p2="-49.101512174557342" q2="-14.798015859406568">
+    <iidm:line id="_04553477-c766-11e1-8775-005056c00008" name="11-13" r="3.8768400000000001" x="12.7369442" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="41" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04851e1b-c766-11e1-8775-005056c00008" p1="45.45263293209355" q1="16.223424718172229" p2="-44.913745865762856" q2="-16.239537618633385">
         <iidm:alias>_0479fa89-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0485452a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10211,7 +10334,7 @@
             <iidm:temporaryLimit name="_efbf8de7-4b84-4834-bb7c-6250b6072211" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04488a45-c766-11e1-8775-005056c00008" name="103-105" r="9.3218399999999999" x="28.314" g1="0" b1="0.0001170799" g2="0" b2="0.0001170799" node1="42" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="43.796632771531776" q1="12.535284934855737" p2="-42.678602333513169" q2="-13.121378577174825">
+    <iidm:line id="_04488a45-c766-11e1-8775-005056c00008" name="103-105" r="9.3218399999999999" x="28.314" g1="0" b1="0.0001170799" g2="0" b2="0.0001170799" node1="42" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="43.796517187654473" q1="12.535374643964831" p2="-42.678490756394403" q2="-13.121480345340627">
         <iidm:alias>_044f8f24-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04611b58-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10219,7 +10342,7 @@
             <iidm:temporaryLimit name="_22b6919a-a7a0-49fc-9e90-329069c55055" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046009e6-c766-11e1-8775-005056c00008" name="45-49" r="11.918016400000001" x="32.408639999999998" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="32" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="118" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-40.951574829579442" q1="-7.9613894171297437" p2="42.162985367949688" q2="6.7786494622755935">
+    <iidm:line id="_046009e6-c766-11e1-8775-005056c00008" name="45-49" r="11.918016400000001" x="32.408639999999998" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="32" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="118" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-40.81382630168978" q1="-8.0385437577323824" p2="42.017974070169679" q2="6.8361812328268519">
         <iidm:alias>_044ca8f9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047dcb1b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10227,7 +10350,7 @@
             <iidm:temporaryLimit name="_8b91f4fd-4038-45b7-870c-fbc08592b95a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046a6a27-c766-11e1-8775-005056c00008" name="88-89" r="2.4219360000000001" x="12.4058876" g1="0" b1="5.549815e-05" g2="0" b2="5.549815e-05" node1="22" voltageLevelId1="_0470f9d2-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-111.93236938702131" q1="-6.6776289807594535" p2="113.74392487168865" q2="14.048209543831247">
+    <iidm:line id="_046a6a27-c766-11e1-8775-005056c00008" name="88-89" r="2.4219360000000001" x="12.4058876" g1="0" b1="5.549815e-05" g2="0" b2="5.549815e-05" node1="22" voltageLevelId1="_0470f9d2-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-111.8317785491125" q1="-8.1166969672801645" p2="113.64660980367066" q2="15.506026155570421">
         <iidm:alias>_045ef879-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04649dc1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10235,7 +10358,7 @@
             <iidm:temporaryLimit name="_970bc323-73bf-440d-a3c5-00aebc3a1992" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048a7540-c766-11e1-8775-005056c00008" name="80-98" r="4.1469120000000004" x="18.817920000000001" g1="0" b1="8.20707e-05" g2="0" b2="8.20707e-05" node1="79" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04773b62-c766-11e1-8775-005056c00008" p1="11.391018382090706" q1="11.980193183122429" p2="-11.322203507956649" q2="-14.712270112405552">
+    <iidm:line id="_048a7540-c766-11e1-8775-005056c00008" name="80-98" r="4.1469120000000004" x="18.817920000000001" g1="0" b1="8.20707e-05" g2="0" b2="8.20707e-05" node1="79" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04773b62-c766-11e1-8775-005056c00008" p1="11.397613902329457" q1="11.978642223704606" p2="-11.328775191105454" q2="-14.710611659794056">
         <iidm:alias>_045338a2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04887972-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10243,7 +10366,7 @@
             <iidm:temporaryLimit name="_cb084dc7-1b26-415f-9495-4695df661912" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04640183-c766-11e1-8775-005056c00008" name="91-92" r="6.7430880000000002" x="22.163329999999998" g1="0" b1="9.3778700000000004e-05" g2="0" b2="9.3778700000000004e-05" node1="22" voltageLevelId1="_044f8f29-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="-5.6960744432636394" q1="-14.594605253865064" p2="5.7795335888222992" q2="11.731656209297697">
+    <iidm:line id="_04640183-c766-11e1-8775-005056c00008" name="91-92" r="6.7430880000000002" x="22.163329999999998" g1="0" b1="9.3778700000000004e-05" g2="0" b2="9.3778700000000004e-05" node1="22" voltageLevelId1="_044f8f29-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="-5.671599196918411" q1="-14.58444499583433" p2="5.7548407251027403" q2="11.721036586770753">
         <iidm:alias>_04492680-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_044c5ad5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10251,7 +10374,7 @@
             <iidm:temporaryLimit name="_3a165a76-f6ba-461b-84d6-159a5e0b5077" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0474a358-c766-11e1-8775-005056c00008" name="7-12" r="1.501949" x="5.9241599999999996" g1="0" b1="2.5080350000000001e-05" g2="0" b2="2.5080350000000001e-05" node1="22" voltageLevelId1="_047eb571-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="23.783437501414731" q1="-9.9681387492273377" p2="-23.725536346344064" q2="9.3409910280743738">
+    <iidm:line id="_0474a358-c766-11e1-8775-005056c00008" name="7-12" r="1.501949" x="5.9241599999999996" g1="0" b1="2.5080350000000001e-05" g2="0" b2="2.5080350000000001e-05" node1="22" voltageLevelId1="_047eb571-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="19.54890594338891" q1="-7.9193474855412882" p2="-19.510288391716717" q2="7.2158372983832582">
         <iidm:alias>_046ab848-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0477feb7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10259,7 +10382,7 @@
             <iidm:temporaryLimit name="_b19bc945-cc51-4d77-8eaa-3f6afe2d9316" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04765108-c766-11e1-8775-005056c00008" name="99-100" r="3.13632" x="14.165711399999999" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_04644fa4-c766-11e1-8775-005056c00008" node2="80" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-40.05467143919563" q1="12.292240697982427" p2="40.363357080384603" q2="-13.138777745776986">
+    <iidm:line id="_04765108-c766-11e1-8775-005056c00008" name="99-100" r="3.13632" x="14.165711399999999" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_04644fa4-c766-11e1-8775-005056c00008" node2="80" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-40.048047715858573" q1="12.290715103503617" p2="40.356634385389704" q2="-13.137699630437849">
         <iidm:alias>_0471e436-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047e4040-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10267,7 +10390,7 @@
             <iidm:temporaryLimit name="_a9e283ed-fcad-4f4c-ab57-8531875bb098" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047b8128-c766-11e1-8775-005056c00008" name="114-115" r="0.400752" x="1.8120959999999999" g1="0" b1="7.9201000000000006e-06" g2="0" b2="7.9201000000000006e-06" node1="22" voltageLevelId1="_04791027-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="4.0003331966642675" q1="1.3401141154478307" p2="-3.9998796312122602" q2="-1.5920919299667042">
+    <iidm:line id="_047b8128-c766-11e1-8775-005056c00008" name="114-115" r="0.400752" x="1.8120959999999999" g1="0" b1="7.9201000000000006e-06" g2="0" b2="7.9201000000000006e-06" node1="22" voltageLevelId1="_04791027-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="4.5915768451328862" q1="0.96852921870723574" p2="-4.5910221597682437" q2="-1.2209842045502477">
         <iidm:alias>_046c17d3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d0233-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10275,7 +10398,7 @@
             <iidm:temporaryLimit name="_c59e4022-b1c0-4811-a32e-f54656bff32d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046931a5-c766-11e1-8775-005056c00008" name="83-84" r="10.890000000000001" x="22.999680000000001" g1="0" b1="7.4035799999999993e-05" g2="0" b2="7.4035799999999993e-05" node1="33" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b0bf4-c766-11e1-8775-005056c00008" p1="-32.525705948475682" q1="20.54018086558516" p2="33.532624506222106" q2="-20.849229194142659">
+    <iidm:line id="_046931a5-c766-11e1-8775-005056c00008" name="83-84" r="10.890000000000001" x="22.999680000000001" g1="0" b1="7.4035799999999993e-05" g2="0" b2="7.4035799999999993e-05" node1="33" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b0bf4-c766-11e1-8775-005056c00008" p1="-32.316618659852999" q1="21.057365043859075" p2="33.332285252956567" q2="-21.339169201440956">
         <iidm:alias>_0465d645-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479102b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10283,7 +10406,7 @@
             <iidm:temporaryLimit name="_1268eb09-e233-44ce-b8af-22dc30eb16ad" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047ae4ea-c766-11e1-8775-005056c00008" name="14-15" r="10.367279999999999" x="33.976799999999997" g1="0" b1="0.0001440542" g2="0" b2="0.0001440542" node1="21" voltageLevelId1="_047b8129-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="21.216486881079796" q1="5.9079869784626107" p2="-20.893275186061292" q2="-9.50725273873765">
+    <iidm:line id="_047ae4ea-c766-11e1-8775-005056c00008" name="14-15" r="10.367279999999999" x="33.976799999999997" g1="0" b1="0.0001440542" g2="0" b2="0.0001440542" node1="21" voltageLevelId1="_047b8129-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="16.476373363241503" q1="7.3862971647903173" p2="-16.247771140417228" q2="-11.294227378053408">
         <iidm:alias>_0449e9d9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046ed6fa-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10291,7 +10414,7 @@
             <iidm:temporaryLimit name="_9c0c454b-ecc3-40f6-b505-f32fec412522" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046e3ab2-c766-11e1-8775-005056c00008" name="80-96" r="6.2029439999999996" x="31.711680000000001" g1="0" b1="0.0001417585" g2="0" b2="0.0001417585" node1="80" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="4.6618082820476916" q1="26.195983124500223" p2="-4.3803698049533768" q2="-29.839247750647207">
+    <iidm:line id="_046e3ab2-c766-11e1-8775-005056c00008" name="80-96" r="6.2029439999999996" x="31.711680000000001" g1="0" b1="0.0001417585" g2="0" b2="0.0001417585" node1="80" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="4.7040458905421234" q1="26.395287771045773" p2="-4.4186767550714157" q2="-30.016685402693067">
         <iidm:alias>_045338a4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04865695-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10299,7 +10422,7 @@
             <iidm:temporaryLimit name="_1432f4d6-9299-4b0d-bd7f-16e059f9de66" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04893cc4-c766-11e1-8775-005056c00008" name="56-59" r="13.9914722" x="41.643360000000001" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="59" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-20.154720988284115" q1="-7.6678489196446655" p2="20.537373763042012" q2="3.7682045315055368">
+    <iidm:line id="_04893cc4-c766-11e1-8775-005056c00008" name="56-59" r="13.9914722" x="41.643360000000001" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="59" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-20.140170192061767" q1="-7.6736076186176643" p2="20.522358869363398" q2="3.772582934473232">
         <iidm:alias>_046b5484-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04798557-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10307,7 +10430,7 @@
             <iidm:temporaryLimit name="_193f6952-4267-4cc8-a541-726c095028ba" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c1243-c766-11e1-8775-005056c00008" name="92-100" r="11.290752400000001" x="51.400799999999997" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="71" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="36.825958768478614" q1="-17.275368358414635" p2="-35.780089057191816" q2="17.285299444011706">
+    <iidm:line id="_045c1243-c766-11e1-8775-005056c00008" name="92-100" r="11.290752400000001" x="51.400799999999997" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="71" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="36.863205885563254" q1="-17.294926563664632" p2="-35.815018776558887" q2="17.315645925713891">
         <iidm:alias>_045e8348-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045ed164-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10315,7 +10438,7 @@
             <iidm:temporaryLimit name="_579249ce-1c81-4d29-8d3f-5fc627a18f99" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0474a356-c766-11e1-8775-005056c00008" name="43-44" r="10.593792000000001" x="42.7584953" g1="0" b1="0.00017412765" g2="0" b2="0.00017412765" node1="22" voltageLevelId1="_045e8349-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04544a15-c766-11e1-8775-005056c00008" p1="-5.68655214266487" q1="-11.085968900934011" p2="5.7553965394741056" q2="5.7461792306922961">
+    <iidm:line id="_0474a356-c766-11e1-8775-005056c00008" name="43-44" r="10.593792000000001" x="42.7584953" g1="0" b1="0.00017412765" g2="0" b2="0.00017412765" node1="22" voltageLevelId1="_045e8349-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04544a15-c766-11e1-8775-005056c00008" p1="-5.4100601779390702" q1="-11.238242812784147" p2="5.4786352081414185" q2="5.8998751546732944">
         <iidm:alias>_04642899-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047b0bf2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10323,7 +10446,7 @@
             <iidm:temporaryLimit name="_3d2cb4b5-ee82-4866-9855-4a5f4803cd3b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04627ae6-c766-11e1-8775-005056c00008" name="109-110" r="4.8438720000000002" x="13.2770882" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="22" voltageLevelId1="_046b7b99-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="12.734917710233457" q1="-2.9685136164121144" p2="-12.684428154859287" q2="1.2605573762183058">
+    <iidm:line id="_04627ae6-c766-11e1-8775-005056c00008" name="109-110" r="4.8438720000000002" x="13.2770882" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="22" voltageLevelId1="_046b7b99-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="12.738045165135775" q1="-2.9696698267409753" p2="-12.68752997985133" q2="1.2617843365125361">
         <iidm:alias>_0466e7b5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a6fbb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10331,7 +10454,7 @@
             <iidm:temporaryLimit name="_6fc48d8d-05f8-4104-a6a2-3686d430a091" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0478c207-c766-11e1-8775-005056c00008" name="68-81" r="0.84699999999999998" x="9.7767990000000005" g1="0" b1="0.00083471078000000004" g2="0" b2="0.00083471078000000004" node1="38" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_048a272b-c766-11e1-8775-005056c00008" p1="-151.02128110808408" q1="-3.814827767196785" p2="151.44482730418122" q2="-71.538889492229501">
+    <iidm:line id="_0478c207-c766-11e1-8775-005056c00008" name="68-81" r="0.84699999999999998" x="9.7767990000000005" g1="0" b1="0.00083471078000000004" g2="0" b2="0.00083471078000000004" node1="38" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_048a272b-c766-11e1-8775-005056c00008" p1="-150.40398183392313" q1="-3.8791512793861922" p2="150.82417800716462" q2="-71.513704851255923">
         <iidm:alias>_044a37f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045b4ef6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10339,7 +10462,7 @@
             <iidm:temporaryLimit name="_191836a1-39cd-402b-8dcf-4f3867c45bd0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0467d215-c766-11e1-8775-005056c00008" name="85-89" r="4.1643359999999996" x="30.143518400000001" g1="0" b1="0.00013487144999999999" g2="0" b2="0.00013487144999999999" node1="52" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-83.810371160714354" q1="-2.3396315407073875" p2="85.583212901777756" q2="10.573457143936182">
+    <iidm:line id="_0467d215-c766-11e1-8775-005056c00008" name="85-89" r="4.1643359999999996" x="30.143518400000001" g1="0" b1="0.00013487144999999999" g2="0" b2="0.00013487144999999999" node1="52" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-83.597678506625826" q1="-3.7805428956057154" p2="85.371393700942036" q2="12.032288299069">
         <iidm:alias>_047629f9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0478e915-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10347,7 +10470,7 @@
             <iidm:temporaryLimit name="_66cbdeeb-a4e4-4bfc-aec1-9fb7a2d2b6bc" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044a37f2-c766-11e1-8775-005056c00008" name="89-90" r="4.1469120000000004" x="17.371727" g1="0" b1="0.00030417815" g2="0" b2="0.00030417815" node1="62" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="112.73308217662428" q1="21.233896013701916" p2="-109.57185672046761" q2="-18.20613332430182">
+    <iidm:line id="_044a37f2-c766-11e1-8775-005056c00008" name="89-90" r="4.1469120000000004" x="17.371727" g1="0" b1="0.00030417815" g2="0" b2="0.00030417815" node1="62" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="112.75007965492559" q1="21.245266358727186" p2="-109.58780878748409" q2="-18.212986475848282">
         <iidm:alias>_045386c2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048719e9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10355,7 +10478,7 @@
             <iidm:temporaryLimit name="_8489e809-6588-4ed2-a9a4-43c44a0d47da" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04658820-c766-11e1-8775-005056c00008" name="98-100" r="6.9173280000000004" x="31.188960999999999" g1="0" b1="0.0001365932" g2="0" b2="0.0001365932" node1="22" voltageLevelId1="_04773b62-c766-11e1-8775-005056c00008" node2="82" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-22.677779142908939" q1="6.7122772167422431" p2="22.904843516681716" q2="-10.642699189970578">
+    <iidm:line id="_04658820-c766-11e1-8775-005056c00008" name="98-100" r="6.9173280000000004" x="31.188960999999999" g1="0" b1="0.0001365932" g2="0" b2="0.0001365932" node1="22" voltageLevelId1="_04773b62-c766-11e1-8775-005056c00008" node2="82" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-22.67121040314564" q1="6.7106179544720392" p2="22.898150200189505" q2="-10.641602742866851">
         <iidm:alias>_046f4c22-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046fe865-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10363,7 +10486,7 @@
             <iidm:temporaryLimit name="_620beaaf-63c8-4020-bea5-c3609c0eaadf" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c5ada-c766-11e1-8775-005056c00008" name="28-29" r="4.1294880000000003" x="16.430831900000001" g1="0" b1="6.8296599999999999e-05" g2="0" b2="6.8296599999999999e-05" node1="22" voltageLevelId1="_04819ba0-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04588fd5-c766-11e1-8775-005056c00008" p1="32.092428749982901" q1="-11.576054491977288" p2="-31.799346629350129" q2="10.541871482140047">
+    <iidm:line id="_044c5ada-c766-11e1-8775-005056c00008" name="28-29" r="4.1294880000000003" x="16.430831900000001" g1="0" b1="6.8296599999999999e-05" g2="0" b2="6.8296599999999999e-05" node1="22" voltageLevelId1="_04819ba0-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04588fd5-c766-11e1-8775-005056c00008" p1="28.999550469355889" q1="-9.0736279266908539" p2="-28.768134259203222" q2="7.7870898069630465">
         <iidm:alias>_0461697a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04697fc1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10371,7 +10494,13 @@
             <iidm:temporaryLimit name="_6748d0d0-aec8-4b7b-a9ab-be6aecda7c5d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0468e382-c766-11e1-8775-005056c00008" name="3-5" r="4.1991839999999998" x="18.817920000000001" g1="0" b1="8.1496799999999995e-05" g2="0" b2="8.1496799999999995e-05" node1="31" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-72.438527992733526" q1="-15.523843233947288" p2="73.827563858381367" q2="18.960771751897902">
+    <iidm:line id="_044c5ada-c766-11e1-8775-005056c00008-1" name="28-29-open-ended" r="4.1294880000000003" x="16.430831900000001" g1="0" b1="6.8296599999999999e-05" g2="0" b2="6.8296599999999999e-05" node1="25" voltageLevelId1="_04819ba0-c766-11e1-8775-005056c00008" node2="25" voltageLevelId2="_04588fd5-c766-11e1-8775-005056c00008" p1="0.0003115931732340085" q1="-2.2059277519732641" p2="0" q2="0">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_accb8136-1faf-4399-9787-3cd567284fd2-1" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_6748d0d0-aec8-4b7b-a9ab-be6aecda7c5d-1" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0468e382-c766-11e1-8775-005056c00008" name="3-5" r="4.1991839999999998" x="18.817920000000001" g1="0" b1="8.1496799999999995e-05" g2="0" b2="8.1496799999999995e-05" node1="31" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-70.219127053608759" q1="-16.699845291479534" p2="71.535006505729086" q2="19.804759748965537">
         <iidm:alias>_046b0668-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04742e24-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10379,7 +10508,7 @@
             <iidm:temporaryLimit name="_828ca44c-560b-4f94-b825-21e237285fae" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0447c6f1-c766-11e1-8775-005056c00008" name="82-96" r="2.8226879999999999" x="9.2347199999999994" g1="0" b1="0.00015610649999999999" g2="0" b2="0.00015610649999999999" node1="33" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="-15.555754771554611" q1="-8.8573501000375483" p2="15.602943227462546" q2="3.7346463053384236">
+    <iidm:line id="_0447c6f1-c766-11e1-8775-005056c00008" name="82-96" r="2.8226879999999999" x="9.2347199999999994" g1="0" b1="0.00015610649999999999" g2="0" b2="0.00015610649999999999" node1="33" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="-15.75935259582519" q1="-9.5715128536320044" p2="15.809284346550998" q2="4.4639520450948815">
         <iidm:alias>_0478e91a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0480d856-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10387,7 +10516,7 @@
             <iidm:temporaryLimit name="_233b7735-85f4-4a6f-9d87-15129fe42ef5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0483e594-c766-11e1-8775-005056c00008" name="38-65" r="4.3608399999999996" x="47.7224" g1="0" b1="0.0010805785" g2="0" b2="0.0010805785" node1="29" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-162.95132402338842" q1="-97.244240128106156" p2="166.09806536928323" q2="34.848627736229624">
+    <iidm:line id="_0483e594-c766-11e1-8775-005056c00008" name="38-65" r="4.3608399999999996" x="47.7224" g1="0" b1="0.0010805785" g2="0" b2="0.0010805785" node1="29" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-161.51633432686432" q1="-97.767769516177111" p2="164.62071436801929" q2="34.926821433569422">
         <iidm:alias>_04638c56-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d5054-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10395,7 +10524,7 @@
             <iidm:temporaryLimit name="_990ce3c5-c90c-41b9-abee-fb803d9df3a5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04784cd4-c766-11e1-8775-005056c00008" name="106-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_04479fe8-c766-11e1-8775-005056c00008" node2="24" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="23.852683947391828" q1="-0.69450887536857553" p2="-23.524281750164398" q2="-2.4550992031592509">
+    <iidm:line id="_04784cd4-c766-11e1-8775-005056c00008" name="106-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_04479fe8-c766-11e1-8775-005056c00008" node2="24" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="23.852901239095477" q1="-0.694582710371206" p2="-23.524493100866259" q2="-2.4550036260889851">
         <iidm:alias>_04483c21-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f0395-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10403,7 +10532,7 @@
             <iidm:temporaryLimit name="_1372c3b0-62d7-47d7-a8c0-ed8e10bc1f1a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046f9a43-c766-11e1-8775-005056c00008" name="27-115" r="2.8575360000000001" x="12.9111843" g1="0" b1="5.6588600000000002e-05" g2="0" b2="5.6588600000000002e-05" node1="43" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="18.044979994987706" q1="3.8487654536982303" p2="-17.983740945555244" q2="-5.3991980670792126">
+    <iidm:line id="_046f9a43-c766-11e1-8775-005056c00008" name="27-115" r="2.8575360000000001" x="12.9111843" g1="0" b1="5.6588600000000002e-05" g2="0" b2="5.6588600000000002e-05" node1="43" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="17.455680968459969" q1="4.200672807055664" p2="-17.397734424249386" q2="-5.7730480154331349">
         <iidm:alias>_046d0238-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048c22f4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10411,7 +10540,7 @@
             <iidm:temporaryLimit name="_64cfd0fb-1d8e-45d2-a52f-469238dfc0c6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04529c61-c766-11e1-8775-005056c00008" name="12-14" r="3.7461600000000002" x="12.3187675" g1="0" b1="5.2112050000000002e-05" g2="0" b2="5.2112050000000002e-05" node1="71" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b8129-c766-11e1-8775-005056c00008" p1="35.503051419239661" q1="6.0946493487098534" p2="-35.215847134692851" q2="-6.9079104094520378">
+    <iidm:line id="_04529c61-c766-11e1-8775-005056c00008" name="12-14" r="3.7461600000000002" x="12.3187675" g1="0" b1="5.2112050000000002e-05" g2="0" b2="5.2112050000000002e-05" node1="71" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b8129-c766-11e1-8775-005056c00008" p1="30.697548281201097" q1="7.3572677522189771" p2="-30.475911241880045" q2="-8.3862421537053109">
         <iidm:alias>_045fbbc1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047bf65b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10419,7 +10548,7 @@
             <iidm:temporaryLimit name="_efe2501d-bcee-42ff-a037-3d8a280487b0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0463da77-c766-11e1-8775-005056c00008" name="76-118" r="2.8575360000000001" x="9.4786560000000009" g1="0" b1="3.8911849999999999e-05" g2="0" b2="3.8911849999999999e-05" node1="22" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="-5.788732014707386" q1="-14.658759460205042" p2="5.8318196479901312" q2="13.596442406480765">
+    <iidm:line id="_0463da77-c766-11e1-8775-005056c00008" name="76-118" r="2.8575360000000001" x="9.4786560000000009" g1="0" b1="3.8911849999999999e-05" g2="0" b2="3.8911849999999999e-05" node1="22" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="-5.6574259209855429" q1="-14.763131905550985" p2="5.7007892460323442" q2="13.701854720615753">
         <iidm:alias>_046931a0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04806320-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10427,7 +10556,7 @@
             <iidm:temporaryLimit name="_2ae204bf-78cc-49cb-b886-a933b33057e4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046931a3-c766-11e1-8775-005056c00008" name="74-75" r="2.1431520000000002" x="7.0741440000000004" g1="0" b1="2.9671699999999999e-05" g2="0" b2="2.9671699999999999e-05" node1="23" voltageLevelId1="_047dcb11-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="-44.695722696603667" q1="-4.4396979114735915" p2="44.964394641317661" q2="4.3658872646705511">
+    <iidm:line id="_046931a3-c766-11e1-8775-005056c00008" name="74-75" r="2.1431520000000002" x="7.0741440000000004" g1="0" b1="2.9671699999999999e-05" g2="0" b2="2.9671699999999999e-05" node1="23" voltageLevelId1="_047dcb11-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="-44.998326031995731" q1="-4.2475409654230942" p2="45.270397153069602" q2="4.1849049301054198">
         <iidm:alias>_044f4103-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04638c58-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10435,7 +10564,7 @@
             <iidm:temporaryLimit name="_e822432e-79af-4bba-8f40-5250468f81a0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045ed162-c766-11e1-8775-005056c00008" name="3-12" r="8.4332159999999998" x="27.878398900000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="32" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-7.3725265230861554" q1="-10.441588689190965" p2="7.437544565009806" q2="6.7479303525245085">
+    <iidm:line id="_045ed162-c766-11e1-8775-005056c00008" name="3-12" r="8.4332159999999998" x="27.878398900000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="32" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-8.6283518382044022" q1="-9.7670487093183951" p2="8.6979213642471436" q2="6.0865639542916652">
         <iidm:alias>_047a48a1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047b5a14-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10443,7 +10572,7 @@
             <iidm:temporaryLimit name="_c437e52c-43d7-4ae9-87ad-dc19396dc6ff" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04499bb6-c766-11e1-8775-005056c00008" name="49-51" r="8.468064" x="23.8708782" g1="0" b1="9.81405e-05" g2="0" b2="9.81405e-05" node1="119" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04542300-c766-11e1-8775-005056c00008" p1="76.812160313545462" q1="18.670159549159337" p2="-73.889108325192794" q2="-13.821585770228923">
+    <iidm:line id="_04499bb6-c766-11e1-8775-005056c00008" name="49-51" r="8.468064" x="23.8708782" g1="0" b1="9.81405e-05" g2="0" b2="9.81405e-05" node1="119" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04542300-c766-11e1-8775-005056c00008" p1="76.83334308077329" q1="18.666784932925751" p2="-73.908849598494058" q2="-13.814139188540365">
         <iidm:alias>_0487dd38-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b1180-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10451,7 +10580,7 @@
             <iidm:temporaryLimit name="_90dcdbe1-437b-443f-b0b5-c2353f7c6954" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04839779-c766-11e1-8775-005056c00008" name="40-42" r="9.6703209999999995" x="31.885919999999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="42" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="-0.88878479298858359" q1="-9.5095572286252601" p2="0.92946173662926068" q2="5.8215191535133677">
+    <iidm:line id="_04839779-c766-11e1-8775-005056c00008" name="40-42" r="9.6703209999999995" x="31.885919999999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="42" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="-0.67878021011927758" q1="-9.6477205292626511" p2="0.72075159295778779" q2="5.9666145904111918">
         <iidm:alias>_044974a9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04616975-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10459,7 +10588,7 @@
             <iidm:temporaryLimit name="_9b8510fa-bd0e-4e63-8f4c-0e5443a3eb63" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0484a8e1-c766-11e1-8775-005056c00008" name="32-113" r="10.71576" x="35.370719999999999" g1="0" b1="0.00014864555000000001" g2="0" b2="0.00014864555000000001" node1="52" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="11.820721768121938" q1="-12.602633586970047" p2="-11.659254027850002" q2="8.2541906187773595">
+    <iidm:line id="_0484a8e1-c766-11e1-8775-005056c00008" name="32-113" r="10.71576" x="35.370719999999999" g1="0" b1="0.00014864555000000001" g2="0" b2="0.00014864555000000001" node1="52" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="7.1910341990978548" q1="-10.571934424085354" p2="-7.112928090901864" q2="5.9407015701778629">
         <iidm:alias>_04723258-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0482860a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10467,7 +10596,7 @@
             <iidm:temporaryLimit name="_336bfd86-a922-4154-9e06-cd87382cdc5f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04898ae4-c766-11e1-8775-005056c00008" name="51-58" r="4.4431200000000004" x="12.5278568" g1="0" b1="5.1308550000000002e-05" g2="0" b2="5.1308550000000002e-05" node1="31" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="25.285307310805965" q1="0.49867119053374831" p2="-25.110004734211195" q2="-1.6589812268039579">
+    <iidm:line id="_04898ae4-c766-11e1-8775-005056c00008" name="51-58" r="4.4431200000000004" x="12.5278568" g1="0" b1="5.1308550000000002e-05" g2="0" b2="5.1308550000000002e-05" node1="31" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="25.298540035626022" q1="0.49318909522853005" p2="-25.123057479329908" q2="-1.6529840673348644">
         <iidm:alias>_044778d4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04789af1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10475,7 +10604,7 @@
             <iidm:temporaryLimit name="_2be10dec-f0ac-470d-83f7-a2a4e70f3491" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046efe04-c766-11e1-8775-005056c00008" name="29-31" r="1.8817919999999999" x="5.7673439999999996" g1="0" b1="2.3817700000000001e-05" g2="0" b2="2.3817700000000001e-05" node1="22" voltageLevelId1="_04588fd5-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="7.8010692128099244" q1="-14.541391133156814" p2="-7.7706427646321794" q2="13.861723444887961">
+    <iidm:line id="_046efe04-c766-11e1-8775-005056c00008" name="29-31" r="1.8817919999999999" x="5.7673439999999996" g1="0" b1="2.3817700000000001e-05" g2="0" b2="2.3817700000000001e-05" node1="22" voltageLevelId1="_04588fd5-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="4.768882079617291" q1="-11.78688194127365" p2="-4.7511171834740917" q2="11.067918057582997">
         <iidm:alias>_04492688-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047cb9a5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10483,7 +10612,7 @@
             <iidm:temporaryLimit name="_f0e21213-6535-44a7-89b6-3063f8738d6b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044a10e4-c766-11e1-8775-005056c00008" name="65-68" r="0.66791999999999996" x="7.7439999999999998" g1="0" b1="0.00065909092999999995" g2="0" b2="0.00065909092999999995" node1="41" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0449e9d2-c766-11e1-8775-005056c00008" p1="-164.80406691678701" q1="24.086384850568017" p2="165.21847702820398" q2="-83.316260916010947">
+    <iidm:line id="_044a10e4-c766-11e1-8775-005056c00008" name="65-68" r="0.66791999999999996" x="7.7439999999999998" g1="0" b1="0.00065909092999999995" g2="0" b2="0.00065909092999999995" node1="41" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0449e9d2-c766-11e1-8775-005056c00008" p1="-163.17505275975756" q1="23.877731131302355" p2="163.58184248721238" q2="-83.196204508167028">
         <iidm:alias>_0461dea7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047629f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10491,7 +10620,7 @@
             <iidm:temporaryLimit name="_ab31cd46-6d0c-4d9c-95f1-396a45a237e1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046b7b92-c766-11e1-8775-005056c00008" name="49-54" r="12.719519999999999" x="50.355361899999998" g1="0" b1="0.00021177684999999999" g2="0" b2="0.00021177684999999999" node1="120" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="46.749192860138074" q1="11.853495384782416" p2="-45.058733896646068" q2="-12.403308501463872">
+    <iidm:line id="_046b7b92-c766-11e1-8775-005056c00008" name="49-54" r="12.719519999999999" x="50.355361899999998" g1="0" b1="0.00021177684999999999" g2="0" b2="0.00021177684999999999" node1="120" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="46.768134293414256" q1="11.851197097753674" p2="-45.07649486953494" q2="-12.396337268838179">
         <iidm:alias>_0462f017-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047120e1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10499,7 +10628,7 @@
             <iidm:temporaryLimit name="_1bf78539-b6fa-4d8b-ba8e-9b5970019be6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04607f15-c766-11e1-8775-005056c00008" name="70-71" r="1.536797" x="6.1855200000000004" g1="0" b1="2.5195149999999999e-05" g2="0" b2="2.5195149999999999e-05" node1="52" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04664b78-c766-11e1-8775-005056c00008" p1="-6.4024532041436526" q1="-4.0707192268917138" p2="6.4073987922639697" q2="3.2390120425220381">
+    <iidm:line id="_04607f15-c766-11e1-8775-005056c00008" name="70-71" r="1.536797" x="6.1855200000000004" g1="0" b1="2.5195149999999999e-05" g2="0" b2="2.5195149999999999e-05" node1="52" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04664b78-c766-11e1-8775-005056c00008" p1="-5.6840663824012481" q1="-4.5590341823737637" p2="5.6885653946265329" q2="3.7251472947662969">
         <iidm:alias>_04486336-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f51b4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10507,7 +10636,7 @@
             <iidm:temporaryLimit name="_08ff3ae4-d1dd-49f7-9eda-32ffc8eb0010" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c5ad7-c766-11e1-8775-005056c00008" name="55-56" r="0.85029100000000002" x="2.631024" g1="0" b1="1.0732300000000001e-05" g2="0" b2="1.0732300000000001e-05" node1="31" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="-28.668583988648084" q1="-7.0103338157039117" p2="28.715428966019079" q2="6.8159228140853294">
+    <iidm:line id="_044c5ad7-c766-11e1-8775-005056c00008" name="55-56" r="0.85029100000000002" x="2.631024" g1="0" b1="1.0732300000000001e-05" g2="0" b2="1.0732300000000001e-05" node1="31" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="-28.680569410610801" q1="-7.0064679076354315" p2="28.727448626304586" q2="6.8121630145112047">
         <iidm:alias>_04558294-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045868c2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10515,7 +10644,7 @@
             <iidm:temporaryLimit name="_94316214-afd8-4c0d-bca4-916acb92af85" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048a2725-c766-11e1-8775-005056c00008" name="35-37" r="1.9166399999999999" x="8.6597279999999994" g1="0" b1="3.7821399999999997e-05" g2="0" b2="3.7821399999999997e-05" node1="21" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-29.683637294177274" q1="-14.387258976042308" p2="29.817447492327698" q2="13.817076698703106">
+    <iidm:line id="_048a2725-c766-11e1-8775-005056c00008" name="35-37" r="1.9166399999999999" x="8.6597279999999994" g1="0" b1="3.7821399999999997e-05" g2="0" b2="3.7821399999999997e-05" node1="21" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-29.599526029736879" q1="-14.423084617794057" p2="29.732970294559756" q2="13.852377744719055">
         <iidm:alias>_0471bd29-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04808a30-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10523,7 +10652,7 @@
             <iidm:temporaryLimit name="_4ea6b532-d914-4b0c-97ee-9f02a14a40b3" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04614263-c766-11e1-8775-005056c00008" name="4-5" r="0.30666199999999999" x="1.3904350000000001" g1="0" b1="6.0261499999999999e-06" g2="0" b2="6.0261499999999999e-06" node1="22" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-113.15094756021473" q1="-17.993137504400387" p2="113.37940131631579" q2="18.815933238605727">
+    <iidm:line id="_04614263-c766-11e1-8775-005056c00008" name="4-5" r="0.30666199999999999" x="1.3904350000000001" g1="0" b1="6.0261499999999999e-06" g2="0" b2="6.0261499999999999e-06" node1="22" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-108.61166164609952" q1="-19.860277658738173" p2="108.82341939961304" q2="20.606962085813489">
         <iidm:alias>_04529c66-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04753f92-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10531,7 +10660,7 @@
             <iidm:temporaryLimit name="_2a95fb2b-6661-46e7-a9f6-fe63c1b7433c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0451b208-c766-11e1-8775-005056c00008" name="20-21" r="3.1885919999999999" x="14.7929754" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_046b2d70-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0460f448-c766-11e1-8775-005056c00008" p1="-34.479398477879656" q1="2.2164013742604611" p2="34.728027226818014" q2="-2.9778698740368856">
+    <iidm:line id="_0451b208-c766-11e1-8775-005056c00008" name="20-21" r="3.1885919999999999" x="14.7929754" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_046b2d70-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0460f448-c766-11e1-8775-005056c00008" p1="-32.334166395923056" q1="1.1444504175270678" p2="32.551654115449885" q2="-2.0535300208469538">
         <iidm:alias>_046c65f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048c22f6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10539,7 +10668,7 @@
             <iidm:temporaryLimit name="_4b67f5f5-f0e1-4bfb-9d57-4d3474720a45" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047d55e4-c766-11e1-8775-005056c00008" name="104-105" r="1.731946" x="6.5862720000000001" g1="0" b1="2.8294300000000001e-05" g2="0" b2="2.8294300000000001e-05" node1="32" voltageLevelId1="_0483977a-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="48.02955789476654" q1="0.86584587495976839" p2="-47.785961057547702" q2="-0.86331540790792061">
+    <iidm:line id="_047d55e4-c766-11e1-8775-005056c00008" name="104-105" r="1.731946" x="6.5862720000000001" g1="0" b1="2.8294300000000001e-05" g2="0" b2="2.8294300000000001e-05" node1="32" voltageLevelId1="_0483977a-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="48.031165380789467" q1="0.8654225077242127" p2="-47.787552330698126" q2="-0.86283025292524762">
         <iidm:alias>_0451d910-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046c65f2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10547,7 +10676,7 @@
             <iidm:temporaryLimit name="_1ca40dc7-6736-4fa8-b4cb-ca696949e421" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046dc589-c766-11e1-8775-005056c00008" name="44-45" r="3.9029759999999998" x="15.699023199999999" g1="0" b1="6.4279149999999996e-05" g2="0" b2="6.4279149999999996e-05" node1="23" voltageLevelId1="_04544a15-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_045d23b4-c766-11e1-8775-005056c00008" p1="-21.754026295568725" q1="-4.2427649754246097" p2="21.86798155918131" q2="2.5550918710495663">
+    <iidm:line id="_046dc589-c766-11e1-8775-005056c00008" name="44-45" r="3.9029759999999998" x="15.699023199999999" g1="0" b1="6.4279149999999996e-05" g2="0" b2="6.4279149999999996e-05" node1="23" voltageLevelId1="_04544a15-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_045d23b4-c766-11e1-8775-005056c00008" p1="-21.477366391924342" q1="-4.398593443420137" p2="21.588765458357162" q2="2.7009319534598037">
         <iidm:alias>_04518afa-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04667287-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10555,7 +10684,7 @@
             <iidm:temporaryLimit name="_ba738481-ddba-4ebe-a218-8aad0b537f5b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04642896-c766-11e1-8775-005056c00008" name="4-11" r="3.641616" x="11.9877129" g1="0" b1="5.0160700000000002e-05" g2="0" b2="5.0160700000000002e-05" node1="23" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="74.1533053346933" q1="5.9943487124676595" p2="-73.006794853169026" q2="-3.9545280132299658">
+    <iidm:line id="_04642896-c766-11e1-8775-005056c00008" name="4-11" r="3.641616" x="11.9877129" g1="0" b1="5.0160700000000002e-05" g2="0" b2="5.0160700000000002e-05" node1="23" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="69.613404727851361" q1="7.8611715252889072" p2="-68.597682300611865" q2="-6.2543140897863054">
         <iidm:alias>_0455f7c5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04803c17-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10563,7 +10692,7 @@
             <iidm:temporaryLimit name="_b1d87c24-e527-4174-aa04-cd0b9de271ea" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047d07c0-c766-11e1-8775-005056c00008" name="92-93" r="4.4953919999999998" x="14.775551800000001" g1="0" b1="6.2557400000000005e-05" g2="0" b2="6.2557400000000005e-05" node1="72" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04789af0-c766-11e1-8775-005056c00008" p1="70.557920707283998" q1="-12.787221462521261" p2="-69.209735536341171" q2="15.097791516229385">
+    <iidm:line id="_047d07c0-c766-11e1-8775-005056c00008" name="92-93" r="4.4953919999999998" x="14.775551800000001" g1="0" b1="6.2557400000000005e-05" g2="0" b2="6.2557400000000005e-05" node1="72" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04789af0-c766-11e1-8775-005056c00008" p1="70.616532548057734" q1="-12.724194135927036" p2="-69.266414974751513" q2="15.04147887667343">
         <iidm:alias>_044a5f07-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047602e5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10571,7 +10700,7 @@
             <iidm:temporaryLimit name="_4e1daf8e-7708-4b96-8d3f-67f58f2505f9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044f4109-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="43" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="121" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-53.908571119061286" q1="-18.704288616001364" p2="56.593317394426215" q2="22.725250522505089">
+    <iidm:line id="_044f4109-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="43" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="121" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-53.7018206911712" q1="-18.847455114101713" p2="56.372653283661613" q2="22.807402668631671">
         <iidm:alias>_046958b0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04758db0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10579,7 +10708,7 @@
             <iidm:temporaryLimit name="_c58940cb-bd36-4dfc-9615-11716dd652a7" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046e61c8-c766-11e1-8775-005056c00008" name="69-75" r="7.0567200000000003" x="21.257280000000002" g1="0" b1="0.00035583104999999999" g2="0" b2="0.00035583104999999999" node1="61" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="89.3844876276424" q1="24.626401232622189" p2="-85.99421390657362" q2="-26.86076615301516">
+    <iidm:line id="_046e61c8-c766-11e1-8775-005056c00008" name="69-75" r="7.0567200000000003" x="21.257280000000002" g1="0" b1="0.00035583104999999999" g2="0" b2="0.00035583104999999999" node1="61" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="89.787296497506745" q1="24.532319615742676" p2="-86.371957813427201" q2="-26.691215410098046">
         <iidm:alias>_046d294a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048ac362-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10587,7 +10716,7 @@
             <iidm:temporaryLimit name="_3c9a454c-10ee-4c72-a059-77f723f5b7c7" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0463da71-c766-11e1-8775-005056c00008" name="79-80" r="2.7181440000000001" x="12.2664957" g1="0" b1="5.3661600000000001e-05" g2="0" b2="5.3661600000000001e-05" node1="23" voltageLevelId1="_04481510-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-66.359061624752783" q1="-32.268347555978828" p2="67.187413794283145" q2="34.047132792375848">
+    <iidm:line id="_0463da71-c766-11e1-8775-005056c00008" name="79-80" r="2.7181440000000001" x="12.2664957" g1="0" b1="5.3661600000000001e-05" g2="0" b2="5.3661600000000001e-05" node1="23" voltageLevelId1="_04481510-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-66.454706157513556" q1="-32.375330419005678" p2="67.28620372762235" q2="34.168488932832844">
         <iidm:alias>_0464ebe9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04662468-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10595,7 +10724,7 @@
             <iidm:temporaryLimit name="_270a7d04-9ff9-4178-8b72-b610735a72ac" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044fdd41-c766-11e1-8775-005056c00008" name="51-52" r="3.5370720000000002" x="10.2453117" g1="0" b1="4.0059699999999999e-05" g2="0" b2="4.0059699999999999e-05" node1="32" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04806326-c766-11e1-8775-005056c00008" p1="31.603809977771157" q1="5.3229217034458527" p2="-31.378630472739498" q2="-5.959019078206099">
+    <iidm:line id="_044fdd41-c766-11e1-8775-005056c00008" name="51-52" r="3.5370720000000002" x="10.2453117" g1="0" b1="4.0059699999999999e-05" g2="0" b2="4.0059699999999999e-05" node1="32" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04806326-c766-11e1-8775-005056c00008" p1="31.610319034296253" q1="5.3209578938032935" p2="-31.385053867329287" q2="-5.9568000179489768">
         <iidm:alias>_045115c2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0464ebe5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10603,7 +10732,7 @@
             <iidm:temporaryLimit name="_9d1eb182-ceb5-426e-9440-5f4d426a31cb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c3958-c766-11e1-8775-005056c00008" name="53-54" r="4.5825120000000004" x="21.257280000000002" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="22" voltageLevelId1="_04876804-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="-9.7042394598997461" q1="-6.7094318979080105" p2="9.7402939928687502" q2="4.0777826489356066">
+    <iidm:line id="_045c3958-c766-11e1-8775-005056c00008" name="53-54" r="4.5825120000000004" x="21.257280000000002" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="22" voltageLevelId1="_04876804-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="-9.6978868361882853" q1="-6.7119533908674782" p2="9.7339131189527244" q2="4.0801770529434886">
         <iidm:alias>_044f6817-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0455f7c6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10611,7 +10740,7 @@
             <iidm:temporaryLimit name="_735ac8df-6a6a-43f0-86f2-49d3280c9a3b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044ef2e1-c766-11e1-8775-005056c00008" name="54-55" r="2.9446560000000002" x="12.3187675" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="63" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04767817-c766-11e1-8775-005056c00008" p1="10.14992545071631" q1="1.7068697045209431" p2="-10.129555682117344" q2="-3.4567901234130609">
+    <iidm:line id="_044ef2e1-c766-11e1-8775-005056c00008" name="54-55" r="2.9446560000000002" x="12.3187675" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="63" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04767817-c766-11e1-8775-005056c00008" p1="10.154205856163568" q1="1.7062373320364224" p2="-10.133820599886466" q2="-3.4560925511902596">
         <iidm:alias>_04640181-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047dcb17-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10619,7 +10748,7 @@
             <iidm:temporaryLimit name="_52aadf8d-53f2-4827-8c70-421bdf1ba822" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0456e226-c766-11e1-8775-005056c00008" name="80-97" r="3.1885919999999999" x="16.2740154" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="82" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="12.172874909492007" q1="30.798474121666509" p2="-11.972680892319799" q2="-32.443258782511712">
+    <iidm:line id="_0456e226-c766-11e1-8775-005056c00008" name="80-97" r="3.1885919999999999" x="16.2740154" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="82" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="12.21653134249379" q1="30.998995075446977" p2="-12.013967385003765" q2="-32.631203050802554">
         <iidm:alias>_04479fe9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047df222-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10627,7 +10756,7 @@
             <iidm:temporaryLimit name="_fece5807-6af8-4161-8de8-8f8473d92f11" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0487b624-c766-11e1-8775-005056c00008" name="103-110" r="6.8058139999999998" x="31.5897121" g1="0" b1="0.00013228879999999999" g2="0" b2="0.00013228879999999999" node1="43" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="57.716611200468115" q1="18.497721243292638" p2="-56.274638190320523" q2="-16.258437846349793">
+    <iidm:line id="_0487b624-c766-11e1-8775-005056c00008" name="103-110" r="6.8058139999999998" x="31.5897121" g1="0" b1="0.00013228879999999999" g2="0" b2="0.00013228879999999999" node1="43" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="57.720004700118352" q1="18.497417359460481" p2="-56.277886638954698" q2="-16.257460382229244">
         <iidm:alias>_046a9139-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b3895-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10635,7 +10764,7 @@
             <iidm:temporaryLimit name="_3eacc034-737e-41de-a7b6-b610d3bd0921" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045338a8-c766-11e1-8775-005056c00008" name="56-58" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="61" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="-13.045783334275141" q1="-0.68999970133478039" p2="13.11000841817509" q2="-1.3410172000905174">
+    <iidm:line id="_045338a8-c766-11e1-8775-005056c00008" name="56-58" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="61" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="-13.058706928248952" q1="-0.68363407023392175" p2="13.123061214039847" q2="-1.3470142321955065">
         <iidm:alias>_0451d915-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04817494-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10643,7 +10772,7 @@
             <iidm:temporaryLimit name="_0d0c3ec5-798a-48a4-9bc8-d19c57128a13" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04854529-c766-11e1-8775-005056c00008" name="15-33" r="6.6211200000000003" x="21.675455100000001" g1="0" b1="9.1655200000000003e-05" g2="0" b2="9.1655200000000003e-05" node1="52" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456bb11-c766-11e1-8775-005056c00008" p1="62.642110837675688" q1="-8.1843800201296695" p2="-60.966638733617494" q2="10.831094432895316">
+    <iidm:line id="_04854529-c766-11e1-8775-005056c00008" name="15-33" r="6.6211200000000003" x="21.675455100000001" g1="0" b1="9.1655200000000003e-05" g2="0" b2="9.1655200000000003e-05" node1="52" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456bb11-c766-11e1-8775-005056c00008" p1="63.76919181823181" q1="-8.2704852285586075" p2="-62.031786305897171" q2="11.122678509296897">
         <iidm:alias>_0448d862-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047d2ed5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10651,7 +10780,7 @@
             <iidm:temporaryLimit name="_5b0395f4-534d-4975-a1af-e0b6ef439193" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04649dc2-c766-11e1-8775-005056c00008" name="35-36" r="0.39029799999999998" x="1.7772479999999999" g1="0" b1="7.6905500000000004e-06" g2="0" b2="7.6905500000000004e-06" node1="22" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="-3.3088818613990725" q1="5.3906611634069108" p2="3.3099317639542067" q2="-5.6218676612246572">
+    <iidm:line id="_04649dc2-c766-11e1-8775-005056c00008" name="35-36" r="0.39029799999999998" x="1.7772479999999999" g1="0" b1="7.6905500000000004e-06" g2="0" b2="7.6905500000000004e-06" node1="22" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="-3.3935312683802143" q1="5.4262386613393243" p2="3.3946066165744289" q2="-5.6570970585803817">
         <iidm:alias>_044c0cb5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0456e225-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10659,7 +10788,7 @@
             <iidm:temporaryLimit name="_74c4b341-7b99-4a81-b88a-2ed3b0c4b1de" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0470d2c9-c766-11e1-8775-005056c00008" name="37-40" r="10.3324327" x="29.272320000000001" g1="0" b1="0.0001205234" g2="0" b2="0.0001205234" node1="61" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="55.957634865813418" q1="10.362684217842791" p2="-53.799362424409239" q2="-7.8333418827674901">
+    <iidm:line id="_0470d2c9-c766-11e1-8775-005056c00008" name="37-40" r="10.3324327" x="29.272320000000001" g1="0" b1="0.0001205234" g2="0" b2="0.0001205234" node1="61" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="56.179157538829237" q1="10.273731338363307" p2="-54.003958383964203" q2="-7.6931518486046322">
         <iidm:alias>_045b9d10-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046a4317-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10667,7 +10796,7 @@
             <iidm:temporaryLimit name="_e98d56fe-a54b-45e4-acff-0ac310beb3dd" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044e56a2-c766-11e1-8775-005056c00008" name="48-49" r="3.1188959999999999" x="8.7991200000000003" g1="0" b1="3.6099649999999999e-05" g2="0" b2="3.6099649999999999e-05" node1="23" voltageLevelId1="_044778d3-c766-11e1-8775-005056c00008" node2="122" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-28.897238667563407" q1="1.3348139803741361" p2="29.041360155902662" q2="-2.2445130312477946">
+    <iidm:line id="_044e56a2-c766-11e1-8775-005056c00008" name="48-49" r="3.1188959999999999" x="8.7991200000000003" g1="0" b1="3.6099649999999999e-05" g2="0" b2="3.6099649999999999e-05" node1="23" voltageLevelId1="_044778d3-c766-11e1-8775-005056c00008" node2="122" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-28.864324637023149" q1="1.324371109123184" p2="29.008112179042723" q2="-2.2350134819570844">
         <iidm:alias>_0454bf49-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0460a623-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10675,7 +10804,7 @@
             <iidm:temporaryLimit name="_f2e58700-2366-46e0-8408-9472d85acd23" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047eb573-c766-11e1-8775-005056c00008" name="56-59" r="14.3748007" x="43.734237700000001" g1="0" b1="0.0001632805" g2="0" b2="0.0001632805" node1="62" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-19.199898820655459" q1="-7.7051351613939261" p2="19.557903570173412" q2="3.4455811504299092">
+    <iidm:line id="_047eb573-c766-11e1-8775-005056c00008" name="56-59" r="14.3748007" x="43.734237700000001" g1="0" b1="0.0001632805" g2="0" b2="0.0001632805" node1="62" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-19.185977561718776" q1="-7.7105390344843903" p2="19.5435481079471" q2="3.4496650707513363">
         <iidm:alias>_0468bc78-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048915b0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10683,7 +10812,7 @@
             <iidm:temporaryLimit name="_89654167-95a6-4c76-aad7-63a881116e17" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046f9a4b-c766-11e1-8775-005056c00008" name="94-100" r="3.1014719999999998" x="10.105919999999999" g1="0" b1="0.00017332415000000001" g2="0" b2="0.00017332415000000001" node1="52" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-6.0993558226676958" q1="-51.959080611680072" p2="6.5450840610457224" q2="47.345404622249433">
+    <iidm:line id="_046f9a4b-c766-11e1-8775-005056c00008" name="94-100" r="3.1014719999999998" x="10.105919999999999" g1="0" b1="0.00017332415000000001" g2="0" b2="0.00017332415000000001" node1="52" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-6.1173962840595033" q1="-52.233522754747028" p2="6.5682677016052491" q2="47.637621524622851">
         <iidm:alias>_04812676-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048a2722-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10691,7 +10820,7 @@
             <iidm:temporaryLimit name="_216c0f3b-03e8-4b7d-96fc-a5f891331f7f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046735d0-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="123" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-92.566894200537547" q1="-2.4504235348212626" p2="94.035153985074487" q2="7.2883476799120741">
+    <iidm:line id="_046735d0-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="123" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-92.464111321841088" q1="-2.4787209656408402" p2="93.929124003714733" q2="7.3000677204051252">
         <iidm:alias>_04570934-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b3894-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10699,7 +10828,7 @@
             <iidm:temporaryLimit name="_32655e4f-e7da-46b0-a908-b601224ddb73" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046d294b-c766-11e1-8775-005056c00008" name="21-22" r="3.641616" x="16.901281399999998" g1="0" b1="7.0592299999999998e-05" g2="0" b2="7.0592299999999998e-05" node1="22" voltageLevelId1="_0460f448-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04773b6a-c766-11e1-8775-005056c00008" p1="-48.721819254568693" q1="-5.0162083267053887" p2="49.282448219512446" q2="5.3894473558318854">
+    <iidm:line id="_046d294b-c766-11e1-8775-005056c00008" name="21-22" r="3.641616" x="16.901281399999998" g1="0" b1="7.0592299999999998e-05" g2="0" b2="7.0592299999999998e-05" node1="22" voltageLevelId1="_0460f448-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04773b6a-c766-11e1-8775-005056c00008" p1="-46.546914745007506" q1="-5.9419548235978477" p2="47.05972604592116" q2="6.0877710131589753">
         <iidm:alias>_044a37f0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_044be5a2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10707,7 +10836,7 @@
             <iidm:temporaryLimit name="_bafaeace-e459-4dc2-87a0-467a9ea25f8d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_6a131803-f462-47e2-bc21-bda919364fe9" name="reactor1" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="36" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="37" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="1.1102230246251565e-14" q1="-83.151383925074384" p2="-1.2490009027033011e-14" q2="92.151023305212902">
+    <iidm:line id="_6a131803-f462-47e2-bc21-bda919364fe9" name="reactor1" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="36" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="37" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="-3.8857805861880479e-14" q1="-83.151388670929833" p2="4.163336342344337e-14" q2="92.151028564721713">
         <iidm:alias>_04531196-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_ca0adad2-ffe3-4efa-b56b-7d333b8ae18f</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10715,7 +10844,7 @@
             <iidm:temporaryLimit name="_ae4eadea-f3fc-4ac6-8899-c1698ece7a89" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_9803b364-2a93-4f21-94b7-8bdbe27a16f2" name="reactor2" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="38" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="3.6797755814665933e-08" q1="27.475286511171888" p2="-3.6797755467721238e-08" q2="-26.590026273577639">
+    <iidm:line id="_9803b364-2a93-4f21-94b7-8bdbe27a16f2" name="reactor2" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="38" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="4.4026933834762083e-08" q1="27.474581854905793" p2="-4.4026934181706778e-08" q2="-26.589367075730259">
         <iidm:alias>_0461b792-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_afe0e60b-3870-44fb-ba93-a056228f9636</iidm:alias>
     </iidm:line>

--- a/tests/main_sa/reference/launch/busbarsection_contingency/outputIIDM.xml
+++ b/tests/main_sa/reference/launch/busbarsection_contingency/outputIIDM.xml
@@ -31,8 +31,8 @@
                     <iidm:alias>_bea273f1-1e21-476d-b0d0-92dd6cb9a2d4</iidm:alias>
                     <iidm:alias>_c94e6b68-da6c-43d1-94fd-09ad60c74134</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_047abdd7-c766-11e1-8775-005056c00008-BREAKER" name="BREAKER-Jay LD" kind="BREAKER" retained="true" open="true" node1="0" node2="8"/>
                 <iidm:internalConnection node1="7" node2="0"/>
-                <iidm:internalConnection node1="8" node2="0"/>
                 <iidm:internalConnection node1="9" node2="1"/>
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="4"/>
@@ -47,7 +47,6 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="0" angle="0" nodes="0,1,4,7,8,9,11,13,14,17,18"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="_047abdd7-c766-11e1-8775-005056c00008" name="Jay LD" loadType="UNDEFINED" p0="14" q0="8" node="8" p="0" q="0">
                 <iidm:alias>_04590500-c766-11e1-8775-005056c00008</iidm:alias>
@@ -139,12 +138,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="127.86727096307516" angle="12.335511471289685" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="128.07789933264459" angle="0.45084682781552038" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045b00d5-c766-11e1-8775-005056c00008" name="Madison LD" loadType="UNDEFINED" p0="62" q0="13" node="14" p="62.02680137953449" q="13.009367423018157">
+            <iidm:load id="_045b00d5-c766-11e1-8775-005056c00008" name="Madison LD" loadType="UNDEFINED" p0="62" q0="13" node="14" p="62.030456604866643" q="13.010645179901086">
                 <iidm:alias>_045b27e3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_04689566-c766-11e1-8775-005056c00008" name="Madison NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="15" p="9.0038905228356523" q="0">
+            <iidm:load id="_04689566-c766-11e1-8775-005056c00008" name="Madison NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="15" p="9.004421120061286" q="0">
                 <iidm:alias>_04765100-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -272,16 +271,16 @@
                 <iidm:internalConnection node1="61" node2="12"/>
                 <iidm:internalConnection node1="62" node2="15"/>
                 <iidm:internalConnection node1="63" node2="18"/>
-                <iidm:bus v="126.06000023360281" angle="-7.467456607148911" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63"/>
+                <iidm:bus v="126.06000111080968" angle="-19.150852668030911" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_046c3ee7-c766-11e1-8775-005056c00008" name="Torrey SM" energySource="THERMAL" minP="20" maxP="80" ratedS="100" voltageRegulatorOn="true" targetP="48" targetV="126.06" targetQ="0" node="21" p="-52.983408363727357" q="-7.3517480401619926">
+            <iidm:generator id="_046c3ee7-c766-11e1-8775-005056c00008" name="Torrey SM" energySource="THERMAL" minP="20" maxP="80" ratedS="100" voltageRegulatorOn="true" targetP="48" targetV="126.06" targetQ="0" node="21" p="-52.973486196047503" q="-7.3646639620828793">
                 <iidm:alias>_047147f3-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_b97aee41-3115-4cfd-9071-b52fb44d0b66"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_5005c073-28d1-4a7d-b257-649dec43ec73"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-30" maxQ="85"/>
             </iidm:generator>
-            <iidm:load id="_044afb44-c766-11e1-8775-005056c00008" name="Torrey LD" loadType="UNDEFINED" p0="113" q0="32" node="20" p="113.00000031410183" q="32.000000148248652">
+            <iidm:load id="_044afb44-c766-11e1-8775-005056c00008" name="Torrey LD" loadType="UNDEFINED" p0="113" q0="32" node="20" p="113.00000149359222" q="32.000000704940291">
                 <iidm:alias>_04522737-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -332,9 +331,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="123.98861357346954" angle="8.5968330550704035" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="123.97825186417884" angle="-3.1568301012715789" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04481515-c766-11e1-8775-005056c00008" name="Darrah LD" loadType="UNDEFINED" p0="68" q0="36" node="8" p="68.033234076878756" q="36.029328962487718">
+            <iidm:load id="_04481515-c766-11e1-8775-005056c00008" name="Darrah LD" loadType="UNDEFINED" p0="68" q0="36" node="8" p="68.033232040826704" q="36.029327165385915">
                 <iidm:alias>_044e7db8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -385,9 +384,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.47363209278868" angle="22.704771565877394" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.46788522768497" angle="10.978536628729783" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044c0cb3-c766-11e1-8775-005056c00008" name="Smythe LD" loadType="UNDEFINED" p0="5" q0="3" node="8" p="5.0001061729567899" q="3.0001061737083012">
+            <iidm:load id="_044c0cb3-c766-11e1-8775-005056c00008" name="Smythe LD" loadType="UNDEFINED" p0="5" q0="3" node="8" p="5.0001070910167451" q="3.0001070917813082">
                 <iidm:alias>_045163e8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -514,9 +513,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="125.90803696781859" angle="-7.6395589568933078" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="125.90799871717907" angle="-19.323038570346313" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0450a093-c766-11e1-8775-005056c00008" name="Sunnysde LD" loadType="UNDEFINED" p0="84" q0="18" node="20" p="83.999957547176905" q="17.999984838280021">
+            <iidm:load id="_0450a093-c766-11e1-8775-005056c00008" name="Sunnysde LD" loadType="UNDEFINED" p0="84" q0="18" node="20" p="83.999956693232292" q="17.999984533299905">
                 <iidm:alias>_045f4695-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -568,12 +567,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="126.97648609304895" angle="8.628357083665076" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="126.98016879172786" angle="-3.1484835388316053" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044b2251-c766-11e1-8775-005056c00008" name="Bellefnt LD" loadType="UNDEFINED" p0="68" q0="27" node="8" p="68.051715902097669" q="27.034232434050075">
+            <iidm:load id="_044b2251-c766-11e1-8775-005056c00008" name="Bellefnt LD" loadType="UNDEFINED" p0="68" q0="27" node="8" p="68.051997465380097" q="27.034418857410103">
                 <iidm:alias>_04622cc1-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0449e9d5-c766-11e1-8775-005056c00008" name="Bellefnt SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.40300000000001" targetDeadband="1" node="9" q="-11.108766306150851">
+            <iidm:shunt id="_0449e9d5-c766-11e1-8775-005056c00008" name="Bellefnt SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.40300000000001" targetDeadband="1" node="9" q="-11.109410690532854">
                 <iidm:alias>_047bcf48-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_6cc38790-c6a6-4309-99f4-a3258e24e785"/>
                 <iidm:shuntLinearModel bPerSection="0.00013779999999999999" gPerSection="0" maximumSectionCount="10"/>
@@ -665,12 +664,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="126.06557822187091" angle="8.3754259377708919" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="126.06555853857735" angle="-3.3571822292296445" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04682035-c766-11e1-8775-005056c00008" name="Fieldale LD" loadType="UNDEFINED" p0="39" q0="30" node="14" p="38.999962581230349" q="29.999952027233739">
+            <iidm:load id="_04682035-c766-11e1-8775-005056c00008" name="Fieldale LD" loadType="UNDEFINED" p0="39" q0="30" node="14" p="38.999963080851103" q="29.999952667772757">
                 <iidm:alias>_0478c20a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_045c6067-c766-11e1-8775-005056c00008" name="Fieldale SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.066" targetDeadband="1" node="15" q="-5.4670303242706417">
+            <iidm:shunt id="_045c6067-c766-11e1-8775-005056c00008" name="Fieldale SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.066" targetDeadband="1" node="15" q="-5.4670286170773554">
                 <iidm:alias>_0451b209-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_2d222dd9-7306-4afd-baa5-fd303b0eeb40"/>
                 <iidm:shuntLinearModel bPerSection="6.8800000000000005e-05" gPerSection="0" maximumSectionCount="10"/>
@@ -780,7 +779,7 @@
                 <iidm:internalConnection node1="51" node2="9"/>
                 <iidm:internalConnection node1="52" node2="12"/>
                 <iidm:internalConnection node1="53" node2="15"/>
-                <iidm:bus v="138.0156028879027" angle="4.3574252416040951" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
+                <iidm:bus v="138.01554544701077" angle="-7.3283391051417839" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="_047f0391-c766-11e1-8775-005056c00008" name="Muskngum SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="392" targetV="138.59999099999999" targetQ="0" node="18" p="-0" q="-0">
                 <iidm:alias>_047eb572-c766-11e1-8775-005056c00008</iidm:alias>
@@ -789,7 +788,7 @@
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
-            <iidm:load id="_047e1936-c766-11e1-8775-005056c00008" name="Muskngum LD" loadType="UNDEFINED" p0="39" q0="18" node="17" p="38.99982880790904" q="17.999868313968861">
+            <iidm:load id="_047e1936-c766-11e1-8775-005056c00008" name="Muskngum LD" loadType="UNDEFINED" p0="39" q0="18" node="17" p="38.999827665620607" q="17.999867435288031">
                 <iidm:alias>_046e88d5-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -876,9 +875,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="221.1000004739644" angle="9.5369096894455296" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="221.10000223795902" angle="-2.1529308933506424" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0458ddf1-c766-11e1-8775-005056c00008" name="Muskngum SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="391" targetV="221.09999999999999" targetQ="0" node="14" p="-431.59401396286245" q="-162.07859466666423">
+            <iidm:generator id="_0458ddf1-c766-11e1-8775-005056c00008" name="Muskngum SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="391" targetV="221.09999999999999" targetQ="0" node="14" p="-431.51318963863685" q="-161.91063049830373">
                 <iidm:alias>_04522732-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_5036c3a5-56f9-489c-9ecb-8c15aa7c70c5"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_12b01822-ca11-4cf8-a6b4-2f8ff805ca20"/>
@@ -886,7 +885,7 @@
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045cae83-c766-11e1-8775-005056c00008" name="65-66" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="42" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="274.20742776937004" q1="97.501586621418014" p2="-274.2074277693701" q2="-70.377375282612419">
+        <iidm:twoWindingsTransformer id="_045cae83-c766-11e1-8775-005056c00008" name="65-66" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="42" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="273.99210310654763" q1="97.48337082536672" p2="-273.99210310654752" q2="-70.398100306377216">
             <iidm:alias>_044b2254-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_044b4964-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_045645e1-c766-11e1-8775-005056c00008</iidm:alias>
@@ -961,9 +960,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="122.74811542338951" angle="2.4576350084492371" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="122.68652777190275" angle="-8.8169316046962312" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0453d4e2-c766-11e1-8775-005056c00008" name="Adams LD" loadType="UNDEFINED" p0="18" q0="3" node="8" p="17.922899198881765" q="2.9786137042509422">
+            <iidm:load id="_0453d4e2-c766-11e1-8775-005056c00008" name="Adams LD" loadType="UNDEFINED" p0="18" q0="3" node="8" p="17.917195530188764" q="2.9770340469159629">
                 <iidm:alias>_0448ff77-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1053,16 +1052,16 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="133.31999293726946" angle="14.124072383038206" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="133.319994590411" angle="2.3918970134655462" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_046bf0c4-c766-11e1-8775-005056c00008" name="Claytor SM" energySource="THERMAL" minP="0" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="40" targetV="133.31999200000001" targetQ="0" node="15" p="-44.152840303106132" q="-83.142073418595842">
+            <iidm:generator id="_046bf0c4-c766-11e1-8775-005056c00008" name="Claytor SM" energySource="THERMAL" minP="0" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="40" targetV="133.31999200000001" targetQ="0" node="15" p="-44.144571830039588" q="-83.146328576709465">
                 <iidm:alias>_0460a627-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e56da2eb-bb6a-4133-953c-40073c5bc5f4"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_d41be6b4-155e-4c8f-b46b-16b50c49f0f4"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-60" maxQ="170"/>
             </iidm:generator>
-            <iidm:load id="_048433b6-c766-11e1-8775-005056c00008" name="Claytor LD" loadType="UNDEFINED" p0="23" q0="16" node="14" p="23.000000242542743" q="16.000000281208976">
+            <iidm:load id="_048433b6-c766-11e1-8775-005056c00008" name="Claytor LD" loadType="UNDEFINED" p0="23" q0="16" node="14" p="23.000000670335925" q="16.00000077720108">
                 <iidm:alias>_0480ff6b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1133,12 +1132,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="129.69495885166324" angle="-4.3180596149625492" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="129.69024619258929" angle="-15.977065439186934" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0449e9d7-c766-11e1-8775-005056c00008" name="N.Newark LD" loadType="UNDEFINED" p0="53" q0="22" node="11" p="52.990168920262214" q="21.993199044623211">
+            <iidm:load id="_0449e9d7-c766-11e1-8775-005056c00008" name="N.Newark LD" loadType="UNDEFINED" p0="53" q0="22" node="11" p="52.990209972476009" q="21.993227442020963">
                 <iidm:alias>_04531191-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_04684741-c766-11e1-8775-005056c00008" name="N.Newark SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.32300000000001" targetDeadband="1" node="12" q="-9.6551290697808732">
+            <iidm:shunt id="_04684741-c766-11e1-8775-005056c00008" name="N.Newark SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.32300000000001" targetDeadband="1" node="12" q="-9.6544274156017948">
                 <iidm:alias>_04607f19-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_eae61817-d3cb-488f-a1f3-13bc8e31431b"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -1191,9 +1190,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="131.60327667859761" angle="12.587184312387768" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="131.70263129784354" angle="0.64897573629212502" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0448d86a-c766-11e1-8775-005056c00008" name="Hillsbro NegG LD" loadType="UNDEFINED" p0="12" q0="0" node="8" p="12.022730771584568" q="0">
+            <iidm:load id="_0448d86a-c766-11e1-8775-005056c00008" name="Hillsbro NegG LD" loadType="UNDEFINED" p0="12" q0="0" node="8" p="12.023187248780291" q="0">
                 <iidm:alias>_044ef2e8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1244,9 +1243,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="125.13553577614593" angle="-6.0483994928992377" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="125.08355902683947" angle="-17.631854219540813" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047dcb12-c766-11e1-8775-005056c00008" name="S.Kenton LD" loadType="UNDEFINED" p0="18" q0="7" node="8" p="17.985354866551713" q="6.990510358456528">
+            <iidm:load id="_047dcb12-c766-11e1-8775-005056c00008" name="S.Kenton LD" loadType="UNDEFINED" p0="18" q0="7" node="8" p="17.985083910626138" q="6.9903348350277357">
                 <iidm:alias>_0451b205-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1281,6 +1280,9 @@
                     <iidm:alias>_8ef85f09-3622-4a12-87bf-fefcecc01e4a</iidm:alias>
                     <iidm:alias>_a0244ab3-80e5-4c20-b201-a142d50e6ec1</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_dffdb415-95a8-496a-ad1a-93cdeb444fae-1" name="DISCONNECTOR723-1" kind="DISCONNECTOR" retained="false" open="false" node1="24" node2="25"/>
+                <iidm:switch id="_aa063f2e-1205-4d1a-a549-3ccc5b31e65d-1" name="BREAKER362-1" kind="BREAKER" retained="false" open="false" node1="23" node2="24"/>
+                <iidm:switch id="_28b3e895-483c-478d-a5a3-7b9d7c9e11f3-1" name="DISCONNECTOR724-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="23"/>
                 <iidm:internalConnection node1="7" node2="0"/>
                 <iidm:internalConnection node1="8" node2="0"/>
                 <iidm:internalConnection node1="9" node2="1"/>
@@ -1297,9 +1299,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="125.22954997908134" angle="21.22833644865069" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.19953729573177" angle="9.5983116255310055" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044afb49-c766-11e1-8775-005056c00008" name="Hazard LD" loadType="UNDEFINED" p0="21" q0="10" node="8" p="20.999658025468875" q="9.9997285931152184">
+            <iidm:load id="_044afb49-c766-11e1-8775-005056c00008" name="Hazard LD" loadType="UNDEFINED" p0="21" q0="10" node="8" p="20.999283636333374" q="9.999431463872277">
                 <iidm:alias>_045e5c31-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1320,6 +1322,9 @@
                     <iidm:alias>_2a61ce12-8d9c-4aae-8bc7-c8f820ecae6c</iidm:alias>
                     <iidm:alias>_a3d5e8cc-be34-4d4a-a586-ce582737826b</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_83a05cd7-017e-4e7a-bc5e-a01ee9681f9f-1" name="DISCONNECTOR725-1" kind="DISCONNECTOR" retained="false" open="false" node1="14" node2="15"/>
+                <iidm:switch id="_cf4393c0-21c2-4e35-b330-c1acda2647ba-1" name="BREAKER363-1" kind="BREAKER" retained="false" open="true" node1="13" node2="14"/>
+                <iidm:switch id="_b9ab29b9-3d90-4536-8d1a-7757d8c22ae4-1" name="DISCONNECTOR726-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="13"/>
                 <iidm:internalConnection node1="4" node2="0"/>
                 <iidm:internalConnection node1="5" node2="0"/>
                 <iidm:internalConnection node1="6" node2="1"/>
@@ -1329,14 +1334,14 @@
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="3"/>
-                <iidm:bus v="31.307387494770328" angle="21.22833644865069" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="31.049884323932936" angle="9.5983116255310055" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13"/>
             </iidm:nodeBreakerTopology>
             <iidm:staticVarCompensator id="_047fc6e6-c766-11e1-8775-005056c00008" name="Pinevlle SVC" bMin="-10" bMax="10" voltageSetpoint="33.494999999999997" regulationMode="VOLTAGE" node="5" p="0" q="0">
                 <iidm:alias>_046ab846-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_98f667da-02d1-4a31-b826-44314a1fbbfe"/>
             </iidm:staticVarCompensator>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045e3525-c766-11e1-8775-005056c00008" name="86-87" r="0.30796918750000002" x="2.2585859312499998" g="0" b="-0.0040863184000000004" ratedU1="132" ratedU2="33" node1="22" voltageLevelId1="_0484f70a-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_04555b88-c766-11e1-8775-005056c00008" p1="1.0061396160665481e-14" q1="4.0052152435609516" p2="-3.0305205241778709e-14" q2="-9.651820649075183e-14">
+        <iidm:twoWindingsTransformer id="_045e3525-c766-11e1-8775-005056c00008" name="86-87" r="0.30796918750000002" x="2.2585859312499998" g="0" b="-0.0040863184000000004" ratedU1="132" ratedU2="33" node1="22" voltageLevelId1="_0484f70a-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_04555b88-c766-11e1-8775-005056c00008" p1="1.1362438767648086e-14" q1="3.9396004312887567" p2="1.9595113928599611e-15" q2="-1.158740356308258e-14">
             <iidm:alias>_0452755a-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04682034-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_048c7110-c766-11e1-8775-005056c00008</iidm:alias>
@@ -1412,6 +1417,82 @@
                 <iidm:temporaryLimit name="_257d56c1-d70a-4a96-b85c-d928ade03ad4" acceptableDuration="60" value="12246"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
+        <iidm:twoWindingsTransformer id="_045e3525-c766-11e1-8775-005056c00008-1" name="86-87-open-ended" r="0.30796918750000002" x="2.2585859312499998" g="0" b="-0.0040863184000000004" ratedU1="132" ratedU2="33" node1="25" voltageLevelId1="_0484f70a-c766-11e1-8775-005056c00008" node2="15" voltageLevelId2="_04555b88-c766-11e1-8775-005056c00008" p1="0" q1="3.9396004312887971" p2="0" q2="0">
+            <iidm:alias>_0452755a-c766-11e1-8775-005056c00008-1</iidm:alias>
+            <iidm:alias>_04682034-c766-11e1-8775-005056c00008-1</iidm:alias>
+            <iidm:alias>_048c7110-c766-11e1-8775-005056c00008-1</iidm:alias>
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="31" loadTapChangingCapabilities="false">
+                <iidm:step r="-78.460970487743992" x="-78.460970487743992" g="364.27347129590328" b="364.27347129590328" rho="0.4641016"/>
+                <iidm:step r="-76.770985444658564" x="-76.770985444658564" g="330.49609255595948" b="330.49609255595948" rho="0.48196488000000004"/>
+                <iidm:step r="-75.017181047101431" x="-75.017181047101431" g="300.27508580410921" b="300.27508580410921" rho="0.49982816000000002"/>
+                <iidm:step r="-73.199557295072623" x="-73.199557295072623" g="273.1281647135425" b="273.1281647135425" rho="0.51769144000000011"/>
+                <iidm:step r="-71.318114188572153" x="-71.318114188572153" g="248.65210975826625" b="248.65210975826625" rho="0.53555472000000004"/>
+                <iidm:step r="-69.372851727600008" x="-69.372851727600008" g="226.50770848984379" b="226.50770848984379" rho="0.55341799999999997"/>
+                <iidm:step r="-67.363769912156158" x="-67.363769912156158" g="206.40793906293555" b="206.40793906293555" rho="0.57128128"/>
+                <iidm:step r="-65.290868742240633" x="-65.290868742240633" g="188.10862264852744" b="188.10862264852744" rho="0.58914456000000004"/>
+                <iidm:step r="-63.154148217853432" x="-63.154148217853432" g="171.40097232995538" b="171.40097232995538" rho="0.60700784000000008"/>
+                <iidm:step r="-60.953608338994556" x="-60.953608338994556" g="156.10561116167679" b="156.10561116167679" rho="0.62487112"/>
+                <iidm:step r="-58.689249105663997" x="-58.689249105663997" g="142.06773741726079" b="142.06773741726079" rho="0.64273440000000004"/>
+                <iidm:step r="-56.361070517861769" x="-56.361070517861769" g="129.15319231405709" b="129.15319231405709" rho="0.66059767999999996"/>
+                <iidm:step r="-53.969072575587838" x="-53.969072575587838" g="117.24524269951107" b="117.24524269951107" rho="0.67846096"/>
+                <iidm:step r="-51.51325527884223" x="-51.51325527884223" g="106.24193390397649" b="106.24193390397649" rho="0.69632424000000004"/>
+                <iidm:step r="-48.993618627624947" x="-48.993618627624947" g="96.053900138385018" b="96.053900138385018" rho="0.71418752000000008"/>
+                <iidm:step r="-46.410162621936003" x="-46.410162621936003" g="86.602544237115268" b="86.602544237115268" rho="0.7320508"/>
+                <iidm:step r="-43.762887261775354" x="-43.762887261775354" g="77.81851722275475" b="77.81851722275475" rho="0.74991407999999993"/>
+                <iidm:step r="-41.051792547143037" x="-41.051792547143037" g="69.640442552852292" b="69.640442552852292" rho="0.76777735999999996"/>
+                <iidm:step r="-38.276878478039045" x="-38.276878478039045" g="62.013841060226049" b="62.013841060226049" rho="0.78564064"/>
+                <iidm:step r="-35.438145054463355" x="-35.438145054463355" g="54.890221299184191" b="54.890221299184191" rho="0.80350392000000004"/>
+                <iidm:step r="-32.53559227641599" x="-32.53559227641599" g="48.2263068397802" b="48.2263068397802" rho="0.82136720000000008"/>
+                <iidm:step r="-29.569220143896956" x="-29.569220143896956" g="41.983377444222199" b="41.983377444222199" rho="0.83923048"/>
+                <iidm:step r="-26.53902865690624" x="-26.53902865690624" g="36.126705339843348" b="36.126705339843348" rho="0.85709376000000004"/>
+                <iidm:step r="-23.445017815443848" x="-23.445017815443848" g="30.625071218648301" b="30.625071218648301" rho="0.87495704000000007"/>
+                <iidm:step r="-20.287187619509762" x="-20.287187619509762" g="25.450347332714429" b="25.450347332714429" rho="0.89282032000000011"/>
+                <iidm:step r="-17.06553806910399" x="-17.06553806910399" g="20.577137262099331" b="20.577137262099331" rho="0.91068360000000004"/>
+                <iidm:step r="-13.780069164226571" x="-13.780069164226571" g="15.982463718828566" b="15.982463718828566" rho="0.92854687999999996"/>
+                <iidm:step r="-10.430780904877434" x="-10.430780904877434" g="11.645497203453271" b="11.645497203453271" rho="0.94641016"/>
+                <iidm:step r="-7.0176732910566368" x="-7.0176732910566368" g="7.5473195169912355" b="7.5473195169912355" rho="0.96427344000000004"/>
+                <iidm:step r="-3.5407463227641656" x="-3.5407463227641656" g="3.6707171036300279" b="3.6707171036300279" rho="0.98213671999999985"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1"/>
+                <iidm:step r="3.6045656772358381" x="3.6045656772358381" g="-3.4791571719583358" b="-3.4791571719583358" rho="1.01786328"/>
+                <iidm:step r="7.272950708943382" x="7.272950708943382" g="-6.7798551833225922" b="-6.7798551833225922" rho="1.0357265600000001"/>
+                <iidm:step r="11.005155095122543" x="11.005155095122543" g="-9.9140937064517427" b="-9.9140937064517427" rho="1.0535898399999999"/>
+                <iidm:step r="14.801178835773431" x="14.801178835773431" g="-12.892880531259154" b="-12.892880531259154" rho="1.0714531199999999"/>
+                <iidm:step r="18.661021930895984" x="18.661021930895984" g="-15.726328348801433" b="-15.726328348801433" rho="1.0893164"/>
+                <iidm:step r="22.584684380490238" x="22.584684380490238" g="-18.423740693731116" b="-18.423740693731116" rho="1.10717968"/>
+                <iidm:step r="26.572166184556178" x="26.572166184556178" g="-20.993688411566747" b="-20.993688411566747" rho="1.12504296"/>
+                <iidm:step r="30.623467343093779" x="30.623467343093779" g="-23.444077826121855" b="-23.444077826121855" rho="1.1429062400000001"/>
+                <iidm:step r="34.738587856103067" x="34.738587856103067" g="-25.782211620922489" b="-25.782211620922489" rho="1.1607695200000001"/>
+                <iidm:step r="38.917527723583987" x="38.917527723583987" g="-28.014843311220961" b="-28.014843311220961" rho="1.1786327999999999"/>
+                <iidm:step r="43.16028694553664" x="43.16028694553664" g="-30.148226066322692" b="-30.148226066322692" rho="1.19649608"/>
+                <iidm:step r="47.466865521960955" x="47.466865521960955" g="-32.188156542116317" b="-32.188156542116317" rho="1.21435936"/>
+                <iidm:step r="51.837263452856973" x="51.837263452856973" g="-34.140014298236885" b="-34.140014298236885" rho="1.23222264"/>
+                <iidm:step r="56.271480738224653" x="56.271480738224653" g="-36.0087973009527" b="-36.0087973009527" rho="1.2500859200000001"/>
+                <iidm:step r="60.769517378063973" x="60.769517378063973" g="-37.799153949786998" b="-37.799153949786998" rho="1.2679491999999999"/>
+                <iidm:step r="65.331373372375026" x="65.331373372375026" g="-39.515412011505823" b="-39.515412011505823" rho="1.2858124799999999"/>
+                <iidm:step r="69.957048721157761" x="69.957048721157761" g="-41.161604798123854" b="-41.161604798123854" rho="1.30367576"/>
+                <iidm:step r="74.646543424412172" x="74.646543424412172" g="-42.741494884907091" b="-42.741494884907091" rho="1.32153904"/>
+                <iidm:step r="79.399857482138245" x="79.399857482138245" g="-44.258595629064871" b="-44.258595629064871" rho="1.33940232"/>
+                <iidm:step r="84.216990894335964" x="84.216990894335964" g="-45.716190719151165" b="-45.716190719151165" rho="1.3572655999999998"/>
+                <iidm:step r="89.097943661005473" x="89.097943661005473" g="-47.11735195848069" b="-47.11735195848069" rho="1.3751288800000001"/>
+                <iidm:step r="94.04271578214653" x="94.04271578214653" g="-48.464955462553469" b="-48.464955462553469" rho="1.3929921599999999"/>
+                <iidm:step r="99.051307257759348" x="99.051307257759348" g="-49.761696430103783" b="-49.761696430103783" rho="1.41085544"/>
+                <iidm:step r="104.12371808784383" x="104.12371808784383" g="-51.010102629540867" b="-51.010102629540867" rho="1.42871872"/>
+                <iidm:step r="109.25994827240002" x="109.25994827240002" g="-52.212546726893493" b="-52.212546726893493" rho="1.446582"/>
+                <iidm:step r="114.45999781142788" x="114.45999781142788" g="-53.371257567609966" b="-53.371257567609966" rho="1.4644452800000001"/>
+                <iidm:step r="119.72386670492732" x="119.72386670492732" g="-54.488330512455207" b="-54.488330512455207" rho="1.4823085599999999"/>
+                <iidm:step r="125.05155495289854" x="125.05155495289854" g="-55.565736917068101" b="-55.565736917068101" rho="1.5001718399999999"/>
+                <iidm:step r="130.44306255534144" x="130.44306255534144" g="-56.605332835313817" b="-56.605332835313817" rho="1.51803512"/>
+                <iidm:step r="135.89838951225599" x="135.89838951225599" g="-57.608867018227542" b="-57.608867018227542" rho="1.5358984"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="2186">
+                <iidm:temporaryLimit name="_580d3b53-5508-4d8d-97cc-4ea463e0cdb9-1" acceptableDuration="900" value="2514"/>
+                <iidm:temporaryLimit name="_a867e68a-58d1-49cb-955f-bb8e59cf2a11-1" acceptableDuration="60" value="3061"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="8747">
+                <iidm:temporaryLimit name="_1a7f23f9-e2c0-46a6-a93c-687f2209e33d-1" acceptableDuration="900" value="10059"/>
+                <iidm:temporaryLimit name="_257d56c1-d70a-4a96-b85c-d928ade03ad4-1" acceptableDuration="60" value="12246"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
     </iidm:substation>
     <iidm:substation id="_045beb3a-c766-11e1-8775-005056c00008" name="Minas Tirith" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
         <iidm:voltageLevel id="_048a9c58-c766-11e1-8775-005056c00008" name="MNT132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -1460,12 +1541,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="132.65984074772453" angle="12.510985856298648" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="132.78339831681512" angle="0.024816376328717842" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0447ee05-c766-11e1-8775-005056c00008" name="NwCarlsl NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="8" p="8.9977457990385972" q="0">
+            <iidm:load id="_0447ee05-c766-11e1-8775-005056c00008" name="NwCarlsl NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="8" p="8.9978786567611273" q="0">
                 <iidm:alias>_04731cb7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_047a48a8-c766-11e1-8775-005056c00008" name="NwCarlsl LD" loadType="UNDEFINED" p0="30" q0="12" node="9" p="29.992485996795327" q="11.994991082765887">
+            <iidm:load id="_047a48a8-c766-11e1-8775-005056c00008" name="NwCarlsl LD" loadType="UNDEFINED" p0="30" q0="12" node="9" p="29.992928855870421" q="11.99528627430168">
                 <iidm:alias>_044c0cb9-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1516,9 +1597,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.62146253954336" angle="9.3986361547541861" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.62143657267602" angle="-2.3337022272990682" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044ecbd1-c766-11e1-8775-005056c00008" name="Blaine LD" loadType="UNDEFINED" p0="2" q0="1" node="8" p="1.9999976522609746" q="0.99999804355157762">
+            <iidm:load id="_044ecbd1-c766-11e1-8775-005056c00008" name="Blaine LD" loadType="UNDEFINED" p0="2" q0="1" node="8" p="1.999997674577644" q="0.99999806214878773">
                 <iidm:alias>_04700f74-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1569,9 +1650,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="133.19657901397807" angle="15.490534792023839" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="133.1718381580001" angle="3.7601976842803269" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046b7b95-c766-11e1-8775-005056c00008" name="Sundial LD" loadType="UNDEFINED" p0="15" q0="9" node="8" p="15.000402459342213" q="9.0004024629416133">
+            <iidm:load id="_046b7b95-c766-11e1-8775-005056c00008" name="Sundial LD" loadType="UNDEFINED" p0="15" q0="9" node="8" p="15.000396741553077" q="9.0003967450509279">
                 <iidm:alias>_046efe07-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1622,9 +1703,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.66888817158649" angle="7.6575366128057825" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.71932607097669" angle="-4.654181663243917" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045645e2-c766-11e1-8775-005056c00008" name="Riversde LD" loadType="UNDEFINED" p0="51" q0="27" node="8" p="50.994652032192015" q="26.995281369818169">
+            <iidm:load id="_045645e2-c766-11e1-8775-005056c00008" name="Riversde LD" loadType="UNDEFINED" p0="51" q0="27" node="8" p="50.995006014282815" q="26.995593685844504">
                 <iidm:alias>_0476ed4b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1675,9 +1756,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="132.85648110310925" angle="17.137582053841019" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="132.99479496148498" angle="5.0225990514264689" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04887973-c766-11e1-8775-005056c00008" name="Randolph LD" loadType="UNDEFINED" p0="10" q0="5" node="8" p="10.173725360947694" q="5.1456078724234278">
+            <iidm:load id="_04887973-c766-11e1-8775-005056c00008" name="Randolph LD" loadType="UNDEFINED" p0="10" q0="5" node="8" p="10.173501115566303" q="5.145418844595846">
                 <iidm:alias>_0462f018-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1728,9 +1809,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.48379392826239" angle="-6.8369629088810813" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.48351199039828" angle="-18.519368406728745" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0477627b-c766-11e1-8775-005056c00008" name="WNwPhil2 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="11.99996016916506" q="2.9999834038371374">
+            <iidm:load id="_0477627b-c766-11e1-8775-005056c00008" name="WNwPhil2 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="11.99995841814339" q="2.9999826742464242">
                 <iidm:alias>_045841b6-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1800,9 +1881,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="126.73010505711302" angle="10.132910205390926" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="126.73007776919961" angle="-1.599185658479676" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0476781a-c766-11e1-8775-005056c00008" name="Cloverdl LD" loadType="UNDEFINED" p0="43" q0="16" node="11" p="42.999948051513577" q="15.999967783897361">
+            <iidm:load id="_0476781a-c766-11e1-8775-005056c00008" name="Cloverdl LD" loadType="UNDEFINED" p0="43" q0="16" node="11" p="42.999948516874369" q="15.999968072492972">
                 <iidm:alias>_0481749a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1872,9 +1953,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="128.1166382492234" angle="11.501883057076837" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="128.11662328185503" angle="-0.23023032799422255" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046b0665-c766-11e1-8775-005056c00008" name="Hancock LD" loadType="UNDEFINED" p0="38" q0="25" node="11" p="37.999973951588906" q="24.999971438152258">
+            <iidm:load id="_046b0665-c766-11e1-8775-005056c00008" name="Hancock LD" loadType="UNDEFINED" p0="38" q0="25" node="11" p="37.999974484970089" q="24.999972022999781">
                 <iidm:alias>_0464c4d5-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1926,12 +2007,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="128.5797625162752" angle="-5.4613039185122432" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="128.56305816599937" angle="-17.100564783747227" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044bbe92-c766-11e1-8775-005056c00008" name="WMVernon LD" loadType="UNDEFINED" p0="16" q0="8" node="8" p="15.994222506018705" q="7.9951860012096168">
+            <iidm:load id="_044bbe92-c766-11e1-8775-005056c00008" name="WMVernon LD" loadType="UNDEFINED" p0="16" q0="8" node="8" p="15.994180226507995" q="7.995150776797157">
                 <iidm:alias>_04500452-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_047825c8-c766-11e1-8775-005056c00008" name="WMVernon SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.21199999999999" targetDeadband="1" node="9" q="-9.4898015586977493">
+            <iidm:shunt id="_047825c8-c766-11e1-8775-005056c00008" name="WMVernon SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.21199999999999" targetDeadband="1" node="9" q="-9.4873359969466353">
                 <iidm:alias>_047084aa-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_2a6c1dcd-201b-4911-83b2-c16acc50a0f4"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -1965,9 +2046,9 @@
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="3"/>
-                <iidm:bus v="230.99998530181458" angle="35.156796869973171" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="230.99998501066631" angle="22.34917817961367" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_045868c0-c766-11e1-8775-005056c00008" name="Breed SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="450" targetV="230.99998500000001" targetQ="0" node="5" p="-496.71945340994387" q="21.996771368902891">
+            <iidm:generator id="_045868c0-c766-11e1-8775-005056c00008" name="Breed SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="450" targetV="230.99998500000001" targetQ="0" node="5" p="-496.62643308794526" q="25.763699742573177">
                 <iidm:alias>_045b7606-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_f26d4eb3-ebdb-4025-8080-f856ce656b42"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_7566f2a7-61eb-42fe-a59a-8276257fdbc6"/>
@@ -2041,9 +2122,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="127.47213265514175" angle="-5.7295048043260985" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="127.47172930707907" angle="-17.411116418731414" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044d1e22-c766-11e1-8775-005056c00008" name="Newcmrst LD" loadType="UNDEFINED" p0="17" q0="8" node="11" p="16.999919701241769" q="7.9999370206809406">
+            <iidm:load id="_044d1e22-c766-11e1-8775-005056c00008" name="Newcmrst LD" loadType="UNDEFINED" p0="17" q0="8" node="11" p="16.999916101867687" q="7.9999341976515339">
                 <iidm:alias>_048a754b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2113,9 +2194,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="138.59999018384804" angle="26.119371895934901" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="138.59999080001867" angle="13.69852521222623" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_045ab2b0-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="220" targetV="138.59999099999999" targetQ="0" node="11" p="-242.84062166708372" q="-34.136942058726767">
+            <iidm:generator id="_045ab2b0-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="220" targetV="138.59999099999999" targetQ="0" node="11" p="-242.7951450652177" q="-31.503206927817079">
                 <iidm:alias>_046ba2a5-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_56975783-9739-40fc-8ec1-e1de8cb06c9a"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b8449cd9-5a17-497e-bf04-70f728b0f9f2"/>
@@ -2168,9 +2249,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="223.29999915947599" angle="28.198360630899973" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="223.29999987279692" angle="15.528534911661" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0483224a-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="314" targetV="223.30000000000001" targetQ="0" node="8" p="-346.59979637938312" q="-27.330094061391542">
+            <iidm:generator id="_0483224a-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="314" targetV="223.30000000000001" targetQ="0" node="8" p="-346.53488886581073" q="-22.870919055988505">
                 <iidm:alias>_045cd594-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_05df66ba-3f64-40cb-8b18-c66d26c4e2c1"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_c1d29442-5f57-41d1-bb60-4b74b4994c20"/>
@@ -2178,7 +2259,7 @@
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045b7604-c766-11e1-8775-005056c00008" name="26-25" r="0" x="6.6559680000000006" g="0" b="0" ratedU1="220" ratedU2="132" node1="22" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="105.42774603201461" q1="22.094922924725815" p2="-105.42774603201495" q2="-18.129848622506572">
+        <iidm:twoWindingsTransformer id="_045b7604-c766-11e1-8775-005056c00008" name="26-25" r="0" x="6.6559680000000006" g="0" b="0" ratedU1="220" ratedU2="132" node1="22" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="92.806339094369505" q1="21.664205253656984" p2="-92.806339094369477" q2="-18.560559328184091">
             <iidm:alias>_0447c6f3-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0463b364-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04803c1c-c766-11e1-8775-005056c00008</iidm:alias>
@@ -2321,9 +2402,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="136.6200003854907" angle="15.010232056505178" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="136.62000177354366" angle="3.2797368335656483" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_048aea70-c766-11e1-8775-005056c00008" name="Sporn SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="513.43743900000004" targetV="136.62" targetQ="-62.132553100000003" node="20" p="-566.74303124506991" q="52.560743335309454">
+            <iidm:generator id="_048aea70-c766-11e1-8775-005056c00008" name="Sporn SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="513.43743900000004" targetV="136.62" targetQ="-62.132553100000003" node="20" p="-566.63689765417678" q="52.909044659206671">
                 <iidm:alias>_04555b84-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_27799004-aa1e-4889-ba95-ee6fdae64895"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_827a9c80-183d-4e33-9e73-ef0aab3dfb13"/>
@@ -2413,9 +2494,9 @@
                 <iidm:internalConnection node1="39" node2="9"/>
                 <iidm:internalConnection node1="40" node2="12"/>
                 <iidm:internalConnection node1="41" node2="3"/>
-                <iidm:bus v="219.70587635202534" angle="11.122137688438809" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41"/>
+                <iidm:bus v="219.70689957353903" angle="-0.58531077830505651" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41"/>
             </iidm:nodeBreakerTopology>
-            <iidm:danglingLine id="_0482fb33-c766-11e1-8775-005056c00008" name="68-116" p0="184" q0="0" r="0.16456000000000001" x="1.9601999999999999" g="0" b="0.00033884300000000002" ucteXnodeCode="XWE_BR21" node="41" p="184.115571291023" q="-14.979533057185579">
+            <iidm:danglingLine id="_0482fb33-c766-11e1-8775-005056c00008" name="68-116" p0="184" q0="0" r="0.16456000000000001" x="1.9601999999999999" g="0" b="0.00033884300000000002" ucteXnodeCode="XWE_BR21" node="41" p="184.11557356293019" q="-14.979698162312779">
                 <iidm:alias>_0459c855-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_04684742-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_5631ccc0-d9d2-11e2-bb49-005056c00008</iidm:alias>
@@ -2428,7 +2509,7 @@
                 </iidm:currentLimits>
             </iidm:danglingLine>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_044f6815-c766-11e1-8775-005056c00008" name="68-69" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-202.594103804811" q1="102.39511635186136" p2="202.59410380481083" q2="-85.682679549741025">
+        <iidm:twoWindingsTransformer id="_044f6815-c766-11e1-8775-005056c00008" name="68-69" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-201.39599079603232" q1="102.32867152927734" p2="201.39599079603227" q2="-85.777784722043165">
             <iidm:alias>_047e8e67-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04840ca7-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0487dd39-c766-11e1-8775-005056c00008</iidm:alias>
@@ -2535,9 +2616,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="131.60559111065587" angle="3.0120905076788267" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="131.60559587362195" angle="-8.6757447216247758" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04547126-c766-11e1-8775-005056c00008" name="Natrium LD" loadType="UNDEFINED" p0="77" q0="14" node="14" p="76.999893368577787" q="13.999967687462734">
+            <iidm:load id="_04547126-c766-11e1-8775-005056c00008" name="Natrium LD" loadType="UNDEFINED" p0="77" q0="14" node="14" p="76.999894618511462" q="13.999968066230167">
                 <iidm:alias>_047b3307-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2588,9 +2669,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="123.56858290480135" angle="-5.120061129041674" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="123.49517984515082" angle="-16.665164127755368" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045d4ac9-c766-11e1-8775-005056c00008" name="Sterling LD" loadType="UNDEFINED" p0="31" q0="17" node="8" p="30.965719640207677" q="16.968680038765172">
+            <iidm:load id="_045d4ac9-c766-11e1-8775-005056c00008" name="Sterling LD" loadType="UNDEFINED" p0="31" q0="17" node="8" p="30.965010852111568" q="16.968032704293783">
                 <iidm:alias>_0477b094-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2698,9 +2779,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="130.31064659053715" angle="17.979181703185169" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="130.28823342369904" angle="6.2496550367621611" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0466246a-c766-11e1-8775-005056c00008" name="Switchbk LD" loadType="UNDEFINED" p0="30" q0="16" node="17" p="30.001098910185576" q="16.000976820980746">
+            <iidm:load id="_0466246a-c766-11e1-8775-005056c00008" name="Switchbk LD" loadType="UNDEFINED" p0="30" q0="16" node="17" p="30.001092352787833" q="16.000970992040845">
                 <iidm:alias>_04882b59-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2751,9 +2832,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="135.08827164158822" angle="15.288746381557504" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="135.08831295402928" angle="3.5582647529903451" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046adf5a-c766-11e1-8775-005056c00008" name="Bradley LD" loadType="UNDEFINED" p0="34" q0="8" node="8" p="34.000139120095255" q="8.0000545569745114">
+            <iidm:load id="_046adf5a-c766-11e1-8775-005056c00008" name="Bradley LD" loadType="UNDEFINED" p0="34" q0="8" node="8" p="34.000141475798088" q="8.0000554807820805">
                 <iidm:alias>_04555b85-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2788,6 +2869,9 @@
                     <iidm:alias>_7f359893-b7c5-41b0-ada8-8df06cf7a8e6</iidm:alias>
                     <iidm:alias>_a4edf081-2fb2-4da4-94db-98a2a596247f</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_312f25f3-55bc-4417-848c-236d31d823f4-1" name="DISCONNECTOR524-1" kind="DISCONNECTOR" retained="false" open="false" node1="24" node2="25"/>
+                <iidm:switch id="_686e884a-a0b1-454e-b7d1-33c7ad46f89f-1" name="BREAKER262-1" kind="BREAKER" retained="false" open="false" node1="23" node2="24"/>
+                <iidm:switch id="_346a5319-3ec2-40a2-aefd-38dfacbbe97c-1" name="DISCONNECTOR523-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="23"/>
                 <iidm:internalConnection node1="7" node2="0"/>
                 <iidm:internalConnection node1="8" node2="0"/>
                 <iidm:internalConnection node1="9" node2="1"/>
@@ -2804,9 +2888,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.97814533944964" angle="10.377839777083391" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.2642327247478" angle="-1.3935344505684828" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047a48a2-c766-11e1-8775-005056c00008" name="Mullin LD" loadType="UNDEFINED" p0="17" q0="7" node="8" p="17.004339730811367" q="7.0029785000552929">
+            <iidm:load id="_047a48a2-c766-11e1-8775-005056c00008" name="Mullin LD" loadType="UNDEFINED" p0="17" q0="7" node="8" p="17.005047595033435" q="7.0034643786400661">
                 <iidm:alias>_0474553a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2972,16 +3056,16 @@
                 <iidm:internalConnection node1="81" node2="18"/>
                 <iidm:internalConnection node1="82" node2="21"/>
                 <iidm:internalConnection node1="83" node2="24"/>
-                <iidm:bus v="134.24398892235678" angle="17.670915131641461" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
+                <iidm:bus v="134.24399057841521" angle="5.9391136591722056" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_044cd00a-c766-11e1-8775-005056c00008" name="Glen Lyn SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="252" targetV="134.243988" targetQ="0" node="27" p="-278.1628939095686" q="-83.852250240961638">
+            <iidm:generator id="_044cd00a-c766-11e1-8775-005056c00008" name="Glen Lyn SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="252" targetV="134.243988" targetQ="0" node="27" p="-278.11080252924938" q="-84.202887345336038">
                 <iidm:alias>_045e5c30-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e54b499b-436c-4b89-9803-b1d75e2fa364"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_32c8ab65-80f7-4c17-b3f5-ff075cce0ba5"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
-            <iidm:load id="_04566cf5-c766-11e1-8775-005056c00008" name="Glen Lyn LD" loadType="UNDEFINED" p0="37" q0="18" node="26" p="37.000000381326572" q="18.000000309183712">
+            <iidm:load id="_04566cf5-c766-11e1-8775-005056c00008" name="Glen Lyn LD" loadType="UNDEFINED" p0="37" q0="18" node="26" p="37.000001065984748" q="18.000000864311964">
                 <iidm:alias>_04577e64-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3032,9 +3116,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.5189449099079" angle="10.121308076969671" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.59504480077709" angle="-2.2349728721859372" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044ea4c0-c766-11e1-8775-005056c00008" name="Kankakee LD" loadType="UNDEFINED" p0="52" q0="22" node="8" p="51.9925860576909" q="21.994772468622251">
+            <iidm:load id="_044ea4c0-c766-11e1-8775-005056c00008" name="Kankakee LD" loadType="UNDEFINED" p0="52" q0="22" node="8" p="51.993098618729583" q="21.995133856700928">
                 <iidm:alias>_047e6758-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3143,12 +3227,12 @@
                 <iidm:internalConnection node1="51" node2="9"/>
                 <iidm:internalConnection node1="52" node2="12"/>
                 <iidm:internalConnection node1="53" node2="15"/>
-                <iidm:bus v="127.42257762326061" angle="10.398887603223082" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
+                <iidm:bus v="127.42256461448811" angle="-1.3332718490806645" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0484cffb-c766-11e1-8775-005056c00008" name="Roanoke LD" loadType="UNDEFINED" p0="31" q0="26" node="17" p="30.999980267398584" q="25.999972416799583">
+            <iidm:load id="_0484cffb-c766-11e1-8775-005056c00008" name="Roanoke LD" loadType="UNDEFINED" p0="31" q0="26" node="17" p="30.999980712719417" q="25.999973039290801">
                 <iidm:alias>_0454983a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0489d903-c766-11e1-8775-005056c00008" name="Roanoke SC" sectionCount="5" voltageRegulatorOn="true" targetV="127.423" targetDeadband="1" node="18" q="-18.639517254802943">
+            <iidm:shunt id="_0489d903-c766-11e1-8775-005056c00008" name="Roanoke SC" sectionCount="5" voltageRegulatorOn="true" targetV="127.423" targetDeadband="1" node="18" q="-18.639513448927541">
                 <iidm:alias>_0476c638-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_5be38d1a-9d01-42d8-b8bb-e9a26cfbcf1a"/>
                 <iidm:shuntLinearModel bPerSection="0.0002296" gPerSection="0" maximumSectionCount="10"/>
@@ -3240,12 +3324,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="120.46983096110191" angle="-10.287194212355869" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="120.43333010920792" angle="-21.913665262790932" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047a219a-c766-11e1-8775-005056c00008" name="Howard LD" loadType="UNDEFINED" p0="37" q0="23" node="14" p="36.974424611042465" q="22.973509081023906">
+            <iidm:load id="_047a219a-c766-11e1-8775-005056c00008" name="Howard LD" loadType="UNDEFINED" p0="37" q0="23" node="14" p="36.974045023897787" q="22.973115997653217">
                 <iidm:alias>_04882b51-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_04488a49-c766-11e1-8775-005056c00008" name="Howard NegG LD" loadType="UNDEFINED" p0="59" q0="0" node="15" p="58.959217623013657" q="0">
+            <iidm:load id="_04488a49-c766-11e1-8775-005056c00008" name="Howard NegG LD" loadType="UNDEFINED" p0="59" q0="0" node="15" p="58.958612335404581" q="0">
                 <iidm:alias>_046d9e74-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3295,7 +3379,7 @@
                 <iidm:internalConnection node1="19" node2="6"/>
                 <iidm:internalConnection node1="20" node2="3"/>
                 <iidm:internalConnection node1="21" node2="6"/>
-                <iidm:bus v="218.77251338047273" angle="12.914235121527945" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
+                <iidm:bus v="218.77305105659559" angle="1.1983516950387125" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_046efe09-c766-11e1-8775-005056c00008" name="CRI132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -3458,20 +3542,20 @@
                 <iidm:internalConnection node1="81" node2="18"/>
                 <iidm:internalConnection node1="82" node2="21"/>
                 <iidm:internalConnection node1="83" node2="24"/>
-                <iidm:bus v="137.28000062237965" angle="15.809775575285117" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
+                <iidm:bus v="137.2800021506506" angle="4.0800713188010427" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_045868c1-c766-11e1-8775-005056c00008" name="CabinCrk SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="477" targetV="137.28" targetQ="0" node="27" p="-526.52262061454053" q="-138.96959791593741">
+            <iidm:generator id="_045868c1-c766-11e1-8775-005056c00008" name="CabinCrk SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="477" targetV="137.28" targetQ="0" node="27" p="-526.42401907322198" q="-139.77560945374285">
                 <iidm:alias>_0487dd36-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_a6ec9760-88da-48df-a23f-7877e7c85ccd"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_e6131af8-c298-413b-84e3-4e21c3b6b06f"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-225" maxQ="640"/>
             </iidm:generator>
-            <iidm:load id="_04747c44-c766-11e1-8775-005056c00008" name="CabinCrk LD" loadType="UNDEFINED" p0="130" q0="26" node="26" p="130.00000088406202" q="26.000000294687332">
+            <iidm:load id="_04747c44-c766-11e1-8775-005056c00008" name="CabinCrk LD" loadType="UNDEFINED" p0="130" q0="26" node="26" p="130.00000305490141" q="26.000001018300484">
                 <iidm:alias>_046a9138-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_0488c79b-c766-11e1-8775-005056c00008" name="81-80" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="21" voltageLevelId1="_048a272b-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-151.01226055397348" q1="71.514127041824509" p2="151.01226055397339" q2="-62.381741520241853">
+        <iidm:twoWindingsTransformer id="_0488c79b-c766-11e1-8775-005056c00008" name="81-80" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="21" voltageLevelId1="_048a272b-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-150.29243776665277" q1="71.485442845884592" p2="150.29243776665277" q2="-62.425387680022737">
             <iidm:alias>_044974a0-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_045a3d83-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_046adf57-c766-11e1-8775-005056c00008</iidm:alias>
@@ -3551,12 +3635,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="134.7472678491971" angle="-1.0168978616800095" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="134.747402889916" angle="-12.69522756403615" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04524e4a-c766-11e1-8775-005056c00008" name="Zanesvll LD" loadType="UNDEFINED" p0="20" q0="11" node="8" p="19.999996828578553" q="10.999997092863827">
+            <iidm:load id="_04524e4a-c766-11e1-8775-005056c00008" name="Zanesvll LD" loadType="UNDEFINED" p0="20" q0="11" node="8" p="19.999998608806237" q="10.999998724739077">
                 <iidm:alias>_045c1240-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_048b5fa9-c766-11e1-8775-005056c00008" name="Zanesvll SC" sectionCount="5" voltageRegulatorOn="true" targetV="134.72300000000001" targetDeadband="1" node="9" q="-15.633027352020829">
+            <iidm:shunt id="_048b5fa9-c766-11e1-8775-005056c00008" name="Zanesvll SC" sectionCount="5" voltageRegulatorOn="true" targetV="134.72300000000001" targetDeadband="1" node="9" q="-15.633058686182094">
                 <iidm:alias>_04736ad5-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_99c6c4ad-5247-4058-96d4-ee8495103e85"/>
                 <iidm:shuntLinearModel bPerSection="0.00017220000000000001" gPerSection="0" maximumSectionCount="10"/>
@@ -3609,9 +3693,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.79049274177234" angle="20.712305078066787" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.77502553905788" angle="8.9851035687305849" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044ca8f2-c766-11e1-8775-005056c00008" name="Tazewell LD" loadType="UNDEFINED" p0="12" q0="7" node="8" p="12.000436442027981" q="7.0004243237824753">
+            <iidm:load id="_044ca8f2-c766-11e1-8775-005056c00008" name="Tazewell LD" loadType="UNDEFINED" p0="12" q0="7" node="8" p="12.000436642224608" q="7.0004245184228084">
                 <iidm:alias>_04542305-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3662,9 +3746,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="119.62072731956403" angle="-8.5754175568146724" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="119.55284432525758" angle="-20.149726882542403" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04778989-c766-11e1-8775-005056c00008" name="NwLibrty LD" loadType="UNDEFINED" p0="27" q0="11" node="8" p="26.972038416778677" q="10.981020294689275">
+            <iidm:load id="_04778989-c766-11e1-8775-005056c00008" name="NwLibrty LD" loadType="UNDEFINED" p0="27" q0="11" node="8" p="26.971426903127188" q="10.980605359231211">
                 <iidm:alias>_0483e592-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3697,12 +3781,12 @@
                 <iidm:internalConnection node1="11" node2="2"/>
                 <iidm:internalConnection node1="12" node2="3"/>
                 <iidm:internalConnection node1="13" node2="3"/>
-                <iidm:bus v="122.60494434279433" angle="5.7282567782729563" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13"/>
+                <iidm:bus v="122.60492389294848" angle="-6.0043522787377199" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0463da70-c766-11e1-8775-005056c00008" name="Danville LD" loadType="UNDEFINED" p0="25" q0="13" node="5" p="24.999974595932876" q="12.999977983149286">
+            <iidm:load id="_0463da70-c766-11e1-8775-005056c00008" name="Danville LD" loadType="UNDEFINED" p0="25" q0="13" node="5" p="24.999974900411921" q="12.999978247030944">
                 <iidm:alias>_0488eeab-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_0448b150-c766-11e1-8775-005056c00008" name="Danville NegG LD" loadType="UNDEFINED" p0="43" q0="0" node="6" p="42.999956305004552" q="0">
+            <iidm:load id="_0448b150-c766-11e1-8775-005056c00008" name="Danville NegG LD" loadType="UNDEFINED" p0="43" q0="0" node="6" p="42.999956828708505" q="0">
                 <iidm:alias>_0457cc88-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3753,9 +3837,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.60535359119328" angle="26.464546943256259" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.46838876203253" angle="14.754245166033224" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045cae82-c766-11e1-8775-005056c00008" name="Fremont LD" loadType="UNDEFINED" p0="48" q0="10" node="8" p="48.000957426423014" q="10.000332441940532">
+            <iidm:load id="_045cae82-c766-11e1-8775-005056c00008" name="Fremont LD" loadType="UNDEFINED" p0="48" q0="10" node="8" p="48.000830625851229" q="10.000288413417527">
                 <iidm:alias>_045f4693-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3901,9 +3985,9 @@
                 <iidm:internalConnection node1="70" node2="15"/>
                 <iidm:internalConnection node1="71" node2="18"/>
                 <iidm:internalConnection node1="72" node2="21"/>
-                <iidm:bus v="132.39431804259249" angle="13.546270144200175" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
+                <iidm:bus v="132.37527489910741" angle="1.8112599115829235" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0448d863-c766-11e1-8775-005056c00008" name="Turner LD" loadType="UNDEFINED" p0="61" q0="28" node="23" p="61.007550320722125" q="28.005776439959966">
+            <iidm:load id="_0448d863-c766-11e1-8775-005056c00008" name="Turner LD" loadType="UNDEFINED" p0="61" q0="28" node="23" p="61.007497372047204" q="28.005735929446217">
                 <iidm:alias>_046e3ab3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3938,6 +4022,9 @@
                     <iidm:alias>_0b877750-4384-4ec3-bb38-08ee5ccf16d3</iidm:alias>
                     <iidm:alias>_1ed822d3-f3ab-4432-80f0-4c55ae3b4b78</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_3be2355e-0065-43df-a264-57a295042faa-1" name="DISCONNECTOR526-1" kind="DISCONNECTOR" retained="false" open="false" node1="24" node2="25"/>
+                <iidm:switch id="_2463ff2c-7690-4dd6-bf44-039f9f475bb1-1" name="BREAKER263-1" kind="BREAKER" retained="false" open="true" node1="23" node2="24"/>
+                <iidm:switch id="_ddcf7aac-e7c3-45e9-bd81-6146e951addd-1" name="DISCONNECTOR525-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="23"/>
                 <iidm:internalConnection node1="7" node2="0"/>
                 <iidm:internalConnection node1="8" node2="0"/>
                 <iidm:internalConnection node1="9" node2="1"/>
@@ -3954,9 +4041,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.16578280560594" angle="9.1245149013088618" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.23697555203793" angle="-2.4936826441169599" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047d7cf6-c766-11e1-8775-005056c00008" name="Grant LD" loadType="UNDEFINED" p0="24" q0="4" node="8" p="24.001945996403805" q="4.000540569166442">
+            <iidm:load id="_047d7cf6-c766-11e1-8775-005056c00008" name="Grant LD" loadType="UNDEFINED" p0="24" q0="4" node="8" p="24.002204297993298" q="4.0006123237438178">
                 <iidm:alias>_0481e9c0-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4026,9 +4113,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="220.78900375449746" angle="18.604065434849602" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="221.26291248415259" angle="5.8258556971574613" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04867dab-c766-11e1-8775-005056c00008" name="Olive NegG LD" loadType="UNDEFINED" p0="28" q0="0" node="11" p="27.98736798650172" q="0">
+            <iidm:load id="_04867dab-c766-11e1-8775-005056c00008" name="Olive NegG LD" loadType="UNDEFINED" p0="28" q0="0" node="11" p="27.98815380291898" q="0">
                 <iidm:alias>_048433b8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4134,15 +4221,15 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="133.11151180385258" angle="13.009077783783999" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="133.24312359339834" angle="0.49901517030053827" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:shunt id="_0447c6f6-c766-11e1-8775-005056c00008" name="Olive SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.67599999999999" targetDeadband="1" node="17" q="-40.682076823527694">
+            <iidm:shunt id="_0447c6f6-c766-11e1-8775-005056c00008" name="Olive SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.67599999999999" targetDeadband="1" node="17" q="-40.762564045389233">
                 <iidm:alias>_045e8340-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_c701959a-91c1-4a35-9a37-71fb790426ca"/>
                 <iidm:shuntLinearModel bPerSection="0.00045919999999999999" gPerSection="0" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_04575750-c766-11e1-8775-005056c00008" name="8-5" r="0" x="4.6522079999999999" g="0" b="0" ratedU1="220" ratedU2="132" node1="32" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="375.17596668256732" q1="58.205494128762567" p2="-375.17596668256743" q2="-21.131152228538941">
+        <iidm:twoWindingsTransformer id="_04575750-c766-11e1-8775-005056c00008" name="8-5" r="0" x="4.6522079999999999" g="0" b="0" ratedU1="220" ratedU2="132" node1="32" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="358.3691034720016" q1="61.17962172240766" p2="-358.3691034720016" q2="-27.330359784402397">
             <iidm:alias>_045eaa55-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_046b2d74-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04745533-c766-11e1-8775-005056c00008</iidm:alias>
@@ -4213,9 +4300,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.78345126343658" angle="19.637779904187674" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.78008024975585" angle="7.9088000185808642" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047b0bf0-c766-11e1-8775-005056c00008" name="Wythe LD" loadType="UNDEFINED" p0="22" q0="15" node="8" p="22.000307040522841" q="15.000348911308217">
+            <iidm:load id="_047b0bf0-c766-11e1-8775-005056c00008" name="Wythe LD" loadType="UNDEFINED" p0="22" q0="15" node="8" p="22.000310537964413" q="15.00035288571083">
                 <iidm:alias>_0479d376-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4266,9 +4353,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="123.63792283369179" angle="-5.1488816283341929" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="123.56490463340205" angle="-16.694788362332016" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0458ddf5-c766-11e1-8775-005056c00008" name="WestLima LD" loadType="UNDEFINED" p0="33" q0="9" node="8" p="32.963612376597098" q="8.9834662511686396">
+            <iidm:load id="_0458ddf5-c766-11e1-8775-005056c00008" name="WestLima LD" loadType="UNDEFINED" p0="33" q0="9" node="8" p="32.962867731691013" q="8.9831280276180383">
                 <iidm:alias>_04492686-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4376,9 +4463,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="128.47078679989679" angle="22.554055785792844" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="128.13562705393969" angle="10.85297706739008" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044b2257-c766-11e1-8775-005056c00008" name="BeaverCk LD" loadType="UNDEFINED" p0="24" q0="15" node="17" p="24.000692564508448" q="15.000721428302267">
+            <iidm:load id="_044b2257-c766-11e1-8775-005056c00008" name="BeaverCk LD" loadType="UNDEFINED" p0="24" q0="15" node="17" p="24.000546951398189" q="15.000569745367834">
                 <iidm:alias>_045868c4-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4437,6 +4524,9 @@
                     <iidm:alias>_2b636cdd-aa2f-4a65-92fc-12b4fc392e5f</iidm:alias>
                     <iidm:alias>_c96e50b9-ea15-4421-b6c8-bd9c9158a69a</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_e5318967-afcc-4fcc-b0de-d5f2522a95a6-1" name="DISCONNECTOR699-1" kind="DISCONNECTOR" retained="false" open="false" node1="43" node2="44"/>
+                <iidm:switch id="_e9f91b69-a29b-44ea-aa0f-cff86ee80320-1" name="BREAKER350-1" kind="BREAKER" retained="true" open="true" node1="42" node2="43"/>
+                <iidm:switch id="_ad86e83d-6334-4dd8-b642-b4c16d65329a-1" name="DISCONNECTOR700-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="42"/>
                 <iidm:internalConnection node1="13" node2="0"/>
                 <iidm:internalConnection node1="14" node2="1"/>
                 <iidm:internalConnection node1="15" node2="2"/>
@@ -4466,7 +4556,7 @@
                 <iidm:internalConnection node1="39" node2="9"/>
                 <iidm:internalConnection node1="40" node2="12"/>
                 <iidm:internalConnection node1="41" node2="3"/>
-                <iidm:bus v="214.01239170299812" angle="16.319018305817462" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41"/>
+                <iidm:bus v="215.04236416728182" angle="3.0499831851433319" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_047bcf46-c766-11e1-8775-005056c00008" name="STN132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -4546,6 +4636,9 @@
                     <iidm:alias>_4aab41d6-d1b6-4dbe-a6aa-cb7ccd941912</iidm:alias>
                     <iidm:alias>_e9315b98-af75-40bb-bf8e-05bd03d43db5</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_b8b0b9a9-af8b-41d2-a4f8-940637e63f70-1" name="DISCONNECTOR701-1" kind="DISCONNECTOR" retained="false" open="false" node1="64" node2="65"/>
+                <iidm:switch id="_0b78ffaa-9859-4658-af17-c8d355633556-1" name="BREAKER351-1" kind="BREAKER" retained="true" open="false" node1="63" node2="64"/>
+                <iidm:switch id="_9dfeeaef-5c49-4c2c-97b1-03876970bee4-1" name="DISCONNECTOR702-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="63"/>
                 <iidm:internalConnection node1="19" node2="0"/>
                 <iidm:internalConnection node1="20" node2="0"/>
                 <iidm:internalConnection node1="21" node2="1"/>
@@ -4590,9 +4683,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="128.9713677735632" angle="9.3854862431202726" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="128.93580548555593" angle="-1.6692300004600893" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045dbff4-c766-11e1-8775-005056c00008" name="Sorenson LD" loadType="UNDEFINED" p0="11" q0="3" node="20" p="10.985534462621583" q="2.9934276384142215">
+            <iidm:load id="_045dbff4-c766-11e1-8775-005056c00008" name="Sorenson LD" loadType="UNDEFINED" p0="11" q0="3" node="20" p="10.986505190693141" q="2.9938685045121995">
                 <iidm:alias>_044d4536-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4613,6 +4706,9 @@
                     <iidm:alias>_340082f1-db9c-446d-97df-80e45aa0058b</iidm:alias>
                     <iidm:alias>_90c04b95-703a-4bae-82b8-7edf3075aa24</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_4d08a684-cdcb-484a-a767-03b10f4ada7f-1" name="DISCONNECTOR735-1" kind="DISCONNECTOR" retained="false" open="false" node1="14" node2="15"/>
+                <iidm:switch id="_f468d841-1bf6-470e-85d4-55d34fab8bff-1" name="BREAKER368-1" kind="BREAKER" retained="true" open="false" node1="13" node2="14"/>
+                <iidm:switch id="_f193bd8f-badf-4600-82ac-f212d1f33534-1" name="DISCONNECTOR736-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="13"/>
                 <iidm:internalConnection node1="4" node2="0"/>
                 <iidm:internalConnection node1="5" node2="1"/>
                 <iidm:internalConnection node1="6" node2="2"/>
@@ -4622,13 +4718,13 @@
                 <iidm:internalConnection node1="10" node2="3"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="0"/>
-                <iidm:bus v="383.28997626697623" angle="16.095041265704022" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="388.06229216949907" angle="0" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15"/>
             </iidm:nodeBreakerTopology>
             <iidm:lccConverterStation id="_7393a68e-c4e6-48dd-9347-543858363fdb" name="Conv1" lossFactor="0" powerFactor="0.80000000000000004" node="12" p="10" q="6">
                 <iidm:alias>_739658a7-e08b-4395-8d79-93e87b7855e3</iidm:alias>
             </iidm:lccConverterStation>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_047120e9-c766-11e1-8775-005056c00008" name="30-17" r="0" x="6.7605125399999997" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_047b8123-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="308.03781188209956" q1="113.3603005307972" p2="-308.0378118820995" q2="-72.649462851345234">
+        <iidm:twoWindingsTransformer id="_047120e9-c766-11e1-8775-005056c00008" name="30-17" r="0" x="6.7605125399999997" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_047b8123-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="210.88892309028299" q1="117.34956302834543" p2="-210.88892309028299" q2="-95.550862822224616">
             <iidm:alias>_044f6811-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0463b36a-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_047d2ed8-c766-11e1-8775-005056c00008</iidm:alias>
@@ -4647,7 +4743,7 @@
                 <iidm:temporaryLimit name="_f62f2fc6-4b6c-4571-a8c5-40d6a89ac703" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_b08e9e50-4e0c-4ac0-9f21-4a27429caeb2" name="PowTrans1" r="0.4840000000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_3bbfa58a-a1ad-4b23-a526-3d76b096c1f4" node2="41" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="-10.000000050607765" q1="-5.9999999532857977" p2="10.001444419670149" q2="6.05416379311868">
+        <iidm:twoWindingsTransformer id="_b08e9e50-4e0c-4ac0-9f21-4a27429caeb2" name="PowTrans1" r="0.4840000000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_3bbfa58a-a1ad-4b23-a526-3d76b096c1f4" node2="41" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="-135.7118715346306" q1="20.269238833383582" p2="135.9069495250194" q2="-12.953814193802565">
             <iidm:alias>_046ba2aa-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_a5bf9702-545a-437d-9663-773550202828</iidm:alias>
             <iidm:alias>_ee9505e1-96d7-49b3-9d1a-924397ffb27e</iidm:alias>
@@ -4667,6 +4763,32 @@
                 <iidm:temporaryLimit name="_611bb05e-9b9a-469c-b1d1-80a944c3ce2f" acceptableDuration="60" value="1400"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
+        <iidm:threeWindingsTransformer id="_86d83c7d-7826-4c16-b161-4ce17174e77f-1" name="T422" r1="-1.5199999809265099" x1="23.199999999999999" g1="0" b1="0" ratedU1="400" r2="2.0000000630528461" x2="19.999999999999996" g2="0" b2="0" ratedU2="220" r3="1.2000000564689806" x3="12" g3="0" b3="0" ratedU3="132" ratedU0="400" node1="15" voltageLevelId1="_3bbfa58a-a1ad-4b23-a526-3d76b096c1f4" node2="44" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" node3="65" voltageLevelId3="_047bcf46-c766-11e1-8775-005056c00008" p1="125.71187154307898" q1="-26.26923882831602" p2="0" q2="0" p3="-125.74691936742755" q3="30.124500416747445">
+            <iidm:alias>_1b2d419c-ac88-4dae-8dfe-2eb92d18c40a-1</iidm:alias>
+            <iidm:alias>_206474da-93c8-46b1-863f-9a308bfc2117-1</iidm:alias>
+            <iidm:alias>_9ac069ea-557b-4b8c-b12e-f9f2aecc3bf5-1</iidm:alias>
+            <iidm:alias>_ae46e10e-1fbe-4139-b493-ed8e2844ee8d-1</iidm:alias>
+            <iidm:ratioTapChanger1 lowTapPosition="1" tapPosition="11" targetDeadband="0" loadTapChangingCapabilities="true" regulating="false" targetV="220">
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.95238095238095233"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.96385542168674687"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.97560975609756106"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.98765432098765438"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0126582278481011"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0256410256410258"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0389610389610389"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0526315789473684"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0666666666666667"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0810810810810809"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.095890410958904"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.1111111111111112"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.1267605633802817"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.1428571428571428"/>
+            </iidm:ratioTapChanger1>
+            <iidm:currentLimits1 permanentLimit="500">
+                <iidm:temporaryLimit name="_3fd18f6e-749a-4fa7-af1b-b0c2d3952638-1" acceptableDuration="1800" value="533"/>
+            </iidm:currentLimits1>
+        </iidm:threeWindingsTransformer>
     </iidm:substation>
     <iidm:substation id="_04642898-c766-11e1-8775-005056c00008" name="Rómenna" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
         <iidm:voltageLevel id="_0457f394-c766-11e1-8775-005056c00008" name="RÓM132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -4905,16 +5027,16 @@
                 <iidm:internalConnection node1="121" node2="30"/>
                 <iidm:internalConnection node1="122" node2="33"/>
                 <iidm:internalConnection node1="123" node2="36"/>
-                <iidm:bus v="135.30000019175077" angle="-0.19803508821045943" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123"/>
+                <iidm:bus v="135.30000104738951" angle="-11.877551075952949" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04859346-c766-11e1-8775-005056c00008" name="Philo SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="204" targetV="135.30000000000001" targetQ="0" node="39" p="-225.17948554584123" q="-176.85755935549975">
+            <iidm:generator id="_04859346-c766-11e1-8775-005056c00008" name="Philo SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="204" targetV="135.30000000000001" targetQ="0" node="39" p="-225.13731633320191" q="-176.81422262179487">
                 <iidm:alias>_048719e2-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e3753d6d-b894-4cce-b6fa-307c50dc107f"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_dff93c01-9c84-4c1f-8529-66c054ed9e37"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
-            <iidm:load id="_045163e2-c766-11e1-8775-005056c00008" name="Philo LD" loadType="UNDEFINED" p0="87" q0="30" node="38" p="87.000000184948036" q="30.000000106291974">
+            <iidm:load id="_045163e2-c766-11e1-8775-005056c00008" name="Philo LD" loadType="UNDEFINED" p0="87" q0="30" node="38" p="87.000001010231543" q="30.000000580592847">
                 <iidm:alias>_04513cd3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4965,9 +5087,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.82675574860278" angle="20.568332071430049" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.5406576748917" angle="8.8565038758755641" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04524e46-c766-11e1-8775-005056c00008" name="BetsyLne LD" loadType="UNDEFINED" p0="11" q0="7" node="8" p="11.000558027977482" q="7.0005918578629602">
+            <iidm:load id="_04524e46-c766-11e1-8775-005056c00008" name="BetsyLne LD" loadType="UNDEFINED" p0="11" q0="7" node="8" p="11.000499696474678" q="7.0005299891346091">
                 <iidm:alias>_04549830-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5020,15 +5142,15 @@
                 <iidm:internalConnection node1="22" node2="6"/>
                 <iidm:internalConnection node1="23" node2="3"/>
                 <iidm:internalConnection node1="24" node2="6"/>
-                <iidm:bus v="124.75879594837447" angle="7.4247471973263952" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24"/>
+                <iidm:bus v="124.7587750602912" angle="-4.3073814593908315" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04566cf3-c766-11e1-8775-005056c00008" name="Reusens NegG LD" loadType="UNDEFINED" p0="22" q0="0" node="8" p="21.999976654073574" q="0">
+            <iidm:load id="_04566cf3-c766-11e1-8775-005056c00008" name="Reusens NegG LD" loadType="UNDEFINED" p0="22" q0="0" node="8" p="21.999976918584803" q="0">
                 <iidm:alias>_0483be81-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_0482fb36-c766-11e1-8775-005056c00008" name="Reusens LD" loadType="UNDEFINED" p0="28" q0="12" node="9" p="27.999970287002736" q="11.999978776438029">
+            <iidm:load id="_0482fb36-c766-11e1-8775-005056c00008" name="Reusens LD" loadType="UNDEFINED" p0="28" q0="12" node="9" p="27.999970623653393" q="11.999979016902616">
                 <iidm:alias>_0486cbc1-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_04558293-c766-11e1-8775-005056c00008" name="Reusens SC" sectionCount="5" voltageRegulatorOn="true" targetV="124.76300000000001" targetDeadband="1" node="10" q="-5.3542764652719201">
+            <iidm:shunt id="_04558293-c766-11e1-8775-005056c00008" name="Reusens SC" sectionCount="5" voltageRegulatorOn="true" targetV="124.76300000000001" targetDeadband="1" node="10" q="-5.3542746723632515">
                 <iidm:alias>_04893ccc-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_99303cd3-6b53-4ee2-a5ce-fe8d5feeb304"/>
                 <iidm:shuntLinearModel bPerSection="6.8800000000000005e-05" gPerSection="0" maximumSectionCount="10"/>
@@ -5101,12 +5223,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="126.42741689807481" angle="24.711876375389394" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="126.42564836052948" angle="12.989603022095157" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045c8777-c766-11e1-8775-005056c00008" name="Holston NegG LD" loadType="UNDEFINED" p0="85" q0="0" node="11" p="85.000594573153023" q="0">
+            <iidm:load id="_045c8777-c766-11e1-8775-005056c00008" name="Holston NegG LD" loadType="UNDEFINED" p0="85" q0="0" node="11" p="85.000600197281145" q="0">
                 <iidm:alias>_0487dd31-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_0451d918-c766-11e1-8775-005056c00008" name="Holston LD" loadType="UNDEFINED" p0="78" q0="42" node="12" p="78.000545608305131" q="42.00048964962064">
+            <iidm:load id="_0451d918-c766-11e1-8775-005056c00008" name="Holston LD" loadType="UNDEFINED" p0="78" q0="42" node="12" p="78.000550769269765" q="42.00049428127727">
                 <iidm:alias>_0485ba54-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5214,9 +5336,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="127.93248313498107" angle="9.652888543878964" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="127.93113105588623" angle="-2.1133250114453253" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04742e27-c766-11e1-8775-005056c00008" name="SthPoint LD" loadType="UNDEFINED" p0="47" q0="11" node="17" p="47.029319822954072" q="11.011439188400649">
+            <iidm:load id="_04742e27-c766-11e1-8775-005056c00008" name="SthPoint LD" loadType="UNDEFINED" p0="47" q0="11" node="17" p="47.029414266065004" q="11.011476043256048">
                 <iidm:alias>_047b3303-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5268,12 +5390,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="132.9510140500816" angle="13.546981229543221" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="132.93822639960209" angle="1.813727651350715" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04716f06-c766-11e1-8775-005056c00008" name="CapitlHl LD" loadType="UNDEFINED" p0="39" q0="32" node="8" p="39.003250255711421" q="32.004444917610343">
+            <iidm:load id="_04716f06-c766-11e1-8775-005056c00008" name="CapitlHl LD" loadType="UNDEFINED" p0="39" q0="32" node="8" p="39.003225505278593" q="32.004411068991274">
                 <iidm:alias>_04700f70-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0466c0a0-c766-11e1-8775-005056c00008" name="CapitlHl SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.00200000000001" targetDeadband="1" node="9" q="-20.292016013212855">
+            <iidm:shunt id="_0466c0a0-c766-11e1-8775-005056c00008" name="CapitlHl SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.00200000000001" targetDeadband="1" node="9" q="-20.288112699936089">
                 <iidm:alias>_045e8346-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_99931a87-ee15-4fd0-b251-9556df7fe598"/>
                 <iidm:shuntLinearModel bPerSection="0.0002296" gPerSection="0" maximumSectionCount="10"/>
@@ -5326,9 +5448,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="132.09781308739596" angle="13.241687809979085" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="132.08090703658914" angle="1.5071566578866309" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046efe03-c766-11e1-8775-005056c00008" name="Chemical LD" loadType="UNDEFINED" p0="71" q0="26" node="8" p="71.007736378656887" q="26.004721904948696">
+            <iidm:load id="_046efe03-c766-11e1-8775-005056c00008" name="Chemical LD" loadType="UNDEFINED" p0="71" q0="26" node="8" p="71.00768355177604" q="26.004689660856361">
                 <iidm:alias>_045d71d5-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5379,9 +5501,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.49329888178411" angle="9.5644948825921148" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.5395809096791" angle="-2.7326393669702123" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046a4319-c766-11e1-8775-005056c00008" name="JacksnRd LD" loadType="UNDEFINED" p0="19" q0="2" node="8" p="18.998328169524019" q="1.9997067050105062">
+            <iidm:load id="_046a4319-c766-11e1-8775-005056c00008" name="JacksnRd LD" loadType="UNDEFINED" p0="19" q0="2" node="8" p="18.998444487257107" q="1.9997271104749064">
                 <iidm:alias>_046c8d06-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5527,9 +5649,9 @@
                 <iidm:internalConnection node1="70" node2="15"/>
                 <iidm:internalConnection node1="71" node2="18"/>
                 <iidm:internalConnection node1="72" node2="21"/>
-                <iidm:bus v="130.61610411713366" angle="24.394759252546336" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
+                <iidm:bus v="130.60945092454634" angle="12.669947246034683" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0458ddf4-c766-11e1-8775-005056c00008" name="Saltvlle LD" loadType="UNDEFINED" p0="65" q0="10" node="23" p="65.001449794564465" q="10.000371744959857">
+            <iidm:load id="_0458ddf4-c766-11e1-8775-005056c00008" name="Saltvlle LD" loadType="UNDEFINED" p0="65" q0="10" node="23" p="65.001459349508195" q="10.000374194981978">
                 <iidm:alias>_045645e4-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5599,9 +5721,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="132.6516309877197" angle="16.106647410629812" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="132.79621793323221" angle="4.0504006384066571" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0476ed42-c766-11e1-8775-005056c00008" name="Trenton NegG LD" loadType="UNDEFINED" p0="13" q0="0" node="11" p="13.03879535147184" q="0">
+            <iidm:load id="_0476ed42-c766-11e1-8775-005056c00008" name="Trenton NegG LD" loadType="UNDEFINED" p0="13" q0="0" node="11" p="13.039177104283709" q="0">
                 <iidm:alias>_0471e432-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5671,9 +5793,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="128.30916619667556" angle="8.596544377759809" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="128.37182587588626" angle="-3.7458457906379707" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044a5f08-c766-11e1-8775-005056c00008" name="HickryCk LD" loadType="UNDEFINED" p0="39" q0="10" node="11" p="38.995001975997369" q="9.9978641835499005">
+            <iidm:load id="_044a5f08-c766-11e1-8775-005056c00008" name="HickryCk LD" loadType="UNDEFINED" p0="39" q0="10" node="11" p="38.995325619864914" q="9.9980024814607198">
                 <iidm:alias>_047d7cf3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5802,9 +5924,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="125.08105345532438" angle="-4.289143263126455" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="125.01047173516336" angle="-15.837790857134562" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:shunt id="_0450eeb7-c766-11e1-8775-005056c00008" name="EastLima SC" sectionCount="5" voltageRegulatorOn="true" targetV="131.565" targetDeadband="1" node="20" q="-22.45096235456348">
+            <iidm:shunt id="_0450eeb7-c766-11e1-8775-005056c00008" name="EastLima SC" sectionCount="5" voltageRegulatorOn="true" targetV="131.565" targetDeadband="1" node="20" q="-22.42563189234799">
                 <iidm:alias>_044aad27-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_6c36f421-303e-4932-93a9-5b0ff86cb7d4"/>
                 <iidm:shuntLinearModel bPerSection="0.00028699999999999998" gPerSection="0" maximumSectionCount="10"/>
@@ -5892,16 +6014,16 @@
                 <iidm:internalConnection node1="41" node2="7"/>
                 <iidm:internalConnection node1="42" node2="12"/>
                 <iidm:internalConnection node1="43" node2="11"/>
-                <iidm:bus v="218.90255112456433" angle="6.8197408521245766" nodes="0,1,2,3,8,9,10,13,17,18,21,22,23,24,25,26,31,32,33,34,35,39,40"/>
-                <iidm:bus v="237.93768351759377" angle="-4.9622578917122464" nodes="11,15,37,43"/>
-                <iidm:bus v="226.19467249571068" angle="6.8197408523165963" nodes="12,16,38,42"/>
-                <iidm:bus v="214.7002492515465" angle="-4.9622578917122446" nodes="4,5,6,7,14,19,20,27,28,29,30,36,41"/>
+                <iidm:bus v="218.90277535261492" angle="-4.86932183258868" nodes="0,1,2,3,8,9,10,13,17,18,21,22,23,24,25,26,31,32,33,34,35,39,40"/>
+                <iidm:bus v="237.93768528652117" angle="-16.648544437660714" nodes="11,15,37,43"/>
+                <iidm:bus v="226.19467427405681" angle="-4.8693218328962331" nodes="12,16,38,42"/>
+                <iidm:bus v="214.70025084771717" angle="-16.648544437660711" nodes="4,5,6,7,14,19,20,27,28,29,30,36,41"/>
             </iidm:nodeBreakerTopology>
-            <iidm:vscConverterStation id="_b46bfb8e-7af6-459e-acf3-53a42c943a7c" name="VSC2" voltageRegulatorOn="true" lossFactor="0.32362458" voltageSetpoint="218.47" reactivePowerSetpoint="0" node="42" p="-0" q="-27.490649968531955">
+            <iidm:vscConverterStation id="_b46bfb8e-7af6-459e-acf3-53a42c943a7c" name="VSC2" voltageRegulatorOn="true" lossFactor="0.32362458" voltageSetpoint="218.47" reactivePowerSetpoint="0" node="42" p="-0" q="-27.489811136731884">
                 <iidm:alias>_a168e701-bd48-4f66-8f0b-0f69b2545530</iidm:alias>
                 <iidm:minMaxReactiveLimits minQ="-1.7976931348623157e+308" maxQ="1.7976931348623157e+308"/>
             </iidm:vscConverterStation>
-            <iidm:vscConverterStation id="_b48ce7cf-abf5-413f-bc51-9e1d3103c9bd" name="VSC1" voltageRegulatorOn="true" lossFactor="0.32467531999999999" voltageSetpoint="213.53999999999999" reactivePowerSetpoint="0" node="43" p="-0" q="-92.151020935009527">
+            <iidm:vscConverterStation id="_b48ce7cf-abf5-413f-bc51-9e1d3103c9bd" name="VSC1" voltageRegulatorOn="true" lossFactor="0.32467531999999999" voltageSetpoint="213.53999999999999" reactivePowerSetpoint="0" node="43" p="-0" q="-92.151020935009612">
                 <iidm:alias>_071bb138-ff00-4874-8acc-a884aa5cf4a9</iidm:alias>
                 <iidm:minMaxReactiveLimits minQ="-1.7976931348623157e+308" maxQ="1.7976931348623157e+308"/>
             </iidm:vscConverterStation>
@@ -5969,7 +6091,7 @@
                 <iidm:internalConnection node1="29" node2="6"/>
                 <iidm:internalConnection node1="30" node2="9"/>
                 <iidm:internalConnection node1="31" node2="3"/>
-                <iidm:bus v="201.47859075969737" angle="-0.26195440007315862" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
+                <iidm:bus v="201.4278605101529" angle="-11.846233323942643" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_0448d867-c766-11e1-8775-005056c00008" name="EDO132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -6055,9 +6177,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="131.34000029275015" angle="4.4004300309642002" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="131.34000131192195" angle="-7.2879497970328835" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0472a789-c766-11e1-8775-005056c00008" name="W.Kammer SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="160" targetV="131.34" targetQ="0" node="14" p="-176.61136121242453" q="93.980780149033635">
+            <iidm:generator id="_0472a789-c766-11e1-8775-005056c00008" name="W.Kammer SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="160" targetV="131.34" targetQ="0" node="14" p="-176.57828732015835" q="93.977845270236855">
                 <iidm:alias>_04697fc0-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_17852426-f663-4add-9a2b-0a635d51f101"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b512ea0a-96d0-4a48-9de1-a5cf499bf0dd"/>
@@ -6206,16 +6328,16 @@
                 <iidm:internalConnection node1="71" node2="15"/>
                 <iidm:internalConnection node1="72" node2="18"/>
                 <iidm:internalConnection node1="73" node2="21"/>
-                <iidm:bus v="130.02000028283689" angle="-4.9622578917122446" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
+                <iidm:bus v="130.02000124945948" angle="-16.648544437660711" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04839777-c766-11e1-8775-005056c00008" name="Tidd SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="155" targetV="130.02000000000001" targetQ="0" node="24" p="-171.09225617453626" q="-95.062090393145183">
+            <iidm:generator id="_04839777-c766-11e1-8775-005056c00008" name="Tidd SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="155" targetV="130.02000000000001" targetQ="0" node="24" p="-171.06021584140339" q="-95.062585786001435">
                 <iidm:alias>_045fe2d8-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_d2a96d8d-65be-4fd6-a012-ceeeabd2bee6"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_29df1e0b-36ca-4536-97b4-6f98b84d49d8"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-90" maxQ="255"/>
             </iidm:generator>
-            <iidm:load id="_04798556-c766-11e1-8775-005056c00008" name="Tidd LD" loadType="UNDEFINED" p0="277" q0="113" node="23" p="277.00000090385106" q="113.0000006145317">
+            <iidm:load id="_04798556-c766-11e1-8775-005056c00008" name="Tidd LD" loadType="UNDEFINED" p0="277" q0="113" node="23" p="277.00000399285045" q="113.0000027147539">
                 <iidm:alias>_04502b62-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6245,13 +6367,13 @@
                 <iidm:internalConnection node1="10" node2="3"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="0"/>
-                <iidm:bus v="360.37742874538873" angle="0" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="360.28599576420385" angle="-11.584146450176304" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
             </iidm:nodeBreakerTopology>
             <iidm:lccConverterStation id="_9793118d-5ba1-4a9c-b2e0-db1d15be5913" name="Conv2" lossFactor="0" powerFactor="-0.75741000000000003" node="12" p="-10" q="8.6206896551724146">
                 <iidm:alias>_453bdc57-5855-4eb5-8712-d6a0255e0da8</iidm:alias>
             </iidm:lccConverterStation>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045c1248-c766-11e1-8775-005056c00008" name="38-37" r="0" x="6.5340005399999992" g="0" b="0" ratedU1="220" ratedU2="132" node1="30" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="173.82114999883541" q1="89.416750934377802" p2="-173.82114999883535" q2="-74.481606517255699">
+        <iidm:twoWindingsTransformer id="_045c1248-c766-11e1-8775-005056c00008" name="38-37" r="0" x="6.5340005399999992" g="0" b="0" ratedU1="220" ratedU2="132" node1="30" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="172.14515974960878" q1="90.03553568805134" p2="-172.14515974960872" q2="-75.276201258254076">
             <iidm:alias>_0453d4e8-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0477d7aa-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_047df228-c766-11e1-8775-005056c00008</iidm:alias>
@@ -6275,7 +6397,7 @@
                 <iidm:temporaryLimit name="_c97df399-5a91-4c8b-b72c-496cade334b5" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_0485ba57-c766-11e1-8775-005056c00008" name="64-61" r="0" x="4.669632" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="158.31430870404913" q1="60.50026265535525" p2="-158.31430870404918" q2="-52.956441325970808">
+        <iidm:twoWindingsTransformer id="_0485ba57-c766-11e1-8775-005056c00008" name="64-61" r="0" x="4.669632" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="158.26981397915583" q1="60.502309224910611" p2="-158.26981397915588" q2="-52.962137851757994">
             <iidm:alias>_04549831-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0472ce92-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0489d905-c766-11e1-8775-005056c00008</iidm:alias>
@@ -6301,7 +6423,7 @@
                 <iidm:temporaryLimit name="_f6b1a81c-eda7-4a08-b290-bd29a5ed9fa4" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_044cd007-c766-11e1-8775-005056c00008" name="63-59" r="0" x="6.7256646120000001" g="0" b="0" ratedU1="220" ratedU2="132" node1="41" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="73" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-2.3592239273284576e-14" q1="83.151382148112901" p2="3.8857805861880479e-14" q2="-80.568830583985502">
+        <iidm:twoWindingsTransformer id="_044cd007-c766-11e1-8775-005056c00008" name="63-59" r="0" x="6.7256646120000001" g="0" b="0" ratedU1="220" ratedU2="132" node1="41" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="73" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="0" q1="83.151383384476816" p2="7.2164496600635175e-14" q2="-80.568831781949939">
             <iidm:alias>_044e7db4-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_046eafe5-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0488797a-c766-11e1-8775-005056c00008</iidm:alias>
@@ -6347,7 +6469,7 @@
                 <iidm:temporaryLimit name="_f2daef4d-6f1a-44d1-9c9b-228acff12575" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_ffd940c8-03c8-4dcf-ad46-62018a0d813d" name="PowTrans2" r="0.3932500000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_04f97116-552a-4a34-afd9-4862f62ac7aa" node2="31" voltageLevelId2="_04742e21-c766-11e1-8775-005056c00008" p1="9.9999999864188194" q1="-8.6206896434647433" p2="-9.9982984534452211" q2="8.6992219345547603">
+        <iidm:twoWindingsTransformer id="_ffd940c8-03c8-4dcf-ad46-62018a0d813d" name="PowTrans2" r="0.3932500000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_04f97116-552a-4a34-afd9-4862f62ac7aa" node2="31" voltageLevelId2="_04742e21-c766-11e1-8775-005056c00008" p1="10.000000123449023" q1="-8.6206895568381157" p2="-9.9982977267273743" q2="8.6992617132238497">
             <iidm:alias>_04479fea-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_c089eb25-9f67-4d82-88a8-635dd4808bae</iidm:alias>
             <iidm:alias>_ea8cd467-31f0-40dc-95d7-4064463724c4</iidm:alias>
@@ -6414,9 +6536,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="124.78747204697984" angle="-8.1276176544228314" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.78725715593262" angle="-19.810392207569375" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0481c2b3-c766-11e1-8775-005056c00008" name="Wooster LD" loadType="UNDEFINED" p0="23" q0="11" node="8" p="22.999937876078366" q="10.999950480976615">
+            <iidm:load id="_0481c2b3-c766-11e1-8775-005056c00008" name="Wooster LD" loadType="UNDEFINED" p0="23" q0="11" node="8" p="22.99993532937107" q="10.99994845099627">
                 <iidm:alias>_04614268-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6486,9 +6608,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="125.56936425648473" angle="-7.8921559560956993" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="125.56932428881906" angle="-19.575782957599472" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044974a8-c766-11e1-8775-005056c00008" name="Wagenhls LD" loadType="UNDEFINED" p0="63" q0="22" node="11" p="62.999970775493011" q="21.999982991030308">
+            <iidm:load id="_044974a8-c766-11e1-8775-005056c00008" name="Wagenhls LD" loadType="UNDEFINED" p0="63" q0="22" node="11" p="62.999970042002154" q="21.999982564131003">
                 <iidm:alias>_048481d4-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6539,9 +6661,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.09904468903038" angle="7.5454058653634313" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.16100929028566" angle="-4.5141725015300276" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047fedf2-c766-11e1-8775-005056c00008" name="Concord LD" loadType="UNDEFINED" p0="34" q0="16" node="8" p="33.980252186691324" q="15.984514517830201">
+            <iidm:load id="_047fedf2-c766-11e1-8775-005056c00008" name="Concord LD" loadType="UNDEFINED" p0="34" q0="16" node="8" p="33.981154120258815" q="15.985221649023146">
                 <iidm:alias>_046d9e75-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6649,9 +6771,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="127.70242551417901" angle="11.490414131913663" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="127.84787305083135" angle="-0.28314582139849936" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045f94ba-c766-11e1-8775-005056c00008" name="Delaware LD" loadType="UNDEFINED" p0="59" q0="23" node="17" p="59.045385258254399" q="23.029495157554308">
+            <iidm:load id="_045f94ba-c766-11e1-8775-005056c00008" name="Delaware LD" loadType="UNDEFINED" p0="59" q0="23" node="17" p="59.04927896604665" q="23.032026320529432">
                 <iidm:alias>_0463654a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6759,9 +6881,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="124.73876800575104" angle="5.0547749222870362" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="124.68705485535101" angle="-6.2647662917605844" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04697fc9-c766-11e1-8775-005056c00008" name="FtWayne LD" loadType="UNDEFINED" p0="90" q0="30" node="17" p="89.840438675061748" q="29.911407216257953">
+            <iidm:load id="_04697fc9-c766-11e1-8775-005056c00008" name="FtWayne LD" loadType="UNDEFINED" p0="90" q0="30" node="17" p="89.843126072656645" q="29.912898464640513">
                 <iidm:alias>_044d1e25-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6812,9 +6934,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.01389865027514" angle="-5.8858450127623394" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.01363133544817" angle="-17.568017291265075" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0474f170-c766-11e1-8775-005056c00008" name="WNwPhil1 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="11.999964852878696" q="2.9999853553804208">
+            <iidm:load id="_0474f170-c766-11e1-8775-005056c00008" name="WNwPhil1 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="11.999963218663149" q="2.9999846744586374">
                 <iidm:alias>_0466c0a7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6885,12 +7007,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="129.64729683518735" angle="15.456086679446468" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="129.54302468863085" angle="3.7252341437258432" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044a5f05-c766-11e1-8775-005056c00008" name="Logan LD" loadType="UNDEFINED" p0="54" q0="27" node="11" p="54.004443536095778" q="27.003703048314552">
+            <iidm:load id="_044a5f05-c766-11e1-8775-005056c00008" name="Logan LD" loadType="UNDEFINED" p0="54" q0="27" node="11" p="54.004333719942032" q="27.003611529894904">
                 <iidm:alias>_04767811-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0475dbd6-c766-11e1-8775-005056c00008" name="Logan SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.41900000000001" targetDeadband="1" node="12" q="-19.296067970018516">
+            <iidm:shunt id="_0475dbd6-c766-11e1-8775-005056c00008" name="Logan SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.41900000000001" targetDeadband="1" node="12" q="-19.265041741810148">
                 <iidm:alias>_04577e67-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_a7768441-642e-48a2-b4a8-0ae06bebf676"/>
                 <iidm:shuntLinearModel bPerSection="0.0002296" gPerSection="0" maximumSectionCount="10"/>
@@ -6964,19 +7086,19 @@
                 <iidm:internalConnection node1="32" node2="3"/>
                 <iidm:internalConnection node1="33" node2="6"/>
                 <iidm:internalConnection node1="34" node2="9"/>
-                <iidm:bus v="132.6600001486789" angle="-1.7636654550788025" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34"/>
+                <iidm:bus v="132.6600009126729" angle="-13.437515174597223" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04633e31-c766-11e1-8775-005056c00008" name="W.Lancst SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="19" targetV="132.66" targetQ="0" node="13" p="-20.972599143975412" q="1.11123270836861">
+            <iidm:generator id="_04633e31-c766-11e1-8775-005056c00008" name="W.Lancst SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="19" targetV="132.66" targetQ="0" node="13" p="-20.968671619268804" q="1.1247084521563815">
                 <iidm:alias>_047bcf42-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_83fae784-1da1-4055-8108-ba978276d1b6"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_5f711f63-f631-45d3-b26c-33821ab2ee56"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-15" maxQ="45"/>
             </iidm:generator>
-            <iidm:load id="_048a9c51-c766-11e1-8775-005056c00008" name="W.Lancst LD" loadType="UNDEFINED" p0="28" q0="10" node="11" p="28.000000047071577" q="10.000000028018794">
+            <iidm:load id="_048a9c51-c766-11e1-8775-005056c00008" name="W.Lancst LD" loadType="UNDEFINED" p0="28" q0="10" node="11" p="28.000000288951178" q="10.000000171994747">
                 <iidm:alias>_044e7db6-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_045b00d9-c766-11e1-8775-005056c00008" name="W.Lancst SC" sectionCount="5" voltageRegulatorOn="true" targetV="132.66" targetDeadband="1" node="12" q="-10.101639817042855">
+            <iidm:shunt id="_045b00d9-c766-11e1-8775-005056c00008" name="W.Lancst SC" sectionCount="5" voltageRegulatorOn="true" targetV="132.66" targetDeadband="1" node="12" q="-10.101639933394317">
                 <iidm:alias>_04758db6-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_be267a3c-f7a7-4bdf-bb17-71b773247fbf"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -7086,9 +7208,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="130.25855442684377" angle="10.448031662011473" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="130.27730422615991" angle="-1.3631672401721144" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045dbff2-c766-11e1-8775-005056c00008" name="Portsmth LD" loadType="UNDEFINED" p0="66" q0="20" node="17" p="66.073556621355294" q="20.037163608139814">
+            <iidm:load id="_045dbff2-c766-11e1-8775-005056c00008" name="Portsmth LD" loadType="UNDEFINED" p0="66" q0="20" node="17" p="66.074134544499913" q="20.037455706193246">
                 <iidm:alias>_0454bf45-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7159,16 +7281,16 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="127.64399964608276" angle="9.1486871520778088" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="127.64399983912573" angle="-2.4137533903380128" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04856c34-c766-11e1-8775-005056c00008" name="DeerCrk SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="7" targetV="127.64400000000001" targetQ="0" node="12" p="-7.7267470530435727" q="-38.874373633948544">
+            <iidm:generator id="_04856c34-c766-11e1-8775-005056c00008" name="DeerCrk SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="7" targetV="127.64400000000001" targetQ="0" node="12" p="-7.7253000702569281" q="-36.252353220636891">
                 <iidm:alias>_0477d7a5-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e5a479a8-ab8d-4a54-bb52-376874ae2784"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b55d80d5-720f-46f9-897f-ff8c5eaf8b44"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-15" maxQ="45"/>
             </iidm:generator>
-            <iidm:load id="_04791028-c766-11e1-8775-005056c00008" name="DeerCrk LD" loadType="UNDEFINED" p0="43" q0="27" node="11" p="42.999999821161488" q="26.999999812843424">
+            <iidm:load id="_04791028-c766-11e1-8775-005056c00008" name="DeerCrk LD" loadType="UNDEFINED" p0="43" q0="27" node="11" p="42.999999918708355" q="26.999999914927347">
                 <iidm:alias>_04486337-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7219,9 +7341,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.06568902860073" angle="11.298428207573522" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.24529660604648" angle="-0.52803834806034355" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0462c904-c766-11e1-8775-005056c00008" name="Medford LD" loadType="UNDEFINED" p0="22" q0="7" node="8" p="22.013448363269699" q="7.0071331608746039">
+            <iidm:load id="_0462c904-c766-11e1-8775-005056c00008" name="Medford LD" loadType="UNDEFINED" p0="22" q0="7" node="8" p="22.014842247392934" q="7.007872658661757">
                 <iidm:alias>_0489b1f7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7310,9 +7432,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="133.45558148115711" angle="18.036792692532821" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="133.59122409470538" angle="5.9201282631204082" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046205b5-c766-11e1-8775-005056c00008" name="CollCrnr LD" loadType="UNDEFINED" p0="7" q0="3" node="14" p="7.0282096794371904" q="3.0201768264741986">
+            <iidm:load id="_046205b5-c766-11e1-8775-005056c00008" name="CollCrnr LD" loadType="UNDEFINED" p0="7" q0="3" node="14" p="7.0281964295901913" q="3.0201673368939841">
                 <iidm:alias>_04486334-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7363,9 +7485,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.9469750659658" angle="16.574908405124805" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.91290552074673" angle="4.8446937473621192" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0483be82-c766-11e1-8775-005056c00008" name="Caldwell LD" loadType="UNDEFINED" p0="42" q0="31" node="8" p="42.001913748459572" q="31.002354250131635">
+            <iidm:load id="_0483be82-c766-11e1-8775-005056c00008" name="Caldwell LD" loadType="UNDEFINED" p0="42" q0="31" node="8" p="42.001892957404699" q="31.002328673061264">
                 <iidm:alias>_045841b9-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7416,9 +7538,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.33104079112478" angle="9.0226321166758261" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.33101441528922" angle="-2.7097800685288664" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045f94b4-c766-11e1-8775-005056c00008" name="Franklin LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="7.9999903966481991" q="2.9999939979075254">
+            <iidm:load id="_045f94b4-c766-11e1-8775-005056c00008" name="Franklin LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="7.9999904850742585" q="2.9999940531737685">
                 <iidm:alias>_047da403-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7469,9 +7591,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="124.29664730105428" angle="5.8170393745694744" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.23341315659503" angle="-5.3467305177076438" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045f6da2-c766-11e1-8775-005056c00008" name="McKinley LD" loadType="UNDEFINED" p0="60" q0="34" node="8" p="59.876373963704985" q="33.883322285866214">
+            <iidm:load id="_045f6da2-c766-11e1-8775-005056c00008" name="McKinley LD" loadType="UNDEFINED" p0="60" q0="34" node="8" p="59.87864501658261" q="33.885464248947052">
                 <iidm:alias>_0465d641-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7618,19 +7740,19 @@
                 <iidm:internalConnection node1="71" node2="18"/>
                 <iidm:internalConnection node1="72" node2="21"/>
                 <iidm:internalConnection node1="73" node2="12"/>
-                <iidm:bus v="130.68000852387331" angle="9.0211730476653251" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
+                <iidm:bus v="130.68000798142123" angle="-3.1786378482783468" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_044ca8f0-c766-11e1-8775-005056c00008" name="TwinBrch SM" energySource="THERMAL" minP="50" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="85" targetV="130.68000799999999" targetQ="0" node="24" p="-93.824785644100515" q="-96.594631554409176">
+            <iidm:generator id="_044ca8f0-c766-11e1-8775-005056c00008" name="TwinBrch SM" energySource="THERMAL" minP="50" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="85" targetV="130.68000799999999" targetQ="0" node="24" p="-93.80721513883411" q="-92.459661059054525">
                 <iidm:alias>_04633e38-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_0f6ab5a4-6b72-42f4-92bc-1993e1ae58a3"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_668eb671-5c36-4351-a95d-53ca850581db"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-60" maxQ="170"/>
             </iidm:generator>
-            <iidm:load id="_048740f1-c766-11e1-8775-005056c00008" name="TwinBrch LD" loadType="UNDEFINED" p0="47" q0="10" node="23" p="47.000000282622182" q="10.000000100220632">
+            <iidm:load id="_048740f1-c766-11e1-8775-005056c00008" name="TwinBrch LD" loadType="UNDEFINED" p0="47" q0="10" node="23" p="46.999999989977027" q="9.9999999964457551">
                 <iidm:alias>_044ecbda-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:danglingLine id="_045338a1-c766-11e1-8775-005056c00008" name="12-117" p0="20" q0="8" r="5.7324960000000003" x="24.393599999999999" g="0" b="0.00020546369999999999" ucteXnodeCode="XMO_TE32" node="73" p="20.161793777909047" q="5.1797255646229869">
+            <iidm:danglingLine id="_045338a1-c766-11e1-8775-005056c00008" name="12-117" p0="20" q0="8" r="5.7324960000000003" x="24.393599999999999" g="0" b="0.00020546369999999999" ucteXnodeCode="XMO_TE32" node="73" p="20.161793610253152" q="5.1797255223058327">
                 <iidm:alias>_044afb42-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_0457f391-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_5631f3d0-d9d2-11e2-bb49-005056c00008</iidm:alias>
@@ -7728,9 +7850,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="123.39565959348926" angle="3.8428825880667734" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="123.33446874619128" angle="-7.4307676762912163" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0479fa87-c766-11e1-8775-005056c00008" name="Lincoln LD" loadType="UNDEFINED" p0="45" q0="25" node="14" p="44.892098050469507" q="24.900170663570055">
+            <iidm:load id="_0479fa87-c766-11e1-8775-005056c00008" name="Lincoln LD" loadType="UNDEFINED" p0="45" q0="25" node="14" p="44.891304835934633" q="24.899437384521754">
                 <iidm:alias>_047fc6e2-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7781,9 +7903,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="134.64754966316477" angle="15.763502245220213" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="134.64758539438176" angle="4.0323044120543194" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044c81e4-c766-11e1-8775-005056c00008" name="Hinton NegG LD" loadType="UNDEFINED" p0="42" q0="0" node="8" p="42.000148484811" q="0">
+            <iidm:load id="_044c81e4-c766-11e1-8775-005056c00008" name="Hinton NegG LD" loadType="UNDEFINED" p0="42" q0="0" node="8" p="42.000151110367831" q="0">
                 <iidm:alias>_04494d96-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7834,9 +7956,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.12071779055648" angle="8.3473519096330921" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.1011371822691" angle="-3.493494422431743" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_048bfbe0-c766-11e1-8775-005056c00008" name="N. E. LD" loadType="UNDEFINED" p0="25" q0="10" node="8" p="24.98945768249807" q="9.9929727762935272">
+            <iidm:load id="_048bfbe0-c766-11e1-8775-005056c00008" name="N. E. LD" loadType="UNDEFINED" p0="25" q0="10" node="8" p="24.990073718497118" q="9.9933833548684063">
                 <iidm:alias>_0480b140-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7887,9 +8009,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.13735230442479" angle="-6.8092139987404998" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.13693152932467" angle="-18.491138462901663" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04854525-c766-11e1-8775-005056c00008" name="SCoshoct LD" loadType="UNDEFINED" p0="18" q0="5" node="8" p="17.999908680681536" q="4.9999577226092438">
+            <iidm:load id="_04854525-c766-11e1-8775-005056c00008" name="SCoshoct LD" loadType="UNDEFINED" p0="18" q0="5" node="8" p="17.999904657408564" q="4.9999558599893064">
                 <iidm:alias>_04747c42-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7940,9 +8062,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="125.22623708933112" angle="8.7000106636617378" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="125.22074025148564" angle="-3.0604328917108101" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044aad24-c766-11e1-8775-005056c00008" name="WHuntngd LD" loadType="UNDEFINED" p0="33" q0="15" node="8" p="33.018690692039115" q="15.014162288275642">
+            <iidm:load id="_044aad24-c766-11e1-8775-005056c00008" name="WHuntngd LD" loadType="UNDEFINED" p0="33" q0="15" node="8" p="33.018730492338264" q="15.014192451413452">
                 <iidm:alias>_04784cd2-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7974,9 +8096,9 @@
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="3"/>
-                <iidm:bus v="129.36000095445269" angle="9.9257847834402231" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="129.36000257629306" angle="-1.807196281847427" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0452ea80-c766-11e1-8775-005056c00008" name="DanRiver SM" energySource="THERMAL" minP="20" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="36" targetV="129.36000000000001" targetQ="0" node="5" p="-39.737556272795516" q="-20.309733268994858">
+            <iidm:generator id="_0452ea80-c766-11e1-8775-005056c00008" name="DanRiver SM" energySource="THERMAL" minP="20" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="36" targetV="129.36000000000001" targetQ="0" node="5" p="-39.730114647035627" q="-20.311892369015947">
                 <iidm:alias>_046a4316-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_fec62959-21c5-4921-90b2-7c85e9f3bfab"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_9db08c95-4586-4a2b-87e3-5a17c944b43a"/>
@@ -8049,9 +8171,9 @@
                 <iidm:internalConnection node1="29" node2="3"/>
                 <iidm:internalConnection node1="30" node2="9"/>
                 <iidm:internalConnection node1="31" node2="6"/>
-                <iidm:bus v="130.55660234694056" angle="10.68294114865987" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
+                <iidm:bus v="130.59010541875753" angle="-1.1491352128781747" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
             </iidm:nodeBreakerTopology>
-            <iidm:danglingLine id="_044ef2e7-c766-11e1-8775-005056c00008" name="71-73" p0="6" q0="0" r="1.508918" x="7.9104960000000002" g="0" b="6.76079e-05" ucteXnodeCode="XMO_TE31" node="31" p="6.0031903250409036" q="-1.135653113064949">
+            <iidm:danglingLine id="_044ef2e7-c766-11e1-8775-005056c00008" name="71-73" p0="6" q0="0" r="1.508918" x="7.9104960000000002" g="0" b="6.76079e-05" ucteXnodeCode="XMO_TE31" node="31" p="6.0031888280047978" q="-1.1362532466654913">
                 <iidm:alias>_04670ec2-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_046b2d7a-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_26a070b9-db0c-47cd-9991-0a461576aec2</iidm:alias>
@@ -8111,9 +8233,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="134.29684065161189" angle="2.9370984075310358" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="134.29678301229026" angle="-8.7496042945102008" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0453add4-c766-11e1-8775-005056c00008" name="Summerfl LD" loadType="UNDEFINED" p0="28" q0="7" node="8" p="27.999923227048807" q="6.9999680112995719">
+            <iidm:load id="_0453add4-c766-11e1-8775-005056c00008" name="Summerfl LD" loadType="UNDEFINED" p0="28" q0="7" node="8" p="27.999922575798408" q="6.9999677399457365">
                 <iidm:alias>_04851e16-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8240,9 +8362,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="132.66000112090276" angle="31.032726966680283" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="132.66000284936985" angle="19.311335357753492" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0489b1fa-c766-11e1-8775-005056c00008" name="ClinchRv SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="607" targetV="132.66" targetQ="0" node="20" p="-670.01935159963557" q="-45.698709494902268">
+            <iidm:generator id="_0489b1fa-c766-11e1-8775-005056c00008" name="ClinchRv SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="607" targetV="132.66" targetQ="0" node="20" p="-669.89387752085076" q="-48.747997007288149">
                 <iidm:alias>_04840caa-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_2621b09a-22e3-4630-b3bd-32c102e36741"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b0d662e5-64c9-4d59-b8e0-9b1ed175769b"/>
@@ -8297,9 +8419,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.45979757079638" angle="8.1016087578638363" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.47767689778985" angle="-4.1400964036518779" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0485e168-c766-11e1-8775-005056c00008" name="Pokagon LD" loadType="UNDEFINED" p0="20" q0="9" node="8" p="19.999228667448417" q="8.999421508023266">
+            <iidm:load id="_0485e168-c766-11e1-8775-005056c00008" name="Pokagon LD" loadType="UNDEFINED" p0="20" q0="9" node="8" p="19.99927850986758" q="8.9994588889075597">
                 <iidm:alias>_0462c902-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8350,9 +8472,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.89764621184656" angle="7.544203743316082" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.90688566293528" angle="-4.4291929548946731" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04812679-c766-11e1-8775-005056c00008" name="GoshenJt LD" loadType="UNDEFINED" p0="14" q0="1" node="8" p="13.993190889084234" q="0.99918952298195929">
+            <iidm:load id="_04812679-c766-11e1-8775-005056c00008" name="GoshenJt LD" loadType="UNDEFINED" p0="14" q0="1" node="8" p="13.993434149925351" q="0.99921847338293324">
                 <iidm:alias>_045b9d17-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8403,9 +8525,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="117.82785922574946" angle="-11.050711385245055" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="117.77184395410436" angle="-22.650261985005056" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0489b1f2-c766-11e1-8775-005056c00008" name="S.Tiffin LD" loadType="UNDEFINED" p0="37" q0="10" node="8" p="36.965684111508992" q="9.9845471718167733">
+            <iidm:load id="_0489b1f2-c766-11e1-8775-005056c00008" name="S.Tiffin LD" loadType="UNDEFINED" p0="37" q0="10" node="8" p="36.964997745472552" q="9.9842381910319542">
                 <iidm:alias>_046476b8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8456,9 +8578,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="123.20174481103504" angle="-0.2373791834009347" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="123.11822072388985" angle="-11.664997814533242" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045cfca7-c766-11e1-8775-005056c00008" name="Haviland LD" loadType="UNDEFINED" p0="23" q0="9" node="8" p="22.96551782108445" q="8.9775228626999652">
+            <iidm:load id="_045cfca7-c766-11e1-8775-005056c00008" name="Haviland LD" loadType="UNDEFINED" p0="23" q0="9" node="8" p="22.965409329575099" q="8.9774521782155539">
                 <iidm:alias>_0482ad17-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8528,9 +8650,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="131.00675552624384" angle="3.0475123015684833" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="131.00679866314402" angle="-8.6406259853593763" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04555b82-c766-11e1-8775-005056c00008" name="SWKammer LD" loadType="UNDEFINED" p0="78" q0="3" node="11" p="77.999813940106804" q="2.9999880730932524">
+            <iidm:load id="_04555b82-c766-11e1-8775-005056c00008" name="SWKammer LD" loadType="UNDEFINED" p0="78" q0="3" node="11" p="77.999817643304709" q="2.9999883104773599">
                 <iidm:alias>_0474ca6b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8638,9 +8760,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="130.42319773048317" angle="15.869857063341767" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="130.37532638994028" angle="4.1391436831681121" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04817492-c766-11e1-8775-005056c00008" name="Baileysv LD" loadType="UNDEFINED" p0="38" q0="15" node="17" p="38.002016417425118" q="15.001326613875682">
+            <iidm:load id="_04817492-c766-11e1-8775-005056c00008" name="Baileysv LD" loadType="UNDEFINED" p0="38" q0="15" node="17" p="38.001988699842912" q="15.001308377983591">
                 <iidm:alias>_0474f17b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8691,9 +8813,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.0519279864462" angle="24.25301120791735" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.04820400887635" angle="12.529696059158695" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0461b790-c766-11e1-8775-005056c00008" name="HolstonT NegG LD" loadType="UNDEFINED" p0="10" q0="0" node="8" p="10.00013348764876" q="0">
+            <iidm:load id="_0461b790-c766-11e1-8775-005056c00008" name="HolstonT NegG LD" loadType="UNDEFINED" p0="10" q0="0" node="8" p="10.000134501472827" q="0">
                 <iidm:alias>_0464ebe7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8744,9 +8866,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.11068976027582" angle="11.285038841360421" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.2853764973223" angle="-0.53360851552366584" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044c81e5-c766-11e1-8775-005056c00008" name="WMedford LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="8.0050788278494736" q="3.003174939090119">
+            <iidm:load id="_044c81e5-c766-11e1-8775-005056c00008" name="WMedford LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="8.0055891600045754" q="3.0034940384477848">
                 <iidm:alias>_04570939-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8836,12 +8958,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="124.4118856382678" angle="-4.5896992765639615" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="124.33853334643032" angle="-16.132089526581805" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04854520-c766-11e1-8775-005056c00008" name="Rockhill LD" loadType="UNDEFINED" p0="59" q0="26" node="14" p="58.935562146696874" q="25.952689994951182">
+            <iidm:load id="_04854520-c766-11e1-8775-005056c00008" name="Rockhill LD" loadType="UNDEFINED" p0="59" q0="26" node="14" p="58.934216502064452" q="25.95170239564435">
                 <iidm:alias>_0461b799-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0460cd38-c766-11e1-8775-005056c00008" name="Rockhill SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.81399999999999" targetDeadband="1" node="15" q="-12.42908878231975">
+            <iidm:shunt id="_0460cd38-c766-11e1-8775-005056c00008" name="Rockhill SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.81399999999999" targetDeadband="1" node="15" q="-12.414436912417317">
                 <iidm:alias>_048b86b4-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_069d84c6-bd26-4c26-ac6c-e801a0202a00"/>
                 <iidm:shuntLinearModel bPerSection="0.0001606" gPerSection="0" maximumSectionCount="10"/>
@@ -8914,12 +9036,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="128.7425013002717" angle="17.167179393064739" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="128.56609991503097" angle="5.4404003646455266" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047a48a5-c766-11e1-8775-005056c00008" name="Sprigg LD" loadType="UNDEFINED" p0="20" q0="10" node="11" p="20.001609856361309" q="10.001341582962397">
+            <iidm:load id="_047a48a5-c766-11e1-8775-005056c00008" name="Sprigg LD" loadType="UNDEFINED" p0="20" q0="10" node="11" p="20.001545273320193" q="10.001287760931397">
                 <iidm:alias>_0472ce97-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_04553478-c766-11e1-8775-005056c00008" name="Sprigg SC" sectionCount="5" voltageRegulatorOn="true" targetV="129.935" targetDeadband="1" node="12" q="-9.5138385619629648">
+            <iidm:shunt id="_04553478-c766-11e1-8775-005056c00008" name="Sprigg SC" sectionCount="5" voltageRegulatorOn="true" targetV="129.935" targetDeadband="1" node="12" q="-9.4877849351856334">
                 <iidm:alias>_045bc428-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_f4cdc674-4a66-4ab8-8d4f-552cb066e259"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -9011,12 +9133,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="118.27663263955904" angle="-10.128076050126012" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="118.2143130764921" angle="-21.716662558250093" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04819ba4-c766-11e1-8775-005056c00008" name="West End NegG LD" loadType="UNDEFINED" p0="46" q0="0" node="14" p="45.954844293584713" q="0">
+            <iidm:load id="_04819ba4-c766-11e1-8775-005056c00008" name="West End NegG LD" loadType="UNDEFINED" p0="46" q0="0" node="14" p="45.95387455898495" q="0">
                 <iidm:alias>_04627ae0-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_04555b89-c766-11e1-8775-005056c00008" name="West End LD" loadType="UNDEFINED" p0="20" q0="23" node="15" p="19.980367084167266" q="22.962382559027695">
+            <iidm:load id="_04555b89-c766-11e1-8775-005056c00008" name="West End LD" loadType="UNDEFINED" p0="20" q0="23" node="15" p="19.97994546042824" q="22.96157498148159">
                 <iidm:alias>_04592c18-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9067,9 +9189,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.83373622354222" angle="9.546895760059531" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.82696589250631" angle="-1.5996317114683365" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046d0232-c766-11e1-8775-005056c00008" name="Deer Crk NegG LD" loadType="UNDEFINED" p0="6" q0="0" node="8" p="5.9935610949443667" q="0">
+            <iidm:load id="_046d0232-c766-11e1-8775-005056c00008" name="Deer Crk NegG LD" loadType="UNDEFINED" p0="6" q0="0" node="8" p="5.9941458101556648" q="0">
                 <iidm:alias>_0480150a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9139,9 +9261,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="133.90834278073075" angle="0.63964312099880249" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="133.91234133382676" angle="-11.0448399459341" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046c3ee3-c766-11e1-8775-005056c00008" name="Crooksvl LD" loadType="UNDEFINED" p0="34" q0="0" node="11" p="33.998482957719602" q="0">
+            <iidm:load id="_046c3ee3-c766-11e1-8775-005056c00008" name="Crooksvl LD" loadType="UNDEFINED" p0="34" q0="0" node="11" p="33.998571960715587" q="0">
                 <iidm:alias>_047e4047-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9192,9 +9314,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="132.05232472268438" angle="-2.6231687624274307" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="132.05208805476155" angle="-14.303604073667673" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046dc585-c766-11e1-8775-005056c00008" name="WCambrdg LD" loadType="UNDEFINED" p0="17" q0="4" node="8" p="16.999957409603812" q="3.9999832978977952">
+            <iidm:load id="_046dc585-c766-11e1-8775-005056c00008" name="WCambrdg LD" loadType="UNDEFINED" p0="17" q0="4" node="8" p="16.999955433121823" q="3.999982522808144">
                 <iidm:alias>_045dbff8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9283,9 +9405,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="130.18340737613195" angle="9.594214644731025" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="130.24375840206378" angle="-2.6790541967433326" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_048b5fa5-c766-11e1-8775-005056c00008" name="SouthBnd LD" loadType="UNDEFINED" p0="70" q0="23" node="14" p="69.987764369168133" q="22.993299925906371">
+            <iidm:load id="_048b5fa5-c766-11e1-8775-005056c00008" name="SouthBnd LD" loadType="UNDEFINED" p0="70" q0="23" node="14" p="69.988534504845944" q="22.993721619272705">
                 <iidm:alias>_04522734-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9335,11 +9457,11 @@
                 <iidm:internalConnection node1="19" node2="6"/>
                 <iidm:internalConnection node1="20" node2="3"/>
                 <iidm:internalConnection node1="21" node2="6"/>
-                <iidm:bus v="227.66764830108508" angle="26.755267788777097" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
+                <iidm:bus v="227.92161962245493" angle="13.9534988512036" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:line id="_044cd006-c766-11e1-8775-005056c00008" name="31-32" r="5.1923519999999996" x="17.16264" g1="0" b1="7.20271e-05" g2="0" b2="7.20271e-05" node1="31" voltageLevelId1="_04636548-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="-35.45331909945709" q1="9.911054583031861" p2="35.893044292573542" q2="-10.805748798711971">
+    <iidm:line id="_044cd006-c766-11e1-8775-005056c00008" name="31-32" r="5.1923519999999996" x="17.16264" g1="0" b1="7.20271e-05" g2="0" b2="7.20271e-05" node1="31" voltageLevelId1="_04636548-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="-32.62390803495439" q1="7.8375096610893245" p2="32.988968970018703" q2="-8.9816740007199325">
         <iidm:alias>_04682030-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0471bd25-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9347,7 +9469,7 @@
             <iidm:temporaryLimit name="_de6da3cb-8cb5-4900-9c33-8ad45632b535" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045a3d89-c766-11e1-8775-005056c00008" name="2-12" r="3.2582879999999999" x="10.7331839" g1="0" b1="4.5110200000000001e-05" g2="0" b2="4.5110200000000001e-05" node1="21" voltageLevelId1="_045d4ac5-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-30.312872747932314" q1="-17.913381056164255" p2="30.552505576631233" q2="17.187996062652829">
+    <iidm:line id="_045a3d89-c766-11e1-8775-005056c00008" name="2-12" r="3.2582879999999999" x="10.7331839" g1="0" b1="4.5110200000000001e-05" g2="0" b2="4.5110200000000001e-05" node1="21" voltageLevelId1="_045d4ac5-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-31.299505522530275" q1="-17.384946444409934" p2="31.547542979799253" q2="16.687040061970588">
         <iidm:alias>_046adf51-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046fe868-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9355,7 +9477,7 @@
             <iidm:temporaryLimit name="_6bd63dd1-1344-4183-b7bd-af326919f4eb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04513cd7-c766-11e1-8775-005056c00008" name="32-114" r="2.3522400000000001" x="10.6634884" g1="0" b1="4.6717149999999997e-05" g2="0" b2="4.6717149999999997e-05" node1="49" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04791027-c766-11e1-8775-005056c00008" p1="6.6959269234206031" q1="4.8573100071861122" p2="-6.6849055334191281" q2="-6.324020370818328">
+    <iidm:line id="_04513cd7-c766-11e1-8775-005056c00008" name="32-114" r="2.3522400000000001" x="10.6634884" g1="0" b1="4.6717149999999997e-05" g2="0" b2="4.6717149999999997e-05" node1="49" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04791027-c766-11e1-8775-005056c00008" p1="7.783142620403531" q1="4.2780615432463076" p2="-7.7707668876751663" q2="-5.742444749243095">
         <iidm:alias>_046d0237-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0470d2c7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9363,7 +9485,7 @@
             <iidm:temporaryLimit name="_5f05650a-c63d-46e5-a426-2db4f036929f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045d71d4-c766-11e1-8775-005056c00008" name="24-72" r="8.5029120000000002" x="34.151040000000002" g1="0" b1="0.00014003675" g2="0" b2="0.00014003675" node1="30" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="30.729196475305205" q1="-5.0789217092322954" p2="-30.269598550488432" q2="2.0353417731321874">
+    <iidm:line id="_045d71d4-c766-11e1-8775-005056c00008" name="24-72" r="8.5029120000000002" x="34.151040000000002" g1="0" b1="0.00014003675" g2="0" b2="0.00014003675" node1="30" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="29.819839164213242" q1="-4.7394639074497649" p2="-29.388602049522845" q2="1.5729376943843485">
         <iidm:alias>_04667281-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d0234-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9371,7 +9493,7 @@
             <iidm:temporaryLimit name="_d2074163-ab09-4251-a1d7-6983091dc4f1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045f94b8-c766-11e1-8775-005056c00008" name="17-18" r="2.1431520000000002" x="8.7991200000000003" g1="0" b1="3.7247499999999999e-05" g2="0" b2="3.7247499999999999e-05" node1="57" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04689563-c766-11e1-8775-005056c00008" p1="123.60988496778609" q1="41.324561275494801" p2="-121.41453809227507" q2="-33.506166849995431">
+    <iidm:line id="_045f94b8-c766-11e1-8775-005056c00008" name="17-18" r="2.1431520000000002" x="8.7991200000000003" g1="0" b1="3.7247499999999999e-05" g2="0" b2="3.7247499999999999e-05" node1="57" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04689563-c766-11e1-8775-005056c00008" p1="126.92883849458576" q1="41.119292524949046" p2="-124.62730173707092" q2="-32.863988258820008">
         <iidm:alias>_045e0e17-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0485ba59-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9379,7 +9501,7 @@
             <iidm:temporaryLimit name="_2b6693c7-4e29-4c2c-91d0-3485bbe8fe87" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048963d8-c766-11e1-8775-005056c00008" name="17-113" r="1.590811" x="5.244624" g1="0" b1="2.2038549999999999e-05" g2="0" b2="2.2038549999999999e-05" node1="58" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="-7.2295640195175119" q1="5.2233972476960524" p2="7.2375512018311783" q2="-5.9294443930353973">
+    <iidm:line id="_048963d8-c766-11e1-8775-005056c00008" name="17-113" r="1.590811" x="5.244624" g1="0" b1="2.2038549999999999e-05" g2="0" b2="2.2038549999999999e-05" node1="58" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="-2.7791549645497713" q1="3.1546908986527962" p2="2.7810804255518984" q2="-3.8804818951308215">
         <iidm:alias>_045841b5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046958b4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9387,7 +9509,7 @@
             <iidm:temporaryLimit name="_786432da-fa4d-4751-a275-87d0e20529f1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0458ddf0-c766-11e1-8775-005056c00008" name="49-50" r="4.6522079999999999" x="13.102848099999999" g1="0" b1="5.3776400000000002e-05" g2="0" b2="5.3776400000000002e-05" node1="112" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044d1e26-c766-11e1-8775-005056c00008" p1="62.197773833755221" q1="11.688804617924992" p2="-61.173821920889239" q2="-10.727043740367408">
+    <iidm:line id="_0458ddf0-c766-11e1-8775-005056c00008" name="49-50" r="4.6522079999999999" x="13.102848099999999" g1="0" b1="5.3776400000000002e-05" g2="0" b2="5.3776400000000002e-05" node1="112" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044d1e26-c766-11e1-8775-005056c00008" p1="62.21815904244081" q1="11.68494342381379" p2="-61.193587463064937" q2="-10.721433919437215">
         <iidm:alias>_0464ebe8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f9fd8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9395,7 +9517,7 @@
             <iidm:temporaryLimit name="_1f0844a5-ea5c-42b2-abcb-6fac2c426092" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04535fb7-c766-11e1-8775-005056c00008" name="1-3" r="2.2476959999999999" x="7.3877759999999997" g1="0" b1="3.1049149999999997e-05" g2="0" b2="3.1049149999999997e-05" node1="21" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_047eb579-c766-11e1-8775-005056c00008" p1="-40.747784139817149" q1="-15.929204992203697" p2="41.01373896504807" q2="15.793997573798201">
+    <iidm:line id="_04535fb7-c766-11e1-8775-005056c00008" name="1-3" r="2.2476959999999999" x="7.3877759999999997" g1="0" b1="3.1049149999999997e-05" g2="0" b2="3.1049149999999997e-05" node1="21" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_047eb579-c766-11e1-8775-005056c00008" p1="-39.765027951850598" q1="-16.468173922637483" p2="40.022062815861609" q2="16.302751981966278">
         <iidm:alias>_044ef2e9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047c4474-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9403,7 +9525,7 @@
             <iidm:temporaryLimit name="_4ea43e34-67a3-42b8-9601-2189db7790d4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0478e912-c766-11e1-8775-005056c00008" name="92-102" r="2.1431520000000002" x="9.7400160000000007" g1="0" b1="4.2011000000000001e-05" g2="0" b2="4.2011000000000001e-05" node1="66" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="49.778738780220536" q1="-8.9981865462992889" p2="-49.458846240456374" q2="9.0201069062060153">
+    <iidm:line id="_0478e912-c766-11e1-8775-005056c00008" name="92-102" r="2.1431520000000002" x="9.7400160000000007" g1="0" b1="4.2011000000000001e-05" g2="0" b2="4.2011000000000001e-05" node1="66" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="49.813171224189304" q1="-9.0167310532699823" p2="-49.492776489596274" q2="9.0410697597291971">
         <iidm:alias>_045a1673-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0468bc79-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9411,7 +9533,7 @@
             <iidm:temporaryLimit name="_23cc194e-9273-46e9-a793-84a9c2911737" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04547127-c766-11e1-8775-005056c00008" name="93-94" r="3.8855520000000001" x="12.7543688" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="21" voltageLevelId1="_04789af0-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="56.806680848450306" q1="-21.997460792904729" p2="-55.959750988198628" q2="22.956512104518115">
+    <iidm:line id="_04547127-c766-11e1-8775-005056c00008" name="93-94" r="3.8855520000000001" x="12.7543688" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="21" voltageLevelId1="_04789af0-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="56.859478728148773" q1="-21.939896437625841" p2="-56.011519731181338" q2="22.902856466585416">
         <iidm:alias>_04500450-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047b0bfb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9419,7 +9541,7 @@
             <iidm:temporaryLimit name="_1a9fe09e-3f63-4904-8e36-aa38c5e16c59" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04791021-c766-11e1-8775-005056c00008" name="46-48" r="10.4718237" x="32.931359999999998" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044778d3-c766-11e1-8775-005056c00008" p1="-8.8398161600071834" q1="-7.9348921789473312" p2="8.9046502796620821" q2="3.2958633888301607">
+    <iidm:line id="_04791021-c766-11e1-8775-005056c00008" name="46-48" r="10.4718237" x="32.931359999999998" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044778d3-c766-11e1-8775-005056c00008" p1="-8.8015961185068647" q1="-7.9481382005061523" p2="8.8661166440787849" q2="3.3081182759444188">
         <iidm:alias>_0459ef69-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04640186-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9427,7 +9549,7 @@
             <iidm:temporaryLimit name="_467ba04d-dbad-4fe1-81c8-3bc87b41fcd1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046958b6-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="113" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-92.833398390146456" q1="-2.3815906294207925" p2="94.310097175748581" q2="7.2625875226567631">
+    <iidm:line id="_046958b6-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="113" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-92.713082056500923" q1="-2.4147594225321809" p2="94.185968531663391" q2="7.2762934657707401">
         <iidm:alias>_04776270-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a96c8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9435,7 +9557,7 @@
             <iidm:temporaryLimit name="_d0737ab4-5a3a-46c8-8aeb-789313f0f332" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046f4c26-c766-11e1-8775-005056c00008" name="75-118" r="2.5264799999999998" x="8.3809430000000003" g1="0" b1="3.4377849999999998e-05" g2="0" b2="3.4377849999999998e-05" node1="48" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="40.629649950287472" q1="28.763670896766424" p2="-40.242065253663903" q2="-28.579711761986765">
+    <iidm:line id="_046f4c26-c766-11e1-8775-005056c00008" name="75-118" r="2.5264799999999998" x="8.3809430000000003" g1="0" b1="3.4377849999999998e-05" g2="0" b2="3.4377849999999998e-05" node1="48" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="40.468107600565197" q1="28.872005916475686" p2="-40.081554479334585" q2="-28.691409546092633">
         <iidm:alias>_04619088-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04814d8a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9443,7 +9565,7 @@
             <iidm:temporaryLimit name="_173dc7ff-ae18-4410-b2e1-a4c2abac8ff6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c3954-c766-11e1-8775-005056c00008" name="94-96" r="4.6870560000000001" x="15.1414566" g1="0" b1="6.60009e-05" g2="0" b2="6.60009e-05" node1="49" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="37.641951196001642" q1="-12.980949533781017" p2="-37.212027959128221" q2="12.126367863552231">
+    <iidm:line id="_045c3954-c766-11e1-8775-005056c00008" name="94-96" r="4.6870560000000001" x="15.1414566" g1="0" b1="6.60009e-05" g2="0" b2="6.60009e-05" node1="49" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="37.7048746808739" q1="-12.780369071495087" p2="-37.27479455145123" q2="11.927503747530526">
         <iidm:alias>_046ba2a0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0472ce94-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9451,7 +9573,7 @@
             <iidm:temporaryLimit name="_efde58bf-c92e-496d-b558-d0095a271083" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04518af7-c766-11e1-8775-005056c00008" name="62-67" r="4.4953919999999998" x="20.38608" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="39" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="-2.5712053115248503" q1="-18.346815372404411" p2="2.646229138952676" q2="15.541878584441662">
+    <iidm:line id="_04518af7-c766-11e1-8775-005056c00008" name="62-67" r="4.4953919999999998" x="20.38608" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="39" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="-2.587468066606184" q1="-18.342849379483894" p2="2.6624790670948171" q2="15.537855688524232">
         <iidm:alias>_04544a10-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04814d86-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9459,7 +9581,7 @@
             <iidm:temporaryLimit name="_8a81d4ae-2bc8-4038-8650-27a6150946b1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0452c375-c766-11e1-8775-005056c00008" name="47-49" r="3.3279839999999998" x="10.890000000000001" g1="0" b1="4.6028449999999998e-05" g2="0" b2="4.6028449999999998e-05" node1="30" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="114" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="17.512254547392558" q1="-23.111740582147863" p2="-17.363154689853406" q2="21.931675249650311">
+    <iidm:line id="_0452c375-c766-11e1-8775-005056c00008" name="47-49" r="3.3279839999999998" x="10.890000000000001" g1="0" b1="4.6028449999999998e-05" g2="0" b2="4.6028449999999998e-05" node1="30" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="114" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="17.394029060753319" q1="-23.029109299111177" p2="-17.246386640254741" q2="21.844225564045004">
         <iidm:alias>_0465fd54-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0471e431-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9467,7 +9589,7 @@
             <iidm:temporaryLimit name="_8d6a074c-900d-4a37-830c-5da4c1de1ab5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046c17d9-c766-11e1-8775-005056c00008" name="100-106" r="10.54152" x="39.900959999999998" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="76" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="59.43710598125962" q1="10.055527307093122" p2="-57.267759795331187" q2="-7.9079934597814967">
+    <iidm:line id="_046c17d9-c766-11e1-8775-005056c00008" name="100-106" r="10.54152" x="39.900959999999998" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="76" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="59.439220407088357" q1="10.055352954254031" p2="-57.269729950046752" q2="-7.9072718714663095">
         <iidm:alias>_045d98e5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0480d851-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9475,7 +9597,7 @@
             <iidm:temporaryLimit name="_3154dc30-b0e5-4570-8e52-9333bae20ef2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046b2d77-c766-11e1-8775-005056c00008" name="77-78" r="0.655142" x="2.1605759999999998" g1="0" b1="3.6271800000000001e-05" g2="0" b2="3.6271800000000001e-05" node1="66" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044fb634-c766-11e1-8775-005056c00008" p1="44.484264153459804" q1="4.1588548631692133" p2="-44.409442768792033" q2="-5.1808215379855307">
+    <iidm:line id="_046b2d77-c766-11e1-8775-005056c00008" name="77-78" r="0.655142" x="2.1605759999999998" g1="0" b1="3.6271800000000001e-05" g2="0" b2="3.6271800000000001e-05" node1="66" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044fb634-c766-11e1-8775-005056c00008" p1="44.374392665376014" q1="4.0584132334961183" p2="-44.299950460218554" q2="-5.0812855128356604">
         <iidm:alias>_046ed6fb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04893cc3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9483,7 +9605,7 @@
             <iidm:temporaryLimit name="_cce754c5-b9d5-4105-a431-32da96e4a6cf" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c8776-c766-11e1-8775-005056c00008" name="6-7" r="0.79976199999999997" x="3.6241919999999999" g1="0" b1="1.5782850000000001e-05" g2="0" b2="1.5782850000000001e-05" node1="21" voltageLevelId1="_044f6818-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047eb571-c766-11e1-8775-005056c00008" p1="43.790301480976936" q1="-8.7866952378261516" p2="-43.696868942588168" q2="8.6724708164345508">
+    <iidm:line id="_045c8776-c766-11e1-8775-005056c00008" name="6-7" r="0.79976199999999997" x="3.6241919999999999" g1="0" b1="1.5782850000000001e-05" g2="0" b2="1.5782850000000001e-05" node1="21" voltageLevelId1="_044f6818-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047eb571-c766-11e1-8775-005056c00008" p1="39.417823763969054" q1="-6.7915925242199364" p2="-39.342968264644703" q2="6.5926803211051626">
         <iidm:alias>_046efe08-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04720b4a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9491,7 +9613,7 @@
             <iidm:temporaryLimit name="_361a9cc3-fb33-4037-9b9a-c20adb90b66b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047ba839-c766-11e1-8775-005056c00008" name="77-80" r="5.1226560000000001" x="18.295200000000001" g1="0" b1="6.5426999999999995e-05" g2="0" b2="6.5426999999999995e-05" node1="67" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="76" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-45.362181063743982" q1="-23.02582377228952" p2="46.103452668313686" q2="23.293377127616417">
+    <iidm:line id="_047ba839-c766-11e1-8775-005056c00008" name="77-80" r="5.1226560000000001" x="18.295200000000001" g1="0" b1="6.5426999999999995e-05" g2="0" b2="6.5426999999999995e-05" node1="67" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="76" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-45.475722242647279" q1="-23.122889254773575" p2="46.221470894759307" q2="23.406761924056806">
         <iidm:alias>_047c6b85-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0480b148-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9499,7 +9621,7 @@
             <iidm:temporaryLimit name="_da00c66f-a882-4938-923b-f2455f7f9a81" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04592c16-c766-11e1-8775-005056c00008" name="78-79" r="0.95135000000000003" x="4.2514560000000001" g1="0" b1="1.8595050000000001e-05" g2="0" b2="1.8595050000000001e-05" node1="22" voltageLevelId1="_044fb634-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04481510-c766-11e1-8775-005056c00008" p1="-26.598293827222854" q1="-20.823900210506661" p2="26.659774822908233" q2="20.445484474802207">
+    <iidm:line id="_04592c16-c766-11e1-8775-005056c00008" name="78-79" r="0.95135000000000003" x="4.2514560000000001" g1="0" b1="1.8595050000000001e-05" g2="0" b2="1.8595050000000001e-05" node1="22" voltageLevelId1="_044fb634-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04481510-c766-11e1-8775-005056c00008" p1="-26.707733840816335" q1="-20.923403608881522" p2="26.7697719078914" q2="20.547623625331447">
         <iidm:alias>_0453add6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045b7605-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9507,7 +9629,7 @@
             <iidm:temporaryLimit name="_ba4abe9d-8490-4c19-b19b-c9d2c3597fc9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047b3301-c766-11e1-8775-005056c00008" name="103-104" r="8.1195839999999997" x="27.599615100000001" g1="0" b1="0.00011679295" g2="0" b2="0.00011679295" node1="40" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="33.038740276685061" q1="13.987180003957622" p2="-32.422227366334397" q2="-15.884493669000632">
+    <iidm:line id="_047b3301-c766-11e1-8775-005056c00008" name="103-104" r="8.1195839999999997" x="27.599615100000001" g1="0" b1="0.00011679295" g2="0" b2="0.00011679295" node1="40" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="33.038135529557152" q1="13.987407763893616" p2="-32.421637545510812" q2="-15.884771769121942">
         <iidm:alias>_0459a142-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045d98e6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9515,7 +9637,7 @@
             <iidm:temporaryLimit name="_2320da74-eda7-4f7f-ade9-1ed0e994f3af" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045e5c32-c766-11e1-8775-005056c00008" name="95-96" r="2.9795039999999999" x="9.5309279999999994" g1="0" b1="4.2298000000000001e-05" g2="0" b2="4.2298000000000001e-05" node1="21" voltageLevelId1="_044f4108-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="14.130142199830987" q1="-24.95927986604551" p2="-13.98893552222594" q2="23.988175714407163">
+    <iidm:line id="_045e5c32-c766-11e1-8775-005056c00008" name="95-96" r="2.9795039999999999" x="9.5309279999999994" g1="0" b1="4.2298000000000001e-05" g2="0" b2="4.2298000000000001e-05" node1="21" voltageLevelId1="_044f4108-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="14.186335518736644" q1="-24.784413959993316" p2="-14.046281136162156" q2="23.810523488054571">
         <iidm:alias>_04597a34-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04801509-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9523,7 +9645,7 @@
             <iidm:temporaryLimit name="_3bc03415-e95f-47a7-8e92-01089d304a9c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045ed169-c766-11e1-8775-005056c00008" name="77-80" r="2.9620799999999998" x="8.4506409999999992" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="68" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="77" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-99.019647332605103" q1="-42.531010621366086" p2="100.94907201901395" q2="43.108849929724649">
+    <iidm:line id="_045ed169-c766-11e1-8775-005056c00008" name="77-80" r="2.9620799999999998" x="8.4506409999999992" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="68" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="77" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-99.273288950154694" q1="-42.72110534403587" p2="101.21436675533597" q2="43.332873183472003">
         <iidm:alias>_0464289a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04828605-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9531,7 +9653,7 @@
             <iidm:temporaryLimit name="_f93b6d4c-39fa-4f6f-a42d-c63a4cf21a67" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047f78c2-c766-11e1-8775-005056c00008" name="5-11" r="3.5370720000000002" x="11.8831682" g1="0" b1="4.987375e-05" g2="0" b2="4.987375e-05" node1="48" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="89.469416248876058" q1="7.8743789060582312" p2="-87.856159135087211" q2="-4.1834137531370468">
+    <iidm:line id="_047f78c2-c766-11e1-8775-005056c00008" name="5-11" r="3.5370720000000002" x="11.8831682" g1="0" b1="4.987375e-05" g2="0" b2="4.987375e-05" node1="48" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="84.183655968530033" q1="9.9341208371622081" p2="-82.748414293811933" q2="-6.843749628537064">
         <iidm:alias>_045bc426-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0476c633-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9539,7 +9661,7 @@
             <iidm:temporaryLimit name="_3bc4ab96-7a0d-4e18-b9f5-d89f63a82f0a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04845ac7-c766-11e1-8775-005056c00008" name="71-72" r="7.7711040000000002" x="31.363201100000001" g1="0" b1="0.00012752525" g2="0" b2="0.00012752525" node1="29" voltageLevelId1="_04664b78-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="-18.097462606905513" q1="-1.7440127502569274" p2="18.246867609920749" q2="-2.0353423263687018">
+    <iidm:line id="_04845ac7-c766-11e1-8775-005056c00008" name="71-72" r="7.7711040000000002" x="31.363201100000001" g1="0" b1="0.00012752525" g2="0" b2="0.00012752525" node1="29" voltageLevelId1="_04664b78-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="-17.230128862630238" q1="-2.2678531609571682" p2="17.365414563977367" q2="-1.57293753692668">
         <iidm:alias>_04642891-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046b0661-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9547,7 +9669,7 @@
             <iidm:temporaryLimit name="_bcb69c6e-125e-449c-acb3-a4deb151668d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047343c2-c766-11e1-8775-005056c00008" name="66-67" r="3.9029759999999998" x="17.685359999999999" g1="0" b1="7.6962800000000001e-05" g2="0" b2="7.6962800000000001e-05" node1="50" voltageLevelId1="_047147f4-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="30.946232375423616" q1="21.047499530625707" p2="-30.646152393658515" q2="-22.541846590197586">
+    <iidm:line id="_047343c2-c766-11e1-8775-005056c00008" name="66-67" r="3.9029759999999998" x="17.685359999999999" g1="0" b1="7.6962800000000001e-05" g2="0" b2="7.6962800000000001e-05" node1="50" voltageLevelId1="_047147f4-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="30.962660780768193" q1="21.044289957427051" p2="-30.662401774373954" q2="-22.537823399862784">
         <iidm:alias>_0465af34-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04860874-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9555,7 +9677,7 @@
             <iidm:temporaryLimit name="_b4b8a31d-dc3c-4b51-88ad-a22e070eb96c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04569409-c766-11e1-8775-005056c00008" name="34-43" r="7.1961120000000003" x="29.289743399999999" g1="0" b1="0.0001212695" g2="0" b2="0.0001212695" node1="40" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_045e8349-c766-11e1-8775-005056c00008" p1="12.088254403775462" q1="-7.748520868061723" p2="-12.004290594626291" q2="4.314276808965035">
+    <iidm:line id="_04569409-c766-11e1-8775-005056c00008" name="34-43" r="7.1961120000000003" x="29.289743399999999" g1="0" b1="0.0001212695" g2="0" b2="0.0001212695" node1="40" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_045e8349-c766-11e1-8775-005056c00008" p1="12.415850535400544" q1="-7.9060725835790793" p2="-12.327165996923133" q2="4.4948328342033887">
         <iidm:alias>_04500454-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04505274-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9563,7 +9685,7 @@
             <iidm:temporaryLimit name="_5585c67a-0839-48e6-8847-4393e1e9b9c7" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04817498-c766-11e1-8775-005056c00008" name="52-53" r="7.0567200000000003" x="28.488240000000001" g1="0" b1="0.00011644859999999999" g2="0" b2="0.00011644859999999999" node1="21" voltageLevelId1="_04806326-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04876804-c766-11e1-8775-005056c00008" p1="13.406782046418556" q1="0.94941541700867449" p2="-13.32357990018428" q2="-4.279623540553561">
+    <iidm:line id="_04817498-c766-11e1-8775-005056c00008" name="52-53" r="7.0567200000000003" x="28.488240000000001" g1="0" b1="0.00011644859999999999" g2="0" b2="0.00011644859999999999" node1="21" voltageLevelId1="_04806326-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04876804-c766-11e1-8775-005056c00008" p1="13.414269594718418" q1="0.94682947274492069" p2="-13.330984278463449" q2="-4.2766832294326536">
         <iidm:alias>_045115c7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0472a784-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9571,7 +9693,7 @@
             <iidm:temporaryLimit name="_e7c9dfab-fb45-4470-964f-4ba9e391f60b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044b7078-c766-11e1-8775-005056c00008" name="105-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="49" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="23" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="26.889958183470775" q1="1.3295825349419705" p2="-26.47162091711925" q2="-4.1924691998078218">
+    <iidm:line id="_044b7078-c766-11e1-8775-005056c00008" name="105-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="49" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="23" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="26.889709212297312" q1="1.3296714063801685" p2="-26.471379121089917" q2="-4.1925816908352855">
         <iidm:alias>_0452c378-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0481c2b7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9579,7 +9701,7 @@
             <iidm:temporaryLimit name="_fff133bf-25fd-46b2-b144-a227c31ee882" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048ac367-c766-11e1-8775-005056c00008" name="100-101" r="4.8264480000000001" x="21.9890881" g1="0" b1="9.4123049999999997e-05" g2="0" b2="9.4123049999999997e-05" node1="77" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046ed6f7-c766-11e1-8775-005056c00008" p1="-21.62149356360294" q1="24.646612259056695" p2="21.932545324187561" q2="-26.535617541783395">
+    <iidm:line id="_048ac367-c766-11e1-8775-005056c00008" name="100-101" r="4.8264480000000001" x="21.9890881" g1="0" b1="9.4123049999999997e-05" g2="0" b2="9.4123049999999997e-05" node1="77" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046ed6f7-c766-11e1-8775-005056c00008" p1="-21.65371746446818" q1="24.675613965090808" p2="21.965552130271217" q2="-26.560969415876478">
         <iidm:alias>_044afb45-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b5fa2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9587,7 +9709,7 @@
             <iidm:temporaryLimit name="_217e3c95-24b5-438f-a721-d2257e1a43b4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0481c2b1-c766-11e1-8775-005056c00008" name="56-57" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="57" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="-30.850436877159776" q1="-5.4510377951557212" p2="31.21637539865285" q2="4.2427239252529958">
+    <iidm:line id="_0481c2b1-c766-11e1-8775-005056c00008" name="56-57" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="57" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="-30.869016672990092" q1="-5.4420538071974542" p2="31.23535829533165" q2="4.2348806226420441">
         <iidm:alias>_045e0e12-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0487dd35-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9595,7 +9717,7 @@
             <iidm:temporaryLimit name="_f5547027-3d48-4a53-937b-bd5ba63ef70d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047a6fb7-c766-11e1-8775-005056c00008" name="47-69" r="14.705855400000001" x="48.403869999999998" g1="0" b1="0.00020351240000000001" g2="0" b2="0.00020351240000000001" node1="31" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="57" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-84.676298019353226" q1="26.400968362594007" p2="91.29716619541918" q2="-12.056419924012019">
+    <iidm:line id="_047a6fb7-c766-11e1-8775-005056c00008" name="47-69" r="14.705855400000001" x="48.403869999999998" g1="0" b1="0.00020351240000000001" g2="0" b2="0.00020351240000000001" node1="31" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="57" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-84.427456919113126" q1="26.261119852376989" p2="91.006555441182286" q2="-12.054272960755139">
         <iidm:alias>_04758db9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0485ba56-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9603,7 +9725,7 @@
             <iidm:temporaryLimit name="_e9fec217-cf6f-4d39-9495-26ed10c05100" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0453fbf0-c766-11e1-8775-005056c00008" name="110-111" r="3.8332799999999998" x="13.1551189" g1="0" b1="5.7392100000000002e-05" g2="0" b2="5.7392100000000002e-05" node1="40" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_046a1c00-c766-11e1-8775-005056c00008" p1="-39.272200563578259" q1="-20.585221149355331" p2="39.737556912342789" q2="20.309733756268837">
+    <iidm:line id="_0453fbf0-c766-11e1-8775-005056c00008" name="110-111" r="3.8332799999999998" x="13.1551189" g1="0" b1="5.7392100000000002e-05" g2="0" b2="5.7392100000000002e-05" node1="40" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_046a1c00-c766-11e1-8775-005056c00008" p1="-39.264874365059512" q1="-20.587773213954744" p2="39.730116301991295" q2="20.311893441035757">
         <iidm:alias>_0447c6f5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04812675-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9611,7 +9733,7 @@
             <iidm:temporaryLimit name="_ea48fee0-31b6-4990-a332-25d08b7d731f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04778984-c766-11e1-8775-005056c00008" name="41-42" r="7.14384" x="23.522401800000001" g1="0" b1="9.8714400000000005e-05" g2="0" b2="9.8714400000000005e-05" node1="21" voltageLevelId1="_048c4a08-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="-11.027200363380899" q1="-11.20201324920752" p2="11.139507106964849" q2="8.768671708537676">
+    <iidm:line id="_04778984-c766-11e1-8775-005056c00008" name="41-42" r="7.14384" x="23.522401800000001" g1="0" b1="9.8714400000000005e-05" g2="0" b2="9.8714400000000005e-05" node1="21" voltageLevelId1="_048c4a08-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="-10.788565948560572" q1="-11.368348294564676" p2="10.900010421882728" q2="8.934338335509306">
         <iidm:alias>_044d1e2a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046512f1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9619,7 +9741,7 @@
             <iidm:temporaryLimit name="_063af52c-fe10-4c1e-85d4-dd80dcc1d2f9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04653a08-c766-11e1-8775-005056c00008" name="80-99" r="7.9104960000000002" x="35.893439999999998" g1="0" b1="0.00015668044999999999" g2="0" b2="0.00015668044999999999" node1="78" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04644fa4-c766-11e1-8775-005056c00008" p1="2.5128137361066427" q1="6.5618198290637544" p2="-2.4721646104722637" q2="-12.170755563978569">
+    <iidm:line id="_04653a08-c766-11e1-8775-005056c00008" name="80-99" r="7.9104960000000002" x="35.893439999999998" g1="0" b1="0.00015668044999999999" g2="0" b2="0.00015668044999999999" node1="78" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04644fa4-c766-11e1-8775-005056c00008" p1="2.5255912750160023" q1="6.5588840571244855" p2="-2.4849385727851363" q2="-12.16780513679018">
         <iidm:alias>_04773b69-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0477b092-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9627,7 +9749,7 @@
             <iidm:temporaryLimit name="_c05229ce-6abb-4209-ad4f-0dcd4a070f28" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04581aa5-c766-11e1-8775-005056c00008" name="54-59" r="8.7642720000000001" x="39.953229999999998" g1="0" b1="0.0001716024" g2="0" b2="0.0001716024" node1="58" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-19.641202267121692" q1="-10.520864915771078" p2="19.887467988131394" q2="6.0155756912345808">
+    <iidm:line id="_04581aa5-c766-11e1-8775-005056c00008" name="54-59" r="8.7642720000000001" x="39.953229999999998" g1="0" b1="0.0001716024" g2="0" b2="0.0001716024" node1="58" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-19.621664958269207" q1="-10.526055181152987" p2="19.867552245194869" q2="6.0190407277945637">
         <iidm:alias>_0457cc82-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045cae81-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9635,7 +9757,7 @@
             <iidm:temporaryLimit name="_ac528cbe-6fc1-41dd-ba9d-d8b7a4c77576" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04690a93-c766-11e1-8775-005056c00008" name="92-94" r="8.3809430000000003" x="27.529920000000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="67" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="64.706903882884305" q1="-16.365344072614214" p2="-62.548513676008966" q2="19.489246038429052">
+    <iidm:line id="_04690a93-c766-11e1-8775-005056c00008" name="92-94" r="8.3809430000000003" x="27.529920000000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="67" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="64.761221296548882" q1="-16.302159313011092" p2="-62.600044036191314" q2="19.436099236893746">
         <iidm:alias>_044c33c1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0483706b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9643,7 +9765,7 @@
             <iidm:temporaryLimit name="_6ac84228-6b04-4b10-b560-29655c8e93b4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046009e3-c766-11e1-8775-005056c00008" name="37-39" r="5.5931040000000003" x="18.469439999999999" g1="0" b1="7.7479350000000006e-05" g2="0" b2="7.7479350000000006e-05" node1="57" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046bf0c7-c766-11e1-8775-005056c00008" p1="66.347595113116853" q1="17.940688965911413" p2="-64.642760638426225" q2="-14.631864029927454">
+    <iidm:line id="_046009e3-c766-11e1-8775-005056c00008" name="37-39" r="5.5931040000000003" x="18.469439999999999" g1="0" b1="7.7479350000000006e-05" g2="0" b2="7.7479350000000006e-05" node1="57" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046bf0c7-c766-11e1-8775-005056c00008" p1="66.611857661615431" q1="17.847501456353186" p2="-64.893815432563912" q2="-14.492436531413567">
         <iidm:alias>_044c33c9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04789afa-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9651,7 +9773,7 @@
             <iidm:temporaryLimit name="_2ccdc288-c132-40d1-a928-3887bec4ff67" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0458b6e8-c766-11e1-8775-005056c00008" name="46-47" r="6.6211200000000003" x="22.12848" g1="0" b1="9.0679499999999998e-05" g2="0" b2="9.0679499999999998e-05" node1="33" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_0457f396-c766-11e1-8775-005056c00008" p1="-32.758384923332812" q1="1.4281978897484151" p2="33.165560488735643" q2="-3.2892277975779503">
+    <iidm:line id="_0458b6e8-c766-11e1-8775-005056c00008" name="46-47" r="6.6211200000000003" x="22.12848" g1="0" b1="9.0679499999999998e-05" g2="0" b2="9.0679499999999998e-05" node1="33" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_0457f396-c766-11e1-8775-005056c00008" p1="-32.630968479562377" q1="1.3598937831958577" p2="33.0348557591307" q2="-3.2320106150442784">
         <iidm:alias>_04507980-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0464c4da-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9659,7 +9781,7 @@
             <iidm:temporaryLimit name="_06ca3245-2668-448f-a5c6-961924217a5c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044f8f22-c766-11e1-8775-005056c00008" name="82-83" r="1.9514879999999999" x="6.3858959999999998" g1="0" b1="0.0001089302" g2="0" b2="0.0001089302" node1="31" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728074-c766-11e1-8775-005056c00008" p1="-65.9200746195406" q1="37.848551244793008" p2="66.607387829213366" q2="-39.235864164257329">
+    <iidm:line id="_044f8f22-c766-11e1-8775-005056c00008" name="82-83" r="1.9514879999999999" x="6.3858959999999998" g1="0" b1="0.0001089302" g2="0" b2="0.0001089302" node1="31" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728074-c766-11e1-8775-005056c00008" p1="-65.52878545772684" q1="39.183355637377367" p2="66.223721757410118" q2="-40.537835074868241">
         <iidm:alias>_047a48a6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b3891-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9667,7 +9789,7 @@
             <iidm:temporaryLimit name="_dfbd2f07-76ab-41e3-910f-dc706979ea4b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045cfca6-c766-11e1-8775-005056c00008" name="108-109" r="1.82952" x="5.0181120000000004" g1="0" b1="2.1809000000000001e-05" g2="0" b2="2.1809000000000001e-05" node1="21" voltageLevelId1="_046c65f4-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b7b99-c766-11e1-8775-005056c00008" p1="20.845139823812804" q1="-0.55263317415954893" p2="-20.795552198729816" q2="-0.009080067741133041">
+    <iidm:line id="_045cfca6-c766-11e1-8775-005056c00008" name="108-109" r="1.82952" x="5.0181120000000004" g1="0" b1="2.1809000000000001e-05" g2="0" b2="2.1809000000000001e-05" node1="21" voltageLevelId1="_046c65f4-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b7b99-c766-11e1-8775-005056c00008" p1="20.848767949260445" q1="-0.55392004785622972" p2="-20.799162982570689" q2="-0.007745339742328515">
         <iidm:alias>_04481514-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04716f00-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9675,7 +9797,7 @@
             <iidm:temporaryLimit name="_11451cec-81c7-4f83-a7db-df7dcaffa94e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04784cd5-c766-11e1-8775-005056c00008" name="70-74" r="6.9870239999999999" x="23.051952400000001" g1="0" b1="9.6648299999999994e-05" g2="0" b2="9.6648299999999994e-05" node1="48" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047dcb11-c766-11e1-8775-005056c00008" p1="26.115186542329216" q1="9.3523021318232047" p2="-25.784585940320266" q2="-11.459690538313545">
+    <iidm:line id="_04784cd5-c766-11e1-8775-005056c00008" name="70-74" r="6.9870239999999999" x="23.051952400000001" g1="0" b1="9.6648299999999994e-05" g2="0" b2="9.6648299999999994e-05" node1="48" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047dcb11-c766-11e1-8775-005056c00008" p1="25.745502928773973" q1="9.5382282019559028" p2="-25.42118885605214" q2="-11.666919968703338">
         <iidm:alias>_045e5c33-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046ab84b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9683,7 +9805,7 @@
             <iidm:temporaryLimit name="_37a5cc00-bd7f-4ec7-a77c-e140e23450d2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04747c40-c766-11e1-8775-005056c00008" name="77-82" r="5.1923519999999996" x="14.8626719" g1="0" b1="0.0002345615" g2="0" b2="0.0002345615" node1="69" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_046512f8-c766-11e1-8775-005056c00008" p1="-26.482869841147895" q1="30.252013503840175" p2="27.040426440312725" q2="-36.710116992734335">
+    <iidm:line id="_04747c40-c766-11e1-8775-005056c00008" name="77-82" r="5.1923519999999996" x="14.8626719" g1="0" b1="0.0002345615" g2="0" b2="0.0002345615" node1="69" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_046512f8-c766-11e1-8775-005056c00008" p1="-26.288995481080967" q1="30.943227809598422" p2="26.857874253004848" q2="-37.361400522530488">
         <iidm:alias>_0451b202-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0452ea84-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9691,7 +9813,7 @@
             <iidm:temporaryLimit name="_e9798d58-b518-4fab-984c-c72076dfc2ae" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045e3524-c766-11e1-8775-005056c00008" name="23-24" r="2.3522400000000001" x="8.5726080000000007" g1="0" b1="0.00014290635" g2="0" b2="0.00014290635" node1="39" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_048c22fa-c766-11e1-8775-005056c00008" p1="68.176563646700799" q1="-7.5649057142703731" p2="-67.559363054493488" q2="4.7543956521093778">
+    <iidm:line id="_045e3524-c766-11e1-8775-005056c00008" name="23-24" r="2.3522400000000001" x="8.5726080000000007" g1="0" b1="0.00014290635" g2="0" b2="0.00014290635" node1="39" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_048c22fa-c766-11e1-8775-005056c00008" p1="66.234451754943834" q1="-7.233728024950592" p2="-65.653340097483735" q2="4.2810325711301633">
         <iidm:alias>_046cb413-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f9fd3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9699,7 +9821,7 @@
             <iidm:temporaryLimit name="_e8ec73b8-1ecf-4d18-9ef9-80eabf3a4969" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0474f177-c766-11e1-8775-005056c00008" name="15-17" r="2.2999679999999998" x="7.6142880000000002" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="48" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-163.73055972140617" q1="-15.83282656643013" p2="167.72149855039197" q2="24.943480579321669">
+    <iidm:line id="_0474f177-c766-11e1-8775-005056c00008" name="15-17" r="2.2999679999999998" x="7.6142880000000002" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="48" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-172.40168447230116" q1="-12.692468169115124" p2="176.81571546052245" q2="23.20662564360946">
         <iidm:alias>_044c5ad2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046931a7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9707,7 +9829,7 @@
             <iidm:temporaryLimit name="_2ceac3d1-f73d-43db-8d37-9e329f1787bb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0483be84-c766-11e1-8775-005056c00008" name="8-30" r="2.0860400000000001" x="24.393599999999999" g1="0" b1="0.00053099175999999997" g2="0" b2="0.00053099175999999997" node1="30" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="38" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="82.009275599169285" q1="29.97832596338564" p2="-81.587932175659191" q2="-75.256034048290999">
+    <iidm:line id="_0483be84-c766-11e1-8775-005056c00008" name="8-30" r="2.0860400000000001" x="24.393599999999999" g1="0" b1="0.00053099175999999997" g2="0" b2="0.00053099175999999997" node1="30" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="38" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="98.762033300242138" q1="24.270781706688211" p2="-98.23876095664825" q2="-68.702451628233689">
         <iidm:alias>_0454e651-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04801506-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9715,7 +9837,7 @@
             <iidm:temporaryLimit name="_ca795ad3-97e5-4416-aaba-53cce27f6434" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0488eea6-c766-11e1-8775-005056c00008" name="49-69" r="17.16264" x="56.453762099999999" g1="0" b1="0.00023760329999999999" g2="0" b2="0.00023760329999999999" node1="115" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-76.316535506918527" q1="27.155058688497292" p2="82.707497985017724" q2="-14.917467563440576">
+    <iidm:line id="_0488eea6-c766-11e1-8775-005056c00008" name="49-69" r="17.16264" x="56.453762099999999" g1="0" b1="0.00023760329999999999" g2="0" b2="0.00023760329999999999" node1="115" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-76.080394156069161" q1="27.006967761886223" p2="82.428889507116097" q2="-14.909065611165095">
         <iidm:alias>_04492681-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046735d6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9723,7 +9845,7 @@
             <iidm:temporaryLimit name="_c42dc3ef-3a2e-4070-8efb-78e5c0cd5554" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047566a0-c766-11e1-8775-005056c00008" name="13-15" r="12.9634562" x="42.584255200000001" g1="0" b1="0.00017986685000000001" g2="0" b2="0.00017986685000000001" node1="21" voltageLevelId1="_04851e1b-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="16.8672107002158" q1="-0.64400370277742236" p2="-16.634797281728218" q2="-4.2968149623256773">
+    <iidm:line id="_047566a0-c766-11e1-8775-005056c00008" name="13-15" r="12.9634562" x="42.584255200000001" g1="0" b1="0.00017986685000000001" g2="0" b2="0.00017986685000000001" node1="21" voltageLevelId1="_04851e1b-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="12.516125864141401" q1="0.84268074372559831" p2="-12.379255912690835" q2="-6.0978683452131381">
         <iidm:alias>_04662461-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04865694-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9731,7 +9853,7 @@
             <iidm:temporaryLimit name="_ad988fd9-9270-4230-95a2-1858f32259df" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0476c63a-c766-11e1-8775-005056c00008" name="69-70" r="5.2271999999999998" x="22.12848" g1="0" b1="0.00035009184999999998" g2="0" b2="0.00035009184999999998" node1="59" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="69.944446203510964" q1="18.766508467580113" p2="-68.395089574046025" q2="-24.682148658370227">
+    <iidm:line id="_0476c63a-c766-11e1-8775-005056c00008" name="69-70" r="5.2271999999999998" x="22.12848" g1="0" b1="0.00035009184999999998" g2="0" b2="0.00035009184999999998" node1="59" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="71.01728295773863" q1="18.48860776022623" p2="-69.429490783309461" q2="-24.243247807073747">
         <iidm:alias>_047e193a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b1184-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9739,7 +9861,7 @@
             <iidm:temporaryLimit name="_519e3ecb-3561-4d11-ac6b-172a0b4b09b2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04520028-c766-11e1-8775-005056c00008" name="19-20" r="4.3908480000000001" x="20.38608" g1="0" b1="8.5514249999999999e-05" g2="0" b2="8.5514249999999999e-05" node1="39" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b2d70-c766-11e1-8775-005056c00008" p1="18.016708395721636" q1="-1.0459196873282888" p2="-17.923084368281351" q2="-1.1099308410418431">
+    <iidm:line id="_04520028-c766-11e1-8775-005056c00008" name="19-20" r="4.3908480000000001" x="20.38608" g1="0" b1="8.5514249999999999e-05" g2="0" b2="8.5514249999999999e-05" node1="39" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b2d70-c766-11e1-8775-005056c00008" p1="18.011038019874206" q1="-1.0428798407684725" p2="-17.917379778747293" q2="-1.1102281647630396">
         <iidm:alias>_0472f5a9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04745537-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9747,7 +9869,7 @@
             <iidm:temporaryLimit name="_b88528bf-cb1c-4c00-ad79-d5937197d40c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04862f83-c766-11e1-8775-005056c00008" name="94-95" r="2.2999679999999998" x="7.5620159999999998" g1="0" b1="3.1852600000000001e-05" g2="0" b2="3.1852600000000001e-05" node1="51" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f4108-c766-11e1-8775-005056c00008" p1="56.572095209281478" q1="6.4193612858208722" p2="-56.132056126391838" q2="-6.0430742563803665">
+    <iidm:line id="_04862f83-c766-11e1-8775-005056c00008" name="94-95" r="2.2999679999999998" x="7.5620159999999998" g1="0" b1="3.1852600000000001e-05" g2="0" b2="3.1852600000000001e-05" node1="51" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f4108-c766-11e1-8775-005056c00008" p1="56.629645376350815" q1="6.5991956927285251" p2="-56.188228978319458" q2="-6.2179143414426266">
         <iidm:alias>_044ca8f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04837060-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9755,7 +9877,7 @@
             <iidm:temporaryLimit name="_b70e76a1-6e79-4fb6-b487-dffa9bfeab7b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047b0bf6-c766-11e1-8775-005056c00008" name="12-16" r="3.6938879999999998" x="14.5316162" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="68" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046f7338-c766-11e1-8775-005056c00008" p1="16.19383813824313" q1="8.9375701920523962" p2="-16.115543260949249" q2="-10.702098059644971">
+    <iidm:line id="_047b0bf6-c766-11e1-8775-005056c00008" name="12-16" r="3.6938879999999998" x="14.5316162" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="68" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046f7338-c766-11e1-8775-005056c00008" p1="9.3870025879415433" q1="10.781157144012719" p2="-9.3376718732981079" q2="-12.659318432003857">
         <iidm:alias>_0450798a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045c8772-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9763,7 +9885,7 @@
             <iidm:temporaryLimit name="_af73f526-c58b-40e7-8e1c-14f05a39f6a2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04524e47-c766-11e1-8775-005056c00008" name="100-103" r="2.7878400000000001" x="9.1476000000000006" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="78" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0475b4c0-c766-11e1-8775-005056c00008" p1="115.57862418173808" q1="-20.688319046888793" p2="-113.46247770425641" q2="22.126162388830355">
+    <iidm:line id="_04524e47-c766-11e1-8775-005056c00008" name="100-103" r="2.7878400000000001" x="9.1476000000000006" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="78" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0475b4c0-c766-11e1-8775-005056c00008" p1="115.59050751535189" q1="-20.691150490642123" p2="-113.47392043574489" q2="22.130439422119309">
         <iidm:alias>_04684744-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048aea71-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9771,7 +9893,7 @@
             <iidm:temporaryLimit name="_1631e50b-21a3-470b-803b-f9665b6fcd60" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04682038-c766-11e1-8775-005056c00008" name="27-32" r="3.9900959999999999" x="13.1551189" g1="0" b1="5.5268600000000001e-05" g2="0" b2="5.5268600000000001e-05" node1="40" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="17.247815589322808" q1="-4.3977904068699845" p2="-17.172236712508518" q2="2.8420105618128995">
+    <iidm:line id="_04682038-c766-11e1-8775-005056c00008" name="27-32" r="3.9900959999999999" x="13.1551189" g1="0" b1="5.5268600000000001e-05" g2="0" b2="5.5268600000000001e-05" node1="40" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="15.25228355537328" q1="-3.1911478656262462" p2="-15.19442863350881" q2="1.5718993723270729">
         <iidm:alias>_0455347a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479ac63-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9779,7 +9901,7 @@
             <iidm:temporaryLimit name="_52eb4b09-42bb-4106-ac26-fe1059639d3a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0482fb31-c766-11e1-8775-005056c00008" name="59-61" r="5.7150720000000002" x="26.1360016" g1="0" b1="0.0001113407" g2="0" b2="0.0001113407" node1="68" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-100.99801990204698" q1="22.340163378952887" p2="104.64484665386948" q2="-9.4654867091081716">
+    <iidm:line id="_0482fb31-c766-11e1-8775-005056c00008" name="59-61" r="5.7150720000000002" x="26.1360016" g1="0" b1="0.0001113407" g2="0" b2="0.0001113407" node1="68" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-100.97635341920994" q1="22.331542426530966" p2="104.62155955091796" q2="-9.464277187409067">
         <iidm:alias>_044a10e9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0473b8f5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9787,7 +9909,7 @@
             <iidm:temporaryLimit name="_b5a7dea0-bfce-4548-a04d-7bb7b6d9f80a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047d55e3-c766-11e1-8775-005056c00008" name="100-104" r="7.8582239999999999" x="35.544960000000003" g1="0" b1="0.00015524565000000001" g2="0" b2="0.00015524565000000001" node1="79" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="55.042175344451202" q1="10.976964284070869" p2="-53.638368128917371" q2="-9.9730828193212471">
+    <iidm:line id="_047d55e3-c766-11e1-8775-005056c00008" name="100-104" r="7.8582239999999999" x="35.544960000000003" g1="0" b1="0.00015524565000000001" g2="0" b2="0.00015524565000000001" node1="79" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="55.044739875370297" q1="10.976743100620798" p2="-53.640812244922529" q2="-9.9723164389454517">
         <iidm:alias>_04636547-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048aea76-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9795,7 +9917,7 @@
             <iidm:temporaryLimit name="_17a10cd0-b653-4dcf-bdc3-4d5005ea9591" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04653a02-c766-11e1-8775-005056c00008" name="75-77" r="10.4718237" x="34.830577900000002" g1="0" b1="0.00014284895" g2="0" b2="0.00014284895" node1="49" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-34.490758790566503" q1="-7.2343224587338657" p2="35.267240944638104" q2="4.9751362370960655">
+    <iidm:line id="_04653a02-c766-11e1-8775-005056c00008" name="75-77" r="10.4718237" x="34.830577900000002" g1="0" b1="0.00014284895" g2="0" b2="0.00014284895" node1="49" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-34.705463830682405" q1="-7.0866923617235971" p2="35.490557557713373" q2="4.8569189636285577">
         <iidm:alias>_04642894-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04720b47-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9803,7 +9925,7 @@
             <iidm:temporaryLimit name="_6f81df11-7e71-4b6e-a6ee-a8c5f72f4ba5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04483c2a-c766-11e1-8775-005056c00008" name="23-32" r="5.5234079999999999" x="20.089872400000001" g1="0" b1="0.00033660465000000001" g2="0" b2="0.00033660465000000001" node1="40" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="101.10055788969805" q1="9.9577863141481675" p2="-97.85176887253624" q2="-9.6255917826220188">
+    <iidm:line id="_04483c2a-c766-11e1-8775-005056c00008" name="23-32" r="5.5234079999999999" x="20.089872400000001" g1="0" b1="0.00033660465000000001" g2="0" b2="0.00033660465000000001" node1="40" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="96.442399322379885" q1="10.646598511012527" p2="-93.477921618827978" q2="-11.373212044350149">
         <iidm:alias>_044b978a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0461dea6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9811,7 +9933,7 @@
             <iidm:temporaryLimit name="_a8f6a7d2-e58d-4671-a776-97be7291355e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048719e5-c766-11e1-8775-005056c00008" name="96-97" r="3.0143520000000001" x="15.42024" g1="0" b1="6.8870549999999994e-05" g2="0" b2="6.8870549999999994e-05" node1="50" voltageLevelId1="_045a1672-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="2.7718108185881647" q1="-25.145692626075821" p2="-2.6685967272256148" q2="23.280337731989274">
+    <iidm:line id="_048719e5-c766-11e1-8775-005056c00008" name="96-97" r="3.0143520000000001" x="15.42024" g1="0" b1="6.8870549999999994e-05" g2="0" b2="6.8870549999999994e-05" node1="50" voltageLevelId1="_045a1672-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="2.7255056584584612" q1="-25.322797847747903" p2="-2.6207420283793872" q2="23.466683487489608">
         <iidm:alias>_0451b207-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04828601-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9819,7 +9941,7 @@
             <iidm:temporaryLimit name="_ea6d39aa-df95-4d3e-b7b6-a800e552e72a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048481d0-c766-11e1-8775-005056c00008" name="25-27" r="5.5408330000000001" x="28.401121100000001" g1="0" b1="0.000506198385" g2="0" b2="0.000506198385" node1="30" voltageLevelId1="_04728079-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0476c639-c766-11e1-8775-005056c00008" p1="156.44475252236109" q1="30.10185445722508" p2="-148.92781758443684" q2="-9.5720715005618153">
+    <iidm:line id="_048481d0-c766-11e1-8775-005056c00008" name="25-27" r="5.5408330000000001" x="28.401121100000001" g1="0" b1="0.000506198385" g2="0" b2="0.000506198385" node1="30" voltageLevelId1="_04728079-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0476c639-c766-11e1-8775-005056c00008" p1="150.75754253663482" q1="28.84609018855306" p2="-143.77293576635125" q2="-11.072196095364923">
         <iidm:alias>_046d2947-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04725960-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9827,7 +9949,7 @@
             <iidm:temporaryLimit name="_d9d53af2-5ffa-4f2a-a4e6-ed22371332d6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04885268-c766-11e1-8775-005056c00008" name="110-112" r="4.3037280000000004" x="11.1513615" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="41" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="13" voltageLevelId2="_04784cd1-c766-11e1-8775-005056c00008" p1="69.354327535268027" q1="11.00739727162791" p2="-67.999931147162357" q2="-12.999977945026748">
+    <iidm:line id="_04885268-c766-11e1-8775-005056c00008" name="110-112" r="4.3037280000000004" x="11.1513615" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="41" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="13" voltageLevelId2="_04784cd1-c766-11e1-8775-005056c00008" p1="69.354329294600063" q1="11.007400549798453" p2="-67.999932399523502" q2="-12.999978134475947">
         <iidm:alias>_04611b55-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0481c2ba-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9835,7 +9957,7 @@
             <iidm:temporaryLimit name="_d50299b9-a055-408a-aa1e-2e93a715120f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0484a8e4-c766-11e1-8775-005056c00008" name="89-92" r="1.7249760000000001" x="8.7991200000000003" g1="0" b1="0.00015725434999999999" g2="0" b2="0.00015725434999999999" node1="57" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="68" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="227.51939179395072" q1="-3.35445557070152" p2="-222.44548143051364" q2="23.786206927186104">
+    <iidm:line id="_0484a8e4-c766-11e1-8775-005056c00008" name="89-92" r="1.7249760000000001" x="8.7991200000000003" g1="0" b1="0.00015725434999999999" g2="0" b2="0.00015725434999999999" node1="57" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="68" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="227.64205122146288" q1="-3.2652486903991362" p2="-222.56267818089634" q2="23.725138451514976">
         <iidm:alias>_04481517-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04808a3c-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9843,7 +9965,7 @@
             <iidm:temporaryLimit name="_eee9ca2b-764f-4ab8-a745-405338044743" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04689568-c766-11e1-8775-005056c00008" name="49-54" r="15.1414566" x="50.703842199999997" g1="0" b1="0.00020948120000000001" g2="0" b2="0.00020948120000000001" node1="116" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="46.580813138004004" q1="9.6151682783921242" p2="-44.636508386811727" q2="-10.267993717683147">
+    <iidm:line id="_04689568-c766-11e1-8775-005056c00008" name="49-54" r="15.1414566" x="50.703842199999997" g1="0" b1="0.00020948120000000001" g2="0" b2="0.00020948120000000001" node1="116" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="46.602350767492823" q1="9.6116199031833744" p2="-44.656464982013347" q2="-10.259151064701785">
         <iidm:alias>_046030f0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04605808-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9851,7 +9973,7 @@
             <iidm:temporaryLimit name="_690202a4-aad2-4ad3-8842-961b39e37709" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046c8d04-c766-11e1-8775-005056c00008" name="40-41" r="2.5264799999999998" x="8.4854880000000001" g1="0" b1="3.5066600000000001e-05" g2="0" b2="3.5066600000000001e-05" node1="40" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048c4a08-c766-11e1-8775-005056c00008" p1="26.061448272342631" q1="-1.7818779136966434" p2="-25.938483705227135" q2="1.2174661083342622">
+    <iidm:line id="_046c8d04-c766-11e1-8775-005056c00008" name="40-41" r="2.5264799999999998" x="8.4854880000000001" g1="0" b1="3.5066600000000001e-05" g2="0" b2="3.5066600000000001e-05" node1="40" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048c4a08-c766-11e1-8775-005056c00008" p1="26.301879900087371" q1="-1.939198448449353" p2="-26.176431333459782" q2="1.3841090475078062">
         <iidm:alias>_045cae80-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a2194-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9859,7 +9981,7 @@
             <iidm:temporaryLimit name="_34f2ef7c-32da-4444-b989-d02f5f931c50" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046735d5-c766-11e1-8775-005056c00008" name="39-40" r="3.206016" x="10.54152" g1="0" b1="4.4536249999999999e-05" g2="0" b2="4.4536249999999999e-05" node1="22" voltageLevelId1="_046bf0c7-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="37.670722214973431" q1="3.6508438290983038" p2="-37.348650948008753" q2="-3.8521676904974949">
+    <iidm:line id="_046735d5-c766-11e1-8775-005056c00008" name="39-40" r="3.206016" x="10.54152" g1="0" b1="4.4536249999999999e-05" g2="0" b2="4.4536249999999999e-05" node1="22" voltageLevelId1="_046bf0c7-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="37.922389031852497" q1="3.5118303773619548" p2="-37.595949038192899" q2="-3.697410217180404">
         <iidm:alias>_045115c1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048badc2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9867,7 +9989,7 @@
             <iidm:temporaryLimit name="_38d58455-5205-46bb-8e44-c66873f62938" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0470d2c4-c766-11e1-8775-005056c00008" name="89-92" r="6.8476319999999999" x="27.5473423" g1="0" b1="0.00011880164999999999" g2="0" b2="0.00011880164999999999" node1="58" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="71.770681399544443" q1="-5.8718313822962447" p2="-69.760856312505922" q2="9.839582557255941">
+    <iidm:line id="_0470d2c4-c766-11e1-8775-005056c00008" name="89-92" r="6.8476319999999999" x="27.5473423" g1="0" b1="0.00011880164999999999" g2="0" b2="0.00011880164999999999" node1="58" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="71.810789045177472" q1="-5.8456261919217267" p2="-69.798800138766836" q2="9.8222886178241708">
         <iidm:alias>_04690a97-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04690a98-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9875,7 +9997,7 @@
             <iidm:temporaryLimit name="_0cce41c7-b99f-4fec-93d2-73ea24433fa1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0479ac60-c766-11e1-8775-005056c00008" name="33-37" r="7.2309599999999996" x="24.742080000000001" g1="0" b1="0.00010502754999999999" g2="0" b2="0.00010502754999999999" node1="21" voltageLevelId1="_0456bb11-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="38.444450261940972" q1="-20.630914797428346" p2="-37.567715724362493" q2="20.39346286065657">
+    <iidm:line id="_0479ac60-c766-11e1-8775-005056c00008" name="33-37" r="7.2309599999999996" x="24.742080000000001" g1="0" b1="0.00010502754999999999" g2="0" b2="0.00010502754999999999" node1="21" voltageLevelId1="_0456bb11-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="39.610812034618306" q1="-20.935389111912162" p2="-38.683843746962197" q2="20.873836066878987">
         <iidm:alias>_04716f08-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0483be89-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9883,7 +10005,7 @@
             <iidm:temporaryLimit name="_343677c6-7477-4bf6-a12c-2c7e4a684d6f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048c4a00-c766-11e1-8775-005056c00008" name="105-108" r="4.5476640000000002" x="12.249072099999999" g1="0" b1="5.2915499999999998e-05" g2="0" b2="5.2915499999999998e-05" node1="50" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_046c65f4-c766-11e1-8775-005056c00008" p1="22.993217030708134" q1="-0.8613420092172932" p2="-22.845137483237021" q2="-0.44736486610489135">
+    <iidm:line id="_048c4a00-c766-11e1-8775-005056c00008" name="105-108" r="4.5476640000000002" x="12.249072099999999" g1="0" b1="5.2915499999999998e-05" g2="0" b2="5.2915499999999998e-05" node1="50" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_046c65f4-c766-11e1-8775-005056c00008" p1="22.996892568682146" q1="-0.86250073551127526" p2="-22.848765643430255" q2="-0.44607800499761735">
         <iidm:alias>_046adf53-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04795e46-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9891,7 +10013,7 @@
             <iidm:temporaryLimit name="_74cf84b9-e14f-4f81-9e8b-3a791cd474a0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04631724-c766-11e1-8775-005056c00008" name="34-37" r="0.44605400000000001" x="1.637856" g1="0" b1="2.8236900000000001e-05" g2="0" b2="2.8236900000000001e-05" node1="41" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-59.252805164962844" q1="-34.999544794770301" p2="59.388407074900108" q2="34.618624884309355">
+    <iidm:line id="_04631724-c766-11e1-8775-005056c00008" name="34-37" r="0.44605400000000001" x="1.637856" g1="0" b1="2.8236900000000001e-05" g2="0" b2="2.8236900000000001e-05" node1="41" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-58.281549910705955" q1="-35.449432492842234" p2="58.41492237051483" q2="35.061339969653027">
         <iidm:alias>_04592c19-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04719611-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9899,7 +10021,7 @@
             <iidm:temporaryLimit name="_8e90bf2e-3be4-41be-a84e-c1d4e709f8a1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04814d85-c766-11e1-8775-005056c00008" name="61-62" r="1.435738" x="6.5514239999999999" g1="0" b1="2.812215e-05" g2="0" b2="2.812215e-05" node1="40" voltageLevelId1="_0448d867-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="60.043551385107406" q1="-18.193525663401406" p2="-59.717387375774486" q2="18.709657339046153">
+    <iidm:line id="_04814d85-c766-11e1-8775-005056c00008" name="61-62" r="1.435738" x="6.5514239999999999" g1="0" b1="2.812215e-05" g2="0" b2="2.812215e-05" node1="40" voltageLevelId1="_0448d867-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="60.019489753982015" q1="-18.188935134011285" p2="-59.693579724615361" q2="18.703907829484333">
         <iidm:alias>_045a3d85-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047abdd8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9907,7 +10029,7 @@
             <iidm:temporaryLimit name="_39a23399-348e-44d9-8032-8fc62e6c7d63" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046a4318-c766-11e1-8775-005056c00008" name="101-102" r="4.2863040000000003" x="19.5148811" g1="0" b1="8.4366399999999999e-05" g2="0" b2="8.4366399999999999e-05" node1="22" voltageLevelId1="_046ed6f7-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="-43.93285245375403" q1="11.535268688684038" p2="44.458740045732746" q2="-12.020213066844162">
+    <iidm:line id="_046a4318-c766-11e1-8775-005056c00008" name="101-102" r="4.2863040000000003" x="19.5148811" g1="0" b1="8.4366399999999999e-05" g2="0" b2="8.4366399999999999e-05" node1="22" voltageLevelId1="_046ed6f7-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="-43.965862907064349" q1="11.560616690652079" p2="44.492669341542808" q2="-12.041176816375241">
         <iidm:alias>_04878f1b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04885261-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9915,7 +10037,7 @@
             <iidm:temporaryLimit name="_0501dacc-29fc-44a2-8cad-31a20b011d25" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c81e3-c766-11e1-8775-005056c00008" name="26-30" r="3.8671600000000002" x="41.624000000000002" g1="0" b1="0.00093801650000000002" g2="0" b2="0.00093801650000000002" node1="21" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="241.17205141901391" q1="5.2351709462697293" p2="-236.45132412611051" q2="-44.158430275625946">
+    <iidm:line id="_044c81e3-c766-11e1-8775-005056c00008" name="26-30" r="3.8671600000000002" x="41.624000000000002" g1="0" b1="0.00093801650000000002" g2="0" b2="0.00093801650000000002" node1="21" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="253.72854928759304" q1="1.2067145190657658" p2="-248.55711165865415" q2="-35.693297206309168">
         <iidm:alias>_0463654b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04747c4a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9923,7 +10045,7 @@
             <iidm:temporaryLimit name="_c95a66fd-913c-48c7-b8ef-cf3007c60af6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048915b9-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="41" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="117" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-54.119256945249305" q1="-18.867990541574308" p2="56.834052504248568" q2="23.032743726751814">
+    <iidm:line id="_048915b9-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="41" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="117" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-53.877628189963424" q1="-19.035992012737275" p2="56.576149128204676" q2="23.129394855380099">
         <iidm:alias>_044bbe98-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0456e224-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9931,7 +10053,7 @@
             <iidm:temporaryLimit name="_6cd83bc2-204f-44d5-afd4-fbfef8d2146f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c5ad6-c766-11e1-8775-005056c00008" name="105-106" r="2.4393600000000002" x="9.5309279999999994" g1="0" b1="4.1150150000000001e-05" g2="0" b2="4.1150150000000001e-05" node1="51" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="9.6098864712838932" q1="6.1484796248739553" p2="-9.5890308501665409" q2="-7.3960214787258574">
+    <iidm:line id="_044c5ad6-c766-11e1-8775-005056c00008" name="105-106" r="2.4393600000000002" x="9.5309279999999994" g1="0" b1="4.1150150000000001e-05" g2="0" b2="4.1150150000000001e-05" node1="51" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="9.6081628990874002" q1="6.1491021192025705" p2="-9.5873109753889505" q2="-7.3966579983645557">
         <iidm:alias>_04505270-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04531190-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9939,7 +10061,7 @@
             <iidm:temporaryLimit name="_487e1317-48f9-4747-b931-f3f79e95f55a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048badc5-c766-11e1-8775-005056c00008" name="60-61" r="0.45999400000000001" x="2.3522400000000001" g1="0" b1="4.1781450000000003e-05" g2="0" b2="4.1781450000000003e-05" node1="30" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-169.46020862916976" q1="15.901122618016245" p2="170.23727273566641" q2="-13.365326406035782">
+    <iidm:line id="_048badc5-c766-11e1-8775-005056c00008" name="60-61" r="0.45999400000000001" x="2.3522400000000001" g1="0" b1="4.1781450000000003e-05" g2="0" b2="4.1781450000000003e-05" node1="30" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-169.43026775652942" q1="15.896879311439427" p2="170.20705562274108" q2="-13.362496174016417">
         <iidm:alias>_04793734-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048a4e31-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9947,7 +10069,7 @@
             <iidm:temporaryLimit name="_3c55a929-a755-409b-af5f-bae188892af1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044cd003-c766-11e1-8775-005056c00008" name="23-25" r="2.7181440000000001" x="13.9391994" g1="0" b1="0.00024793390000000002" g2="0" b2="0.00024793390000000002" node1="41" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="-186.51444886465219" q1="-4.1171228345047606" p2="191.82359956813698" q2="22.164935893852512">
+    <iidm:line id="_044cd003-c766-11e1-8775-005056c00008" name="23-25" r="2.7181440000000001" x="13.9391994" g1="0" b1="0.00024793390000000002" g2="0" b2="0.00024793390000000002" node1="41" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="-179.91386872649744" q1="-5.1228863460495706" p2="184.84393123399815" q2="21.217676524566922">
         <iidm:alias>_045ed161-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0473b8f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9955,7 +10077,7 @@
             <iidm:temporaryLimit name="_9658628a-596f-41a9-96a7-c5a8aaf5400c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0457a574-c766-11e1-8775-005056c00008" name="19-34" r="13.102848099999999" x="43.037277199999998" g1="0" b1="0.00018135905000000001" g2="0" b2="0.00018135905000000001" node1="40" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0483be8b-c766-11e1-8775-005056c00008" p1="48.135380227366738" q1="-16.473778059676196" p2="-45.97971642504293" q2="17.985621368126868">
+    <iidm:line id="_0457a574-c766-11e1-8775-005056c00008" name="19-34" r="13.102848099999999" x="43.037277199999998" g1="0" b1="0.00018135905000000001" g2="0" b2="0.00018135905000000001" node1="40" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0483be8b-c766-11e1-8775-005056c00008" p1="49.674205399143588" q1="-16.658463505226589" p2="-47.382295771914066" q2="18.623863582239959">
         <iidm:alias>_04502b61-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04686e5b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9963,7 +10085,7 @@
             <iidm:temporaryLimit name="_b69ab61b-751d-487a-a538-2d47eea7572e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04595326-c766-11e1-8775-005056c00008" name="59-60" r="5.5234079999999999" x="25.264800000000001" g1="0" b1="0.00010789715" g2="0" b2="0.00010789715" node1="69" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_045cfca4-c766-11e1-8775-005056c00008" p1="-89.346144307491073" q1="19.208030033196298" p2="92.098856913153156" q2="-10.292594781866985">
+    <iidm:line id="_04595326-c766-11e1-8775-005056c00008" name="59-60" r="5.5234079999999999" x="25.264800000000001" g1="0" b1="0.00010789715" g2="0" b2="0.00010789715" node1="69" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_045cfca4-c766-11e1-8775-005056c00008" p1="-89.326260069431768" q1="19.200432224250147" p2="92.077707443791923" q2="-10.290785555152508">
         <iidm:alias>_04611b57-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0463b366-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9971,7 +10093,7 @@
             <iidm:temporaryLimit name="_a38d4859-b54a-482f-a2ad-0b4ce4c4da2a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045a8ba1-c766-11e1-8775-005056c00008" name="15-19" r="2.0908799999999998" x="6.865056" g1="0" b1="2.8983e-05" g2="0" b2="2.8983e-05" node1="50" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="50.336745596814438" q1="9.123986346472531" p2="-49.983942092347554" q2="-8.8578926963591567">
+    <iidm:line id="_045a8ba1-c766-11e1-8775-005056c00008" name="15-19" r="2.0908799999999998" x="6.865056" g1="0" b1="2.8983e-05" g2="0" b2="2.8983e-05" node1="50" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="48.690376065592517" q1="9.7501295244595081" p2="-48.357541978939864" q2="-9.548790715038308">
         <iidm:alias>_047629f1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0481e9c1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9979,7 +10101,7 @@
             <iidm:temporaryLimit name="_15d16bd2-d87c-4584-93d2-b294dc1be116" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04513cd6-c766-11e1-8775-005056c00008" name="90-91" r="4.4256960000000003" x="14.566463499999999" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="31" voltageLevelId1="_047d07c3-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044f8f29-c766-11e1-8775-005056c00008" p1="4.2366961056025598" q1="-16.332845480478298" p2="-4.166474960797375" q2="14.575452851936546">
+    <iidm:line id="_04513cd6-c766-11e1-8775-005056c00008" name="90-91" r="4.4256960000000003" x="14.566463499999999" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="31" voltageLevelId1="_047d07c3-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044f8f29-c766-11e1-8775-005056c00008" p1="4.2596645910551745" q1="-16.322467056349389" p2="-4.189475413532052" q2="14.56505524076552">
         <iidm:alias>_045f94b9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04627ae1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9987,7 +10109,7 @@
             <iidm:temporaryLimit name="_7d2a67fb-9d8c-4745-a67e-ce6ade5e520e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0487b623-c766-11e1-8775-005056c00008" name="22-23" r="5.9590079999999999" x="27.704158799999998" g1="0" b1="0.00011593205" g2="0" b2="0.00011593205" node1="21" voltageLevelId1="_04773b6a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_047f9fdb-c766-11e1-8775-005056c00008" p1="-10.174048251945814" q1="-2.6521140675401731" p2="10.209118043692579" q2="-1.2959360485849769">
+    <iidm:line id="_0487b623-c766-11e1-8775-005056c00008" name="22-23" r="5.9590079999999999" x="27.704158799999998" g1="0" b1="0.00011593205" g2="0" b2="0.00011593205" node1="21" voltageLevelId1="_04773b6a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_047f9fdb-c766-11e1-8775-005056c00008" p1="-10.173829495386242" q1="-2.6467245045750527" p2="10.208820971873026" q2="-1.3101520345817543">
         <iidm:alias>_045e0e18-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0477b095-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9995,7 +10117,7 @@
             <iidm:temporaryLimit name="_6477d99a-dd64-4083-8f56-1396610879f0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048b1189-c766-11e1-8775-005056c00008" name="83-85" r="7.4923200000000003" x="25.787520000000001" g1="0" b1="9.9862250000000004e-05" g2="0" b2="9.9862250000000004e-05" node1="32" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-54.403576595806449" q1="18.340448676274224" p2="55.922223064777029" q2="-16.416860220574289">
+    <iidm:line id="_048b1189-c766-11e1-8775-005056c00008" name="83-85" r="7.4923200000000003" x="25.787520000000001" g1="0" b1="9.9862250000000004e-05" g2="0" b2="9.9862250000000004e-05" node1="32" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-54.23013581715599" q1="19.099940192398197" p2="55.758355664773987" q2="-17.130280229284185">
         <iidm:alias>_0455d0b1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0462c906-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10003,7 +10125,7 @@
             <iidm:temporaryLimit name="_38cb3e5b-af1a-4684-aa2f-242826ed460c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045868c5-c766-11e1-8775-005056c00008" name="17-31" r="8.2589760000000005" x="27.233711199999998" g1="0" b1="0.00011449725" g2="0" b2="0.00011449725" node1="60" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="4.0350828386092017" q1="3.163018883790873" p2="-4.014247892776412" q2="-6.864321961290198">
+    <iidm:line id="_045868c5-c766-11e1-8775-005056c00008" name="17-31" r="8.2589760000000005" x="27.233711199999998" g1="0" b1="0.00011449725" g2="0" b2="0.00011449725" node1="60" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="8.9038853173509658" q1="1.5632981580373788" p2="-8.858528957961699" q2="-5.1826925159982071">
         <iidm:alias>_04544a16-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0467f924-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10011,7 +10133,7 @@
             <iidm:temporaryLimit name="_9066b19a-f404-42c3-88ce-51d375f6fdb5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0488c796-c766-11e1-8775-005056c00008" name="89-90" r="9.0256319999999999" x="32.75712" g1="0" b1="0.00015151515000000001" g2="0" b2="0.00015151515000000001" node1="59" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="59.653363292529264" q1="9.2503998980368678" p2="-57.755511924182855" q2="-7.4507128983863193">
+    <iidm:line id="_0488c796-c766-11e1-8775-005056c00008" name="89-90" r="9.0256319999999999" x="32.75712" g1="0" b1="0.00015151515000000001" g2="0" b2="0.00015151515000000001" node1="59" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="59.661957001027858" q1="9.2560255961860705" p2="-57.763511035051515" q2="-7.4541129123341427">
         <iidm:alias>_0459ef61-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04837069-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10019,7 +10141,7 @@
             <iidm:temporaryLimit name="_924b4a0b-bef5-432a-ad87-ab5c10d9c019" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0462c907-c766-11e1-8775-005056c00008" name="70-75" r="7.4574720000000001" x="24.56784" g1="0" b1="0.0001033058" g2="0" b2="0.0001033058" node1="50" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="12.064771494818633" q1="6.9831008158197916" p2="-11.967252879687704" q2="-10.105432917854165">
+    <iidm:line id="_0462c907-c766-11e1-8775-005056c00008" name="70-75" r="7.4574720000000001" x="24.56784" g1="0" b1="0.0001033058" g2="0" b2="0.0001033058" node1="50" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="11.606396987539044" q1="7.2229308181385745" p2="-11.511803545563469" q2="-10.355368498649934">
         <iidm:alias>_04649dc9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04784cdb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10027,7 +10149,7 @@
             <iidm:temporaryLimit name="_d432d118-553c-4f4c-a734-e98e0762ec40" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045fbbc3-c766-11e1-8775-005056c00008" name="50-57" r="8.2589760000000005" x="23.34816" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="22" voltageLevelId1="_044d1e26-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="44.173864498582738" q1="6.7270604449591858" p2="-43.216340261614107" q2="-7.2427092785411276">
+    <iidm:line id="_045fbbc3-c766-11e1-8775-005056c00008" name="50-57" r="8.2589760000000005" x="23.34816" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="22" voltageLevelId1="_044d1e26-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="44.193631962791279" q1="6.7214514103825316" p2="-43.235321564114152" q2="-7.2348652862496632">
         <iidm:alias>_04500455-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0468e383-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10035,7 +10157,7 @@
             <iidm:temporaryLimit name="_2f32bda4-7275-4485-9901-12f8cff9e4a1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044b9789-c766-11e1-8775-005056c00008" name="5-6" r="2.0734560000000002" x="9.4089600000000004" g1="0" b1="4.0920549999999999e-05" g2="0" b2="4.0920549999999999e-05" node1="49" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f6818-c766-11e1-8775-005056c00008" p1="96.918606048153379" q1="16.939609119455483" p2="-95.782887765873596" q2="-13.208076976017397">
+    <iidm:line id="_044b9789-c766-11e1-8775-005056c00008" name="5-6" r="2.0734560000000002" x="9.4089600000000004" g1="0" b1="4.0920549999999999e-05" g2="0" b2="4.0920549999999999e-05" node1="49" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f6818-c766-11e1-8775-005056c00008" p1="92.452371996047759" q1="18.505052157565874" p2="-91.410922367918573" q2="-15.203541347371468">
         <iidm:alias>_044a5f01-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0455d0b2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10043,7 +10165,7 @@
             <iidm:temporaryLimit name="_b3b0e81b-a434-4e9c-ad94-1161ff47b077" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04720b41-c766-11e1-8775-005056c00008" name="55-59" r="8.2572340000000004" x="37.600994100000001" g1="0" b1="0.00016201790000000001" g2="0" b2="0.00016201790000000001" node1="30" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-24.167783954744511" q1="-11.542778462249942" p2="24.515963180861199" q2="7.8346942796017265">
+    <iidm:line id="_04720b41-c766-11e1-8775-005056c00008" name="55-59" r="8.2572340000000004" x="37.600994100000001" g1="0" b1="0.00016201790000000001" g2="0" b2="0.00016201790000000001" node1="30" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-24.148818317091841" q1="-11.5481035929624" p2="24.496568046453834" q2="7.8380651950228062">
         <iidm:alias>_04656113-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04675ce4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10051,7 +10173,7 @@
             <iidm:temporaryLimit name="_6db0d250-4a2e-4169-abf0-f842aeca485d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048963d9-c766-11e1-8775-005056c00008" name="1-2" r="5.2794720000000002" x="17.4065762" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="22" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_045d4ac5-c766-11e1-8775-005056c00008" p1="-10.24686810722139" q1="-11.06607617086633" p2="10.313644026716506" q2="8.9139595885182938">
+    <iidm:line id="_048963d9-c766-11e1-8775-005056c00008" name="1-2" r="5.2794720000000002" x="17.4065762" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="22" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_045d4ac5-c766-11e1-8775-005056c00008" p1="-11.229978050037197" q1="-10.527419774320137" p2="11.300227015027652" q2="8.3854875536436353">
         <iidm:alias>_044b9786-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04845acb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10059,7 +10181,7 @@
             <iidm:temporaryLimit name="_9f39cb45-314c-445e-b177-909854a9ce45" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0484f709-c766-11e1-8775-005056c00008" name="11-12" r="1.0367280000000001" x="3.4151039999999999" g1="0" b1="1.4405399999999999e-05" g2="0" b2="1.4405399999999999e-05" node1="40" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="40.425052579856022" q1="-31.197267263300212" p2="-40.26647724265132" q2="31.229489572811904">
+    <iidm:line id="_0484f709-c766-11e1-8775-005056c00008" name="11-12" r="1.0367280000000001" x="3.4151039999999999" g1="0" b1="1.4405399999999999e-05" g2="0" b2="1.4405399999999999e-05" node1="40" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="35.216675958271203" q1="-27.383186785371343" p2="-35.095867227548574" q2="27.29077504169981">
         <iidm:alias>_0456e227-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04880440-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10067,7 +10189,7 @@
             <iidm:temporaryLimit name="_70fad3e1-4529-4a7f-9e6c-8ab249d65460" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044bbe91-c766-11e1-8775-005056c00008" name="8-9" r="1.18096" x="14.762" g1="0" b1="0.001200413215" g2="0" b2="0.001200413215" node1="31" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_045c8779-c766-11e1-8775-005056c00008" p1="-485.17261028640604" q1="-88.183819738076068" p2="490.89653064834249" q2="38.994852241933046">
+    <iidm:line id="_044bbe91-c766-11e1-8775-005056c00008" name="8-9" r="1.18096" x="14.762" g1="0" b1="0.001200413215" g2="0" b2="0.001200413215" node1="31" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_045c8779-c766-11e1-8775-005056c00008" p1="-485.11929056318513" q1="-85.450403464344134" p2="490.81341263812004" q2="35.498584359099524">
         <iidm:alias>_04745535-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048a7548-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="2000">
@@ -10075,7 +10197,7 @@
             <iidm:temporaryLimit name="_205e5d8a-f05a-479d-adaa-3514f48f6857" acceptableDuration="60" value="2400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04566cf8-c766-11e1-8775-005056c00008" name="64-65" r="1.30196" x="14.6168" g1="0" b1="0.000392562" g2="0" b2="0.000392562" node1="35" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-158.31430870128361" q1="-33.895863134456917" p2="159.00147457873388" q2="3.6091233754006051">
+    <iidm:line id="_04566cf8-c766-11e1-8775-005056c00008" name="64-65" r="1.30196" x="14.6168" g1="0" b1="0.000392562" g2="0" b2="0.000392562" node1="35" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-158.26981398358541" q1="-33.89869403333654" p2="158.95659801229135" q2="3.6076285045229586">
         <iidm:alias>_044a10e2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04793738-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10083,7 +10205,7 @@
             <iidm:temporaryLimit name="_8cee2b62-2953-439b-ba4b-4a48d55116c0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046783f3-c766-11e1-8775-005056c00008" name="54-56" r="0.47915999999999997" x="1.6639919999999999" g1="0" b1="2.1005500000000001e-05" g2="0" b2="2.1005500000000001e-05" node1="60" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="29.530056885876427" q1="2.7181787344477604" p2="-29.503482156006651" q2="-3.2926896431010584">
+    <iidm:line id="_046783f3-c766-11e1-8775-005056c00008" name="54-56" r="0.47915999999999997" x="1.6639919999999999" g1="0" b1="2.1005500000000001e-05" g2="0" b2="2.1005500000000001e-05" node1="60" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="29.543692910710316" q1="2.7172582152056575" p2="-29.517094061682581" q2="-3.2916851669208964">
         <iidm:alias>_0460f444-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d2949-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10091,7 +10213,7 @@
             <iidm:temporaryLimit name="_640627c7-0672-413e-8dc8-c9965709a5cb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04670ec6-c766-11e1-8775-005056c00008" name="84-85" r="5.2620480000000001" x="11.1687832" g1="0" b1="3.541095e-05" g2="0" b2="3.541095e-05" node1="21" voltageLevelId1="_047b0bf4-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-44.194979863383601" q1="13.755388767964686" p2="44.890156922647421" q2="-13.442916260374419">
+    <iidm:line id="_04670ec6-c766-11e1-8775-005056c00008" name="84-85" r="5.2620480000000001" x="11.1687832" g1="0" b1="3.541095e-05" g2="0" b2="3.541095e-05" node1="21" voltageLevelId1="_047b0bf4-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-43.993254322184228" q1="14.244950305313415" p2="44.690391710020414" q2="-13.922684351416514">
         <iidm:alias>_0453fbf5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046512f7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10099,7 +10221,7 @@
             <iidm:temporaryLimit name="_8b888209-5038-4b98-80fc-062b5ea55747" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0460cd36-c766-11e1-8775-005056c00008" name="34-36" r="1.51763" x="4.669632" g1="0" b1="1.6299349999999998e-05" g2="0" b2="1.6299349999999998e-05" node1="43" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="34.208704912124269" q1="11.238843464519501" p2="-34.081017804609132" q2="-11.347124412444099">
+    <iidm:line id="_0460cd36-c766-11e1-8775-005056c00008" name="34-36" r="1.51763" x="4.669632" g1="0" b1="1.6299349999999998e-05" g2="0" b2="1.6299349999999998e-05" node1="43" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="34.313779800619713" q1="11.194374352030101" p2="-34.185336007978378" q2="-11.299734040175633">
         <iidm:alias>_046a6a26-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0487b620-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10107,7 +10229,7 @@
             <iidm:temporaryLimit name="_c0a08025-3a61-4d24-9944-f3ef0b079f64" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04549836-c766-11e1-8775-005056c00008" name="24-70" r="0.38507000000000002" x="71.699759999999998" g1="0" b1="0.00029264234999999998" g2="0" b2="0.00029264234999999998" node1="32" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="23.791370715800703" q1="0.32452447934281092" p2="-23.778328351648661" q2="-8.0108614689006838">
+    <iidm:line id="_04549836-c766-11e1-8775-005056c00008" name="24-70" r="0.38507000000000002" x="71.699759999999998" g1="0" b1="0.00029264234999999998" g2="0" b2="0.00029264234999999998" node1="32" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="22.794323261628733" q1="0.45843096216073054" p2="-22.782288356916862" q2="-8.3450174383792213">
         <iidm:alias>_04549834-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04854522-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10115,7 +10237,7 @@
             <iidm:temporaryLimit name="_32793450-bbfd-4dcd-a911-89e199600780" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0452273a-c766-11e1-8775-005056c00008" name="85-86" r="6.0983999999999998" x="21.431519999999999" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="50" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0484f70a-c766-11e1-8775-005056c00008" p1="21.234486442334948" q1="12.280937406161394" p2="-20.999658093978095" q2="-14.004943815439866">
+    <iidm:line id="_0452273a-c766-11e1-8775-005056c00008" name="85-86" r="6.0983999999999998" x="21.431519999999999" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="50" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0484f70a-c766-11e1-8775-005056c00008" p1="21.283308435522141" q1="16.354675221401795" p2="-20.999283810936234" q2="-17.878632277015001">
         <iidm:alias>_044afb43-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479fa85-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10123,7 +10245,7 @@
             <iidm:temporaryLimit name="_2ec4bef5-7abb-4f52-bb62-49ee474d672b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0450eeb5-c766-11e1-8775-005056c00008" name="16-17" r="7.9104960000000002" x="31.380622899999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="22" voltageLevelId1="_046f7338-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-8.8739146497171681" q1="0.70912562009819258" p2="8.9153749183963136" q2="-4.9984223127557446">
+    <iidm:line id="_0450eeb5-c766-11e1-8775-005056c00008" name="16-17" r="7.9104960000000002" x="31.380622899999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="22" voltageLevelId1="_046f7338-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-15.652401830143017" q1="2.6659350682222658" p2="15.780052990280199" q2="-6.6114133163429152">
         <iidm:alias>_044ef2ea-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04837066-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10131,7 +10253,7 @@
             <iidm:temporaryLimit name="_9280074c-8555-49ff-9e62-8ed8f7d95060" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048a4e33-c766-11e1-8775-005056c00008" name="62-66" r="8.3983679999999996" x="37.984317799999999" g1="0" b1="0.00016586315" g2="0" b2="0.00016586315" node1="41" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-15.357578705937952" q1="-21.554356852245498" p2="15.641172199458756" q2="16.804832406723829">
+    <iidm:line id="_048a4e33-c766-11e1-8775-005056c00008" name="62-66" r="8.3983679999999996" x="37.984317799999999" g1="0" b1="0.00016586315" g2="0" b2="0.00016586315" node1="41" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-15.373917167474211" q1="-21.550123845337016" p2="15.657677422824944" q2="16.801356055676393">
         <iidm:alias>_046e13a9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a96c7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10139,7 +10261,7 @@
             <iidm:temporaryLimit name="_ace48562-0a49-4b76-ae82-c896a00b04f9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0478e913-c766-11e1-8775-005056c00008" name="76-77" r="7.736256" x="25.787520000000001" g1="0" b1="0.00010560145" g2="0" b2="0.00010560145" node1="21" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-60.855985814208111" q1="-21.408382126340953" p2="62.916663329617109" q2="24.802868278268065">
+    <iidm:line id="_0478e913-c766-11e1-8775-005056c00008" name="76-77" r="7.736256" x="25.787520000000001" g1="0" b1="0.00010560145" g2="0" b2="0.00010560145" node1="21" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-61.016701172191503" q1="-21.297411662375062" p2="63.085382957070479" q2="24.7193824880374">
         <iidm:alias>_044b9785-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04725965-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10147,7 +10269,7 @@
             <iidm:temporaryLimit name="_3f744dba-88dc-4d89-90d4-a6f196054b28" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048badc1-c766-11e1-8775-005056c00008" name="60-62" r="2.1431520000000002" x="9.7748640000000009" g1="0" b1="4.2125800000000002e-05" g2="0" b2="4.2125800000000002e-05" node1="32" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="-0.63846231029675549" q1="-8.6085159097571182" p2="0.64627794177144848" q2="7.1915472104319162">
+    <iidm:line id="_048badc1-c766-11e1-8775-005056c00008" name="60-62" r="2.1431520000000002" x="9.7748640000000009" g1="0" b1="4.2125800000000002e-05" g2="0" b2="4.2125800000000002e-05" node1="32" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="-0.64725771760086015" q1="-8.606082063284207" p2="0.65506996271219953" q2="7.1890973899024031">
         <iidm:alias>_045b7600-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04720b44-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10155,7 +10277,7 @@
             <iidm:temporaryLimit name="_43f91aaf-c5f4-4995-85a2-37afac616331" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0472a780-c766-11e1-8775-005056c00008" name="27-28" r="3.3332109999999999" x="14.89752" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="42" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04819ba0-c766-11e1-8775-005056c00008" p1="37.21786524681395" q1="-1.073064958551595" p2="-36.93547607023234" q2="0.32236033313557122">
+    <iidm:line id="_0472a780-c766-11e1-8775-005056c00008" name="27-28" r="3.3332109999999999" x="14.89752" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="42" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04819ba0-c766-11e1-8775-005056c00008" p1="35.146842367561305" q1="-1.3184836578424624" p2="-34.895816172367638" q2="0.41975480415444172">
         <iidm:alias>_04531198-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0475188b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10163,7 +10285,7 @@
             <iidm:temporaryLimit name="_2c20e8bd-84e6-4a1e-b88e-071f631327cb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c81e1-c766-11e1-8775-005056c00008" name="45-46" r="6.9695999999999998" x="23.626943600000001" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="31" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="34" voltageLevelId2="_048a7544-c766-11e1-8775-005056c00008" p1="-34.077107891401766" q1="-7.1026588043150349" p2="34.570799743341333" q2="5.4971014137431142">
+    <iidm:line id="_044c81e1-c766-11e1-8775-005056c00008" name="45-46" r="6.9695999999999998" x="23.626943600000001" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="31" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="34" voltageLevelId2="_048a7544-c766-11e1-8775-005056c00008" p1="-33.911785590205092" q1="-7.1850006979243179" p2="34.40123439873409" q2="5.5651758297027829">
         <iidm:alias>_04561ed6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045c877a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10171,7 +10293,7 @@
             <iidm:temporaryLimit name="_6ad31f7e-233f-4801-898f-9ffc883ec724" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c1249-c766-11e1-8775-005056c00008" name="18-19" r="1.949746" x="8.5900320000000008" g1="0" b1="3.2770900000000002e-05" g2="0" b2="3.2770900000000002e-05" node1="22" voltageLevelId1="_04689563-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="61.538161282802449" q1="-0.37715146234505725" p2="-61.060246842121288" q2="1.4774230583385117">
+    <iidm:line id="_045c1249-c766-11e1-8775-005056c00008" name="18-19" r="1.949746" x="8.5900320000000008" g1="0" b1="3.2770900000000002e-05" g2="0" b2="3.2770900000000002e-05" node1="22" voltageLevelId1="_04689563-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="64.748657230818978" q1="-1.0214758906647006" p2="-64.219005635680617" q2="2.3506966012583899">
         <iidm:alias>_046b066b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047ae4e0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10179,7 +10301,7 @@
             <iidm:temporaryLimit name="_a025c9d8-58f9-4320-a1fe-73ecc68d4147" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044a5f09-c766-11e1-8775-005056c00008" name="9-10" r="1.2487200000000001" x="15.584800700000001" g1="0" b1="0.0012706611300000001" g2="0" b2="0.0012706611300000001" node1="21" voltageLevelId1="_045c8779-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_044f4102-c766-11e1-8775-005056c00008" p1="-490.89653064834226" q1="-38.994852241932712" p2="496.71945676167024" q2="-21.996772236477913">
+    <iidm:line id="_044a5f09-c766-11e1-8775-005056c00008" name="9-10" r="1.2487200000000001" x="15.584800700000001" g1="0" b1="0.0012706611300000001" g2="0" b2="0.0012706611300000001" node1="21" voltageLevelId1="_045c8779-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_044f4102-c766-11e1-8775-005056c00008" p1="-490.81341263812038" q1="-35.498584359100086" p2="496.62643253498595" q2="-25.763699568537412">
         <iidm:alias>_04614262-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04834957-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="2000">
@@ -10187,7 +10309,7 @@
             <iidm:temporaryLimit name="_b7fac0a3-c5af-48b9-af49-261fd8d46e00" acceptableDuration="60" value="2400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0480b14b-c766-11e1-8775-005056c00008" name="85-88" r="3.4847999999999999" x="17.772480000000002" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="51" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0470f9d2-c766-11e1-8775-005056c00008" p1="-62.663829113790094" q1="4.9596741686252859" p2="63.501213749427329" q2="-3.3265905860415446">
+    <iidm:line id="_0480b14b-c766-11e1-8775-005056c00008" name="85-88" r="3.4847999999999999" x="17.772480000000002" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="51" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0470f9d2-c766-11e1-8775-005056c00008" p1="-62.563316908313737" q1="3.5210075949019815" p2="63.39901457328574" q2="-1.8869055690718228">
         <iidm:alias>_047602e2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04765105-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10195,7 +10317,7 @@
             <iidm:temporaryLimit name="_51646744-d343-42b5-8ba7-fcedc7cc3a98" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04486330-c766-11e1-8775-005056c00008" name="69-77" r="5.3840159999999999" x="17.598240000000001" g1="0" b1="0.00029786500000000002" g2="0" b2="0.00029786500000000002" node1="60" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="33.282588508026777" q1="17.398473878153474" p2="-32.811020719567189" q2="-26.637814770793778">
+    <iidm:line id="_04486330-c766-11e1-8775-005056c00008" name="69-77" r="5.3840159999999999" x="17.598240000000001" g1="0" b1="0.00029786500000000002" g2="0" b2="0.00029786500000000002" node1="60" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="33.395089153931295" q1="17.513927424583979" p2="-32.919824592603788" q2="-26.739683278456656">
         <iidm:alias>_046205b9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479d379-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10203,7 +10325,7 @@
             <iidm:temporaryLimit name="_76311a15-b79a-4439-a7ce-47afa8fa6fe2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04553477-c766-11e1-8775-005056c00008" name="11-13" r="3.8768400000000001" x="12.7369442" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="41" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04851e1b-c766-11e1-8775-005056c00008" p1="51.518204579834013" q1="15.762158649588182" p2="-50.847463336796039" q2="-15.340510206101321">
+    <iidm:line id="_04553477-c766-11e1-8775-005056c00008" name="11-13" r="3.8768400000000001" x="12.7369442" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="41" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04851e1b-c766-11e1-8775-005056c00008" p1="47.076683557411286" q1="16.947776589779401" p2="-46.497279936702604" q2="-16.827902426124133">
         <iidm:alias>_0479fa89-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0485452a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10211,7 +10333,7 @@
             <iidm:temporaryLimit name="_efbf8de7-4b84-4834-bb7c-6250b6072211" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04488a45-c766-11e1-8775-005056c00008" name="103-105" r="9.3218399999999999" x="28.314" g1="0" b1="0.0001170799" g2="0" b2="0.0001170799" node1="42" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="43.794279261468624" q1="12.536960497655187" p2="-42.676331174388643" q2="-13.123297097371866">
+    <iidm:line id="_04488a45-c766-11e1-8775-005056c00008" name="103-105" r="9.3218399999999999" x="28.314" g1="0" b1="0.0001170799" g2="0" b2="0.0001170799" node1="42" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="43.794143402210324" q1="12.537063613765415" p2="-42.676200001872779" q2="-13.123414112376775">
         <iidm:alias>_044f8f24-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04611b58-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10219,7 +10341,7 @@
             <iidm:temporaryLimit name="_22b6919a-a7a0-49fc-9e90-329069c55055" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046009e6-c766-11e1-8775-005056c00008" name="45-49" r="11.918016400000001" x="32.408639999999998" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="32" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="118" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-41.079899417341771" q1="-8.067696157012314" p2="42.300453334509044" q2="6.9112155512338207">
+    <iidm:line id="_046009e6-c766-11e1-8775-005056c00008" name="45-49" r="11.918016400000001" x="32.408639999999998" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="32" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="118" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-40.91872739018261" q1="-8.1587984185857394" p2="42.130777599521004" q2="6.9793494120777799">
         <iidm:alias>_044ca8f9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047dcb1b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10227,7 +10349,7 @@
             <iidm:temporaryLimit name="_8b91f4fd-4038-45b7-870c-fbc08592b95a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046a6a27-c766-11e1-8775-005056c00008" name="88-89" r="2.4219360000000001" x="12.4058876" g1="0" b1="5.549815e-05" g2="0" b2="5.549815e-05" node1="22" voltageLevelId1="_0470f9d2-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-111.50217137578429" q1="-6.6737418024392978" p2="113.29952454334793" q2="13.971400739481288">
+    <iidm:line id="_046a6a27-c766-11e1-8775-005056c00008" name="88-89" r="2.4219360000000001" x="12.4058876" g1="0" b1="5.549815e-05" g2="0" b2="5.549815e-05" node1="22" voltageLevelId1="_0470f9d2-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-111.39984571555151" q1="-8.1133827077026481" p2="113.20040030771239" q2="15.42940957873531">
         <iidm:alias>_045ef879-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04649dc1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10235,7 +10357,7 @@
             <iidm:temporaryLimit name="_970bc323-73bf-440d-a3c5-00aebc3a1992" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048a7540-c766-11e1-8775-005056c00008" name="80-98" r="4.1469120000000004" x="18.817920000000001" g1="0" b1="8.20707e-05" g2="0" b2="8.20707e-05" node1="79" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04773b62-c766-11e1-8775-005056c00008" p1="11.915463691826133" q1="11.857288567433939" p2="-11.844687549172333" q2="-14.58050256365469">
+    <iidm:line id="_048a7540-c766-11e1-8775-005056c00008" name="80-98" r="4.1469120000000004" x="18.817920000000001" g1="0" b1="8.20707e-05" g2="0" b2="8.20707e-05" node1="79" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04773b62-c766-11e1-8775-005056c00008" p1="11.928182103451368" q1="11.854317409777218" p2="-11.857356757723741" q2="-14.577309082026963">
         <iidm:alias>_045338a2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04887972-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10243,7 +10365,7 @@
             <iidm:temporaryLimit name="_cb084dc7-1b26-415f-9495-4695df661912" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04640183-c766-11e1-8775-005056c00008" name="91-92" r="6.7430880000000002" x="22.163329999999998" g1="0" b1="9.3778700000000004e-05" g2="0" b2="9.3778700000000004e-05" node1="22" voltageLevelId1="_044f8f29-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="-5.8336585672358598" q1="-14.575452850281289" p2="5.9175556425039204" q2="11.71357271415766">
+    <iidm:line id="_04640183-c766-11e1-8775-005056c00008" name="91-92" r="6.7430880000000002" x="22.163329999999998" g1="0" b1="9.3778700000000004e-05" g2="0" b2="9.3778700000000004e-05" node1="22" voltageLevelId1="_044f8f29-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="-5.8106591927671243" q1="-14.565055235597219" p2="5.894340510866563" q2="11.702718367729419">
         <iidm:alias>_04492680-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_044c5ad5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10251,7 +10373,7 @@
             <iidm:temporaryLimit name="_3a165a76-f6ba-461b-84d6-159a5e0b5077" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0474a358-c766-11e1-8775-005056c00008" name="7-12" r="1.501949" x="5.9241599999999996" g1="0" b1="2.5080350000000001e-05" g2="0" b2="2.5080350000000001e-05" node1="22" voltageLevelId1="_047eb571-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="24.69854073011177" q1="-10.672177468718937" p2="-24.635478022861378" q2="10.065532111835685">
+    <iidm:line id="_0474a358-c766-11e1-8775-005056c00008" name="7-12" r="1.501949" x="5.9241599999999996" g1="0" b1="2.5080350000000001e-05" g2="0" b2="2.5080350000000001e-05" node1="22" voltageLevelId1="_047eb571-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="20.344523779457692" q1="-8.5924074345529782" p2="-20.302166804397253" q2="7.9037891517537489">
         <iidm:alias>_046ab848-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0477feb7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10259,7 +10381,7 @@
             <iidm:temporaryLimit name="_b19bc945-cc51-4d77-8eaa-3f6afe2d9316" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04765108-c766-11e1-8775-005056c00008" name="99-100" r="3.13632" x="14.165711399999999" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_04644fa4-c766-11e1-8775-005056c00008" node2="80" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-39.527984003735838" q1="12.170755562447702" p2="39.828850888887857" q2="-13.052631184360155">
+    <iidm:line id="_04765108-c766-11e1-8775-005056c00008" name="99-100" r="3.13632" x="14.165711399999999" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_04644fa4-c766-11e1-8775-005056c00008" node2="80" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-39.515212918826037" q1="12.167805137399263" p2="39.815891448936249" q2="-13.050532120194802">
         <iidm:alias>_0471e436-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047e4040-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10267,7 +10389,7 @@
             <iidm:temporaryLimit name="_a9e283ed-fcad-4f4c-ab57-8531875bb098" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047b8128-c766-11e1-8775-005056c00008" name="114-115" r="0.400752" x="1.8120959999999999" g1="0" b1="7.9201000000000006e-06" g2="0" b2="7.9201000000000006e-06" node1="22" voltageLevelId1="_04791027-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="-1.3201731712689624" q1="3.3208452001065556" p2="1.3205114193700895" q2="-3.5751572696076881">
+    <iidm:line id="_047b8128-c766-11e1-8775-005056c00008" name="114-115" r="0.400752" x="1.8120959999999999" g1="0" b1="7.9201000000000006e-06" g2="0" b2="7.9201000000000006e-06" node1="22" voltageLevelId1="_04791027-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="-0.23482225787957622" q1="2.7389506339289804" p2="0.23502697710540257" q2="-2.9945802123082932">
         <iidm:alias>_046c17d3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d0233-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10275,7 +10397,7 @@
             <iidm:temporaryLimit name="_c59e4022-b1c0-4811-a32e-f54656bff32d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046931a5-c766-11e1-8775-005056c00008" name="83-84" r="10.890000000000001" x="22.999680000000001" g1="0" b1="7.4035799999999993e-05" g2="0" b2="7.4035799999999993e-05" node1="33" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b0bf4-c766-11e1-8775-005056c00008" p1="-32.205421176029347" q1="20.40791252361273" p2="33.194421785320763" q2="-20.755980592470948">
+    <iidm:line id="_046931a5-c766-11e1-8775-005056c00008" name="83-84" r="10.890000000000001" x="22.999680000000001" g1="0" b1="7.4035799999999993e-05" g2="0" b2="7.4035799999999993e-05" node1="33" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b0bf4-c766-11e1-8775-005056c00008" p1="-31.995131457514681" q1="20.924392219416159" p2="32.992754493108002" q2="-21.245480204236923">
         <iidm:alias>_0465d645-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479102b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10283,7 +10405,7 @@
             <iidm:temporaryLimit name="_1268eb09-e233-44ce-b8af-22dc30eb16ad" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047ae4ea-c766-11e1-8775-005056c00008" name="14-15" r="10.367279999999999" x="33.976799999999997" g1="0" b1="0.0001440542" g2="0" b2="0.0001440542" node1="21" voltageLevelId1="_047b8129-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="23.332487476418443" q1="6.7113168422738596" p2="-22.9410604879061" q2="-10.063341082954629">
+    <iidm:line id="_047ae4ea-c766-11e1-8775-005056c00008" name="14-15" r="10.367279999999999" x="33.976799999999997" g1="0" b1="0.0001440542" g2="0" b2="0.0001440542" node1="21" voltageLevelId1="_047b8129-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="18.398841930760902" q1="8.2448927971223274" p2="-18.117029080211079" q2="-11.954641685939078">
         <iidm:alias>_0449e9d9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046ed6fa-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10291,7 +10413,7 @@
             <iidm:temporaryLimit name="_9c0c454b-ecc3-40f6-b505-f32fec412522" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046e3ab2-c766-11e1-8775-005056c00008" name="80-96" r="6.2029439999999996" x="31.711680000000001" g1="0" b1="0.0001417585" g2="0" b2="0.0001417585" node1="80" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="5.0220104517520303" q1="26.02956050032919" p2="-4.7425772939796866" q2="-29.683891790207799">
+    <iidm:line id="_046e3ab2-c766-11e1-8775-005056c00008" name="80-96" r="6.2029439999999996" x="31.711680000000001" g1="0" b1="0.0001417585" g2="0" b2="0.0001417585" node1="80" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="5.070835520866086" q1="26.227241782616804" p2="-4.7874924221198834" q2="-29.859814284926379">
         <iidm:alias>_045338a4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04865695-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10299,7 +10421,7 @@
             <iidm:temporaryLimit name="_1432f4d6-9299-4b0d-bd7f-16e059f9de66" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04893cc4-c766-11e1-8775-005056c00008" name="56-59" r="13.9914722" x="41.643360000000001" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="59" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-20.123858437388293" q1="-7.6804143423896782" p2="20.505531447432627" q2="3.777861396247177">
+    <iidm:line id="_04893cc4-c766-11e1-8775-005056c00008" name="56-59" r="13.9914722" x="41.643360000000001" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="59" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-20.106873348876633" q1="-7.6871336059803284" p2="20.488005728282982" q2="3.7829730028177404">
         <iidm:alias>_046b5484-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04798557-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10307,7 +10429,7 @@
             <iidm:temporaryLimit name="_193f6952-4267-4cc8-a541-726c095028ba" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c1243-c766-11e1-8775-005056c00008" name="92-100" r="11.290752400000001" x="51.400799999999997" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="71" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="36.662398918363493" q1="-17.236702346850848" p2="-35.625408318353685" q2="17.205874050558041">
+    <iidm:line id="_045c1243-c766-11e1-8775-005056c00008" name="92-100" r="11.290752400000001" x="51.400799999999997" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="71" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="36.697433416806589" q1="-17.255847883370141" p2="-35.65825289493359" q2="17.235224480034116">
         <iidm:alias>_045e8348-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045ed164-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10315,7 +10437,7 @@
             <iidm:temporaryLimit name="_579249ce-1c81-4d29-8d3f-5fc627a18f99" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0474a356-c766-11e1-8775-005056c00008" name="43-44" r="10.593792000000001" x="42.7584953" g1="0" b1="0.00017412765" g2="0" b2="0.00017412765" node1="22" voltageLevelId1="_045e8349-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04544a15-c766-11e1-8775-005056c00008" p1="-5.9810642599074395" q1="-11.30478715106293" p2="6.0550484818088526" q2="5.9979433995086469">
+    <iidm:line id="_0474a356-c766-11e1-8775-005056c00008" name="43-44" r="10.593792000000001" x="42.7584953" g1="0" b1="0.00017412765" g2="0" b2="0.00017412765" node1="22" voltageLevelId1="_045e8349-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04544a15-c766-11e1-8775-005056c00008" p1="-5.6579176567622094" q1="-11.48516811452248" p2="5.7315610334473703" q2="6.1799612277108054">
         <iidm:alias>_04642899-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047b0bf2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10323,7 +10445,7 @@
             <iidm:temporaryLimit name="_3d2cb4b5-ee82-4866-9855-4a5f4803cd3b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04627ae6-c766-11e1-8775-005056c00008" name="109-110" r="4.8438720000000002" x="13.2770882" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="22" voltageLevelId1="_046b7b99-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="12.795561773368791" q1="-2.990913920525315" p2="-12.744573988889943" q2="1.2843351877822404">
+    <iidm:line id="_04627ae6-c766-11e1-8775-005056c00008" name="109-110" r="4.8438720000000002" x="13.2770882" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="22" voltageLevelId1="_046b7b99-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="12.799172419024599" q1="-2.9922486859582693" p2="-12.74815489005004" q2="1.2857521570607244">
         <iidm:alias>_0466e7b5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a6fbb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10331,7 +10453,7 @@
             <iidm:temporaryLimit name="_6fc48d8d-05f8-4104-a6a2-3686d430a091" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0478c207-c766-11e1-8775-005056c00008" name="68-81" r="0.84699999999999998" x="9.7767990000000005" g1="0" b1="0.00083471078000000004" g2="0" b2="0.00083471078000000004" node1="38" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_048a272b-c766-11e1-8775-005056c00008" p1="-150.59105649936907" q1="-3.8664626401707509" p2="151.01226055397379" q2="-71.514127041823926">
+    <iidm:line id="_0478c207-c766-11e1-8775-005056c00008" name="68-81" r="0.84699999999999998" x="9.7767990000000005" g1="0" b1="0.00083471078000000004" g2="0" b2="0.00083471078000000004" node1="38" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_048a272b-c766-11e1-8775-005056c00008" p1="-149.87510622870644" q1="-3.9404184101597823" p2="150.29243776665294" q2="-71.485442845884108">
         <iidm:alias>_044a37f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045b4ef6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10339,7 +10461,7 @@
             <iidm:temporaryLimit name="_191836a1-39cd-402b-8dcf-4f3867c45bd0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0467d215-c766-11e1-8775-005056c00008" name="85-89" r="4.1643359999999996" x="30.143518400000001" g1="0" b1="0.00013487144999999999" g2="0" b2="0.00013487144999999999" node1="52" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-83.383729983184935" q1="-2.3815564576486317" p2="85.138018996384574" q2="10.480388230613174">
+    <iidm:line id="_0467d215-c766-11e1-8775-005056c00008" name="85-89" r="4.1643359999999996" x="30.143518400000001" g1="0" b1="0.00013487144999999999" g2="0" b2="0.00013487144999999999" node1="52" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-83.169286119957604" q1="-3.823287810742547" p2="84.924355949983138" q2="11.939370962381798">
         <iidm:alias>_047629f9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0478e915-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10347,7 +10469,7 @@
             <iidm:temporaryLimit name="_66cbdeeb-a4e4-4bfc-aec1-9fb7a2d2b6bc" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044a37f2-c766-11e1-8775-005056c00008" name="89-90" r="4.1469120000000004" x="17.371727" g1="0" b1="0.00030417815" g2="0" b2="0.00030417815" node1="62" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="112.63838281514573" q1="21.222811679818061" p2="-109.48232505585513" q2="-18.216931091032233">
+    <iidm:line id="_044a37f2-c766-11e1-8775-005056c00008" name="89-90" r="4.1469120000000004" x="17.371727" g1="0" b1="0.00030417815" g2="0" b2="0.00030417815" node1="62" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="112.65435284479987" q1="21.23407244076634" p2="-109.49730629128938" q2="-18.223913835516431">
         <iidm:alias>_045386c2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048719e9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10355,7 +10477,7 @@
             <iidm:temporaryLimit name="_8489e809-6588-4ed2-a9a4-43c44a0d47da" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04658820-c766-11e1-8775-005056c00008" name="98-100" r="6.9173280000000004" x="31.188960999999999" g1="0" b1="0.0001365932" g2="0" b2="0.0001365932" node1="22" voltageLevelId1="_04773b62-c766-11e1-8775-005056c00008" node2="82" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-22.155451663715471" q1="6.5804480272969146" p2="22.372720905196019" q2="-10.555095871949097">
+    <iidm:line id="_04658820-c766-11e1-8775-005056c00008" name="98-100" r="6.9173280000000004" x="31.188960999999999" g1="0" b1="0.0001365932" g2="0" b2="0.0001365932" node1="22" voltageLevelId1="_04773b62-c766-11e1-8775-005056c00008" node2="82" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-22.142785010027968" q1="6.5772536706506468" p2="22.359819468817619" q2="-10.552961692658208">
         <iidm:alias>_046f4c22-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046fe865-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10363,7 +10485,7 @@
             <iidm:temporaryLimit name="_620beaaf-63c8-4020-bea5-c3609c0eaadf" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c5ada-c766-11e1-8775-005056c00008" name="28-29" r="4.1294880000000003" x="16.430831900000001" g1="0" b1="6.8296599999999999e-05" g2="0" b2="6.8296599999999999e-05" node1="22" voltageLevelId1="_04819ba0-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04588fd5-c766-11e1-8775-005056c00008" p1="19.931136483740826" q1="-7.3253390347649106" p2="-19.819471971381773" q2="5.5640308876678306">
+    <iidm:line id="_044c5ada-c766-11e1-8775-005056c00008" name="28-29" r="4.1294880000000003" x="16.430831900000001" g1="0" b1="6.8296599999999999e-05" g2="0" b2="6.8296599999999999e-05" node1="22" voltageLevelId1="_04819ba0-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04588fd5-c766-11e1-8775-005056c00008" p1="17.890455945490601" q1="-5.2096879342959657" p2="-17.804555752496022" q2="3.3396615086956052">
         <iidm:alias>_0461697a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04697fc1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10371,7 +10493,13 @@
             <iidm:temporaryLimit name="_6748d0d0-aec8-4b7b-a9ab-be6aecda7c5d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0468e382-c766-11e1-8775-005056c00008" name="3-5" r="4.1991839999999998" x="18.817920000000001" g1="0" b1="8.1496799999999995e-05" g2="0" b2="8.1496799999999995e-05" node1="31" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-72.90553414648403" q1="-15.127330698878003" p2="74.309729112550883" q2="18.634271808791567">
+    <iidm:line id="_044c5ada-c766-11e1-8775-005056c00008-1" name="28-29-open-ended" r="4.1294880000000003" x="16.430831900000001" g1="0" b1="6.8296599999999999e-05" g2="0" b2="6.8296599999999999e-05" node1="25" voltageLevelId1="_04819ba0-c766-11e1-8775-005056c00008" node2="25" voltageLevelId2="_04588fd5-c766-11e1-8775-005056c00008" p1="0.0003126671968724801" q1="-2.2135313157029635" p2="0" q2="0">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_accb8136-1faf-4399-9787-3cd567284fd2-1" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_6748d0d0-aec8-4b7b-a9ab-be6aecda7c5d-1" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0468e382-c766-11e1-8775-005056c00008" name="3-5" r="4.1991839999999998" x="18.817920000000001" g1="0" b1="8.1496799999999995e-05" g2="0" b2="8.1496799999999995e-05" node1="31" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-70.622432315164957" q1="-16.321275778228529" p2="71.950498043751622" q2="19.482889158265415">
         <iidm:alias>_046b0668-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04742e24-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10379,7 +10507,7 @@
             <iidm:temporaryLimit name="_828ca44c-560b-4f94-b825-21e237285fae" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0447c6f1-c766-11e1-8775-005056c00008" name="82-96" r="2.8226879999999999" x="9.2347199999999994" g1="0" b1="0.00015610649999999999" g2="0" b2="0.00015610649999999999" node1="33" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="-15.124795572885077" q1="-8.8460691857272948" p2="15.169713405009816" q2="3.7137142978704083">
+    <iidm:line id="_0447c6f1-c766-11e1-8775-005056c00008" name="82-96" r="2.8226879999999999" x="9.2347199999999994" g1="0" b1="0.00015610649999999999" g2="0" b2="0.00015610649999999999" node1="33" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="-15.333423154835648" q1="-9.5605244678797003" p2="15.381073352420497" q2="4.4432767408488321">
         <iidm:alias>_0478e91a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0480d856-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10387,7 +10515,7 @@
             <iidm:temporaryLimit name="_233b7735-85f4-4a6f-9d87-15129fe42ef5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0483e594-c766-11e1-8775-005056c00008" name="38-65" r="4.3608399999999996" x="47.7224" g1="0" b1="0.0010805785" g2="0" b2="0.0010805785" node1="29" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-163.82285154539017" q1="-98.115972868933454" p2="167.02214178801015" q2="36.438170768856622">
+    <iidm:line id="_0483e594-c766-11e1-8775-005056c00008" name="38-65" r="4.3608399999999996" x="47.7224" g1="0" b1="0.0010805785" g2="0" b2="0.0010805785" node1="29" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-162.14686202288115" q1="-98.734797401275159" p2="165.29656327363583" q2="36.536409004532416">
         <iidm:alias>_04638c56-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d5054-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10395,7 +10523,7 @@
             <iidm:temporaryLimit name="_990ce3c5-c90c-41b9-abee-fb803d9df3a5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04784cd4-c766-11e1-8775-005056c00008" name="106-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_04479fe8-c766-11e1-8775-005056c00008" node2="24" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="23.856842442591578" q1="-0.69595279503568208" p2="-23.528326199978839" q2="-2.4532330757024892">
+    <iidm:line id="_04784cd4-c766-11e1-8775-005056c00008" name="106-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_04479fe8-c766-11e1-8775-005056c00008" node2="24" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="23.857091990885383" q1="-0.69603805766478888" p2="-23.528568907011962" q2="-2.453122548634187">
         <iidm:alias>_04483c21-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f0395-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10403,7 +10531,7 @@
             <iidm:temporaryLimit name="_1372c3b0-62d7-47d7-a8c0-ed8e10bc1f1a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046f9a43-c766-11e1-8775-005056c00008" name="27-115" r="2.8575360000000001" x="12.9111843" g1="0" b1="5.6588600000000002e-05" g2="0" b2="5.6588600000000002e-05" node1="43" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="23.431445296125865" q1="2.0335580853287993" p2="-23.333959502815926" q2="-3.4319764996410442">
+    <iidm:line id="_046f9a43-c766-11e1-8775-005056c00008" name="27-115" r="2.8575360000000001" x="12.9111843" g1="0" b1="5.6588600000000002e-05" g2="0" b2="5.6588600000000002e-05" node1="43" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="22.338932154552701" q1="2.5711819898281374" p2="-22.249869197382385" q2="-4.0132926476076323">
         <iidm:alias>_046d0238-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048c22f4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10411,7 +10539,7 @@
             <iidm:temporaryLimit name="_64cfd0fb-1d8e-45d2-a52f-469238dfc0c6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04529c61-c766-11e1-8775-005056c00008" name="12-14" r="3.7461600000000002" x="12.3187675" g1="0" b1="5.2112050000000002e-05" g2="0" b2="5.2112050000000002e-05" node1="71" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b8129-c766-11e1-8775-005056c00008" p1="37.650373503188568" q1="7.0224721006187467" p2="-37.325678410682706" q2="-7.71050616379899">
+    <iidm:line id="_04529c61-c766-11e1-8775-005056c00008" name="12-14" r="3.7461600000000002" x="12.3187675" g1="0" b1="5.2112050000000002e-05" g2="0" b2="5.2112050000000002e-05" node1="71" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b8129-c766-11e1-8775-005056c00008" p1="32.644647415900913" q1="8.3181257063296812" p2="-32.392276073017982" q2="-9.2441112818545825">
         <iidm:alias>_045fbbc1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047bf65b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10419,7 +10547,7 @@
             <iidm:temporaryLimit name="_efe2501d-bcee-42ff-a037-3d8a280487b0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0463da77-c766-11e1-8775-005056c00008" name="76-118" r="2.8575360000000001" x="9.4786560000000009" g1="0" b1="3.8911849999999999e-05" g2="0" b2="3.8911849999999999e-05" node1="22" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="-7.1772486767432486" q1="-14.620946490676831" p2="7.2233743800067955" q2="13.565549619599745">
+    <iidm:line id="_0463da77-c766-11e1-8775-005056c00008" name="76-118" r="2.8575360000000001" x="9.4786560000000009" g1="0" b1="3.8911849999999999e-05" g2="0" b2="3.8911849999999999e-05" node1="22" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="-7.0165324977610206" q1="-14.731913895898096" p2="7.0628232101558872" q2="13.677217919394238">
         <iidm:alias>_046931a0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04806320-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10427,7 +10555,7 @@
             <iidm:temporaryLimit name="_2ae204bf-78cc-49cb-b886-a933b33057e4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046931a3-c766-11e1-8775-005056c00008" name="74-75" r="2.1431520000000002" x="7.0741440000000004" g1="0" b1="2.9671699999999999e-05" g2="0" b2="2.9671699999999999e-05" node1="23" voltageLevelId1="_047dcb11-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="-42.267130302954776" q1="-4.4657754136808139" p2="42.506715416166045" q2="4.2925750084289369">
+    <iidm:line id="_046931a3-c766-11e1-8775-005056c00008" name="74-75" r="2.1431520000000002" x="7.0741440000000004" g1="0" b1="2.9671699999999999e-05" g2="0" b2="2.9671699999999999e-05" node1="23" voltageLevelId1="_047dcb11-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="-42.630810346642484" q1="-4.2580862235295145" p2="42.874271031461817" q2="4.097660869981457">
         <iidm:alias>_044f4103-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04638c58-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10435,7 +10563,7 @@
             <iidm:temporaryLimit name="_e822432e-79af-4bba-8f40-5250468f81a0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045ed162-c766-11e1-8775-005056c00008" name="3-12" r="8.4332159999999998" x="27.878398900000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="32" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-7.1032069195771514" q1="-10.664530894634666" p2="7.1682396191093876" q2="6.9718464135281142">
+    <iidm:line id="_045ed162-c766-11e1-8775-005056c00008" name="3-12" r="8.4332159999999998" x="27.878398900000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="32" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-8.3949561129791093" q1="-9.9794786948303074" p2="8.4642625142219838" q2="6.2990483401115602">
         <iidm:alias>_047a48a1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047b5a14-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10443,7 +10571,7 @@
             <iidm:temporaryLimit name="_c437e52c-43d7-4ae9-87ad-dc19396dc6ff" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04499bb6-c766-11e1-8775-005056c00008" name="49-51" r="8.468064" x="23.8708782" g1="0" b1="9.81405e-05" g2="0" b2="9.81405e-05" node1="119" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04542300-c766-11e1-8775-005056c00008" p1="76.900173711196487" q1="18.656264221427001" p2="-73.971126555208357" q2="-13.790753830780437">
+    <iidm:line id="_04499bb6-c766-11e1-8775-005056c00008" name="49-51" r="8.468064" x="23.8708782" g1="0" b1="9.81405e-05" g2="0" b2="9.81405e-05" node1="119" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04542300-c766-11e1-8775-005056c00008" p1="76.924862772138511" q1="18.65233433571186" p2="-73.994133216639582" q2="-13.782071309726835">
         <iidm:alias>_0487dd38-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b1180-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10451,7 +10579,7 @@
             <iidm:temporaryLimit name="_90dcdbe1-437b-443f-b0b5-c2353f7c6954" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04839779-c766-11e1-8775-005056c00008" name="40-42" r="9.6703209999999995" x="31.885919999999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="42" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="-1.1225103181765013" q1="-9.6639322464153459" p2="1.1653647046932627" q2="5.9938001039243138">
+    <iidm:line id="_04839779-c766-11e1-8775-005056c00008" name="40-42" r="9.6703209999999995" x="31.885919999999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="42" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="-0.87823392668523492" q1="-9.8265633491728099" p2="0.92258940242899734" q2="6.1645274181254059">
         <iidm:alias>_044974a9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04616975-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10459,7 +10587,7 @@
             <iidm:temporaryLimit name="_9b8510fa-bd0e-4e63-8f4c-0e5443a3eb63" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0484a8e1-c766-11e1-8775-005056c00008" name="32-113" r="10.71576" x="35.370719999999999" g1="0" b1="0.00014864555000000001" g2="0" b2="0.00014864555000000001" node1="52" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="13.389650184118887" q1="-10.297477210770015" p2="-13.231112283334465" q2="5.9294446025618548">
+    <iidm:line id="_0484a8e1-c766-11e1-8775-005056c00008" name="32-113" r="10.71576" x="35.370719999999999" g1="0" b1="0.00014864555000000001" g2="0" b2="0.00014864555000000001" node1="52" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="8.8509597819762629" q1="-8.5271018730836765" p2="-8.7752262190731152" q2="3.8804819032948865">
         <iidm:alias>_04723258-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0482860a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10467,7 +10595,7 @@
             <iidm:temporaryLimit name="_336bfd86-a922-4154-9e06-cd87382cdc5f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04898ae4-c766-11e1-8775-005056c00008" name="51-58" r="4.4431200000000004" x="12.5278568" g1="0" b1="5.1308550000000002e-05" g2="0" b2="5.1308550000000002e-05" node1="31" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="25.338962227114191" q1="0.47642623051247468" p2="-25.162928989829087" q2="-1.6346434363411402">
+    <iidm:line id="_04898ae4-c766-11e1-8775-005056c00008" name="51-58" r="4.4431200000000004" x="12.5278568" g1="0" b1="5.1308550000000002e-05" g2="0" b2="5.1308550000000002e-05" node1="31" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="25.354388931510286" q1="0.47003658706094159" p2="-25.178145313137044" q2="-1.6276516651901107">
         <iidm:alias>_044778d4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04789af1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10475,7 +10603,7 @@
             <iidm:temporaryLimit name="_2be10dec-f0ac-470d-83f7-a2a4e70f3491" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046efe04-c766-11e1-8775-005056c00008" name="29-31" r="1.8817919999999999" x="5.7673439999999996" g1="0" b1="2.3817700000000001e-05" g2="0" b2="2.3817700000000001e-05" node1="22" voltageLevelId1="_04588fd5-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="-4.1824739661126209" q1="-9.5645715436992766" p2="4.1943148889214177" q2="8.827640942596604">
+    <iidm:line id="_046efe04-c766-11e1-8775-005056c00008" name="29-31" r="1.8817919999999999" x="5.7673439999999996" g1="0" b1="2.3817700000000001e-05" g2="0" b2="2.3817700000000001e-05" node1="22" voltageLevelId1="_04588fd5-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="-6.1976485247788027" q1="-7.3402738593593408" p2="6.2077354060954892" q2="6.5975360673368">
         <iidm:alias>_04492688-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047cb9a5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10483,7 +10611,7 @@
             <iidm:temporaryLimit name="_f0e21213-6535-44a7-89b6-3063f8738d6b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044a10e4-c766-11e1-8775-005056c00008" name="65-68" r="0.66791999999999996" x="7.7439999999999998" g1="0" b1="0.00065909092999999995" g2="0" b2="0.00065909092999999995" node1="41" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0449e9d2-c766-11e1-8775-005056c00008" p1="-168.63703180971373" q1="24.529715807685854" p2="169.0695890131573" q2="-83.549120654507846">
+    <iidm:line id="_044a10e4-c766-11e1-8775-005056c00008" name="65-68" r="0.66791999999999996" x="7.7439999999999998" g1="0" b1="0.00065909092999999995" g2="0" b2="0.00065909092999999995" node1="41" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0449e9d2-c766-11e1-8775-005056c00008" p1="-166.73207647901691" q1="24.283227510949708" p2="167.15552346180849" q2="-83.408554956805006">
         <iidm:alias>_0461dea7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047629f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10491,7 +10619,7 @@
             <iidm:temporaryLimit name="_ab31cd46-6d0c-4d9c-95f1-396a45a237e1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046b7b92-c766-11e1-8775-005056c00008" name="49-54" r="12.719519999999999" x="50.355361899999998" g1="0" b1="0.00021177684999999999" g2="0" b2="0.00021177684999999999" node1="120" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="46.829807851344057" q1="11.84372088312554" p2="-45.134320801989638" q2="-12.373628180861635">
+    <iidm:line id="_046b7b92-c766-11e1-8775-005056c00008" name="49-54" r="12.719519999999999" x="50.355361899999998" g1="0" b1="0.00021177684999999999" g2="0" b2="0.00021177684999999999" node1="120" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="46.851886155304626" q1="11.841047272847414" p2="-45.155020400705112" q2="-12.365496504387652">
         <iidm:alias>_0462f017-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047120e1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10499,7 +10627,7 @@
             <iidm:temporaryLimit name="_1bf78539-b6fa-4d8b-ba8e-9b5970019be6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04607f15-c766-11e1-8775-005056c00008" name="70-71" r="1.536797" x="6.1855200000000004" g1="0" b1="2.5195149999999999e-05" g2="0" b2="2.5195149999999999e-05" node1="52" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04664b78-c766-11e1-8775-005056c00008" p1="-12.080097014256642" q1="-3.6795566613993897" p2="12.094272281864619" q2="2.8796658633219505">
+    <iidm:line id="_04607f15-c766-11e1-8775-005056c00008" name="70-71" r="1.536797" x="6.1855200000000004" g1="0" b1="2.5195149999999999e-05" g2="0" b2="2.5195149999999999e-05" node1="52" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04664b78-c766-11e1-8775-005056c00008" p1="-11.214257098381124" q1="-4.2103472700738696" p2="11.226940034625439" q2="3.4041064076233631">
         <iidm:alias>_04486336-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f51b4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10507,7 +10635,7 @@
             <iidm:temporaryLimit name="_08ff3ae4-d1dd-49f7-9eda-32ffc8eb0010" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c5ad7-c766-11e1-8775-005056c00008" name="55-56" r="0.85029100000000002" x="2.631024" g1="0" b1="1.0732300000000001e-05" g2="0" b2="1.0732300000000001e-05" node1="31" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="-28.699474996236006" q1="-6.9994031478915195" p2="28.746407613569779" q2="6.8052643287194829">
+    <iidm:line id="_044c5ad7-c766-11e1-8775-005056c00008" name="55-56" r="0.85029100000000002" x="2.631024" g1="0" b1="1.0732300000000001e-05" g2="0" b2="1.0732300000000001e-05" node1="31" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="-28.713458600555303" q1="-6.9948925074120885" p2="28.760431220329519" q2="6.8008776774124629">
         <iidm:alias>_04558294-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045868c2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10515,7 +10643,7 @@
             <iidm:temporaryLimit name="_94316214-afd8-4c0d-bca4-916acb92af85" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048a2725-c766-11e1-8775-005056c00008" name="35-37" r="1.9166399999999999" x="8.6597279999999994" g1="0" b1="3.7821399999999997e-05" g2="0" b2="3.7821399999999997e-05" node1="21" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-29.849336784808063" q1="-14.374688460312834" p2="29.984916382265066" q2="13.817385093219823">
+    <iidm:line id="_048a2725-c766-11e1-8775-005056c00008" name="35-37" r="1.9166399999999999" x="8.6597279999999994" g1="0" b1="3.7821399999999997e-05" g2="0" b2="3.7821399999999997e-05" node1="21" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-29.743595356063885" q1="-14.421517278388945" p2="29.878709064768039" q2="13.863459248224641">
         <iidm:alias>_0471bd29-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04808a30-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10523,7 +10651,7 @@
             <iidm:temporaryLimit name="_4ea6b532-d914-4b0c-97ee-9f02a14a40b3" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04614263-c766-11e1-8775-005056c00008" name="4-5" r="0.30666199999999999" x="1.3904350000000001" g1="0" b1="6.0261499999999999e-06" g2="0" b2="6.0261499999999999e-06" node1="22" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-114.24549354863522" q1="-17.522613933596247" p2="114.47821527298679" q2="18.364969217760951">
+    <iidm:line id="_04614263-c766-11e1-8775-005056c00008" name="4-5" r="0.30666199999999999" x="1.3904350000000001" g1="0" b1="6.0261499999999999e-06" g2="0" b2="6.0261499999999999e-06" node1="22" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-109.56729578233386" q1="-19.40799011682854" p2="109.78257746367149" q2="20.170861676796541">
         <iidm:alias>_04529c66-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04753f92-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10531,7 +10659,7 @@
             <iidm:temporaryLimit name="_2a95fb2b-6661-46e7-a9f6-fe63c1b7433c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0451b208-c766-11e1-8775-005056c00008" name="20-21" r="3.1885919999999999" x="14.7929754" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_046b2d70-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0460f448-c766-11e1-8775-005056c00008" p1="0.00018491731764905652" q1="-1.8686802377575862" p2="-3.2330257561153716e-14" q2="-9.0589374136356773e-14">
+    <iidm:line id="_0451b208-c766-11e1-8775-005056c00008" name="20-21" r="3.1885919999999999" x="14.7929754" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_046b2d70-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0460f448-c766-11e1-8775-005056c00008" p1="0.00018473180326602362" q1="-1.8668055245731996" p2="1.030333627570859e-14" q2="6.6339014971452328e-14">
         <iidm:alias>_046c65f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048c22f6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10539,7 +10667,7 @@
             <iidm:temporaryLimit name="_4b67f5f5-f0e1-4bfb-9d57-4d3474720a45" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047d55e4-c766-11e1-8775-005056c00008" name="104-105" r="1.731946" x="6.5862720000000001" g1="0" b1="2.8294300000000001e-05" g2="0" b2="2.8294300000000001e-05" node1="32" voltageLevelId1="_0483977a-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="48.060621408568352" q1="0.85760513313048325" p2="-47.816710889499724" q2="-0.85387812765421733">
+    <iidm:line id="_047d55e4-c766-11e1-8775-005056c00008" name="104-105" r="1.731946" x="6.5862720000000001" g1="0" b1="2.8294300000000001e-05" g2="0" b2="2.8294300000000001e-05" node1="32" voltageLevelId1="_0483977a-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="48.062474934269986" q1="0.85711641958696894" p2="-47.818545694914576" q2="-0.85331802198964146">
         <iidm:alias>_0451d910-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046c65f2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10547,7 +10675,7 @@
             <iidm:temporaryLimit name="_1ca40dc7-6736-4fa8-b4cb-ca696949e421" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046dc589-c766-11e1-8775-005056c00008" name="44-45" r="3.9029759999999998" x="15.699023199999999" g1="0" b1="6.4279149999999996e-05" g2="0" b2="6.4279149999999996e-05" node1="23" voltageLevelId1="_04544a15-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_045d23b4-c766-11e1-8775-005056c00008" p1="-22.049270962300419" q1="-4.5033278764964093" p2="22.166838420342593" q2="2.8322849066028821">
+    <iidm:line id="_046dc589-c766-11e1-8775-005056c00008" name="44-45" r="3.9029759999999998" x="15.699023199999999" g1="0" b1="6.4279149999999996e-05" g2="0" b2="6.4279149999999996e-05" node1="23" voltageLevelId1="_04544a15-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_045d23b4-c766-11e1-8775-005056c00008" p1="-21.725741140521674" q1="-4.6877762103632836" p2="21.840303079322883" q2="3.0049987559905329">
         <iidm:alias>_04518afa-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04667287-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10555,7 +10683,7 @@
             <iidm:temporaryLimit name="_ba738481-ddba-4ebe-a218-8aad0b537f5b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04642896-c766-11e1-8775-005056c00008" name="4-11" r="3.641616" x="11.9877129" g1="0" b1="5.0160700000000002e-05" g2="0" b2="5.0160700000000002e-05" node1="23" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="75.255261567183737" q1="5.5276231503912889" p2="-74.074862696260581" q2="-3.3747771592218312">
+    <iidm:line id="_04642896-c766-11e1-8775-005056c00008" name="4-11" r="3.641616" x="11.9877129" g1="0" b1="5.0160700000000002e-05" g2="0" b2="5.0160700000000002e-05" node1="23" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="70.576488287242498" q1="7.4127038211234817" p2="-69.533479706689505" q2="-5.7145618181431956">
         <iidm:alias>_0455f7c5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04803c17-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10563,7 +10691,7 @@
             <iidm:temporaryLimit name="_b1d87c24-e527-4174-aa04-cd0b9de271ea" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047d07c0-c766-11e1-8775-005056c00008" name="92-93" r="4.4953919999999998" x="14.775551800000001" g1="0" b1="6.2557400000000005e-05" g2="0" b2="6.2557400000000005e-05" node1="72" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04789af0-c766-11e1-8775-005056c00008" p1="70.139290462484269" q1="-12.739500916121434" p2="-68.807117343314886" q2="14.997036501660322">
+    <iidm:line id="_047d07c0-c766-11e1-8775-005056c00008" name="92-93" r="4.4953919999999998" x="14.775551800000001" g1="0" b1="6.2557400000000005e-05" g2="0" b2="6.2557400000000005e-05" node1="72" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04789af0-c766-11e1-8775-005056c00008" p1="70.193851832975113" q1="-12.675781215630916" p2="-68.859915511667097" q2="14.939472008383865">
         <iidm:alias>_044a5f07-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047602e5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10571,7 +10699,7 @@
             <iidm:temporaryLimit name="_4e1daf8e-7708-4b96-8d3f-67f58f2505f9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044f4109-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="43" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="121" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-54.119256945249305" q1="-18.867990541574308" p2="56.834052504248568" q2="23.032743726751814">
+    <iidm:line id="_044f4109-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="43" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="121" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-53.877628189963424" q1="-19.035992012737275" p2="56.576149128204676" q2="23.129394855380099">
         <iidm:alias>_046958b0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04758db0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10579,7 +10707,7 @@
             <iidm:temporaryLimit name="_c58940cb-bd36-4dfc-9615-11716dd652a7" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046e61c8-c766-11e1-8775-005056c00008" name="69-75" r="7.0567200000000003" x="21.257280000000002" g1="0" b1="0.00035583104999999999" g2="0" b2="0.00035583104999999999" node1="61" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="86.917230973445044" q1="23.930843007876305" p2="-83.707673705272342" q2="-26.727929556001843">
+    <iidm:line id="_046e61c8-c766-11e1-8775-005056c00008" name="69-75" r="7.0567200000000003" x="21.257280000000002" g1="0" b1="0.00035583104999999999" g2="0" b2="0.00035583104999999999" node1="61" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="87.393106764839231" q1="23.829545096222908" p2="-84.154526314582057" q2="-26.539080823177287">
         <iidm:alias>_046d294a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048ac362-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10587,7 +10715,7 @@
             <iidm:temporaryLimit name="_3c9a454c-10ee-4c72-a059-77f723f5b7c7" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0463da71-c766-11e1-8775-005056c00008" name="79-80" r="2.7181440000000001" x="12.2664957" g1="0" b1="5.3661600000000001e-05" g2="0" b2="5.3661600000000001e-05" node1="23" voltageLevelId1="_04481510-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-65.663025225500434" q1="-32.157913264734475" p2="66.475833840678106" q2="33.866155915581956">
+    <iidm:line id="_0463da71-c766-11e1-8775-005056c00008" name="79-80" r="2.7181440000000001" x="12.2664957" g1="0" b1="5.3661600000000001e-05" g2="0" b2="5.3661600000000001e-05" node1="23" voltageLevelId1="_04481510-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-65.77299790274887" q1="-32.263921600555456" p2="66.589207268951412" q2="33.987693662229333">
         <iidm:alias>_0464ebe9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04662468-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10595,7 +10723,7 @@
             <iidm:temporaryLimit name="_270a7d04-9ff9-4178-8b72-b610735a72ac" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044fdd41-c766-11e1-8775-005056c00008" name="51-52" r="3.5370720000000002" x="10.2453117" g1="0" b1="4.0059699999999999e-05" g2="0" b2="4.0059699999999999e-05" node1="32" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04806326-c766-11e1-8775-005056c00008" p1="31.632244613597816" q1="5.3143905852000239" p2="-31.40669074172402" q2="-5.9493731365113804">
+    <iidm:line id="_044fdd41-c766-11e1-8775-005056c00008" name="51-52" r="3.5370720000000002" x="10.2453117" g1="0" b1="4.0059699999999999e-05" g2="0" b2="4.0059699999999999e-05" node1="32" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04806326-c766-11e1-8775-005056c00008" p1="31.639828115578684" q1="5.3121005543204678" p2="-31.414174325687306" q2="-5.9467853161842275">
         <iidm:alias>_045115c2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0464ebe5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10603,7 +10731,7 @@
             <iidm:temporaryLimit name="_9d1eb182-ceb5-426e-9440-5f4d426a31cb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c3958-c766-11e1-8775-005056c00008" name="53-54" r="4.5825120000000004" x="21.257280000000002" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="22" voltageLevelId1="_04876804-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="-9.676357995817801" q1="-6.7203269315498719" p2="9.7122881952934588" q2="4.0881183744196701">
+    <iidm:line id="_045c3958-c766-11e1-8775-005056c00008" name="53-54" r="4.5825120000000004" x="21.257280000000002" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="22" voltageLevelId1="_04876804-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="-9.6689511480337096" q1="-6.7232651774762981" p2="9.7048485480273445" q2="4.0909092219100511">
         <iidm:alias>_044f6817-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0455f7c6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10611,7 +10739,7 @@
             <iidm:temporaryLimit name="_735ac8df-6a6a-43f0-86f2-49d3280c9a3b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044ef2e1-c766-11e1-8775-005056c00008" name="54-55" r="2.9446560000000002" x="12.3187675" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="63" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04767817-c766-11e1-8775-005056c00008" p1="10.15309461604584" q1="1.7079377745716648" p2="-10.132711883641916" q2="-3.4578013613117609">
+    <iidm:line id="_044ef2e1-c766-11e1-8775-005056c00008" name="54-55" r="2.9446560000000002" x="12.3187675" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="63" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04767817-c766-11e1-8775-005056c00008" p1="10.158094233176323" q1="1.7071990597728421" p2="-10.137693403635893" q2="-3.4569863693674927">
         <iidm:alias>_04640181-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047dcb17-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10619,7 +10747,7 @@
             <iidm:temporaryLimit name="_52aadf8d-53f2-4827-8c70-421bdf1ba822" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0456e226-c766-11e1-8775-005056c00008" name="80-97" r="3.1885919999999999" x="16.2740154" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="82" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="12.531716867112152" q1="30.634290671667518" p2="-12.331805777791665" q2="-32.280740166847167">
+    <iidm:line id="_0456e226-c766-11e1-8775-005056c00008" name="80-97" r="3.1885919999999999" x="16.2740154" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="82" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="12.581940791190549" q1="30.833231751902812" p2="-12.379654857187196" q2="-32.46708014122148">
         <iidm:alias>_04479fe9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047df222-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10627,7 +10755,7 @@
             <iidm:temporaryLimit name="_fece5807-6af8-4161-8de8-8f8473d92f11" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0487b624-c766-11e1-8775-005056c00008" name="103-110" r="6.8058139999999998" x="31.5897121" g1="0" b1="0.00013228879999999999" g2="0" b2="0.00013228879999999999" node1="43" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="57.782298867646467" q1="18.491771674727644" p2="-56.337515706897157" q2="-16.239432909814838">
+    <iidm:line id="_0487b624-c766-11e1-8775-005056c00008" name="103-110" r="6.8058139999999998" x="31.5897121" g1="0" b1="0.00013228879999999999" g2="0" b2="0.00013228879999999999" node1="43" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="57.786214294006555" q1="18.491420671077428" p2="-56.341263506858631" q2="-16.238303257062618">
         <iidm:alias>_046a9139-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b3895-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10635,7 +10763,7 @@
             <iidm:temporaryLimit name="_3eacc034-737e-41de-a7b6-b610d3bd0921" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045338a8-c766-11e1-8775-005056c00008" name="56-58" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="61" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="-13.098218469935558" q1="-0.66417598184598248" p2="13.162968810445808" q2="-1.3653399654227085">
+    <iidm:line id="_045338a8-c766-11e1-8775-005056c00008" name="56-58" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="61" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="-13.11328511735311" q1="-0.65675297274786559" p2="13.178186844578747" q2="-1.3723309983258429">
         <iidm:alias>_0451d915-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04817494-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10643,7 +10771,7 @@
             <iidm:temporaryLimit name="_0d0c3ec5-798a-48a4-9bc8-d19c57128a13" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04854529-c766-11e1-8775-005056c00008" name="15-33" r="6.6211200000000003" x="21.675455100000001" g1="0" b1="9.1655200000000003e-05" g2="0" b2="9.1655200000000003e-05" node1="52" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456bb11-c766-11e1-8775-005056c00008" p1="63.129231220831585" q1="-8.8424062052045969" p2="-61.409968393789981" q2="11.6533925773973">
+    <iidm:line id="_04854529-c766-11e1-8775-005056c00008" name="15-33" r="6.6211200000000003" x="21.675455100000001" g1="0" b1="9.1655200000000003e-05" g2="0" b2="9.1655200000000003e-05" node1="52" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456bb11-c766-11e1-8775-005056c00008" p1="64.364467974889166" q1="-8.918050013286404" p2="-62.576221030213773" q2="11.957936498119851">
         <iidm:alias>_0448d862-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047d2ed5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10651,7 +10779,7 @@
             <iidm:temporaryLimit name="_5b0395f4-534d-4975-a1af-e0b6ef439193" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04649dc2-c766-11e1-8775-005056c00008" name="35-36" r="0.39029799999999998" x="1.7772479999999999" g1="0" b1="7.6905500000000004e-06" g2="0" b2="7.6905500000000004e-06" node1="22" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="-3.1142756138179348" q1="5.3912224182215596" p2="3.1152980720158601" q2="-5.6215554227489033">
+    <iidm:line id="_04649dc2-c766-11e1-8775-005056c00008" name="35-36" r="0.39029799999999998" x="1.7772479999999999" g1="0" b1="7.6905500000000004e-06" g2="0" b2="7.6905500000000004e-06" node1="22" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="-3.2192719377005465" q1="5.4383883105447124" p2="3.2203259049646706" q2="-5.6682995497175632">
         <iidm:alias>_044c0cb5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0456e225-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10659,7 +10787,7 @@
             <iidm:temporaryLimit name="_74c4b341-7b99-4a81-b88a-2ed3b0c4b1de" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0470d2c9-c766-11e1-8775-005056c00008" name="37-40" r="10.3324327" x="29.272320000000001" g1="0" b1="0.0001205234" g2="0" b2="0.0001205234" node1="61" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="55.667947152915723" q1="10.162407067722402" p2="-53.525498342690867" q2="-7.6644045774187557">
+    <iidm:line id="_0470d2c9-c766-11e1-8775-005056c00008" name="37-40" r="10.3324327" x="29.272320000000001" g1="0" b1="0.0001205234" g2="0" b2="0.0001205234" node1="61" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="55.923514399672584" q1="10.055696409493942" p2="-53.761515901423152" q2="-7.4984048936093783">
         <iidm:alias>_045b9d10-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046a4317-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10667,7 +10795,7 @@
             <iidm:temporaryLimit name="_e98d56fe-a54b-45e4-acff-0ac310beb3dd" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044e56a2-c766-11e1-8775-005056c00008" name="48-49" r="3.1188959999999999" x="8.7991200000000003" g1="0" b1="3.6099649999999999e-05" g2="0" b2="3.6099649999999999e-05" node1="23" voltageLevelId1="_044778d3-c766-11e1-8775-005056c00008" node2="122" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-28.904647121830777" q1="1.3371668775517738" p2="29.048843834560639" q2="-2.2466534370572555">
+    <iidm:line id="_044e56a2-c766-11e1-8775-005056c00008" name="48-49" r="3.1188959999999999" x="8.7991200000000003" g1="0" b1="3.6099649999999999e-05" g2="0" b2="3.6099649999999999e-05" node1="23" voltageLevelId1="_044778d3-c766-11e1-8775-005056c00008" node2="122" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-28.866115328733137" q1="1.3249417265299421" p2="29.009921036927356" q2="-2.235532721514081">
         <iidm:alias>_0454bf49-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0460a623-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10675,7 +10803,7 @@
             <iidm:temporaryLimit name="_f2e58700-2366-46e0-8408-9472d85acd23" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047eb573-c766-11e1-8775-005056c00008" name="56-59" r="14.3748007" x="43.734237700000001" g1="0" b1="0.0001632805" g2="0" b2="0.0001632805" node1="62" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-19.170369298373785" q1="-7.7169313892038573" p2="19.527457393305639" q2="3.4545965450581617">
+    <iidm:line id="_047eb573-c766-11e1-8775-005056c00008" name="56-59" r="14.3748007" x="43.734237700000001" g1="0" b1="0.0001632805" g2="0" b2="0.0001632805" node1="62" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-19.15411908337709" q1="-7.7232365827665035" p2="19.51070137161182" q2="3.4593643919151442">
         <iidm:alias>_0468bc78-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048915b0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10683,7 +10811,7 @@
             <iidm:temporaryLimit name="_89654167-95a6-4c76-aad7-63a881116e17" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046f9a4b-c766-11e1-8775-005056c00008" name="94-100" r="3.1014719999999998" x="10.105919999999999" g1="0" b1="0.00017332415000000001" g2="0" b2="0.00017332415000000001" node1="52" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-5.706880771696385" q1="-51.885146645224992" p2="6.150321786613155" q2="47.263320626815954">
+    <iidm:line id="_046f9a4b-c766-11e1-8775-005056c00008" name="94-100" r="3.1014719999999998" x="10.105919999999999" g1="0" b1="0.00017332415000000001" g2="0" b2="0.00017332415000000001" node1="52" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-5.7240489770168574" q1="-52.15875311579088" p2="6.1726035379332842" q2="47.554601496194678">
         <iidm:alias>_04812676-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048a2722-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10691,7 +10819,7 @@
             <iidm:temporaryLimit name="_216c0f3b-03e8-4b7d-96fc-a5f891331f7f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046735d0-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="123" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-92.833398390146456" q1="-2.3815906294207925" p2="94.310097175748581" q2="7.2625875226567631">
+    <iidm:line id="_046735d0-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="123" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-92.713082056500923" q1="-2.4147594225321809" p2="94.185968531663391" q2="7.2762934657707401">
         <iidm:alias>_04570934-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b3894-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10699,7 +10827,7 @@
             <iidm:temporaryLimit name="_32655e4f-e7da-46b0-a908-b601224ddb73" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046d294b-c766-11e1-8775-005056c00008" name="21-22" r="3.641616" x="16.901281399999998" g1="0" b1="7.0592299999999998e-05" g2="0" b2="7.0592299999999998e-05" node1="22" voltageLevelId1="_0460f448-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04773b6a-c766-11e1-8775-005056c00008" p1="-5.2701941031348161e-14" q1="1.7106771075185792e-13" p2="0.00032107848647556711" q2="-2.4935157429704464">
+    <iidm:line id="_046d294b-c766-11e1-8775-005056c00008" name="21-22" r="3.641616" x="16.901281399999998" g1="0" b1="7.0592299999999998e-05" g2="0" b2="7.0592299999999998e-05" node1="22" voltageLevelId1="_0460f448-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04773b6a-c766-11e1-8775-005056c00008" p1="-5.2849729472009806e-14" q1="-3.8357578831174755e-14" p2="0.0003217473694863953" q2="-2.4987103305114422">
         <iidm:alias>_044a37f0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_044be5a2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10707,7 +10835,7 @@
             <iidm:temporaryLimit name="_bafaeace-e459-4dc2-87a0-467a9ea25f8d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_6a131803-f462-47e2-bc21-bda919364fe9" name="reactor1" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="36" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="37" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="8.3266726846886741e-15" q1="-83.151382148113058" p2="-8.3266726846886741e-15" q2="92.151021335927567">
+    <iidm:line id="_6a131803-f462-47e2-bc21-bda919364fe9" name="reactor1" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="36" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="37" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="5.5511151231257827e-15" q1="-83.151383384476645" p2="-5.5511151231257827e-15" q2="92.151022706105195">
         <iidm:alias>_04531196-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_ca0adad2-ffe3-4efa-b56b-7d333b8ae18f</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10715,7 +10843,7 @@
             <iidm:temporaryLimit name="_ae4eadea-f3fc-4ac6-8899-c1698ece7a89" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_9803b364-2a93-4f21-94b7-8bdbe27a16f2" name="reactor2" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="38" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="2.7656939238784872e-09" q1="27.490650089090508" p2="-2.7656946177678776e-09" q2="-26.60439952089834">
+    <iidm:line id="_9803b364-2a93-4f21-94b7-8bdbe27a16f2" name="reactor2" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="38" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="-4.4297381734947905e-09" q1="27.489811689581622" p2="4.4297381734947905e-09" q2="-26.603615191572867">
         <iidm:alias>_0461b792-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_afe0e60b-3870-44fb-ba93-a056228f9636</iidm:alias>
     </iidm:line>

--- a/tests/main_sa/reference/launch/dangling_line_contingency/outputIIDM.xml
+++ b/tests/main_sa/reference/launch/dangling_line_contingency/outputIIDM.xml
@@ -31,8 +31,8 @@
                     <iidm:alias>_bea273f1-1e21-476d-b0d0-92dd6cb9a2d4</iidm:alias>
                     <iidm:alias>_c94e6b68-da6c-43d1-94fd-09ad60c74134</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_047abdd7-c766-11e1-8775-005056c00008-BREAKER" name="BREAKER-Jay LD" kind="BREAKER" retained="true" open="false" node1="0" node2="8"/>
                 <iidm:internalConnection node1="7" node2="0"/>
-                <iidm:internalConnection node1="8" node2="0"/>
                 <iidm:internalConnection node1="9" node2="1"/>
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="4"/>
@@ -47,9 +47,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="125.18253022136108" angle="4.3426265019481809" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="125.26150174283647" angle="-3.2716867584982658" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047abdd7-c766-11e1-8775-005056c00008" name="Jay LD" loadType="UNDEFINED" p0="14" q0="8" node="8" p="14.020574330998153" q="8.0196041980936918">
+            <iidm:load id="_047abdd7-c766-11e1-8775-005056c00008" name="Jay LD" loadType="UNDEFINED" p0="14" q0="8" node="8" p="14.019636723992615" q="8.0187103843209133">
                 <iidm:alias>_04590500-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -139,12 +139,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="127.85998768725186" angle="7.2774339420229044" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="128.03825970699341" angle="-0.51793244102112257" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045b00d5-c766-11e1-8775-005056c00008" name="Madison LD" loadType="UNDEFINED" p0="62" q0="13" node="14" p="62.025911294172197" q="13.009056283535712">
+            <iidm:load id="_045b00d5-c766-11e1-8775-005056c00008" name="Madison LD" loadType="UNDEFINED" p0="62" q0="13" node="14" p="62.023463813289681" q="13.00820075404533">
                 <iidm:alias>_045b27e3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_04689566-c766-11e1-8775-005056c00008" name="Madison NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="15" p="9.0037613168959645" q="0">
+            <iidm:load id="_04689566-c766-11e1-8775-005056c00008" name="Madison NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="15" p="9.0034060374130167" q="0">
                 <iidm:alias>_04765100-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -272,16 +272,16 @@
                 <iidm:internalConnection node1="61" node2="12"/>
                 <iidm:internalConnection node1="62" node2="15"/>
                 <iidm:internalConnection node1="63" node2="18"/>
-                <iidm:bus v="126.06002147333582" angle="-7.1183482334597485" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63"/>
+                <iidm:bus v="126.06008310882774" angle="-14.760963905732421" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_046c3ee7-c766-11e1-8775-005056c00008" name="Torrey SM" energySource="THERMAL" minP="20" maxP="80" ratedS="100" voltageRegulatorOn="true" targetP="48" targetV="126.06" targetQ="0" node="21" p="-50.871458960076865" q="-8.2083225674086222">
+            <iidm:generator id="_046c3ee7-c766-11e1-8775-005056c00008" name="Torrey SM" energySource="THERMAL" minP="20" maxP="80" ratedS="100" voltageRegulatorOn="true" targetP="48" targetV="126.06" targetQ="0" node="21" p="-50.863134285965131" q="-8.218681805315601">
                 <iidm:alias>_047147f3-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_b97aee41-3115-4cfd-9071-b52fb44d0b66"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_5005c073-28d1-4a7d-b257-649dec43ec73"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-30" maxQ="85"/>
             </iidm:generator>
-            <iidm:load id="_044afb44-c766-11e1-8775-005056c00008" name="Torrey LD" loadType="UNDEFINED" p0="113" q0="32" node="20" p="113.00002887300154" q="32.000013627376525">
+            <iidm:load id="_044afb44-c766-11e1-8775-005056c00008" name="Torrey LD" loadType="UNDEFINED" p0="113" q0="32" node="20" p="113.0001117479662" q="32.000052742420316">
                 <iidm:alias>_04522737-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -332,9 +332,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="123.8006608930331" angle="8.5002754433239431" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="123.78682870761324" angle="0.8053284419804102" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04481515-c766-11e1-8775-005056c00008" name="Darrah LD" loadType="UNDEFINED" p0="68" q0="36" node="8" p="67.992148597086526" q="35.99307255817893">
+            <iidm:load id="_04481515-c766-11e1-8775-005056c00008" name="Darrah LD" loadType="UNDEFINED" p0="68" q0="36" node="8" p="67.99139639225767" q="35.992408901572979">
                 <iidm:alias>_044e7db8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -385,9 +385,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.58159216331677" angle="21.244984463395507" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.5760394349503" angle="13.570980882012035" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044c0cb3-c766-11e1-8775-005056c00008" name="Smythe LD" loadType="UNDEFINED" p0="5" q0="3" node="8" p="5.0016849727676354" q="3.0016851620360967">
+            <iidm:load id="_044c0cb3-c766-11e1-8775-005056c00008" name="Smythe LD" loadType="UNDEFINED" p0="5" q0="3" node="8" p="5.0016922373259725" q="3.0016924282299389">
                 <iidm:alias>_045163e8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -514,9 +514,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="125.90647500429665" angle="-7.2849205798494863" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="125.90650543292465" angle="-14.927599267192516" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0450a093-c766-11e1-8775-005056c00008" name="Sunnysde LD" loadType="UNDEFINED" p0="84" q0="18" node="20" p="83.999570455084068" q="17.999846591362946">
+            <iidm:load id="_0450a093-c766-11e1-8775-005056c00008" name="Sunnysde LD" loadType="UNDEFINED" p0="84" q0="18" node="20" p="83.99963250771637" q="17.999868752947247">
                 <iidm:alias>_045f4695-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -568,12 +568,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="126.64381127664232" angle="8.2792410825221872" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="126.63928471874338" angle="0.56798647788899914" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044b2251-c766-11e1-8775-005056c00008" name="Bellefnt LD" loadType="UNDEFINED" p0="68" q0="27" node="8" p="67.982041011268038" q="26.988116421388693">
+            <iidm:load id="_044b2251-c766-11e1-8775-005056c00008" name="Bellefnt LD" loadType="UNDEFINED" p0="68" q0="27" node="8" p="67.980617628730428" q="26.987174649489248">
                 <iidm:alias>_04622cc1-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0449e9d5-c766-11e1-8775-005056c00008" name="Bellefnt SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.40300000000001" targetDeadband="1" node="9" q="-11.050633249990245">
+            <iidm:shunt id="_0449e9d5-c766-11e1-8775-005056c00008" name="Bellefnt SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.40300000000001" targetDeadband="1" node="9" q="-11.049843311077641">
                 <iidm:alias>_047bcf48-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_6cc38790-c6a6-4309-99f4-a3258e24e785"/>
                 <iidm:shuntLinearModel bPerSection="0.00013779999999999999" gPerSection="0" maximumSectionCount="10"/>
@@ -665,12 +665,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="126.06106041569575" angle="7.0856086585599733" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="126.06112830465408" angle="-0.59448938612581259" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04682035-c766-11e1-8775-005056c00008" name="Fieldale LD" loadType="UNDEFINED" p0="39" q0="30" node="14" p="38.999439349889833" q="29.999281221251806">
+            <iidm:load id="_04682035-c766-11e1-8775-005056c00008" name="Fieldale LD" loadType="UNDEFINED" p0="39" q0="30" node="14" p="38.999479938535778" q="29.999333257496701">
                 <iidm:alias>_0478c20a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_045c6067-c766-11e1-8775-005056c00008" name="Fieldale SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.066" targetDeadband="1" node="15" q="-5.4666384878766152">
+            <iidm:shunt id="_045c6067-c766-11e1-8775-005056c00008" name="Fieldale SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.066" targetDeadband="1" node="15" q="-5.4666443758882064">
                 <iidm:alias>_0451b209-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_2d222dd9-7306-4afd-baa5-fd303b0eeb40"/>
                 <iidm:shuntLinearModel bPerSection="6.8800000000000005e-05" gPerSection="0" maximumSectionCount="10"/>
@@ -780,7 +780,7 @@
                 <iidm:internalConnection node1="51" node2="9"/>
                 <iidm:internalConnection node1="52" node2="12"/>
                 <iidm:internalConnection node1="53" node2="15"/>
-                <iidm:bus v="138.02463690664325" angle="5.1886304270618711" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
+                <iidm:bus v="138.02471110112802" angle="-2.4556774735704354" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="_047f0391-c766-11e1-8775-005056c00008" name="Muskngum SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="392" targetV="138.59999099999999" targetQ="0" node="18" p="-0" q="-0">
                 <iidm:alias>_047eb572-c766-11e1-8775-005056c00008</iidm:alias>
@@ -789,7 +789,7 @@
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
-            <iidm:load id="_047e1936-c766-11e1-8775-005056c00008" name="Muskngum LD" loadType="UNDEFINED" p0="39" q0="18" node="17" p="39.00079611792264" q="18.000612402569036">
+            <iidm:load id="_047e1936-c766-11e1-8775-005056c00008" name="Muskngum LD" loadType="UNDEFINED" p0="39" q0="18" node="17" p="39.000829388704169" q="18.000637995833472">
                 <iidm:alias>_046e88d5-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -876,9 +876,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="221.10003903897086" angle="10.697603611703032" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="221.10014898500981" angle="3.0502335286660669" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0458ddf1-c766-11e1-8775-005056c00008" name="Muskngum SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="391" targetV="221.09999999999999" targetQ="0" node="14" p="-414.39042611229297" q="-172.49391246299984">
+            <iidm:generator id="_0458ddf1-c766-11e1-8775-005056c00008" name="Muskngum SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="391" targetV="221.09999999999999" targetQ="0" node="14" p="-414.32261470442427" q="-172.33619408417934">
                 <iidm:alias>_04522732-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_5036c3a5-56f9-489c-9ecb-8c15aa7c70c5"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_12b01822-ca11-4cf8-a6b4-2f8ff805ca20"/>
@@ -886,7 +886,7 @@
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045cae83-c766-11e1-8775-005056c00008" name="65-66" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="42" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="291.61787880999037" q1="98.931131834644702" p2="-291.61787880999037" q2="-68.562103919057122">
+        <iidm:twoWindingsTransformer id="_045cae83-c766-11e1-8775-005056c00008" name="65-66" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="42" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="291.45658298198151" q1="98.915527180188263" p2="-291.45658298198146" q2="-68.577637111527949">
             <iidm:alias>_044b2254-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_044b4964-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_045645e1-c766-11e1-8775-005056c00008</iidm:alias>
@@ -961,9 +961,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="124.60664615228002" angle="2.5523963188190506" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.63133661852744" angle="-4.9475996660161528" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0453d4e2-c766-11e1-8775-005056c00008" name="Adams LD" loadType="UNDEFINED" p0="18" q0="3" node="8" p="18.028214132926117" q="3.0078413532754151">
+            <iidm:load id="_0453d4e2-c766-11e1-8775-005056c00008" name="Adams LD" loadType="UNDEFINED" p0="18" q0="3" node="8" p="18.027170306987532" q="3.0075511043166521">
                 <iidm:alias>_0448ff77-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1053,16 +1053,16 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="133.32005015377715" angle="12.926325711787587" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="133.32014064866488" angle="5.2465914731541963" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_046bf0c4-c766-11e1-8775-005056c00008" name="Claytor SM" energySource="THERMAL" minP="0" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="40" targetV="133.31999200000001" targetQ="0" node="15" p="-42.392882466730732" q="-84.050089512536857">
+            <iidm:generator id="_046bf0c4-c766-11e1-8775-005056c00008" name="Claytor SM" energySource="THERMAL" minP="0" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="40" targetV="133.31999200000001" targetQ="0" node="15" p="-42.385945238304281" q="-84.053698858285884">
                 <iidm:alias>_0460a627-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e56da2eb-bb6a-4133-953c-40073c5bc5f4"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_d41be6b4-155e-4c8f-b46b-16b50c49f0f4"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-60" maxQ="170"/>
             </iidm:generator>
-            <iidm:load id="_048433b6-c766-11e1-8775-005056c00008" name="Claytor LD" loadType="UNDEFINED" p0="23" q0="16" node="14" p="23.000015048797263" q="16.000017447884691">
+            <iidm:load id="_048433b6-c766-11e1-8775-005056c00008" name="Claytor LD" loadType="UNDEFINED" p0="23" q0="16" node="14" p="23.000038466701746" q="16.000044599099347">
                 <iidm:alias>_0480ff6b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1133,12 +1133,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="129.7720976880162" angle="-4.0424443154283809" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="129.76857603708896" angle="-11.66646312185971" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0449e9d7-c766-11e1-8775-005056c00008" name="N.Newark LD" loadType="UNDEFINED" p0="53" q0="22" node="11" p="53.004139476207627" q="22.002863863127807">
+            <iidm:load id="_0449e9d7-c766-11e1-8775-005056c00008" name="N.Newark LD" loadType="UNDEFINED" p0="53" q0="22" node="11" p="53.00438816390318" q="22.00303592044639">
                 <iidm:alias>_04531191-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_04684741-c766-11e1-8775-005056c00008" name="N.Newark SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.32300000000001" targetDeadband="1" node="12" q="-9.6666176722117658">
+            <iidm:shunt id="_04684741-c766-11e1-8775-005056c00008" name="N.Newark SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.32300000000001" targetDeadband="1" node="12" q="-9.6660930295222052">
                 <iidm:alias>_04607f19-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_eae61817-d3cb-488f-a1f3-13bc8e31431b"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -1191,9 +1191,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="131.24194599698995" angle="9.6538098505185186" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="131.30510264801237" angle="1.8287240507176761" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0448d86a-c766-11e1-8775-005056c00008" name="Hillsbro NegG LD" loadType="UNDEFINED" p0="12" q0="0" node="8" p="12.009917184788993" q="0">
+            <iidm:load id="_0448d86a-c766-11e1-8775-005056c00008" name="Hillsbro NegG LD" loadType="UNDEFINED" p0="12" q0="0" node="8" p="12.009131766882447" q="0">
                 <iidm:alias>_044ef2e8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1244,9 +1244,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="125.71697752946751" angle="-6.2292174884005957" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="125.67649291442925" angle="-13.796359615311124" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047dcb12-c766-11e1-8775-005056c00008" name="S.Kenton LD" loadType="UNDEFINED" p0="18" q0="7" node="8" p="18.019595883477905" q="7.0127056440674993">
+            <iidm:load id="_047dcb12-c766-11e1-8775-005056c00008" name="S.Kenton LD" loadType="UNDEFINED" p0="18" q0="7" node="8" p="18.01996557575314" q="7.0129454349458564">
                 <iidm:alias>_0451b205-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1281,6 +1281,9 @@
                     <iidm:alias>_8ef85f09-3622-4a12-87bf-fefcecc01e4a</iidm:alias>
                     <iidm:alias>_a0244ab3-80e5-4c20-b201-a142d50e6ec1</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_dffdb415-95a8-496a-ad1a-93cdeb444fae-1" name="DISCONNECTOR723-1" kind="DISCONNECTOR" retained="false" open="false" node1="24" node2="25"/>
+                <iidm:switch id="_aa063f2e-1205-4d1a-a549-3ccc5b31e65d-1" name="BREAKER362-1" kind="BREAKER" retained="false" open="false" node1="23" node2="24"/>
+                <iidm:switch id="_28b3e895-483c-478d-a5a3-7b9d7c9e11f3-1" name="DISCONNECTOR724-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="23"/>
                 <iidm:internalConnection node1="7" node2="0"/>
                 <iidm:internalConnection node1="8" node2="0"/>
                 <iidm:internalConnection node1="9" node2="1"/>
@@ -1297,9 +1300,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="125.36463355388483" angle="19.897045364115922" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.33378764432402" angle="12.319365329289081" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044afb49-c766-11e1-8775-005056c00008" name="Hazard LD" loadType="UNDEFINED" p0="21" q0="10" node="8" p="21.008525461681756" q="10.006767155028589">
+            <iidm:load id="_044afb49-c766-11e1-8775-005056c00008" name="Hazard LD" loadType="UNDEFINED" p0="21" q0="10" node="8" p="21.008183170940427" q="10.006495423666346">
                 <iidm:alias>_045e5c31-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1320,6 +1323,9 @@
                     <iidm:alias>_2a61ce12-8d9c-4aae-8bc7-c8f820ecae6c</iidm:alias>
                     <iidm:alias>_a3d5e8cc-be34-4d4a-a586-ce582737826b</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_83a05cd7-017e-4e7a-bc5e-a01ee9681f9f-1" name="DISCONNECTOR725-1" kind="DISCONNECTOR" retained="false" open="false" node1="14" node2="15"/>
+                <iidm:switch id="_cf4393c0-21c2-4e35-b330-c1acda2647ba-1" name="BREAKER363-1" kind="BREAKER" retained="false" open="true" node1="13" node2="14"/>
+                <iidm:switch id="_b9ab29b9-3d90-4536-8d1a-7757d8c22ae4-1" name="DISCONNECTOR726-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="13"/>
                 <iidm:internalConnection node1="4" node2="0"/>
                 <iidm:internalConnection node1="5" node2="0"/>
                 <iidm:internalConnection node1="6" node2="1"/>
@@ -1329,14 +1335,14 @@
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="3"/>
-                <iidm:bus v="31.341158388471218" angle="19.897045364115915" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="31.083446911081012" angle="12.319365329289079" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13"/>
             </iidm:nodeBreakerTopology>
             <iidm:staticVarCompensator id="_047fc6e6-c766-11e1-8775-005056c00008" name="Pinevlle SVC" bMin="-10" bMax="10" voltageSetpoint="33.494999999999997" regulationMode="VOLTAGE" node="5" p="0" q="0">
                 <iidm:alias>_046ab846-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_98f667da-02d1-4a31-b826-44314a1fbbfe"/>
             </iidm:staticVarCompensator>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045e3525-c766-11e1-8775-005056c00008" name="86-87" r="0.30796918750000002" x="2.2585859312499998" g="0" b="-0.0040863184000000004" ratedU1="132" ratedU2="33" node1="22" voltageLevelId1="_0484f70a-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_04555b88-c766-11e1-8775-005056c00008" p1="5.6898930012039273e-14" q1="4.0138606567079282" p2="-5.3827496415184025e-14" q2="1.4872077914272828e-13">
+        <iidm:twoWindingsTransformer id="_045e3525-c766-11e1-8775-005056c00008" name="86-87" r="0.30796918750000002" x="2.2585859312499998" g="0" b="-0.0040863184000000004" ratedU1="132" ratedU2="33" node1="22" voltageLevelId1="_0484f70a-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_04555b88-c766-11e1-8775-005056c00008" p1="1.8735013540549517e-14" q1="3.9481218572029229" p2="-1.8583666854428794e-14" q2="3.608120826772475e-14">
             <iidm:alias>_0452755a-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04682034-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_048c7110-c766-11e1-8775-005056c00008</iidm:alias>
@@ -1412,6 +1418,82 @@
                 <iidm:temporaryLimit name="_257d56c1-d70a-4a96-b85c-d928ade03ad4" acceptableDuration="60" value="12246"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
+        <iidm:twoWindingsTransformer id="_045e3525-c766-11e1-8775-005056c00008-1" name="86-87-open-ended" r="0.30796918750000002" x="2.2585859312499998" g="0" b="-0.0040863184000000004" ratedU1="132" ratedU2="33" node1="25" voltageLevelId1="_0484f70a-c766-11e1-8775-005056c00008" node2="15" voltageLevelId2="_04555b88-c766-11e1-8775-005056c00008" p1="1.7347234759768071e-16" q1="3.9481218572030534" p2="0" q2="0">
+            <iidm:alias>_0452755a-c766-11e1-8775-005056c00008-1</iidm:alias>
+            <iidm:alias>_04682034-c766-11e1-8775-005056c00008-1</iidm:alias>
+            <iidm:alias>_048c7110-c766-11e1-8775-005056c00008-1</iidm:alias>
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="31" loadTapChangingCapabilities="false">
+                <iidm:step r="-78.460970487743992" x="-78.460970487743992" g="364.27347129590328" b="364.27347129590328" rho="0.4641016"/>
+                <iidm:step r="-76.770985444658564" x="-76.770985444658564" g="330.49609255595948" b="330.49609255595948" rho="0.48196488000000004"/>
+                <iidm:step r="-75.017181047101431" x="-75.017181047101431" g="300.27508580410921" b="300.27508580410921" rho="0.49982816000000002"/>
+                <iidm:step r="-73.199557295072623" x="-73.199557295072623" g="273.1281647135425" b="273.1281647135425" rho="0.51769144000000011"/>
+                <iidm:step r="-71.318114188572153" x="-71.318114188572153" g="248.65210975826625" b="248.65210975826625" rho="0.53555472000000004"/>
+                <iidm:step r="-69.372851727600008" x="-69.372851727600008" g="226.50770848984379" b="226.50770848984379" rho="0.55341799999999997"/>
+                <iidm:step r="-67.363769912156158" x="-67.363769912156158" g="206.40793906293555" b="206.40793906293555" rho="0.57128128"/>
+                <iidm:step r="-65.290868742240633" x="-65.290868742240633" g="188.10862264852744" b="188.10862264852744" rho="0.58914456000000004"/>
+                <iidm:step r="-63.154148217853432" x="-63.154148217853432" g="171.40097232995538" b="171.40097232995538" rho="0.60700784000000008"/>
+                <iidm:step r="-60.953608338994556" x="-60.953608338994556" g="156.10561116167679" b="156.10561116167679" rho="0.62487112"/>
+                <iidm:step r="-58.689249105663997" x="-58.689249105663997" g="142.06773741726079" b="142.06773741726079" rho="0.64273440000000004"/>
+                <iidm:step r="-56.361070517861769" x="-56.361070517861769" g="129.15319231405709" b="129.15319231405709" rho="0.66059767999999996"/>
+                <iidm:step r="-53.969072575587838" x="-53.969072575587838" g="117.24524269951107" b="117.24524269951107" rho="0.67846096"/>
+                <iidm:step r="-51.51325527884223" x="-51.51325527884223" g="106.24193390397649" b="106.24193390397649" rho="0.69632424000000004"/>
+                <iidm:step r="-48.993618627624947" x="-48.993618627624947" g="96.053900138385018" b="96.053900138385018" rho="0.71418752000000008"/>
+                <iidm:step r="-46.410162621936003" x="-46.410162621936003" g="86.602544237115268" b="86.602544237115268" rho="0.7320508"/>
+                <iidm:step r="-43.762887261775354" x="-43.762887261775354" g="77.81851722275475" b="77.81851722275475" rho="0.74991407999999993"/>
+                <iidm:step r="-41.051792547143037" x="-41.051792547143037" g="69.640442552852292" b="69.640442552852292" rho="0.76777735999999996"/>
+                <iidm:step r="-38.276878478039045" x="-38.276878478039045" g="62.013841060226049" b="62.013841060226049" rho="0.78564064"/>
+                <iidm:step r="-35.438145054463355" x="-35.438145054463355" g="54.890221299184191" b="54.890221299184191" rho="0.80350392000000004"/>
+                <iidm:step r="-32.53559227641599" x="-32.53559227641599" g="48.2263068397802" b="48.2263068397802" rho="0.82136720000000008"/>
+                <iidm:step r="-29.569220143896956" x="-29.569220143896956" g="41.983377444222199" b="41.983377444222199" rho="0.83923048"/>
+                <iidm:step r="-26.53902865690624" x="-26.53902865690624" g="36.126705339843348" b="36.126705339843348" rho="0.85709376000000004"/>
+                <iidm:step r="-23.445017815443848" x="-23.445017815443848" g="30.625071218648301" b="30.625071218648301" rho="0.87495704000000007"/>
+                <iidm:step r="-20.287187619509762" x="-20.287187619509762" g="25.450347332714429" b="25.450347332714429" rho="0.89282032000000011"/>
+                <iidm:step r="-17.06553806910399" x="-17.06553806910399" g="20.577137262099331" b="20.577137262099331" rho="0.91068360000000004"/>
+                <iidm:step r="-13.780069164226571" x="-13.780069164226571" g="15.982463718828566" b="15.982463718828566" rho="0.92854687999999996"/>
+                <iidm:step r="-10.430780904877434" x="-10.430780904877434" g="11.645497203453271" b="11.645497203453271" rho="0.94641016"/>
+                <iidm:step r="-7.0176732910566368" x="-7.0176732910566368" g="7.5473195169912355" b="7.5473195169912355" rho="0.96427344000000004"/>
+                <iidm:step r="-3.5407463227641656" x="-3.5407463227641656" g="3.6707171036300279" b="3.6707171036300279" rho="0.98213671999999985"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1"/>
+                <iidm:step r="3.6045656772358381" x="3.6045656772358381" g="-3.4791571719583358" b="-3.4791571719583358" rho="1.01786328"/>
+                <iidm:step r="7.272950708943382" x="7.272950708943382" g="-6.7798551833225922" b="-6.7798551833225922" rho="1.0357265600000001"/>
+                <iidm:step r="11.005155095122543" x="11.005155095122543" g="-9.9140937064517427" b="-9.9140937064517427" rho="1.0535898399999999"/>
+                <iidm:step r="14.801178835773431" x="14.801178835773431" g="-12.892880531259154" b="-12.892880531259154" rho="1.0714531199999999"/>
+                <iidm:step r="18.661021930895984" x="18.661021930895984" g="-15.726328348801433" b="-15.726328348801433" rho="1.0893164"/>
+                <iidm:step r="22.584684380490238" x="22.584684380490238" g="-18.423740693731116" b="-18.423740693731116" rho="1.10717968"/>
+                <iidm:step r="26.572166184556178" x="26.572166184556178" g="-20.993688411566747" b="-20.993688411566747" rho="1.12504296"/>
+                <iidm:step r="30.623467343093779" x="30.623467343093779" g="-23.444077826121855" b="-23.444077826121855" rho="1.1429062400000001"/>
+                <iidm:step r="34.738587856103067" x="34.738587856103067" g="-25.782211620922489" b="-25.782211620922489" rho="1.1607695200000001"/>
+                <iidm:step r="38.917527723583987" x="38.917527723583987" g="-28.014843311220961" b="-28.014843311220961" rho="1.1786327999999999"/>
+                <iidm:step r="43.16028694553664" x="43.16028694553664" g="-30.148226066322692" b="-30.148226066322692" rho="1.19649608"/>
+                <iidm:step r="47.466865521960955" x="47.466865521960955" g="-32.188156542116317" b="-32.188156542116317" rho="1.21435936"/>
+                <iidm:step r="51.837263452856973" x="51.837263452856973" g="-34.140014298236885" b="-34.140014298236885" rho="1.23222264"/>
+                <iidm:step r="56.271480738224653" x="56.271480738224653" g="-36.0087973009527" b="-36.0087973009527" rho="1.2500859200000001"/>
+                <iidm:step r="60.769517378063973" x="60.769517378063973" g="-37.799153949786998" b="-37.799153949786998" rho="1.2679491999999999"/>
+                <iidm:step r="65.331373372375026" x="65.331373372375026" g="-39.515412011505823" b="-39.515412011505823" rho="1.2858124799999999"/>
+                <iidm:step r="69.957048721157761" x="69.957048721157761" g="-41.161604798123854" b="-41.161604798123854" rho="1.30367576"/>
+                <iidm:step r="74.646543424412172" x="74.646543424412172" g="-42.741494884907091" b="-42.741494884907091" rho="1.32153904"/>
+                <iidm:step r="79.399857482138245" x="79.399857482138245" g="-44.258595629064871" b="-44.258595629064871" rho="1.33940232"/>
+                <iidm:step r="84.216990894335964" x="84.216990894335964" g="-45.716190719151165" b="-45.716190719151165" rho="1.3572655999999998"/>
+                <iidm:step r="89.097943661005473" x="89.097943661005473" g="-47.11735195848069" b="-47.11735195848069" rho="1.3751288800000001"/>
+                <iidm:step r="94.04271578214653" x="94.04271578214653" g="-48.464955462553469" b="-48.464955462553469" rho="1.3929921599999999"/>
+                <iidm:step r="99.051307257759348" x="99.051307257759348" g="-49.761696430103783" b="-49.761696430103783" rho="1.41085544"/>
+                <iidm:step r="104.12371808784383" x="104.12371808784383" g="-51.010102629540867" b="-51.010102629540867" rho="1.42871872"/>
+                <iidm:step r="109.25994827240002" x="109.25994827240002" g="-52.212546726893493" b="-52.212546726893493" rho="1.446582"/>
+                <iidm:step r="114.45999781142788" x="114.45999781142788" g="-53.371257567609966" b="-53.371257567609966" rho="1.4644452800000001"/>
+                <iidm:step r="119.72386670492732" x="119.72386670492732" g="-54.488330512455207" b="-54.488330512455207" rho="1.4823085599999999"/>
+                <iidm:step r="125.05155495289854" x="125.05155495289854" g="-55.565736917068101" b="-55.565736917068101" rho="1.5001718399999999"/>
+                <iidm:step r="130.44306255534144" x="130.44306255534144" g="-56.605332835313817" b="-56.605332835313817" rho="1.51803512"/>
+                <iidm:step r="135.89838951225599" x="135.89838951225599" g="-57.608867018227542" b="-57.608867018227542" rho="1.5358984"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="2186">
+                <iidm:temporaryLimit name="_580d3b53-5508-4d8d-97cc-4ea463e0cdb9-1" acceptableDuration="900" value="2514"/>
+                <iidm:temporaryLimit name="_a867e68a-58d1-49cb-955f-bb8e59cf2a11-1" acceptableDuration="60" value="3061"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="8747">
+                <iidm:temporaryLimit name="_1a7f23f9-e2c0-46a6-a93c-687f2209e33d-1" acceptableDuration="900" value="10059"/>
+                <iidm:temporaryLimit name="_257d56c1-d70a-4a96-b85c-d928ade03ad4-1" acceptableDuration="60" value="12246"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
     </iidm:substation>
     <iidm:substation id="_045beb3a-c766-11e1-8775-005056c00008" name="Minas Tirith" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
         <iidm:voltageLevel id="_048a9c58-c766-11e1-8775-005056c00008" name="MNT132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -1460,12 +1542,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="132.92705269339089" angle="8.1063047515382269" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="133.03791948855317" angle="-0.28804157054889473" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0447ee05-c766-11e1-8775-005056c00008" name="NwCarlsl NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="8" p="9.0047517481506905" q="0">
+            <iidm:load id="_0447ee05-c766-11e1-8775-005056c00008" name="NwCarlsl NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="8" p="9.0045553635673006" q="0">
                 <iidm:alias>_04731cb7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_047a48a8-c766-11e1-8775-005056c00008" name="NwCarlsl LD" loadType="UNDEFINED" p0="30" q0="12" node="9" p="30.015839160502306" q="12.010561298588874">
+            <iidm:load id="_047a48a8-c766-11e1-8775-005056c00008" name="NwCarlsl LD" loadType="UNDEFINED" p0="30" q0="12" node="9" p="30.015184545224333" q="12.01012473798251">
                 <iidm:alias>_044c0cb9-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1516,9 +1598,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.61562327619336" angle="8.1662411065371714" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.61568516322365" angle="0.48636972034156561" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044ecbd1-c766-11e1-8775-005056c00008" name="Blaine LD" loadType="UNDEFINED" p0="2" q0="1" node="8" p="1.9999628684475155" q="0.99996905723109009">
+            <iidm:load id="_044ecbd1-c766-11e1-8775-005056c00008" name="Blaine LD" loadType="UNDEFINED" p0="2" q0="1" node="8" p="1.9999649297803834" q="0.99997077498780884">
                 <iidm:alias>_04700f74-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1569,9 +1651,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="133.28163911607177" angle="15.258447684129694" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="133.25695431444186" angle="7.58030645588462" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046b7b95-c766-11e1-8775-005056c00008" name="Sundial LD" loadType="UNDEFINED" p0="15" q0="9" node="8" p="15.004092125913196" q="9.0040924980240202">
+            <iidm:load id="_046b7b95-c766-11e1-8775-005056c00008" name="Sundial LD" loadType="UNDEFINED" p0="15" q0="9" node="8" p="15.004098577056361" q="9.0040989503413371">
                 <iidm:alias>_046efe07-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1622,9 +1704,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.7737324372913" angle="3.3912697044206355" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.81866004835533" angle="-4.8475736454588088" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045645e2-c766-11e1-8775-005056c00008" name="Riversde LD" loadType="UNDEFINED" p0="51" q0="27" node="8" p="51.011289060175947" q="27.009961670395992">
+            <iidm:load id="_045645e2-c766-11e1-8775-005056c00008" name="Riversde LD" loadType="UNDEFINED" p0="51" q0="27" node="8" p="51.01077640890491" q="27.009509265805743">
                 <iidm:alias>_0476ed4b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1675,9 +1757,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.26923881348985" angle="7.1203411874889566" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.38681521436008" angle="-0.62450709163146456" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04887973-c766-11e1-8775-005056c00008" name="Randolph LD" loadType="UNDEFINED" p0="10" q0="5" node="8" p="10.013076438515684" q="5.0109017812189274">
+            <iidm:load id="_04887973-c766-11e1-8775-005056c00008" name="Randolph LD" loadType="UNDEFINED" p0="10" q0="5" node="8" p="10.012375447058924" q="5.0103171261779771">
                 <iidm:alias>_0462f018-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1728,9 +1810,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.477517441926" angle="-6.4619144239961139" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.47735391994301" angle="-14.103754898110756" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0477627b-c766-11e1-8775-005056c00008" name="WNwPhil2 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="11.999727317546764" q="2.9998863831717522">
+            <iidm:load id="_0477627b-c766-11e1-8775-005056c00008" name="WNwPhil2 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="11.999736231855358" q="2.9998900974116518">
                 <iidm:alias>_045841b6-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1800,9 +1882,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="126.72408454751432" angle="8.9521403030862778" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="126.72414503106823" angle="1.2724726472341372" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0476781a-c766-11e1-8775-005056c00008" name="Cloverdl LD" loadType="UNDEFINED" p0="43" q0="16" node="11" p="42.999173255244415" q="15.999487293359959">
+            <iidm:load id="_0476781a-c766-11e1-8775-005056c00008" name="Cloverdl LD" loadType="UNDEFINED" p0="43" q0="16" node="11" p="42.999217212532031" q="15.999514553353233">
                 <iidm:alias>_0481749a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1872,9 +1954,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="128.11320161597561" angle="10.317360693726709" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="128.11327358235107" angle="2.6376783995385473" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046b0665-c766-11e1-8775-005056c00008" name="Hancock LD" loadType="UNDEFINED" p0="38" q0="25" node="11" p="37.999592451688756" q="24.999553128449271">
+            <iidm:load id="_046b0665-c766-11e1-8775-005056c00008" name="Hancock LD" loadType="UNDEFINED" p0="38" q0="25" node="11" p="37.99963116586774" q="24.999595577917823">
                 <iidm:alias>_0464c4d5-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1926,12 +2008,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="128.78800999824398" angle="-5.3053745730580859" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="128.77527415953088" angle="-12.914461920059344" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044bbe92-c766-11e1-8775-005056c00008" name="WMVernon LD" loadType="UNDEFINED" p0="16" q0="8" node="8" p="16.005163349692502" q="8.0043032542441708">
+            <iidm:load id="_044bbe92-c766-11e1-8775-005056c00008" name="WMVernon LD" loadType="UNDEFINED" p0="16" q0="8" node="8" p="16.00531518281899" q="8.0044298094693964">
                 <iidm:alias>_04500452-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_047825c8-c766-11e1-8775-005056c00008" name="WMVernon SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.21199999999999" targetDeadband="1" node="9" q="-9.5205657720826729">
+            <iidm:shunt id="_047825c8-c766-11e1-8775-005056c00008" name="WMVernon SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.21199999999999" targetDeadband="1" node="9" q="-9.5186828888109858">
                 <iidm:alias>_047084aa-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_2a6c1dcd-201b-4911-83b2-c16acc50a0f4"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -1965,9 +2047,9 @@
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="3"/>
-                <iidm:bus v="231.00000217935818" angle="29.787085970375227" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="230.99999000432283" angle="21.10837768590876" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_045868c0-c766-11e1-8775-005056c00008" name="Breed SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="450" targetV="230.99998500000001" targetQ="0" node="5" p="-476.91992775072072" q="32.816336634865792">
+            <iidm:generator id="_045868c0-c766-11e1-8775-005056c00008" name="Breed SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="450" targetV="230.99998500000001" targetQ="0" node="5" p="-476.84188393092307" q="36.275025784622649">
                 <iidm:alias>_045b7606-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_f26d4eb3-ebdb-4025-8080-f856ce656b42"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_7566f2a7-61eb-42fe-a59a-8276257fdbc6"/>
@@ -2041,9 +2123,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="127.46348753353328" angle="-5.339369964356842" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="127.46322769495045" angle="-12.980590703114173" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044d1e22-c766-11e1-8775-005056c00008" name="Newcmrst LD" loadType="UNDEFINED" p0="17" q0="8" node="11" p="16.999466930306575" q="7.9995819104928811">
+            <iidm:load id="_044d1e22-c766-11e1-8775-005056c00008" name="Newcmrst LD" loadType="UNDEFINED" p0="17" q0="8" node="11" p="16.999479527213278" q="7.9995917902156117">
                 <iidm:alias>_048a754b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2113,9 +2195,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="138.59999940391521" angle="20.504028074381576" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="138.59999541532545" angle="12.236051921740099" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_045ab2b0-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="220" targetV="138.59999099999999" targetQ="0" node="11" p="-233.16085356701902" q="-44.563213339525767">
+            <iidm:generator id="_045ab2b0-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="220" targetV="138.59999099999999" targetQ="0" node="11" p="-233.12269881067351" q="-42.351733586805004">
                 <iidm:alias>_046ba2a5-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_56975783-9739-40fc-8ec1-e1de8cb06c9a"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b8449cd9-5a17-497e-bf04-70f728b0f9f2"/>
@@ -2168,9 +2250,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="223.30001394985362" angle="22.705706129535731" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="223.30000660010043" angle="14.197037722189032" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0483224a-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="314" targetV="223.30000000000001" targetQ="0" node="8" p="-332.78412736383621" q="-18.561273934357597">
+            <iidm:generator id="_0483224a-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="314" targetV="223.30000000000001" targetQ="0" node="8" p="-332.72967012068858" q="-14.154278103060136">
                 <iidm:alias>_045cd594-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_05df66ba-3f64-40cb-8b18-c66d26c4e2c1"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_c1d29442-5f57-41d1-bb60-4b74b4994c20"/>
@@ -2178,7 +2260,7 @@
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045b7604-c766-11e1-8775-005056c00008" name="26-25" r="0" x="6.6559680000000006" g="0" b="0" ratedU1="220" ratedU2="132" node1="22" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="111.64649048785473" q1="22.327339189800515" p2="-111.64649048785475" q2="-17.897436027109297">
+        <iidm:twoWindingsTransformer id="_045b7604-c766-11e1-8775-005056c00008" name="26-25" r="0" x="6.6559680000000006" g="0" b="0" ratedU1="220" ratedU2="132" node1="22" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="99.446104966060062" q1="21.883938548295092" p2="-99.446104966060119" q2="-18.34081014347721">
             <iidm:alias>_0447c6f3-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0463b364-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04803c1c-c766-11e1-8775-005056c00008</iidm:alias>
@@ -2321,9 +2403,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="136.62003118937275" angle="15.581376795777265" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="136.62010572081621" angle="7.9035989179054411" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_048aea70-c766-11e1-8775-005056c00008" name="Sporn SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="513.43743900000004" targetV="136.62" targetQ="-62.132553100000003" node="20" p="-544.15232513865567" q="58.281315232577228">
+            <iidm:generator id="_048aea70-c766-11e1-8775-005056c00008" name="Sporn SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="513.43743900000004" targetV="136.62" targetQ="-62.132553100000003" node="20" p="-544.06327931872988" q="58.355178901115821">
                 <iidm:alias>_04555b84-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_27799004-aa1e-4889-ba95-ee6fdae64895"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_827a9c80-183d-4e33-9e73-ef0aab3dfb13"/>
@@ -2413,7 +2495,7 @@
                 <iidm:internalConnection node1="39" node2="9"/>
                 <iidm:internalConnection node1="40" node2="12"/>
                 <iidm:internalConnection node1="41" node2="3"/>
-                <iidm:bus v="219.65869819138726" angle="12.903135644019983" nodes="0,1,4,5,6,7,8,9,10,11,12,13,14,16,17,18,19,20,21,22,23,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40"/>
+                <iidm:bus v="219.65921639428234" angle="5.24245527221498" nodes="0,1,4,5,6,7,8,9,10,11,12,13,14,16,17,18,19,20,21,22,23,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40"/>
             </iidm:nodeBreakerTopology>
             <iidm:danglingLine id="_0482fb33-c766-11e1-8775-005056c00008" name="68-116" p0="184" q0="0" r="0.16456000000000001" x="1.9601999999999999" g="0" b="0.00033884300000000002" ucteXnodeCode="XWE_BR21" node="41" p="0" q="0">
                 <iidm:alias>_0459c855-c766-11e1-8775-005056c00008</iidm:alias>
@@ -2428,7 +2510,7 @@
                 </iidm:currentLimits>
             </iidm:danglingLine>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_044f6815-c766-11e1-8775-005056c00008" name="68-69" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-139.57952527755197" q1="98.098184784851398" p2="139.57952527755197" q2="-88.654281920942481">
+        <iidm:twoWindingsTransformer id="_044f6815-c766-11e1-8775-005056c00008" name="68-69" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-138.68951540447131" q1="98.062540260843107" p2="138.68951540447136" q2="-88.701309029734716">
             <iidm:alias>_047e8e67-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04840ca7-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0487dd39-c766-11e1-8775-005056c00008</iidm:alias>
@@ -2535,9 +2617,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="131.60414364474158" angle="3.7479875002131919" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="131.60422138109911" angle="-3.8979524614963101" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04547126-c766-11e1-8775-005056c00008" name="Natrium LD" loadType="UNDEFINED" p0="77" q0="14" node="14" p="76.999592077846401" q="13.999876387444468">
+            <iidm:load id="_04547126-c766-11e1-8775-005056c00008" name="Natrium LD" loadType="UNDEFINED" p0="77" q0="14" node="14" p="76.999652705577773" q="13.999894759424214">
                 <iidm:alias>_047b3307-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2588,9 +2670,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="124.38641783812464" angle="-5.530819777684262" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.32838857305792" angle="-13.069234187090592" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045d4ac9-c766-11e1-8775-005056c00008" name="Sterling LD" loadType="UNDEFINED" p0="31" q0="17" node="8" p="31.049042011489149" q="17.04484697653038">
+            <iidm:load id="_045d4ac9-c766-11e1-8775-005056c00008" name="Sterling LD" loadType="UNDEFINED" p0="31" q0="17" node="8" p="31.049834085339707" q="17.045571684471174">
                 <iidm:alias>_0477b094-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2698,9 +2780,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="130.45418828062398" angle="16.982779841999278" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="130.43190243340587" angle="9.3056001806210826" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0466246a-c766-11e1-8775-005056c00008" name="Switchbk LD" loadType="UNDEFINED" p0="30" q0="16" node="17" p="30.013768545523771" q="16.01224057936118">
+            <iidm:load id="_0466246a-c766-11e1-8775-005056c00008" name="Switchbk LD" loadType="UNDEFINED" p0="30" q0="16" node="17" p="30.013794033661366" q="16.012263242421419">
                 <iidm:alias>_04882b59-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2751,9 +2833,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="135.10422224941405" angle="14.946720669739243" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="135.10431631836136" angle="7.2682057702629255" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046adf5a-c766-11e1-8775-005056c00008" name="Bradley LD" loadType="UNDEFINED" p0="34" q0="8" node="8" p="34.001671029112565" q="8.0006553162699117">
+            <iidm:load id="_046adf5a-c766-11e1-8775-005056c00008" name="Bradley LD" loadType="UNDEFINED" p0="34" q0="8" node="8" p="34.001701508232848" q="8.000667269261303">
                 <iidm:alias>_04555b85-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2788,6 +2870,9 @@
                     <iidm:alias>_7f359893-b7c5-41b0-ada8-8df06cf7a8e6</iidm:alias>
                     <iidm:alias>_a4edf081-2fb2-4da4-94db-98a2a596247f</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_312f25f3-55bc-4417-848c-236d31d823f4-1" name="DISCONNECTOR524-1" kind="DISCONNECTOR" retained="false" open="false" node1="24" node2="25"/>
+                <iidm:switch id="_686e884a-a0b1-454e-b7d1-33c7ad46f89f-1" name="BREAKER262-1" kind="BREAKER" retained="false" open="false" node1="23" node2="24"/>
+                <iidm:switch id="_346a5319-3ec2-40a2-aefd-38dfacbbe97c-1" name="DISCONNECTOR523-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="23"/>
                 <iidm:internalConnection node1="7" node2="0"/>
                 <iidm:internalConnection node1="8" node2="0"/>
                 <iidm:internalConnection node1="9" node2="1"/>
@@ -2804,9 +2889,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.97693370087748" angle="5.4944525238570634" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.24200111465686" angle="-2.2081103088034504" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047a48a2-c766-11e1-8775-005056c00008" name="Mullin LD" loadType="UNDEFINED" p0="17" q0="7" node="8" p="17.004354624598928" q="7.0029887230244654">
+            <iidm:load id="_047a48a2-c766-11e1-8775-005056c00008" name="Mullin LD" loadType="UNDEFINED" p0="17" q0="7" node="8" p="17.003965045761028" q="7.0027213213859092">
                 <iidm:alias>_0474553a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2972,16 +3057,16 @@
                 <iidm:internalConnection node1="81" node2="18"/>
                 <iidm:internalConnection node1="82" node2="21"/>
                 <iidm:internalConnection node1="83" node2="24"/>
-                <iidm:bus v="134.24404395121999" angle="16.552734956589802" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
+                <iidm:bus v="134.24413356898313" angle="8.8733148781325006" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_044cd00a-c766-11e1-8775-005056c00008" name="Glen Lyn SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="252" targetV="134.243988" targetQ="0" node="27" p="-267.0751595404036" q="-83.050161350961986">
+            <iidm:generator id="_044cd00a-c766-11e1-8775-005056c00008" name="Glen Lyn SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="252" targetV="134.243988" targetQ="0" node="27" p="-267.03145500131694" q="-83.39785318594059">
                 <iidm:alias>_045e5c30-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e54b499b-436c-4b89-9803-b1d75e2fa364"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_32c8ab65-80f7-4c17-b3f5-ff075cce0ba5"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
-            <iidm:load id="_04566cf5-c766-11e1-8775-005056c00008" name="Glen Lyn LD" loadType="UNDEFINED" p0="37" q0="18" node="26" p="37.000023131710236" q="18.000018755444643">
+            <iidm:load id="_04566cf5-c766-11e1-8775-005056c00008" name="Glen Lyn LD" loadType="UNDEFINED" p0="37" q0="18" node="26" p="37.000060182067543" q="18.000048796297438">
                 <iidm:alias>_04577e64-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3032,9 +3117,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.66854780463797" angle="5.8194384139533284" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.73642906016997" angle="-2.459182015347432" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044ea4c0-c766-11e1-8775-005056c00008" name="Kankakee LD" loadType="UNDEFINED" p0="52" q0="22" node="8" p="52.015708346411628" q="22.011077513406004">
+            <iidm:load id="_044ea4c0-c766-11e1-8775-005056c00008" name="Kankakee LD" loadType="UNDEFINED" p0="52" q0="22" node="8" p="52.01496509138348" q="22.010553320278124">
                 <iidm:alias>_047e6758-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3143,12 +3228,12 @@
                 <iidm:internalConnection node1="51" node2="9"/>
                 <iidm:internalConnection node1="52" node2="12"/>
                 <iidm:internalConnection node1="53" node2="15"/>
-                <iidm:bus v="127.41956305282622" angle="9.2045713658134432" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
+                <iidm:bus v="127.41963619452109" angle="1.5248503296461977" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0484cffb-c766-11e1-8775-005056c00008" name="Roanoke LD" loadType="UNDEFINED" p0="31" q0="26" node="17" p="30.999703858022198" q="25.999586039413735">
+            <iidm:load id="_0484cffb-c766-11e1-8775-005056c00008" name="Roanoke LD" loadType="UNDEFINED" p0="31" q0="26" node="17" p="30.999735472301293" q="25.999630231150356">
                 <iidm:alias>_0454983a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0489d903-c766-11e1-8775-005056c00008" name="Roanoke SC" sectionCount="5" voltageRegulatorOn="true" targetV="127.423" targetDeadband="1" node="18" q="-18.638635315761988">
+            <iidm:shunt id="_0489d903-c766-11e1-8775-005056c00008" name="Roanoke SC" sectionCount="5" voltageRegulatorOn="true" targetV="127.423" targetDeadband="1" node="18" q="-18.63865671375984">
                 <iidm:alias>_0476c638-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_5be38d1a-9d01-42d8-b8bb-e9a26cfbcf1a"/>
                 <iidm:shuntLinearModel bPerSection="0.0002296" gPerSection="0" maximumSectionCount="10"/>
@@ -3240,12 +3325,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="120.85923366165238" angle="-10.176597387535725" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="120.83060550119825" angle="-17.77619039409787" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047a219a-c766-11e1-8775-005056c00008" name="Howard LD" loadType="UNDEFINED" p0="37" q0="23" node="14" p="37.025708982584568" q="23.026641601029173">
+            <iidm:load id="_047a219a-c766-11e1-8775-005056c00008" name="Howard LD" loadType="UNDEFINED" p0="37" q0="23" node="14" p="37.02631218038637" q="23.027266828535726">
                 <iidm:alias>_04882b51-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_04488a49-c766-11e1-8775-005056c00008" name="Howard NegG LD" loadType="UNDEFINED" p0="59" q0="0" node="15" p="59.040995404661878" q="0">
+            <iidm:load id="_04488a49-c766-11e1-8775-005056c00008" name="Howard NegG LD" loadType="UNDEFINED" p0="59" q0="0" node="15" p="59.041957260616108" q="0">
                 <iidm:alias>_046d9e74-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3295,7 +3380,7 @@
                 <iidm:internalConnection node1="19" node2="6"/>
                 <iidm:internalConnection node1="20" node2="3"/>
                 <iidm:internalConnection node1="21" node2="6"/>
-                <iidm:bus v="218.71472096832022" angle="14.063862792050998" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
+                <iidm:bus v="218.71456504973335" angle="6.3966255439951407" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_046efe09-c766-11e1-8775-005056c00008" name="CRI132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -3458,20 +3543,20 @@
                 <iidm:internalConnection node1="81" node2="18"/>
                 <iidm:internalConnection node1="82" node2="21"/>
                 <iidm:internalConnection node1="83" node2="24"/>
-                <iidm:bus v="137.28004133120987" angle="15.925159596369543" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
+                <iidm:bus v="137.28012333498282" angle="8.2471781562075943" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_045868c1-c766-11e1-8775-005056c00008" name="CabinCrk SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="477" targetV="137.28" targetQ="0" node="27" p="-505.53512341576391" q="-129.38486071327148">
+            <iidm:generator id="_045868c1-c766-11e1-8775-005056c00008" name="CabinCrk SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="477" targetV="137.28" targetQ="0" node="27" p="-505.45239696677839" q="-130.27218663705736">
                 <iidm:alias>_0487dd36-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_a6ec9760-88da-48df-a23f-7877e7c85ccd"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_e6131af8-c298-413b-84e3-4e21c3b6b06f"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-225" maxQ="640"/>
             </iidm:generator>
-            <iidm:load id="_04747c44-c766-11e1-8775-005056c00008" name="CabinCrk LD" loadType="UNDEFINED" p0="130" q0="26" node="26" p="130.00005870910934" q="26.000019569706051">
+            <iidm:load id="_04747c44-c766-11e1-8775-005056c00008" name="CabinCrk LD" loadType="UNDEFINED" p0="130" q0="26" node="26" p="130.00017519177632" q="26.000058397285009">
                 <iidm:alias>_046a9138-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_0488c79b-c766-11e1-8775-005056c00008" name="81-80" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="21" voltageLevelId1="_048a272b-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-97.071575614460045" q1="68.448192794822319" p2="97.071575614460087" q2="-63.830966703080215">
+        <iidm:twoWindingsTransformer id="_0488c79b-c766-11e1-8775-005056c00008" name="81-80" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="21" voltageLevelId1="_048a272b-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-96.511421710804342" q1="68.426030954043512" p2="96.511421710804257" q2="-63.845279684461111">
             <iidm:alias>_044974a0-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_045a3d83-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_046adf57-c766-11e1-8775-005056c00008</iidm:alias>
@@ -3551,12 +3636,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="134.74521229605418" angle="-0.60242881691918482" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="134.74537577114739" angle="-8.2411060538087479" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04524e4a-c766-11e1-8775-005056c00008" name="Zanesvll LD" loadType="UNDEFINED" p0="20" q0="11" node="8" p="19.999887880543273" q="10.999897224023385">
+            <iidm:load id="_04524e4a-c766-11e1-8775-005056c00008" name="Zanesvll LD" loadType="UNDEFINED" p0="20" q0="11" node="8" p="19.999900787191226" q="10.999909055075669">
                 <iidm:alias>_045c1240-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_048b5fa9-c766-11e1-8775-005056c00008" name="Zanesvll SC" sectionCount="5" voltageRegulatorOn="true" targetV="134.72300000000001" targetDeadband="1" node="9" q="-15.632550395806206">
+            <iidm:shunt id="_048b5fa9-c766-11e1-8775-005056c00008" name="Zanesvll SC" sectionCount="5" voltageRegulatorOn="true" targetV="134.72300000000001" targetDeadband="1" node="9" q="-15.632588327160343">
                 <iidm:alias>_04736ad5-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_99c6c4ad-5247-4058-96d4-ee8495103e85"/>
                 <iidm:shuntLinearModel bPerSection="0.00017220000000000001" gPerSection="0" maximumSectionCount="10"/>
@@ -3609,9 +3694,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.95147090829056" angle="19.462682290086395" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.93618879052806" angle="11.787739087320146" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044ca8f2-c766-11e1-8775-005056c00008" name="Tazewell LD" loadType="UNDEFINED" p0="12" q0="7" node="8" p="12.00612397313084" q="7.0059548755224412">
+            <iidm:load id="_044ca8f2-c766-11e1-8775-005056c00008" name="Tazewell LD" loadType="UNDEFINED" p0="12" q0="7" node="8" p="12.006139011457645" q="7.0059695010978595">
                 <iidm:alias>_04542305-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3662,9 +3747,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="120.33498769694597" angle="-8.7896484622855962" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="120.28155661768434" angle="-16.349941818073304" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04778989-c766-11e1-8775-005056c00008" name="NwLibrty LD" loadType="UNDEFINED" p0="27" q0="11" node="8" p="27.038554095046742" q="11.026191164985827">
+            <iidm:load id="_04778989-c766-11e1-8775-005056c00008" name="NwLibrty LD" loadType="UNDEFINED" p0="27" q0="11" node="8" p="27.039237862703214" q="11.026655897457546">
                 <iidm:alias>_0483e592-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3697,12 +3782,12 @@
                 <iidm:internalConnection node1="11" node2="2"/>
                 <iidm:internalConnection node1="12" node2="3"/>
                 <iidm:internalConnection node1="13" node2="3"/>
-                <iidm:bus v="122.6003342337869" angle="4.4382826646416405" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13"/>
+                <iidm:bus v="122.60039913733323" angle="-3.2418162537459247" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0463da70-c766-11e1-8775-005056c00008" name="Danville LD" loadType="UNDEFINED" p0="25" q0="13" node="5" p="24.99961746263665" q="12.999668469309414">
+            <iidm:load id="_0463da70-c766-11e1-8775-005056c00008" name="Danville LD" loadType="UNDEFINED" p0="25" q0="13" node="5" p="24.999643506942622" q="12.999691040818838">
                 <iidm:alias>_0488eeab-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_0448b150-c766-11e1-8775-005056c00008" name="Danville NegG LD" loadType="UNDEFINED" p0="43" q0="0" node="6" p="42.99934203573504" q="0">
+            <iidm:load id="_0448b150-c766-11e1-8775-005056c00008" name="Danville NegG LD" loadType="UNDEFINED" p0="43" q0="0" node="6" p="42.999386831941308" q="0">
                 <iidm:alias>_0457cc88-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3753,9 +3838,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.70247689506121" angle="24.81314205116578" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.56536678869114" angle="17.154709061829156" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045cae82-c766-11e1-8775-005056c00008" name="Fremont LD" loadType="UNDEFINED" p0="48" q0="10" node="8" p="48.014811449550898" q="10.005143393390354">
+            <iidm:load id="_045cae82-c766-11e1-8775-005056c00008" name="Fremont LD" loadType="UNDEFINED" p0="48" q0="10" node="8" p="48.014711890550934" q="10.00510881720604">
                 <iidm:alias>_045f4693-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3901,9 +3986,9 @@
                 <iidm:internalConnection node1="70" node2="15"/>
                 <iidm:internalConnection node1="71" node2="18"/>
                 <iidm:internalConnection node1="72" node2="21"/>
-                <iidm:bus v="132.38306816926661" angle="13.587397108027602" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
+                <iidm:bus v="132.36359881983037" angle="5.9059017675517396" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0448d863-c766-11e1-8775-005056c00008" name="Turner LD" loadType="UNDEFINED" p0="61" q0="28" node="23" p="61.005407824505696" q="28.004137255756667">
+            <iidm:load id="_0448d863-c766-11e1-8775-005056c00008" name="Turner LD" loadType="UNDEFINED" p0="61" q0="28" node="23" p="61.005305425380875" q="28.00405891304235">
                 <iidm:alias>_046e3ab3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3938,6 +4023,9 @@
                     <iidm:alias>_0b877750-4384-4ec3-bb38-08ee5ccf16d3</iidm:alias>
                     <iidm:alias>_1ed822d3-f3ab-4432-80f0-4c55ae3b4b78</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_3be2355e-0065-43df-a264-57a295042faa-1" name="DISCONNECTOR526-1" kind="DISCONNECTOR" retained="false" open="false" node1="24" node2="25"/>
+                <iidm:switch id="_2463ff2c-7690-4dd6-bf44-039f9f475bb1-1" name="BREAKER263-1" kind="BREAKER" retained="false" open="true" node1="23" node2="24"/>
+                <iidm:switch id="_ddcf7aac-e7c3-45e9-bd81-6146e951addd-1" name="DISCONNECTOR525-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="23"/>
                 <iidm:internalConnection node1="7" node2="0"/>
                 <iidm:internalConnection node1="8" node2="0"/>
                 <iidm:internalConnection node1="9" node2="1"/>
@@ -3954,9 +4042,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.15976962723352" angle="4.4360942983937157" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.22569424095047" angle="-3.135603290716177" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047d7cf6-c766-11e1-8775-005056c00008" name="Grant LD" loadType="UNDEFINED" p0="24" q0="4" node="8" p="24.001545632691148" q="4.0004293516308875">
+            <iidm:load id="_047d7cf6-c766-11e1-8775-005056c00008" name="Grant LD" loadType="UNDEFINED" p0="24" q0="4" node="8" p="24.001410150611164" q="4.0003917161748292">
                 <iidm:alias>_0481e9c0-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4026,9 +4114,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="221.63989223491828" angle="13.957267061095232" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="222.07645076521305" angle="5.3038063293881166" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04867dab-c766-11e1-8775-005056c00008" name="Olive NegG LD" loadType="UNDEFINED" p0="28" q0="0" node="11" p="28.028726855894991" q="0">
+            <iidm:load id="_04867dab-c766-11e1-8775-005056c00008" name="Olive NegG LD" loadType="UNDEFINED" p0="28" q0="0" node="11" p="28.027681903376511" q="0">
                 <iidm:alias>_048433b8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4134,15 +4222,15 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="133.39228043236284" angle="8.5836086287008353" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="133.51086906929407" angle="0.16798321327467447" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:shunt id="_0447c6f6-c766-11e1-8775-005056c00008" name="Olive SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.67599999999999" targetDeadband="1" node="17" q="-40.853877099660316">
+            <iidm:shunt id="_0447c6f6-c766-11e1-8775-005056c00008" name="Olive SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.67599999999999" targetDeadband="1" node="17" q="-40.926549358529272">
                 <iidm:alias>_045e8340-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_c701959a-91c1-4a35-9a37-71fb790426ca"/>
                 <iidm:shuntLinearModel bPerSection="0.00045919999999999999" gPerSection="0" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_04575750-c766-11e1-8775-005056c00008" name="8-5" r="0" x="4.6522079999999999" g="0" b="0" ratedU1="220" ratedU2="132" node1="32" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="362.53093235805818" q1="63.932931468033516" p2="-362.53093235805818" q2="-29.345037728486151">
+        <iidm:twoWindingsTransformer id="_04575750-c766-11e1-8775-005056c00008" name="8-5" r="0" x="4.6522079999999999" g="0" b="0" ratedU1="220" ratedU2="132" node1="32" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="347.52072854564057" q1="66.882299788087821" p2="-347.52072854564062" q2="-35.041742851529996">
             <iidm:alias>_045eaa55-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_046b2d74-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04745533-c766-11e1-8775-005056c00008</iidm:alias>
@@ -4213,9 +4301,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.85787594351376" angle="18.342598827575888" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.85467420160109" angle="10.665928807796377" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047b0bf0-c766-11e1-8775-005056c00008" name="Wythe LD" loadType="UNDEFINED" p0="22" q0="15" node="8" p="22.005104878801738" q="15.005801447314576">
+            <iidm:load id="_047b0bf0-c766-11e1-8775-005056c00008" name="Wythe LD" loadType="UNDEFINED" p0="22" q0="15" node="8" p="22.005134735094529" q="15.00583538018353">
                 <iidm:alias>_0479d376-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4266,9 +4354,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="124.45168453667466" angle="-5.5535318841190415" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.39394154184588" angle="-13.092516827227076" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0458ddf5-c766-11e1-8775-005056c00008" name="WestLima LD" loadType="UNDEFINED" p0="33" q0="9" node="8" p="33.051841001769112" q="9.0235764288142946">
+            <iidm:load id="_0458ddf5-c766-11e1-8775-005056c00008" name="WestLima LD" loadType="UNDEFINED" p0="33" q0="9" node="8" p="33.052682833680116" q="9.0239594835777446">
                 <iidm:alias>_04492686-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4376,9 +4464,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="128.60497901731952" angle="21.220345931477681" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="128.26970971391978" angle="13.571578762900137" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044b2257-c766-11e1-8775-005056c00008" name="BeaverCk LD" loadType="UNDEFINED" p0="24" q0="15" node="17" p="24.010404544856208" q="15.010839633665896">
+            <iidm:load id="_044b2257-c766-11e1-8775-005056c00008" name="BeaverCk LD" loadType="UNDEFINED" p0="24" q0="15" node="17" p="24.010291246532496" q="15.010721580657545">
                 <iidm:alias>_045868c4-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4437,6 +4525,9 @@
                     <iidm:alias>_2b636cdd-aa2f-4a65-92fc-12b4fc392e5f</iidm:alias>
                     <iidm:alias>_c96e50b9-ea15-4421-b6c8-bd9c9158a69a</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_e5318967-afcc-4fcc-b0de-d5f2522a95a6-1" name="DISCONNECTOR699-1" kind="DISCONNECTOR" retained="false" open="false" node1="43" node2="44"/>
+                <iidm:switch id="_e9f91b69-a29b-44ea-aa0f-cff86ee80320-1" name="BREAKER350-1" kind="BREAKER" retained="true" open="true" node1="42" node2="43"/>
+                <iidm:switch id="_ad86e83d-6334-4dd8-b642-b4c16d65329a-1" name="DISCONNECTOR700-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="42"/>
                 <iidm:internalConnection node1="13" node2="0"/>
                 <iidm:internalConnection node1="14" node2="1"/>
                 <iidm:internalConnection node1="15" node2="2"/>
@@ -4466,7 +4557,7 @@
                 <iidm:internalConnection node1="39" node2="9"/>
                 <iidm:internalConnection node1="40" node2="12"/>
                 <iidm:internalConnection node1="41" node2="3"/>
-                <iidm:bus v="215.29288692105254" angle="11.869320026520846" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41"/>
+                <iidm:bus v="216.26158139854107" angle="2.779975083974517" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_047bcf46-c766-11e1-8775-005056c00008" name="STN132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -4546,6 +4637,9 @@
                     <iidm:alias>_4aab41d6-d1b6-4dbe-a6aa-cb7ccd941912</iidm:alias>
                     <iidm:alias>_e9315b98-af75-40bb-bf8e-05bd03d43db5</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_b8b0b9a9-af8b-41d2-a4f8-940637e63f70-1" name="DISCONNECTOR701-1" kind="DISCONNECTOR" retained="false" open="false" node1="64" node2="65"/>
+                <iidm:switch id="_0b78ffaa-9859-4658-af17-c8d355633556-1" name="BREAKER351-1" kind="BREAKER" retained="true" open="false" node1="63" node2="64"/>
+                <iidm:switch id="_9dfeeaef-5c49-4c2c-97b1-03876970bee4-1" name="DISCONNECTOR702-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="63"/>
                 <iidm:internalConnection node1="19" node2="0"/>
                 <iidm:internalConnection node1="20" node2="0"/>
                 <iidm:internalConnection node1="21" node2="1"/>
@@ -4590,9 +4684,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="129.7628909256272" angle="5.587568878945242" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="129.67457761462097" angle="-1.5104423934446796" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045dbff4-c766-11e1-8775-005056c00008" name="Sorenson LD" loadType="UNDEFINED" p0="11" q0="3" node="20" p="11.011945156257811" q="3.005431581626111">
+            <iidm:load id="_045dbff4-c766-11e1-8775-005056c00008" name="Sorenson LD" loadType="UNDEFINED" p0="11" q0="3" node="20" p="11.011150030000925" q="3.0050699077025089">
                 <iidm:alias>_044d4536-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4613,6 +4707,9 @@
                     <iidm:alias>_340082f1-db9c-446d-97df-80e45aa0058b</iidm:alias>
                     <iidm:alias>_90c04b95-703a-4bae-82b8-7edf3075aa24</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_4d08a684-cdcb-484a-a767-03b10f4ada7f-1" name="DISCONNECTOR735-1" kind="DISCONNECTOR" retained="false" open="false" node1="14" node2="15"/>
+                <iidm:switch id="_f468d841-1bf6-470e-85d4-55d34fab8bff-1" name="BREAKER368-1" kind="BREAKER" retained="true" open="false" node1="13" node2="14"/>
+                <iidm:switch id="_f193bd8f-badf-4600-82ac-f212d1f33534-1" name="DISCONNECTOR736-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="13"/>
                 <iidm:internalConnection node1="4" node2="0"/>
                 <iidm:internalConnection node1="5" node2="1"/>
                 <iidm:internalConnection node1="6" node2="2"/>
@@ -4622,13 +4719,13 @@
                 <iidm:internalConnection node1="10" node2="3"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="0"/>
-                <iidm:bus v="385.59481750500663" angle="11.648005890394046" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="390.35934506777812" angle="0" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15"/>
             </iidm:nodeBreakerTopology>
             <iidm:lccConverterStation id="_7393a68e-c4e6-48dd-9347-543858363fdb" name="Conv1" lossFactor="0" powerFactor="0.80000000000000004" node="12" p="10" q="6">
                 <iidm:alias>_739658a7-e08b-4395-8d79-93e87b7855e3</iidm:alias>
             </iidm:lccConverterStation>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_047120e9-c766-11e1-8775-005056c00008" name="30-17" r="0" x="6.7605125399999997" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_047b8123-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="282.59747938685342" q1="110.94786979703015" p2="-282.59747938685342" q2="-76.532423959180136">
+        <iidm:twoWindingsTransformer id="_047120e9-c766-11e1-8775-005056c00008" name="30-17" r="0" x="6.7605125399999997" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_047b8123-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="193.95706113942683" q1="117.00563995743832" p2="-193.95706113942683" q2="-98.018481739894483">
             <iidm:alias>_044f6811-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0463b36a-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_047d2ed8-c766-11e1-8775-005056c00008</iidm:alias>
@@ -4647,7 +4744,7 @@
                 <iidm:temporaryLimit name="_f62f2fc6-4b6c-4571-a8c5-40d6a89ac703" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_b08e9e50-4e0c-4ac0-9f21-4a27429caeb2" name="PowTrans1" r="0.4840000000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_3bbfa58a-a1ad-4b23-a526-3d76b096c1f4" node2="41" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="-10.000003828864012" q1="-5.9999996566340261" p2="10.001430983243237" q2="6.0535179458596833">
+        <iidm:twoWindingsTransformer id="_b08e9e50-4e0c-4ac0-9f21-4a27429caeb2" name="PowTrans1" r="0.4840000000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_3bbfa58a-a1ad-4b23-a526-3d76b096c1f4" node2="41" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="-125.1049048682378" q1="20.205375704809551" p2="125.26934086641997" q2="-14.039025772979302">
             <iidm:alias>_046ba2aa-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_a5bf9702-545a-437d-9663-773550202828</iidm:alias>
             <iidm:alias>_ee9505e1-96d7-49b3-9d1a-924397ffb27e</iidm:alias>
@@ -4667,6 +4764,32 @@
                 <iidm:temporaryLimit name="_611bb05e-9b9a-469c-b1d1-80a944c3ce2f" acceptableDuration="60" value="1400"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
+        <iidm:threeWindingsTransformer id="_86d83c7d-7826-4c16-b161-4ce17174e77f-1" name="T422" r1="-1.5199999809265099" x1="23.199999999999999" g1="0" b1="0" ratedU1="400" r2="2.0000000630528461" x2="19.999999999999996" g2="0" b2="0" ratedU2="220" r3="1.2000000564689806" x3="12" g3="0" b3="0" ratedU3="132" ratedU0="400" node1="15" voltageLevelId1="_3bbfa58a-a1ad-4b23-a526-3d76b096c1f4" node2="44" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" node3="65" voltageLevelId3="_047bcf46-c766-11e1-8775-005056c00008" p1="115.10490538458428" q1="-26.205375395001113" p2="0" q2="0" p3="-115.13417078823227" q3="29.424570556238166">
+            <iidm:alias>_1b2d419c-ac88-4dae-8dfe-2eb92d18c40a-1</iidm:alias>
+            <iidm:alias>_206474da-93c8-46b1-863f-9a308bfc2117-1</iidm:alias>
+            <iidm:alias>_9ac069ea-557b-4b8c-b12e-f9f2aecc3bf5-1</iidm:alias>
+            <iidm:alias>_ae46e10e-1fbe-4139-b493-ed8e2844ee8d-1</iidm:alias>
+            <iidm:ratioTapChanger1 lowTapPosition="1" tapPosition="11" targetDeadband="0" loadTapChangingCapabilities="true" regulating="false" targetV="220">
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.95238095238095233"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.96385542168674687"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.97560975609756106"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.98765432098765438"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0126582278481011"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0256410256410258"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0389610389610389"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0526315789473684"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0666666666666667"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0810810810810809"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.095890410958904"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.1111111111111112"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.1267605633802817"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.1428571428571428"/>
+            </iidm:ratioTapChanger1>
+            <iidm:currentLimits1 permanentLimit="500">
+                <iidm:temporaryLimit name="_3fd18f6e-749a-4fa7-af1b-b0c2d3952638-1" acceptableDuration="1800" value="533"/>
+            </iidm:currentLimits1>
+        </iidm:threeWindingsTransformer>
     </iidm:substation>
     <iidm:substation id="_04642898-c766-11e1-8775-005056c00008" name="Rómenna" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
         <iidm:voltageLevel id="_0457f394-c766-11e1-8775-005056c00008" name="RÓM132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -4905,16 +5028,16 @@
                 <iidm:internalConnection node1="121" node2="30"/>
                 <iidm:internalConnection node1="122" node2="33"/>
                 <iidm:internalConnection node1="123" node2="36"/>
-                <iidm:bus v="135.30001643665796" angle="0.23454801222224711" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123"/>
+                <iidm:bus v="135.30007579575573" angle="-7.4050351904291727" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04859346-c766-11e1-8775-005056c00008" name="Philo SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="204" targetV="135.30000000000001" targetQ="0" node="39" p="-216.20370058032674" q="-178.48355486973591">
+            <iidm:generator id="_04859346-c766-11e1-8775-005056c00008" name="Philo SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="204" targetV="135.30000000000001" targetQ="0" node="39" p="-216.1683207153518" q="-178.45191169349187">
                 <iidm:alias>_048719e2-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e3753d6d-b894-4cce-b6fa-307c50dc107f"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_dff93c01-9c84-4c1f-8529-66c054ed9e37"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
-            <iidm:load id="_045163e2-c766-11e1-8775-005056c00008" name="Philo LD" loadType="UNDEFINED" p0="87" q0="30" node="38" p="87.000015853539722" q="30.00000911123028">
+            <iidm:load id="_045163e2-c766-11e1-8775-005056c00008" name="Philo LD" loadType="UNDEFINED" p0="87" q0="30" node="38" p="87.000073106781286" q="30.000042015403309">
                 <iidm:alias>_04513cd3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4965,9 +5088,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.01209231474621" angle="19.416951311931104" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.72607021801875" angle="11.757895220455907" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04524e46-c766-11e1-8775-005056c00008" name="BetsyLne LD" loadType="UNDEFINED" p0="11" q0="7" node="8" p="11.006706803401981" q="7.0071147219146663">
+            <iidm:load id="_04524e46-c766-11e1-8775-005056c00008" name="BetsyLne LD" loadType="UNDEFINED" p0="11" q0="7" node="8" p="11.006670922001559" q="7.0070766504581119">
                 <iidm:alias>_04549830-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5020,15 +5143,15 @@
                 <iidm:internalConnection node1="22" node2="6"/>
                 <iidm:internalConnection node1="23" node2="3"/>
                 <iidm:internalConnection node1="24" node2="6"/>
-                <iidm:bus v="124.7541930993406" angle="6.2370291064222645" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24"/>
+                <iidm:bus v="124.75425775790431" angle="-1.4426661927386013" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04566cf3-c766-11e1-8775-005056c00008" name="Reusens NegG LD" loadType="UNDEFINED" p0="22" q0="0" node="8" p="21.999665059338248" q="0">
+            <iidm:load id="_04566cf3-c766-11e1-8775-005056c00008" name="Reusens NegG LD" loadType="UNDEFINED" p0="22" q0="0" node="8" p="21.999687545567198" q="0">
                 <iidm:alias>_0483be81-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_0482fb36-c766-11e1-8775-005056c00008" name="Reusens LD" loadType="UNDEFINED" p0="28" q0="12" node="9" p="27.999573711885045" q="11.99969551003457">
+            <iidm:load id="_0482fb36-c766-11e1-8775-005056c00008" name="Reusens LD" loadType="UNDEFINED" p0="28" q0="12" node="9" p="27.999602330721888" q="11.999715951860374">
                 <iidm:alias>_0486cbc1-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_04558293-c766-11e1-8775-005056c00008" name="Reusens SC" sectionCount="5" voltageRegulatorOn="true" targetV="124.76300000000001" targetDeadband="1" node="10" q="-5.353881391378442">
+            <iidm:shunt id="_04558293-c766-11e1-8775-005056c00008" name="Reusens SC" sectionCount="5" voltageRegulatorOn="true" targetV="124.76300000000001" targetDeadband="1" node="10" q="-5.3538869410816163">
                 <iidm:alias>_04893ccc-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_99303cd3-6b53-4ee2-a5ce-fe8d5feeb304"/>
                 <iidm:shuntLinearModel bPerSection="6.8800000000000005e-05" gPerSection="0" maximumSectionCount="10"/>
@@ -5101,12 +5224,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="126.46352651244685" angle="22.923068291637041" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="126.46187779579483" angle="15.252930171686428" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045c8777-c766-11e1-8775-005056c00008" name="Holston NegG LD" loadType="UNDEFINED" p0="85" q0="0" node="11" p="85.010089386648531" q="0">
+            <iidm:load id="_045c8777-c766-11e1-8775-005056c00008" name="Holston NegG LD" loadType="UNDEFINED" p0="85" q0="0" node="11" p="85.010189112111007" q="0">
                 <iidm:alias>_0487dd31-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_0451d918-c766-11e1-8775-005056c00008" name="Holston LD" loadType="UNDEFINED" p0="78" q0="42" node="12" p="78.009258495983374" q="42.008309235399452">
+            <iidm:load id="_0451d918-c766-11e1-8775-005056c00008" name="Holston LD" loadType="UNDEFINED" p0="78" q0="42" node="12" p="78.009350008760705" q="42.008391368781787">
                 <iidm:alias>_0485ba54-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5214,9 +5337,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="127.64653734867338" angle="9.4644945330532355" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="127.63920446648189" angle="1.7608847898856623" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04742e27-c766-11e1-8775-005056c00008" name="SthPoint LD" loadType="UNDEFINED" p0="47" q0="11" node="17" p="46.988361697159142" q="10.99546061120815">
+            <iidm:load id="_04742e27-c766-11e1-8775-005056c00008" name="SthPoint LD" loadType="UNDEFINED" p0="47" q0="11" node="17" p="46.987605519370881" q="10.995165698518287">
                 <iidm:alias>_047b3303-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5268,12 +5391,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="132.94285711888665" angle="13.614326539581054" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="132.92982774574207" angle="5.933954017802435" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04716f06-c766-11e1-8775-005056c00008" name="CapitlHl LD" loadType="UNDEFINED" p0="39" q0="32" node="8" p="39.002268378542787" q="32.003102116268693">
+            <iidm:load id="_04716f06-c766-11e1-8775-005056c00008" name="CapitlHl LD" loadType="UNDEFINED" p0="39" q0="32" node="8" p="39.002235735357345" q="32.003057474296618">
                 <iidm:alias>_04700f70-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0466c0a0-c766-11e1-8775-005056c00008" name="CapitlHl SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.00200000000001" targetDeadband="1" node="9" q="-20.289526141254761">
+            <iidm:shunt id="_0466c0a0-c766-11e1-8775-005056c00008" name="CapitlHl SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.00200000000001" targetDeadband="1" node="9" q="-20.28554929198053">
                 <iidm:alias>_045e8346-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_99931a87-ee15-4fd0-b251-9556df7fe598"/>
                 <iidm:shuntLinearModel bPerSection="0.0002296" gPerSection="0" maximumSectionCount="10"/>
@@ -5326,9 +5449,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="132.08861403919181" angle="13.291727688967791" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="132.07131872402346" angle="5.6104918819485503" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046efe03-c766-11e1-8775-005056c00008" name="Chemical LD" loadType="UNDEFINED" p0="71" q0="26" node="8" p="71.005671865258179" q="26.003461793979792">
+            <iidm:load id="_046efe03-c766-11e1-8775-005056c00008" name="Chemical LD" loadType="UNDEFINED" p0="71" q0="26" node="8" p="71.005570681760759" q="26.003400035534064">
                 <iidm:alias>_045d71d5-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5379,9 +5502,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.58560014443452" angle="5.3087962444161869" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.6267226325968" angle="-2.9170478936644502" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046a4319-c766-11e1-8775-005056c00008" name="JacksnRd LD" loadType="UNDEFINED" p0="19" q0="2" node="8" p="19.003547868643309" q="2.0006224718368095">
+            <iidm:load id="_046a4319-c766-11e1-8775-005056c00008" name="JacksnRd LD" loadType="UNDEFINED" p0="19" q0="2" node="8" p="19.003374983382376" q="2.0005921374056119">
                 <iidm:alias>_046c8d06-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5527,9 +5650,9 @@
                 <iidm:internalConnection node1="70" node2="15"/>
                 <iidm:internalConnection node1="71" node2="18"/>
                 <iidm:internalConnection node1="72" node2="21"/>
-                <iidm:bus v="130.72538794046517" angle="22.852196327337012" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
+                <iidm:bus v="130.71892120379198" angle="15.179573648805686" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0458ddf4-c766-11e1-8775-005056c00008" name="Saltvlle LD" loadType="UNDEFINED" p0="65" q0="10" node="23" p="65.02218928547191" q="10.005690207774805">
+            <iidm:load id="_0458ddf4-c766-11e1-8775-005056c00008" name="Saltvlle LD" loadType="UNDEFINED" p0="65" q0="10" node="23" p="65.022280191790344" q="10.005713522402576">
                 <iidm:alias>_045645e4-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5599,9 +5722,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="132.10990761001506" angle="11.311976515881414" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="132.2193787165082" angle="3.4047336538457578" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0476ed42-c766-11e1-8775-005056c00008" name="Trenton NegG LD" loadType="UNDEFINED" p0="13" q0="0" node="11" p="13.018403745996569" q="0">
+            <iidm:load id="_0476ed42-c766-11e1-8775-005056c00008" name="Trenton NegG LD" loadType="UNDEFINED" p0="13" q0="0" node="11" p="13.01749754754756" q="0">
                 <iidm:alias>_0471e432-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5671,9 +5794,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="128.44048171536468" angle="4.3056546327587286" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="128.4963548552013" angle="-3.9605654222834654" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044a5f08-c766-11e1-8775-005056c00008" name="HickryCk LD" loadType="UNDEFINED" p0="39" q0="10" node="11" p="39.010609235704088" q="10.004534272517565">
+            <iidm:load id="_044a5f08-c766-11e1-8775-005056c00008" name="HickryCk LD" loadType="UNDEFINED" p0="39" q0="10" node="11" p="39.010135057361879" q="10.004331596273511">
                 <iidm:alias>_047d7cf3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5802,9 +5925,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="125.87212100358566" angle="-4.6745877593208878" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="125.81629191709972" angle="-12.2154041249486" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:shunt id="_0450eeb7-c766-11e1-8775-005056c00008" name="EastLima SC" sectionCount="5" voltageRegulatorOn="true" targetV="131.565" targetDeadband="1" node="20" q="-22.735839863925779">
+            <iidm:shunt id="_0450eeb7-c766-11e1-8775-005056c00008" name="EastLima SC" sectionCount="5" voltageRegulatorOn="true" targetV="131.565" targetDeadband="1" node="20" q="-22.715675912388299">
                 <iidm:alias>_044aad27-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_6c36f421-303e-4932-93a9-5b0ff86cb7d4"/>
                 <iidm:shuntLinearModel bPerSection="0.00028699999999999998" gPerSection="0" maximumSectionCount="10"/>
@@ -5892,16 +6015,16 @@
                 <iidm:internalConnection node1="41" node2="7"/>
                 <iidm:internalConnection node1="42" node2="12"/>
                 <iidm:internalConnection node1="43" node2="11"/>
-                <iidm:bus v="218.83467663750577" angle="7.7479576779731332" nodes="0,1,2,3,8,9,10,13,17,18,21,22,23,24,25,26,31,32,33,34,35,39,40"/>
-                <iidm:bus v="237.93773131515249" angle="-4.5932313997904641" nodes="11,15,37,43"/>
-                <iidm:bus v="226.19471441503669" angle="7.7479577276837546" nodes="12,16,38,42"/>
-                <iidm:bus v="214.70029238110718" angle="-4.593231399790465" nodes="4,5,6,7,14,19,20,27,28,29,30,36,41"/>
+                <iidm:bus v="218.83494705837595" angle="0.10112259710053782" nodes="0,1,2,3,8,9,10,13,17,18,21,22,23,24,25,26,31,32,33,34,35,39,40"/>
+                <iidm:bus v="237.93785473312727" angle="-12.238079460034255" nodes="11,15,37,43"/>
+                <iidm:bus v="226.1948290162328" angle="0.10112268869719915" nodes="12,16,38,42"/>
+                <iidm:bus v="214.70040374585426" angle="-12.238079460034255" nodes="4,5,6,7,14,19,20,27,28,29,30,36,41"/>
             </iidm:nodeBreakerTopology>
-            <iidm:vscConverterStation id="_b46bfb8e-7af6-459e-acf3-53a42c943a7c" name="VSC2" voltageRegulatorOn="true" lossFactor="0.32362458" voltageSetpoint="218.47" reactivePowerSetpoint="0" node="42" p="-0" q="-27.746683647642474">
+            <iidm:vscConverterStation id="_b46bfb8e-7af6-459e-acf3-53a42c943a7c" name="VSC2" voltageRegulatorOn="true" lossFactor="0.32362458" voltageSetpoint="218.47" reactivePowerSetpoint="0" node="42" p="-0" q="-27.746082164564807">
                 <iidm:alias>_a168e701-bd48-4f66-8f0b-0f69b2545530</iidm:alias>
                 <iidm:minMaxReactiveLimits minQ="-1.7976931348623157e+308" maxQ="1.7976931348623157e+308"/>
             </iidm:vscConverterStation>
-            <iidm:vscConverterStation id="_b48ce7cf-abf5-413f-bc51-9e1d3103c9bd" name="VSC1" voltageRegulatorOn="true" lossFactor="0.32467531999999999" voltageSetpoint="213.53999999999999" reactivePowerSetpoint="0" node="43" p="-0" q="-92.151020935010891">
+            <iidm:vscConverterStation id="_b48ce7cf-abf5-413f-bc51-9e1d3103c9bd" name="VSC1" voltageRegulatorOn="true" lossFactor="0.32467531999999999" voltageSetpoint="213.53999999999999" reactivePowerSetpoint="0" node="43" p="-0" q="-92.151020935034637">
                 <iidm:alias>_071bb138-ff00-4874-8acc-a884aa5cf4a9</iidm:alias>
                 <iidm:minMaxReactiveLimits minQ="-1.7976931348623157e+308" maxQ="1.7976931348623157e+308"/>
             </iidm:vscConverterStation>
@@ -5969,7 +6092,7 @@
                 <iidm:internalConnection node1="29" node2="6"/>
                 <iidm:internalConnection node1="30" node2="9"/>
                 <iidm:internalConnection node1="31" node2="3"/>
-                <iidm:bus v="202.03920972481285" angle="-0.26049708023602808" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
+                <iidm:bus v="202.00001484876827" angle="-7.8277705796089316" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_0448d867-c766-11e1-8775-005056c00008" name="EDO132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -6055,9 +6178,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="131.34002592613862" angle="5.124585562654997" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="131.34009354768511" angle="-2.5217798599019225" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0472a789-c766-11e1-8775-005056c00008" name="W.Kammer SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="160" targetV="131.34" targetQ="0" node="14" p="-169.57152986692293" q="92.340787051270269">
+            <iidm:generator id="_0472a789-c766-11e1-8775-005056c00008" name="W.Kammer SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="160" targetV="131.34" targetQ="0" node="14" p="-169.54378095321712" q="92.338699013194812">
                 <iidm:alias>_04697fc0-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_17852426-f663-4add-9a2b-0a635d51f101"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b512ea0a-96d0-4a48-9de1-a5cf499bf0dd"/>
@@ -6206,16 +6329,16 @@
                 <iidm:internalConnection node1="71" node2="15"/>
                 <iidm:internalConnection node1="72" node2="18"/>
                 <iidm:internalConnection node1="73" node2="21"/>
-                <iidm:bus v="130.02002640160251" angle="-4.5932313997904641" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
+                <iidm:bus v="130.0200938428118" angle="-12.238079460034257" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04839777-c766-11e1-8775-005056c00008" name="Tidd SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="155" targetV="130.02000000000001" targetQ="0" node="24" p="-164.27241955858159" q="-97.835920651092337">
+            <iidm:generator id="_04839777-c766-11e1-8775-005056c00008" name="Tidd SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="155" targetV="130.02000000000001" targetQ="0" node="24" p="-164.24553779842907" q="-97.836900402374596">
                 <iidm:alias>_045fe2d8-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_d2a96d8d-65be-4fd6-a012-ceeeabd2bee6"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_29df1e0b-36ca-4536-97b4-6f98b84d49d8"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-90" maxQ="255"/>
             </iidm:generator>
-            <iidm:load id="_04798556-c766-11e1-8775-005056c00008" name="Tidd LD" loadType="UNDEFINED" p0="277" q0="113" node="23" p="277.00008437060751" q="113.0000573638966">
+            <iidm:load id="_04798556-c766-11e1-8775-005056c00008" name="Tidd LD" loadType="UNDEFINED" p0="277" q0="113" node="23" p="277.00029988998114" q="113.00020389639047">
                 <iidm:alias>_04502b62-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6245,13 +6368,13 @@
                 <iidm:internalConnection node1="10" node2="3"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="0"/>
-                <iidm:bus v="361.38784138009368" angle="0" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="361.3172010545166" angle="-7.5671718027122354" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
             </iidm:nodeBreakerTopology>
             <iidm:lccConverterStation id="_9793118d-5ba1-4a9c-b2e0-db1d15be5913" name="Conv2" lossFactor="0" powerFactor="-0.75741000000000003" node="12" p="-10" q="8.6206896551724146">
                 <iidm:alias>_453bdc57-5855-4eb5-8712-d6a0255e0da8</iidm:alias>
             </iidm:lccConverterStation>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045c1248-c766-11e1-8775-005056c00008" name="38-37" r="0" x="6.5340005399999992" g="0" b="0" ratedU1="220" ratedU2="132" node1="30" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="192.22709915661471" q1="82.387277122452801" p2="-192.22709915661474" q2="-65.38540948508917">
+        <iidm:twoWindingsTransformer id="_045c1248-c766-11e1-8775-005056c00008" name="38-37" r="0" x="6.5340005399999992" g="0" b="0" ratedU1="220" ratedU2="132" node1="30" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="190.95538828679014" q1="82.888163166946399" p2="-190.95538828679017" q2="-66.036997381085385">
             <iidm:alias>_0453d4e8-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0477d7aa-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_047df228-c766-11e1-8775-005056c00008</iidm:alias>
@@ -6275,7 +6398,7 @@
                 <iidm:temporaryLimit name="_c97df399-5a91-4c8b-b72c-496cade334b5" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_0485ba57-c766-11e1-8775-005056c00008" name="64-61" r="0" x="4.669632" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="171.60546351810632" q1="59.887957849873175" p2="-171.60546351810632" q2="-51.20645948745446">
+        <iidm:twoWindingsTransformer id="_0485ba57-c766-11e1-8775-005056c00008" name="64-61" r="0" x="4.669632" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="171.57506307638894" q1="59.889399230086362" p2="-171.57506307638897" q2="-51.210618665021414">
             <iidm:alias>_04549831-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0472ce92-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0489d905-c766-11e1-8775-005056c00008</iidm:alias>
@@ -6301,7 +6424,7 @@
                 <iidm:temporaryLimit name="_f6b1a81c-eda7-4a08-b290-bd29a5ed9fa4" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_044cd007-c766-11e1-8775-005056c00008" name="63-59" r="0" x="6.7256646120000001" g="0" b="0" ratedU1="220" ratedU2="132" node1="41" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="73" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-2.9143354396410359e-14" q1="83.151415555460943" p2="-9.7144514654701197e-15" q2="-80.568862953753779">
+        <iidm:twoWindingsTransformer id="_044cd007-c766-11e1-8775-005056c00008" name="63-59" r="0" x="6.7256646120000001" g="0" b="0" ratedU1="220" ratedU2="132" node1="41" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="73" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="9.4368957093138306e-14" q1="83.151501816533425" p2="-8.3266726846886741e-15" q2="-80.568946535692632">
             <iidm:alias>_044e7db4-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_046eafe5-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0488797a-c766-11e1-8775-005056c00008</iidm:alias>
@@ -6347,7 +6470,7 @@
                 <iidm:temporaryLimit name="_f2daef4d-6f1a-44d1-9c9b-228acff12575" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_ffd940c8-03c8-4dcf-ad46-62018a0d813d" name="PowTrans2" r="0.3932500000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_04f97116-552a-4a34-afd9-4862f62ac7aa" node2="31" voltageLevelId2="_04742e21-c766-11e1-8775-005056c00008" p1="9.9999974578413955" q1="-8.6206874636565569" p2="-9.9983054271331717" q2="8.6987811886522906">
+        <iidm:twoWindingsTransformer id="_ffd940c8-03c8-4dcf-ad46-62018a0d813d" name="PowTrans2" r="0.3932500000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_04f97116-552a-4a34-afd9-4862f62ac7aa" node2="31" voltageLevelId2="_04742e21-c766-11e1-8775-005056c00008" p1="10.000005792007565" q1="-8.6206845199291564" p2="-9.9983130984986381" q2="8.6988088357291282">
             <iidm:alias>_04479fea-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_c089eb25-9f67-4d82-88a8-635dd4808bae</iidm:alias>
             <iidm:alias>_ea8cd467-31f0-40dc-95d7-4064463724c4</iidm:alias>
@@ -6414,9 +6537,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="124.78279366157354" angle="-7.7641940735345214" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.78268298501345" angle="-15.406324232612684" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0481c2b3-c766-11e1-8775-005056c00008" name="Wooster LD" loadType="UNDEFINED" p0="23" q0="11" node="8" p="22.999599755705617" q="10.999680966543494">
+            <iidm:load id="_0481c2b3-c766-11e1-8775-005056c00008" name="Wooster LD" loadType="UNDEFINED" p0="23" q0="11" node="8" p="22.999616881099698" q="10.999694617064957">
                 <iidm:alias>_04614268-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6486,9 +6609,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="125.56809342498896" angle="-7.5376416086093059" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="125.56812279396189" angle="-15.180434495986471" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044974a8-c766-11e1-8775-005056c00008" name="Wagenhls LD" loadType="UNDEFINED" p0="63" q0="22" node="11" p="62.999734316678833" q="21.999845369712986">
+            <iidm:load id="_044974a8-c766-11e1-8775-005056c00008" name="Wagenhls LD" loadType="UNDEFINED" p0="63" q0="22" node="11" p="62.999781029895942" q="21.999872557229949">
                 <iidm:alias>_048481d4-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6539,9 +6662,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.49477667874181" angle="3.5862199244332915" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.53467763338753" angle="-4.4278232551087351" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047fedf2-c766-11e1-8775-005056c00008" name="Concord LD" loadType="UNDEFINED" p0="34" q0="16" node="8" p="34.021904552144868" q="16.017183730056448">
+            <iidm:load id="_047fedf2-c766-11e1-8775-005056c00008" name="Concord LD" loadType="UNDEFINED" p0="34" q0="16" node="8" p="34.020493824263191" q="16.016076816943912">
                 <iidm:alias>_046d9e75-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6649,9 +6772,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="127.60097362403985" angle="6.5158689179796774" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="127.71190605951674" angle="-1.1771161213836459" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045f94ba-c766-11e1-8775-005056c00008" name="Delaware LD" loadType="UNDEFINED" p0="59" q0="23" node="17" p="59.028298679799654" q="23.01838908730479">
+            <iidm:load id="_045f94ba-c766-11e1-8775-005056c00008" name="Delaware LD" loadType="UNDEFINED" p0="59" q0="23" node="17" p="59.025997436656652" q="23.016893470714471">
                 <iidm:alias>_0463654a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6759,9 +6882,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="125.79146179175909" angle="2.0080342355780463" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="125.71617714676243" angle="-5.3505969057075804" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04697fc9-c766-11e1-8775-005056c00008" name="FtWayne LD" loadType="UNDEFINED" p0="90" q0="30" node="17" p="90.138307582465231" q="30.076876899153028">
+            <iidm:load id="_04697fc9-c766-11e1-8775-005056c00008" name="FtWayne LD" loadType="UNDEFINED" p0="90" q0="30" node="17" p="90.134214538975513" q="30.074600691527881">
                 <iidm:alias>_044d1e25-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6812,9 +6935,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.00807598827487" angle="-5.5054841733941711" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.00792438906086" angle="-13.147142084938849" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0474f170-c766-11e1-8775-005056c00008" name="WNwPhil1 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="11.999752476296983" q="2.9998968658328651">
+            <iidm:load id="_0474f170-c766-11e1-8775-005056c00008" name="WNwPhil1 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="11.999761297536187" q="2.9999005412995565">
                 <iidm:alias>_0466c0a7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6885,12 +7008,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="129.80766442997717" angle="14.912846592234223" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="129.70338981553172" angle="7.2352106106262442" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044a5f05-c766-11e1-8775-005056c00008" name="Logan LD" loadType="UNDEFINED" p0="54" q0="27" node="11" p="54.030125493298073" q="27.025109245902211">
+            <iidm:load id="_044a5f05-c766-11e1-8775-005056c00008" name="Logan LD" loadType="UNDEFINED" p0="54" q0="27" node="11" p="54.03006244200963" q="27.025056683642429">
                 <iidm:alias>_04767811-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0475dbd6-c766-11e1-8775-005056c00008" name="Logan SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.41900000000001" targetDeadband="1" node="12" q="-19.343834146990861">
+            <iidm:shunt id="_0475dbd6-c766-11e1-8775-005056c00008" name="Logan SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.41900000000001" targetDeadband="1" node="12" q="-19.312768790426464">
                 <iidm:alias>_04577e67-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_a7768441-642e-48a2-b4a8-0ae06bebf676"/>
                 <iidm:shuntLinearModel bPerSection="0.0002296" gPerSection="0" maximumSectionCount="10"/>
@@ -6964,19 +7087,19 @@
                 <iidm:internalConnection node1="32" node2="3"/>
                 <iidm:internalConnection node1="33" node2="6"/>
                 <iidm:internalConnection node1="34" node2="9"/>
-                <iidm:bus v="132.66001285935377" angle="-1.4176114391108496" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34"/>
+                <iidm:bus v="132.66006719620333" angle="-9.0528673484720503" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04633e31-c766-11e1-8775-005056c00008" name="W.Lancst SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="19" targetV="132.66" targetQ="0" node="13" p="-20.136619171697095" q="1.0920045982352391">
+            <iidm:generator id="_04633e31-c766-11e1-8775-005056c00008" name="W.Lancst SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="19" targetV="132.66" targetQ="0" node="13" p="-20.13332398819453" q="1.1025381125298801">
                 <iidm:alias>_047bcf42-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_83fae784-1da1-4055-8108-ba978276d1b6"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_5f711f63-f631-45d3-b26c-33821ab2ee56"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-15" maxQ="45"/>
             </iidm:generator>
-            <iidm:load id="_048a9c51-c766-11e1-8775-005056c00008" name="W.Lancst LD" loadType="UNDEFINED" p0="28" q0="10" node="11" p="28.000004071256377" q="10.000002423367011">
+            <iidm:load id="_048a9c51-c766-11e1-8775-005056c00008" name="W.Lancst LD" loadType="UNDEFINED" p0="28" q0="10" node="11" p="28.000021274241654" q="10.000012663242286">
                 <iidm:alias>_044e7db6-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_045b00d9-c766-11e1-8775-005056c00008" name="W.Lancst SC" sectionCount="5" voltageRegulatorOn="true" targetV="132.66" targetDeadband="1" node="12" q="-10.101641752798404">
+            <iidm:shunt id="_045b00d9-c766-11e1-8775-005056c00008" name="W.Lancst SC" sectionCount="5" voltageRegulatorOn="true" targetV="132.66" targetDeadband="1" node="12" q="-10.101650027959678">
                 <iidm:alias>_04758db6-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_be267a3c-f7a7-4bdf-bb17-71b773247fbf"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -7086,9 +7209,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="129.78159239472851" angle="9.6050283776809362" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="129.78623154019539" angle="1.869514756280515" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045dbff2-c766-11e1-8775-005056c00008" name="Portsmth LD" loadType="UNDEFINED" p0="66" q0="20" node="17" p="65.980632013124293" q="19.990219145316189">
+            <iidm:load id="_045dbff2-c766-11e1-8775-005056c00008" name="Portsmth LD" loadType="UNDEFINED" p0="66" q0="20" node="17" p="65.978478019256997" q="19.989131494299883">
                 <iidm:alias>_0454bf45-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7159,16 +7282,16 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="127.64402556522688" angle="4.5297043018002965" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="127.64400000479721" angle="-2.9941530956482358" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04856c34-c766-11e1-8775-005056c00008" name="DeerCrk SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="7" targetV="127.64400000000001" targetQ="0" node="12" p="-7.4187544316778782" q="-35.95750440996671">
+            <iidm:generator id="_04856c34-c766-11e1-8775-005056c00008" name="DeerCrk SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="7" targetV="127.64400000000001" targetQ="0" node="12" p="-7.4175404167032486" q="-34.061845983787208">
                 <iidm:alias>_0477d7a5-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e5a479a8-ab8d-4a54-bb52-376874ae2784"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b55d80d5-720f-46f9-897f-ff8c5eaf8b44"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-15" maxQ="45"/>
             </iidm:generator>
-            <iidm:load id="_04791028-c766-11e1-8775-005056c00008" name="DeerCrk LD" loadType="UNDEFINED" p0="43" q0="27" node="11" p="43.00001291840757" q="27.000013519265092">
+            <iidm:load id="_04791028-c766-11e1-8775-005056c00008" name="DeerCrk LD" loadType="UNDEFINED" p0="43" q0="27" node="11" p="43.00000000242408" q="27.000000002536829">
                 <iidm:alias>_04486337-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7219,9 +7342,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.01100477701611" angle="6.2825182396925063" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.15688256748068" angle="-1.4593635932916291" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0462c904-c766-11e1-8775-005056c00008" name="Medford LD" loadType="UNDEFINED" p0="22" q0="7" node="8" p="22.010055567983819" q="7.0053333105758924">
+            <iidm:load id="_0462c904-c766-11e1-8775-005056c00008" name="Medford LD" loadType="UNDEFINED" p0="22" q0="7" node="8" p="22.009173789205164" q="7.0048655643874582">
                 <iidm:alias>_0489b1f7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7310,9 +7433,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="132.37680912046918" angle="12.334875959013655" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="132.49178553092651" angle="4.3845842482200403" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046205b5-c766-11e1-8775-005056c00008" name="CollCrnr LD" loadType="UNDEFINED" p0="7" q0="3" node="14" p="7.0067511239672777" q="3.0048237815001726">
+            <iidm:load id="_046205b5-c766-11e1-8775-005056c00008" name="CollCrnr LD" loadType="UNDEFINED" p0="7" q0="3" node="14" p="7.0063374039373087" q="3.004528083038545">
                 <iidm:alias>_04486334-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7363,9 +7486,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.10871561313394" angle="15.763975254641014" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.07473798182636" angle="8.0861744341491839" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0483be82-c766-11e1-8775-005056c00008" name="Caldwell LD" loadType="UNDEFINED" p0="42" q0="31" node="8" p="42.022214152511758" q="31.027331751177201">
+            <iidm:load id="_0483be82-c766-11e1-8775-005056c00008" name="Caldwell LD" loadType="UNDEFINED" p0="42" q0="31" node="8" p="42.022234786739659" q="31.027357143506478">
                 <iidm:alias>_045841b9-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7416,9 +7539,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.32510163549115" angle="7.7745297113347505" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.32516318363612" angle="0.094596311636258354" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045f94b4-c766-11e1-8775-005056c00008" name="Franklin LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="7.9998486456506397" q="2.9999054041282163">
+            <iidm:load id="_045f94b4-c766-11e1-8775-005056c00008" name="Franklin LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="7.9998569165934317" q="2.9999105734040432">
                 <iidm:alias>_047da403-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7469,9 +7592,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="125.41744063942012" angle="2.7073502895110257" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="125.32641355569253" angle="-4.5143105188934065" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045f6da2-c766-11e1-8775-005056c00008" name="McKinley LD" loadType="UNDEFINED" p0="60" q0="34" node="8" p="60.088899716537838" q="34.084002303768948">
+            <iidm:load id="_045f6da2-c766-11e1-8775-005056c00008" name="McKinley LD" loadType="UNDEFINED" p0="60" q0="34" node="8" p="60.08580693685068" q="34.081078510802513">
                 <iidm:alias>_0465d641-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7618,19 +7741,19 @@
                 <iidm:internalConnection node1="71" node2="18"/>
                 <iidm:internalConnection node1="72" node2="21"/>
                 <iidm:internalConnection node1="73" node2="12"/>
-                <iidm:bus v="130.68004106196369" angle="4.8415621387033569" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
+                <iidm:bus v="130.68000866404947" angle="-3.2973109624059083" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_044ca8f0-c766-11e1-8775-005056c00008" name="TwinBrch SM" energySource="THERMAL" minP="50" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="85" targetV="130.68000799999999" targetQ="0" node="24" p="-90.084875241802791" q="-82.979586859265623">
+            <iidm:generator id="_044ca8f0-c766-11e1-8775-005056c00008" name="TwinBrch SM" energySource="THERMAL" minP="50" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="85" targetV="130.68000799999999" targetQ="0" node="24" p="-90.070133631396573" q="-79.780224978746105">
                 <iidm:alias>_04633e38-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_0f6ab5a4-6b72-42f4-92bc-1993e1ae58a3"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_668eb671-5c36-4351-a95d-53ca850581db"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-60" maxQ="170"/>
             </iidm:generator>
-            <iidm:load id="_048740f1-c766-11e1-8775-005056c00008" name="TwinBrch LD" loadType="UNDEFINED" p0="47" q0="10" node="23" p="47.000017836458888" q="10.00000632498622">
+            <iidm:load id="_048740f1-c766-11e1-8775-005056c00008" name="TwinBrch LD" loadType="UNDEFINED" p0="47" q0="10" node="23" p="47.000000358245224" q="10.000000127037314">
                 <iidm:alias>_044ecbda-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:danglingLine id="_045338a1-c766-11e1-8775-005056c00008" name="12-117" p0="20" q0="8" r="5.7324960000000003" x="24.393599999999999" g="0" b="0.00020546369999999999" ucteXnodeCode="XMO_TE32" node="73" p="20.161803813082741" q="5.1797281499404084">
+            <iidm:danglingLine id="_045338a1-c766-11e1-8775-005056c00008" name="12-117" p0="20" q0="8" r="5.7324960000000003" x="24.393599999999999" g="0" b="0.00020546369999999999" ucteXnodeCode="XMO_TE32" node="73" p="20.161793820836461" q="5.1797255765546115">
                 <iidm:alias>_044afb42-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_0457f391-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_5631f3d0-d9d2-11e2-bb49-005056c00008</iidm:alias>
@@ -7728,9 +7851,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="124.67512942433201" angle="1.4194488331298312" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="124.60797513832409" angle="-5.9247386835166065" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0479fa87-c766-11e1-8775-005056c00008" name="Lincoln LD" loadType="UNDEFINED" p0="45" q0="25" node="14" p="45.074783890690817" q="25.069282694385809">
+            <iidm:load id="_0479fa87-c766-11e1-8775-005056c00008" name="Lincoln LD" loadType="UNDEFINED" p0="45" q0="25" node="14" p="45.072992076946541" q="25.067621791984745">
                 <iidm:alias>_047fc6e2-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7781,9 +7904,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="134.66120122802405" angle="15.000263249471251" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="134.66129661169791" angle="7.3212571256385131" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044c81e4-c766-11e1-8775-005056c00008" name="Hinton NegG LD" loadType="UNDEFINED" p0="42" q0="0" node="8" p="42.001772703597737" q="0">
+            <iidm:load id="_044c81e4-c766-11e1-8775-005056c00008" name="Hinton NegG LD" loadType="UNDEFINED" p0="42" q0="0" node="8" p="42.001812054869397" q="0">
                 <iidm:alias>_04494d96-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7834,9 +7957,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.37152748238989" angle="4.2907280706503741" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.3328649803438" angle="-3.5208629738980668" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_048bfbe0-c766-11e1-8775-005056c00008" name="N. E. LD" loadType="UNDEFINED" p0="25" q0="10" node="8" p="25.008590506889096" q="10.00572766053932">
+            <iidm:load id="_048bfbe0-c766-11e1-8775-005056c00008" name="N. E. LD" loadType="UNDEFINED" p0="25" q0="10" node="8" p="25.007749811547452" q="10.005167074876175">
                 <iidm:alias>_0480b140-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7887,9 +8010,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.12822990078078" angle="-6.4262475143328617" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.12795628134342" angle="-14.067713076539745" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04854525-c766-11e1-8775-005056c00008" name="SCoshoct LD" loadType="UNDEFINED" p0="18" q0="5" node="8" p="17.999396932116401" q="4.9997208050238173">
+            <iidm:load id="_04854525-c766-11e1-8775-005056c00008" name="SCoshoct LD" loadType="UNDEFINED" p0="18" q0="5" node="8" p="17.999410441911241" q="4.9997270594203274">
                 <iidm:alias>_04747c42-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7940,9 +8063,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="124.98631104264902" angle="8.5523775428051874" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.97594760536765" angle="0.85270927766577953" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044aad24-c766-11e1-8775-005056c00008" name="WHuntngd LD" loadType="UNDEFINED" p0="33" q0="15" node="8" p="32.99375210986927" q="14.99526704862266">
+            <iidm:load id="_044aad24-c766-11e1-8775-005056c00008" name="WHuntngd LD" loadType="UNDEFINED" p0="33" q0="15" node="8" p="32.993290847802697" q="14.994917653399195">
                 <iidm:alias>_04784cd2-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7974,9 +8097,9 @@
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="3"/>
-                <iidm:bus v="129.36006194978032" angle="8.5565723803424021" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="129.36015282722846" angle="0.87616124151024244" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0452ea80-c766-11e1-8775-005056c00008" name="DanRiver SM" energySource="THERMAL" minP="20" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="36" targetV="129.36000000000001" targetQ="0" node="5" p="-38.153594220057649" q="-20.770971180766644">
+            <iidm:generator id="_0452ea80-c766-11e1-8775-005056c00008" name="DanRiver SM" energySource="THERMAL" minP="20" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="36" targetV="129.36000000000001" targetQ="0" node="5" p="-38.147350714473845" q="-20.772807350001759">
                 <iidm:alias>_046a4316-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_fec62959-21c5-4921-90b2-7c85e9f3bfab"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_9db08c95-4586-4a2b-87e3-5a17c944b43a"/>
@@ -8049,9 +8172,9 @@
                 <iidm:internalConnection node1="29" node2="3"/>
                 <iidm:internalConnection node1="30" node2="9"/>
                 <iidm:internalConnection node1="31" node2="6"/>
-                <iidm:bus v="130.11014598888923" angle="9.4919035889961449" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
+                <iidm:bus v="130.12443328513748" angle="1.7415122632025026" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
             </iidm:nodeBreakerTopology>
-            <iidm:danglingLine id="_044ef2e7-c766-11e1-8775-005056c00008" name="71-73" p0="6" q0="0" r="1.508918" x="7.9104960000000002" g="0" b="6.76079e-05" ucteXnodeCode="XMO_TE31" node="31" p="6.0032134469510963" q="-1.1276700044494965">
+            <iidm:danglingLine id="_044ef2e7-c766-11e1-8775-005056c00008" name="71-73" p0="6" q0="0" r="1.508918" x="7.9104960000000002" g="0" b="6.76079e-05" ucteXnodeCode="XMO_TE31" node="31" p="6.0032178517564958" q="-1.1279250159613681">
                 <iidm:alias>_04670ec2-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_046b2d7a-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_26a070b9-db0c-47cd-9991-0a461576aec2</iidm:alias>
@@ -8111,9 +8234,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="134.29965729873174" angle="3.7252094308003332" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="134.29970838199594" angle="-3.919837569404137" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0453add4-c766-11e1-8775-005056c00008" name="Summerfl LD" loadType="UNDEFINED" p0="28" q0="7" node="8" p="28.00014843376044" q="7.0000618475094729">
+            <iidm:load id="_0453add4-c766-11e1-8775-005056c00008" name="Summerfl LD" loadType="UNDEFINED" p0="28" q0="7" node="8" p="28.000171500285621" q="7.0000714585982351">
                 <iidm:alias>_04851e16-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8240,9 +8363,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="132.66006578671943" angle="29.168042883965143" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="132.66015995483801" angle="21.498772000196194" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0489b1fa-c766-11e1-8775-005056c00008" name="ClinchRv SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="607" targetV="132.66" targetQ="0" node="20" p="-643.31199143263882" q="-43.709544571908623">
+            <iidm:generator id="_0489b1fa-c766-11e1-8775-005056c00008" name="ClinchRv SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="607" targetV="132.66" targetQ="0" node="20" p="-643.20671899126739" q="-46.760741468865085">
                 <iidm:alias>_04840caa-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_2621b09a-22e3-4630-b3bd-32c102e36741"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b0d662e5-64c9-4d59-b8e0-9b1ed175769b"/>
@@ -8297,9 +8420,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.49880852446924" angle="3.8894931377486701" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.51464164890578" angle="-4.2868290542339587" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0485e168-c766-11e1-8775-005056c00008" name="Pokagon LD" loadType="UNDEFINED" p0="20" q0="9" node="8" p="20.001636085291064" q="9.001227097427682">
+            <iidm:load id="_0485e168-c766-11e1-8775-005056c00008" name="Pokagon LD" loadType="UNDEFINED" p0="20" q0="9" node="8" p="20.001558086110901" q="9.001168594928318">
                 <iidm:alias>_0462c902-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8350,9 +8473,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.20706520285162" angle="3.6527840247234109" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.20109165737298" angle="-4.2841359121930109" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04812679-c766-11e1-8775-005056c00008" name="GoshenJt LD" loadType="UNDEFINED" p0="14" q0="1" node="8" p="14.006369678355174" q="1.0007584100387441">
+            <iidm:load id="_04812679-c766-11e1-8775-005056c00008" name="GoshenJt LD" loadType="UNDEFINED" p0="14" q0="1" node="8" p="14.005966582915505" q="1.0007104083925094">
                 <iidm:alias>_045b9d17-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8403,9 +8526,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="118.40864543644679" angle="-11.103998683324765" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="118.36463135265879" angle="-18.683358492168864" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0489b1f2-c766-11e1-8775-005056c00008" name="S.Tiffin LD" loadType="UNDEFINED" p0="37" q0="10" node="8" p="37.042296807386897" q="10.019059875061727">
+            <iidm:load id="_0489b1f2-c766-11e1-8775-005056c00008" name="S.Tiffin LD" loadType="UNDEFINED" p0="37" q0="10" node="8" p="37.043126931873715" q="10.019434092725621">
                 <iidm:alias>_046476b8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8456,9 +8579,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="124.35880405422064" angle="-2.0206106998005207" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.27860477876925" angle="-9.4658779285518921" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045cfca7-c766-11e1-8775-005056c00008" name="Haviland LD" loadType="UNDEFINED" p0="23" q0="9" node="8" p="23.050630036026405" q="9.0330438115297582">
+            <iidm:load id="_045cfca7-c766-11e1-8775-005056c00008" name="Haviland LD" loadType="UNDEFINED" p0="23" q0="9" node="8" p="23.050741975376855" q="9.0331169226690289">
                 <iidm:alias>_0482ad17-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8528,9 +8651,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="130.99895919730028" angle="3.7494782396212045" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="130.99905973058668" angle="-3.8967066096631657" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04555b82-c766-11e1-8775-005056c00008" name="SWKammer LD" loadType="UNDEFINED" p0="78" q0="3" node="11" p="77.998090571086721" q="2.9998776017094619">
+            <iidm:load id="_04555b82-c766-11e1-8775-005056c00008" name="SWKammer LD" loadType="UNDEFINED" p0="78" q0="3" node="11" p="77.998151711424285" q="2.9998815208989322">
                 <iidm:alias>_0474ca6b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8638,9 +8761,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="130.59254501563802" angle="15.290969583463626" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="130.54471003828471" angle="7.6127963750997072" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04817492-c766-11e1-8775-005056c00008" name="Baileysv LD" loadType="UNDEFINED" p0="38" q0="15" node="17" p="38.020936851522052" q="15.013776773998355">
+            <iidm:load id="_04817492-c766-11e1-8775-005056c00008" name="Baileysv LD" loadType="UNDEFINED" p0="38" q0="15" node="17" p="38.020941256728626" q="15.013779673225121">
                 <iidm:alias>_0474f17b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8691,9 +8814,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.11761084189106" angle="22.564027475736481" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.11403895868116" angle="14.892867217899086" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0461b790-c766-11e1-8775-005056c00008" name="HolstonT NegG LD" loadType="UNDEFINED" p0="10" q0="0" node="8" p="10.00210734490774" q="0">
+            <iidm:load id="_0461b790-c766-11e1-8775-005056c00008" name="HolstonT NegG LD" loadType="UNDEFINED" p0="10" q0="0" node="8" p="10.002120153024304" q="0">
                 <iidm:alias>_0464ebe7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8744,9 +8867,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.04915663566553" angle="6.2751218495390599" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.18998406709582" angle="-1.4595467464875904" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044c81e5-c766-11e1-8775-005056c00008" name="WMedford LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="8.0036849009301889" q="3.0023034166699105">
+            <iidm:load id="_044c81e5-c766-11e1-8775-005056c00008" name="WMedford LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="8.0033650719172886" q="3.0021034648227802">
                 <iidm:alias>_04570939-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8836,12 +8959,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="125.23390569432115" angle="-5.0221056863901383" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="125.17598647843961" angle="-12.558543828840122" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04854520-c766-11e1-8775-005056c00008" name="Rockhill LD" loadType="UNDEFINED" p0="59" q0="26" node="14" p="59.093303027679575" q="26.068563764477119">
+            <iidm:load id="_04854520-c766-11e1-8775-005056c00008" name="Rockhill LD" loadType="UNDEFINED" p0="59" q0="26" node="14" p="59.094792308164401" q="26.069658748382146">
                 <iidm:alias>_0461b799-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0460cd38-c766-11e1-8775-005056c00008" name="Rockhill SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.81399999999999" targetDeadband="1" node="15" q="-12.593875501769661">
+            <iidm:shunt id="_0460cd38-c766-11e1-8775-005056c00008" name="Rockhill SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.81399999999999" targetDeadband="1" node="15" q="-12.58222915545295">
                 <iidm:alias>_048b86b4-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_069d84c6-bd26-4c26-ac6c-e801a0202a00"/>
                 <iidm:shuntLinearModel bPerSection="0.0001606" gPerSection="0" maximumSectionCount="10"/>
@@ -8914,12 +9037,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="128.95812353701501" angle="16.391773238648202" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="128.78181453867006" angle="8.7182554465610593" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047a48a5-c766-11e1-8775-005056c00008" name="Sprigg LD" loadType="UNDEFINED" p0="20" q0="10" node="11" p="20.01445807715498" q="10.012051300673715">
+            <iidm:load id="_047a48a5-c766-11e1-8775-005056c00008" name="Sprigg LD" loadType="UNDEFINED" p0="20" q0="10" node="11" p="20.014426368793416" q="10.012024864320077">
                 <iidm:alias>_0472ce97-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_04553478-c766-11e1-8775-005056c00008" name="Sprigg SC" sectionCount="5" voltageRegulatorOn="true" targetV="129.935" targetDeadband="1" node="12" q="-9.5457334374319256">
+            <iidm:shunt id="_04553478-c766-11e1-8775-005056c00008" name="Sprigg SC" sectionCount="5" voltageRegulatorOn="true" targetV="129.935" targetDeadband="1" node="12" q="-9.5196498038707649">
                 <iidm:alias>_045bc428-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_f4cdc674-4a66-4ab8-8d4f-552cb066e259"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -9011,12 +9134,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="118.92276924839126" angle="-10.250477803886207" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="118.87379204391719" angle="-17.821560389839959" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04819ba4-c766-11e1-8775-005056c00008" name="West End NegG LD" loadType="UNDEFINED" p0="46" q0="0" node="14" p="46.059487346219235" q="0">
+            <iidm:load id="_04819ba4-c766-11e1-8775-005056c00008" name="West End NegG LD" loadType="UNDEFINED" p0="46" q0="0" node="14" p="46.060594256942878" q="0">
                 <iidm:alias>_04627ae0-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_04555b89-c766-11e1-8775-005056c00008" name="West End LD" loadType="UNDEFINED" p0="20" q0="23" node="15" p="20.025864063573582" q="23.049594154676054">
+            <iidm:load id="_04555b89-c766-11e1-8775-005056c00008" name="West End LD" loadType="UNDEFINED" p0="20" q0="23" node="15" p="20.026345329105599" q="23.050517382759246">
                 <iidm:alias>_04592c18-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9067,9 +9190,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.51840044150794" angle="5.5984684916824303" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.45733762344159" angle="-1.5752857193305407" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046d0232-c766-11e1-8775-005056c00008" name="Deer Crk NegG LD" loadType="UNDEFINED" p0="6" q0="0" node="8" p="6.0060546415198788" q="0">
+            <iidm:load id="_046d0232-c766-11e1-8775-005056c00008" name="Deer Crk NegG LD" loadType="UNDEFINED" p0="6" q0="0" node="8" p="6.005646998355143" q="0">
                 <iidm:alias>_0480150a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9139,9 +9262,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="133.8946143314835" angle="1.065557360409183" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="133.89770817177535" angle="-6.5777193569018104" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046c3ee3-c766-11e1-8775-005056c00008" name="Crooksvl LD" loadType="UNDEFINED" p0="34" q0="0" node="11" p="33.997277430801049" q="0">
+            <iidm:load id="_046c3ee3-c766-11e1-8775-005056c00008" name="Crooksvl LD" loadType="UNDEFINED" p0="34" q0="0" node="11" p="33.997297259730317" q="0">
                 <iidm:alias>_047e4047-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9192,9 +9315,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="132.04746476741371" angle="-2.2086494972137332" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="132.047336717457" angle="-9.8489507742169149" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046dc585-c766-11e1-8775-005056c00008" name="WCambrdg LD" loadType="UNDEFINED" p0="17" q0="4" node="8" p="16.999713600619799" q="3.9998876871482838">
+            <iidm:load id="_046dc585-c766-11e1-8775-005056c00008" name="WCambrdg LD" loadType="UNDEFINED" p0="17" q0="4" node="8" p="16.999725476431227" q="3.9998923442780145">
                 <iidm:alias>_045dbff8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9283,9 +9406,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="130.33698597744561" angle="5.3728258940681624" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="130.38809897031672" angle="-2.8316670084633229" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_048b5fa5-c766-11e1-8775-005056c00008" name="SouthBnd LD" loadType="UNDEFINED" p0="70" q0="23" node="14" p="70.019944998270375" q="23.010923298279394">
+            <iidm:load id="_048b5fa5-c766-11e1-8775-005056c00008" name="SouthBnd LD" loadType="UNDEFINED" p0="70" q0="23" node="14" p="70.018795472752316" q="23.010293680085788">
                 <iidm:alias>_04522734-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9335,11 +9458,11 @@
                 <iidm:internalConnection node1="19" node2="6"/>
                 <iidm:internalConnection node1="20" node2="3"/>
                 <iidm:internalConnection node1="21" node2="6"/>
-                <iidm:bus v="228.31325841804971" angle="21.733354055809571" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
+                <iidm:bus v="228.54658042505076" angle="13.059524592361964" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:line id="_044cd006-c766-11e1-8775-005056c00008" name="31-32" r="5.1923519999999996" x="17.16264" g1="0" b1="7.20271e-05" g2="0" b2="7.20271e-05" node1="31" voltageLevelId1="_04636548-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="-29.886106143824321" q1="8.7584793702090913" p2="30.202186775660579" q2="-10.059999403312109">
+    <iidm:line id="_044cd006-c766-11e1-8775-005056c00008" name="31-32" r="5.1923519999999996" x="17.16264" g1="0" b1="7.20271e-05" g2="0" b2="7.20271e-05" node1="31" voltageLevelId1="_04636548-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="-27.599443961377794" q1="7.1489059636550696" p2="27.864269794835916" q2="-8.6218815410251555">
         <iidm:alias>_04682030-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0471bd25-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9347,7 +9470,7 @@
             <iidm:temporaryLimit name="_de6da3cb-8cb5-4900-9c33-8ad45632b535" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045a3d89-c766-11e1-8775-005056c00008" name="2-12" r="3.2582879999999999" x="10.7331839" g1="0" b1="4.5110200000000001e-05" g2="0" b2="4.5110200000000001e-05" node1="21" voltageLevelId1="_045d4ac5-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-31.000915781431338" q1="-17.23182158887645" p2="31.244198320486994" q2="16.518006593242372">
+    <iidm:line id="_045a3d89-c766-11e1-8775-005056c00008" name="2-12" r="3.2582879999999999" x="10.7331839" g1="0" b1="4.5110200000000001e-05" g2="0" b2="4.5110200000000001e-05" node1="21" voltageLevelId1="_045d4ac5-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-31.883389211592615" q1="-16.760007948769367" p2="32.134533196326487" q2="16.071906293698255">
         <iidm:alias>_046adf51-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046fe868-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9355,7 +9478,7 @@
             <iidm:temporaryLimit name="_6bd63dd1-1344-4183-b7bd-af326919f4eb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04513cd7-c766-11e1-8775-005056c00008" name="32-114" r="2.3522400000000001" x="10.6634884" g1="0" b1="4.6717149999999997e-05" g2="0" b2="4.6717149999999997e-05" node1="49" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04791027-c766-11e1-8775-005056c00008" p1="7.483378253420379" q1="4.205155023739291" p2="-7.4717253879203875" q2="-5.6670620556915345">
+    <iidm:line id="_04513cd7-c766-11e1-8775-005056c00008" name="32-114" r="2.3522400000000001" x="10.6634884" g1="0" b1="4.6717149999999997e-05" g2="0" b2="4.6717149999999997e-05" node1="49" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04791027-c766-11e1-8775-005056c00008" p1="8.4791839870861825" q1="3.6369564387970921" p2="-8.4660245264177796" q2="-5.0950293715260191">
         <iidm:alias>_046d0237-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0470d2c7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9363,7 +9486,7 @@
             <iidm:temporaryLimit name="_5f05650a-c63d-46e5-a426-2db4f036929f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045d71d4-c766-11e1-8775-005056c00008" name="24-72" r="8.5029120000000002" x="34.151040000000002" g1="0" b1="0.00014003675" g2="0" b2="0.00014003675" node1="30" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="14.670402695019622" q1="-2.5264769150062438" p2="-14.565546358119555" q2="-1.9084998291892252">
+    <iidm:line id="_045d71d4-c766-11e1-8775-005056c00008" name="24-72" r="8.5029120000000002" x="34.151040000000002" g1="0" b1="0.00014003675" g2="0" b2="0.00014003675" node1="30" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="14.040339868896787" q1="-2.2118548218484775" p2="-13.944431686660936" q2="-2.2654354265002516">
         <iidm:alias>_04667281-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d0234-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9371,7 +9494,7 @@
             <iidm:temporaryLimit name="_d2074163-ab09-4251-a1d7-6983091dc4f1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045f94b8-c766-11e1-8775-005056c00008" name="17-18" r="2.1431520000000002" x="8.7991200000000003" g1="0" b1="3.7247499999999999e-05" g2="0" b2="3.7247499999999999e-05" node1="57" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04689563-c766-11e1-8775-005056c00008" p1="103.00404758563171" q1="40.704605701965498" p2="-101.43622298767505" q2="-35.480676701327333">
+    <iidm:line id="_045f94b8-c766-11e1-8775-005056c00008" name="17-18" r="2.1431520000000002" x="8.7991200000000003" g1="0" b1="3.7247499999999999e-05" g2="0" b2="3.7247499999999999e-05" node1="57" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04689563-c766-11e1-8775-005056c00008" p1="106.68389564698597" q1="40.006854627236912" p2="-105.02288909044253" q2="-34.398645731082695">
         <iidm:alias>_045e0e17-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0485ba59-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9379,7 +9502,7 @@
             <iidm:temporaryLimit name="_2b6693c7-4e29-4c2c-91d0-3485bbe8fe87" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048963d8-c766-11e1-8775-005056c00008" name="17-113" r="1.590811" x="5.244624" g1="0" b1="2.2038549999999999e-05" g2="0" b2="2.2038549999999999e-05" node1="58" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="1.1220280278467247" q1="5.3378302454878623" p2="-1.1188299720580561" q2="-6.0680779417833062">
+    <iidm:line id="_048963d8-c766-11e1-8775-005056c00008" name="17-113" r="1.590811" x="5.244624" g1="0" b1="2.2038549999999999e-05" g2="0" b2="2.2038549999999999e-05" node1="58" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="4.809843939044451" q1="3.5438386803788018" p2="-4.806205725486933" q2="-4.2717817985313102">
         <iidm:alias>_045841b5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046958b4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9387,7 +9510,7 @@
             <iidm:temporaryLimit name="_786432da-fa4d-4751-a275-87d0e20529f1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0458ddf0-c766-11e1-8775-005056c00008" name="49-50" r="4.6522079999999999" x="13.102848099999999" g1="0" b1="5.3776400000000002e-05" g2="0" b2="5.3776400000000002e-05" node1="112" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044d1e26-c766-11e1-8775-005056c00008" p1="62.598926720303517" q1="11.614942355157067" p2="-61.562726825720169" q2="-10.618616502805198">
+    <iidm:line id="_0458ddf0-c766-11e1-8775-005056c00008" name="49-50" r="4.6522079999999999" x="13.102848099999999" g1="0" b1="5.3776400000000002e-05" g2="0" b2="5.3776400000000002e-05" node1="112" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044d1e26-c766-11e1-8775-005056c00008" p1="62.614905459034944" q1="11.611946032115528" p2="-61.578217192660269" q2="-10.614243735876276">
         <iidm:alias>_0464ebe8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f9fd8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9395,7 +9518,7 @@
             <iidm:temporaryLimit name="_1f0844a5-ea5c-42b2-abcb-6fac2c426092" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04535fb7-c766-11e1-8775-005056c00008" name="1-3" r="2.2476959999999999" x="7.3877759999999997" g1="0" b1="3.1049149999999997e-05" g2="0" b2="3.1049149999999997e-05" node1="21" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_047eb579-c766-11e1-8775-005056c00008" p1="-40.079165716919285" q1="-16.625748873018061" p2="40.34019327860404" q2="16.472474550945311">
+    <iidm:line id="_04535fb7-c766-11e1-8775-005056c00008" name="1-3" r="2.2476959999999999" x="7.3877759999999997" g1="0" b1="3.1049149999999997e-05" g2="0" b2="3.1049149999999997e-05" node1="21" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_047eb579-c766-11e1-8775-005056c00008" p1="-39.199745468560231" q1="-17.108035144919789" p2="39.453049213966715" q2="16.928574526069344">
         <iidm:alias>_044ef2e9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047c4474-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9403,7 +9526,7 @@
             <iidm:temporaryLimit name="_4ea43e34-67a3-42b8-9601-2189db7790d4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0478e912-c766-11e1-8775-005056c00008" name="92-102" r="2.1431520000000002" x="9.7400160000000007" g1="0" b1="4.2011000000000001e-05" g2="0" b2="4.2011000000000001e-05" node1="66" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="47.435650662468753" q1="-8.5360352121567793" p2="-47.145794462618781" q2="8.4190650845042647">
+    <iidm:line id="_0478e912-c766-11e1-8775-005056c00008" name="92-102" r="2.1431520000000002" x="9.7400160000000007" g1="0" b1="4.2011000000000001e-05" g2="0" b2="4.2011000000000001e-05" node1="66" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="47.46924825869295" q1="-8.5545973659989087" p2="-47.178926873917554" q2="8.4398733208261927">
         <iidm:alias>_045a1673-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0468bc79-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9411,7 +9534,7 @@
             <iidm:temporaryLimit name="_23cc194e-9273-46e9-a793-84a9c2911737" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04547127-c766-11e1-8775-005056c00008" name="93-94" r="3.8855520000000001" x="12.7543688" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="21" voltageLevelId1="_04789af0-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="51.546607056266957" q1="-20.489775067975298" p2="-50.847040700018354" q2="20.960838021404545">
+    <iidm:line id="_04547127-c766-11e1-8775-005056c00008" name="93-94" r="3.8855520000000001" x="12.7543688" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="21" voltageLevelId1="_04789af0-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="51.599431003636454" q1="-20.43181414401392" p2="-50.898965828693818" q2="20.906354281559338">
         <iidm:alias>_04500450-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047b0bfb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9419,7 +9542,7 @@
             <iidm:temporaryLimit name="_1a9fe09e-3f63-4904-8e36-aa38c5e16c59" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04791021-c766-11e1-8775-005056c00008" name="46-48" r="10.4718237" x="32.931359999999998" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044778d3-c766-11e1-8775-005056c00008" p1="-9.423332556200803" q1="-7.7321760237281865" p2="9.4931930914236773" q2="3.1090286723336096">
+    <iidm:line id="_04791021-c766-11e1-8775-005056c00008" name="46-48" r="10.4718237" x="32.931359999999998" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044778d3-c766-11e1-8775-005056c00008" p1="-9.3941714547975597" q1="-7.7423540733669247" p2="9.4637702477545016" q2="3.1183756859576106">
         <iidm:alias>_0459ef69-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04640186-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9427,7 +9550,7 @@
             <iidm:temporaryLimit name="_467ba04d-dbad-4fe1-81c8-3bc87b41fcd1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046958b6-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="113" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-100.51393133775829" q1="-0.28063039755960845" p2="102.24503110145619" q2="6.4603077773302733">
+    <iidm:line id="_046958b6-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="113" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-100.42334463525837" q1="-0.30680661164199374" p2="102.15131530468149" q2="6.4705056267606951">
         <iidm:alias>_04776270-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a96c8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9435,7 +9558,7 @@
             <iidm:temporaryLimit name="_d0737ab4-5a3a-46c8-8aeb-789313f0f332" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046f4c26-c766-11e1-8775-005056c00008" name="75-118" r="2.5264799999999998" x="8.3809430000000003" g1="0" b1="3.4377849999999998e-05" g2="0" b2="3.4377849999999998e-05" node1="48" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="39.041937319539166" q1="28.428431761270744" p2="-38.675282546737662" q2="-28.309326045805065">
+    <iidm:line id="_046f4c26-c766-11e1-8775-005056c00008" name="75-118" r="2.5264799999999998" x="8.3809430000000003" g1="0" b1="3.4377849999999998e-05" g2="0" b2="3.4377849999999998e-05" node1="48" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="38.929553594921579" q1="28.504087991930753" p2="-38.563535063270997" q2="-28.3869394323028">
         <iidm:alias>_04619088-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04814d8a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9443,7 +9566,7 @@
             <iidm:temporaryLimit name="_173dc7ff-ae18-4410-b2e1-a4c2abac8ff6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c3954-c766-11e1-8775-005056c00008" name="94-96" r="4.6870560000000001" x="15.1414566" g1="0" b1="6.60009e-05" g2="0" b2="6.60009e-05" node1="49" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="30.115217841117392" q1="-11.147002213419185" p2="-29.837766318377557" q2="9.7944753547892223">
+    <iidm:line id="_045c3954-c766-11e1-8775-005056c00008" name="94-96" r="4.6870560000000001" x="15.1414566" g1="0" b1="6.60009e-05" g2="0" b2="6.60009e-05" node1="49" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="30.179041391769029" q1="-10.945773085668197" p2="-29.901533049036544" q2="9.5946379666637274">
         <iidm:alias>_046ba2a0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0472ce94-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9451,7 +9574,7 @@
             <iidm:temporaryLimit name="_efde58bf-c92e-496d-b558-d0095a271083" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04518af7-c766-11e1-8775-005056c00008" name="62-67" r="4.4953919999999998" x="20.38608" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="39" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="-3.3305349889611153" q1="-18.207349924826342" p2="3.4055122457416944" q2="15.402168535915935">
+    <iidm:line id="_04518af7-c766-11e1-8775-005056c00008" name="62-67" r="4.4953919999999998" x="20.38608" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="39" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="-3.3433872379370997" q1="-18.204361142742702" p2="3.4183607976430386" q2="15.399159947293354">
         <iidm:alias>_04544a10-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04814d86-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9459,7 +9582,7 @@
             <iidm:temporaryLimit name="_8a81d4ae-2bc8-4038-8650-27a6150946b1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0452c375-c766-11e1-8775-005056c00008" name="47-49" r="3.3279839999999998" x="10.890000000000001" g1="0" b1="4.6028449999999998e-05" g2="0" b2="4.6028449999999998e-05" node1="30" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="114" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="17.285372397153999" q1="-23.212313092069607" p2="-17.136872089173011" q2="22.030454904894938">
+    <iidm:line id="_0452c375-c766-11e1-8775-005056c00008" name="47-49" r="3.3279839999999998" x="10.890000000000001" g1="0" b1="4.6028449999999998e-05" g2="0" b2="4.6028449999999998e-05" node1="30" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="114" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="17.197705183682672" q1="-23.150196792088128" p2="-17.050288747377468" q2="21.964753030190103">
         <iidm:alias>_0465fd54-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0471e431-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9467,7 +9590,7 @@
             <iidm:temporaryLimit name="_8d6a074c-900d-4a37-830c-5da4c1de1ab5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046c17d9-c766-11e1-8775-005056c00008" name="100-106" r="10.54152" x="39.900959999999998" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="76" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="59.886369662525674" q1="10.018461114382488" p2="-57.68624206071523" q2="-7.7541469352867791">
+    <iidm:line id="_046c17d9-c766-11e1-8775-005056c00008" name="100-106" r="10.54152" x="39.900959999999998" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="76" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="59.888226594619709" q1="10.018329123604341" p2="-57.68797380732925" q2="-7.7535481101745338">
         <iidm:alias>_045d98e5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0480d851-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9475,7 +9598,7 @@
             <iidm:temporaryLimit name="_3154dc30-b0e5-4570-8e52-9333bae20ef2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046b2d77-c766-11e1-8775-005056c00008" name="77-78" r="0.655142" x="2.1605759999999998" g1="0" b1="3.6271800000000001e-05" g2="0" b2="3.6271800000000001e-05" node1="66" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044fb634-c766-11e1-8775-005056c00008" p1="43.288041203746239" q1="4.3878735641736197" p2="-43.217048089646717" q2="-5.4222692010317237">
+    <iidm:line id="_046b2d77-c766-11e1-8775-005056c00008" name="77-78" r="0.655142" x="2.1605759999999998" g1="0" b1="3.6271800000000001e-05" g2="0" b2="3.6271800000000001e-05" node1="66" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044fb634-c766-11e1-8775-005056c00008" p1="43.206061924448285" q1="4.276858265250695" p2="-43.135354388454736" q2="-5.3118430257701181">
         <iidm:alias>_046ed6fb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04893cc3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9483,7 +9606,7 @@
             <iidm:temporaryLimit name="_cce754c5-b9d5-4105-a431-32da96e4a6cf" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c8776-c766-11e1-8775-005056c00008" name="6-7" r="0.79976199999999997" x="3.6241919999999999" g1="0" b1="1.5782850000000001e-05" g2="0" b2="1.5782850000000001e-05" node1="21" voltageLevelId1="_044f6818-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047eb571-c766-11e1-8775-005056c00008" p1="40.680960280409195" q1="-6.0690521468687999" p2="-40.601867082579979" q2="5.8888507005521857">
+    <iidm:line id="_045c8776-c766-11e1-8775-005056c00008" name="6-7" r="0.79976199999999997" x="3.6241919999999999" g1="0" b1="1.5782850000000001e-05" g2="0" b2="1.5782850000000001e-05" node1="21" voltageLevelId1="_044f6818-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047eb571-c766-11e1-8775-005056c00008" p1="36.771371591556253" q1="-4.2762893109153808" p2="-36.707352031811567" q2="4.0273307515150165">
         <iidm:alias>_046efe08-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04720b4a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9491,7 +9614,7 @@
             <iidm:temporaryLimit name="_361a9cc3-fb33-4037-9b9a-c20adb90b66b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047ba839-c766-11e1-8775-005056c00008" name="77-80" r="5.1226560000000001" x="18.295200000000001" g1="0" b1="6.5426999999999995e-05" g2="0" b2="6.5426999999999995e-05" node1="67" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="76" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-46.558986192228183" q1="-22.717602462289747" p2="47.328628244719923" q2="23.086673002824739">
+    <iidm:line id="_047ba839-c766-11e1-8775-005056c00008" name="77-80" r="5.1226560000000001" x="18.295200000000001" g1="0" b1="6.5426999999999995e-05" g2="0" b2="6.5426999999999995e-05" node1="67" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="76" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-46.644679618008524" q1="-22.827146119029294" p2="47.418272962051624" q2="23.210664181915313">
         <iidm:alias>_047c6b85-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0480b148-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9499,7 +9622,7 @@
             <iidm:temporaryLimit name="_da00c66f-a882-4938-923b-f2455f7f9a81" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04592c16-c766-11e1-8775-005056c00008" name="78-79" r="0.95135000000000003" x="4.2514560000000001" g1="0" b1="1.8595050000000001e-05" g2="0" b2="1.8595050000000001e-05" node1="22" voltageLevelId1="_044fb634-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04481510-c766-11e1-8775-005056c00008" p1="-27.788626586657557" q1="-20.58119722763605" p2="27.853106868572009" q2="20.216270422496901">
+    <iidm:line id="_04592c16-c766-11e1-8775-005056c00008" name="78-79" r="0.95135000000000003" x="4.2514560000000001" g1="0" b1="1.8595050000000001e-05" g2="0" b2="1.8595050000000001e-05" node1="22" voltageLevelId1="_044fb634-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04481510-c766-11e1-8775-005056c00008" p1="-27.870236021975209" q1="-20.691560884048958" p2="27.93522565202257" q2="20.329059659516449">
         <iidm:alias>_0453add6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045b7605-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9507,7 +9630,7 @@
             <iidm:temporaryLimit name="_ba4abe9d-8490-4c19-b19b-c9d2c3597fc9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047b3301-c766-11e1-8775-005056c00008" name="103-104" r="8.1195839999999997" x="27.599615100000001" g1="0" b1="0.00011679295" g2="0" b2="0.00011679295" node1="40" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="32.909534345264284" q1="14.03554205712782" p2="-32.296203618621398" q2="-15.94357135262157">
+    <iidm:line id="_047b3301-c766-11e1-8775-005056c00008" name="103-104" r="8.1195839999999997" x="27.599615100000001" g1="0" b1="0.00011679295" g2="0" b2="0.00011679295" node1="40" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="32.909072836873079" q1="14.035756842872834" p2="-32.295753615917633" q2="-15.943830219616665">
         <iidm:alias>_0459a142-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045d98e6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9515,7 +9638,7 @@
             <iidm:temporaryLimit name="_2320da74-eda7-4f7f-ade9-1ed0e994f3af" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045e5c32-c766-11e1-8775-005056c00008" name="95-96" r="2.9795039999999999" x="9.5309279999999994" g1="0" b1="4.2298000000000001e-05" g2="0" b2="4.2298000000000001e-05" node1="21" voltageLevelId1="_044f4108-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="7.5969396993569704" q1="-23.120080300769509" p2="-7.496816596083641" q2="22.013921656208112">
+    <iidm:line id="_045e5c32-c766-11e1-8775-005056c00008" name="95-96" r="2.9795039999999999" x="9.5309279999999994" g1="0" b1="4.2298000000000001e-05" g2="0" b2="4.2298000000000001e-05" node1="21" voltageLevelId1="_044f4108-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="7.6540005980330479" q1="-22.944534277377922" p2="-7.5550680936432526" q2="21.835466531751205">
         <iidm:alias>_04597a34-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04801509-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9523,7 +9646,7 @@
             <iidm:temporaryLimit name="_3bc03415-e95f-47a7-8e92-01089d304a9c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045ed169-c766-11e1-8775-005056c00008" name="77-80" r="2.9620799999999998" x="8.4506409999999992" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="68" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="77" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-101.51175539423318" q1="-41.715709521596899" p2="103.51502432645985" q2="42.504624083244622">
+    <iidm:line id="_045ed169-c766-11e1-8775-005056c00008" name="77-80" r="2.9620799999999998" x="8.4506409999999992" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="68" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="77" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-101.70813267724309" q1="-41.936010670481799" p2="103.72168626008286" q2="42.754961834930427">
         <iidm:alias>_0464289a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04828605-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9531,7 +9654,7 @@
             <iidm:temporaryLimit name="_f93b6d4c-39fa-4f6f-a42d-c63a4cf21a67" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047f78c2-c766-11e1-8775-005056c00008" name="5-11" r="3.5370720000000002" x="11.8831682" g1="0" b1="4.987375e-05" g2="0" b2="4.987375e-05" node1="48" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="85.282194215590607" q1="10.321297519462863" p2="-83.811449722722159" q2="-7.1148459332986231">
+    <iidm:line id="_047f78c2-c766-11e1-8775-005056c00008" name="5-11" r="3.5370720000000002" x="11.8831682" g1="0" b1="4.987375e-05" g2="0" b2="4.987375e-05" node1="48" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="80.563498161148374" q1="12.223376993937899" p2="-79.241465663873342" q2="-9.5187823431813339">
         <iidm:alias>_045bc426-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0476c633-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9539,7 +9662,7 @@
             <iidm:temporaryLimit name="_3bc4ab96-7a0d-4e18-b9f5-d89f63a82f0a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04845ac7-c766-11e1-8775-005056c00008" name="71-72" r="7.7711040000000002" x="31.363201100000001" g1="0" b1="0.00012752525" g2="0" b2="0.00012752525" node1="29" voltageLevelId1="_04664b78-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="-2.5451130231079766" q1="-6.2213030794619542" p2="2.5556625917762523" q2="1.9084973937676739">
+    <iidm:line id="_04845ac7-c766-11e1-8775-005056c00008" name="71-72" r="7.7711040000000002" x="31.363201100000001" g1="0" b1="0.00012752525" g2="0" b2="0.00012752525" node1="29" voltageLevelId1="_04664b78-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="-1.9246563582994651" q1="-6.5803274933778662" p2="1.935326820765479" q2="2.2654210031136817">
         <iidm:alias>_04642891-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046b0661-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9547,7 +9670,7 @@
             <iidm:temporaryLimit name="_bcb69c6e-125e-449c-acb3-a4deb151668d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047343c2-c766-11e1-8775-005056c00008" name="66-67" r="3.9029759999999998" x="17.685359999999999" g1="0" b1="7.6962800000000001e-05" g2="0" b2="7.6962800000000001e-05" node1="50" voltageLevelId1="_047147f4-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="31.714654329665482" q1="20.948012313115509" p2="-31.405662997300581" q2="-22.402229967028582">
+    <iidm:line id="_047343c2-c766-11e1-8775-005056c00008" name="66-67" r="3.9029759999999998" x="17.685359999999999" g1="0" b1="7.6962800000000001e-05" g2="0" b2="7.6962800000000001e-05" node1="50" voltageLevelId1="_047147f4-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="31.727680293824267" q1="20.945677741043159" p2="-31.418541413399865" q2="-22.399229450114341">
         <iidm:alias>_0465af34-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04860874-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9555,7 +9678,7 @@
             <iidm:temporaryLimit name="_b4b8a31d-dc3c-4b51-88ad-a22e070eb96c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04569409-c766-11e1-8775-005056c00008" name="34-43" r="7.1961120000000003" x="29.289743399999999" g1="0" b1="0.0001212695" g2="0" b2="0.0001212695" node1="40" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_045e8349-c766-11e1-8775-005056c00008" p1="10.228270974472798" q1="-6.3610643144025616" p2="-10.171145713691001" q2="2.7750074370586968">
+    <iidm:line id="_04569409-c766-11e1-8775-005056c00008" name="34-43" r="7.1961120000000003" x="29.289743399999999" g1="0" b1="0.0001212695" g2="0" b2="0.0001212695" node1="40" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_045e8349-c766-11e1-8775-005056c00008" p1="10.475633247862691" q1="-6.487587389347528" p2="-10.415570116347869" q2="2.9164813520256256">
         <iidm:alias>_04500454-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04505274-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9563,7 +9686,7 @@
             <iidm:temporaryLimit name="_5585c67a-0839-48e6-8847-4393e1e9b9c7" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04817498-c766-11e1-8775-005056c00008" name="52-53" r="7.0567200000000003" x="28.488240000000001" g1="0" b1="0.00011644859999999999" g2="0" b2="0.00011644859999999999" node1="21" voltageLevelId1="_04806326-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04876804-c766-11e1-8775-005056c00008" p1="13.579285772611135" q1="0.89119723696897846" p2="-13.494150488665992" q2="-4.2131972687441692">
+    <iidm:line id="_04817498-c766-11e1-8775-005056c00008" name="52-53" r="7.0567200000000003" x="28.488240000000001" g1="0" b1="0.00011644859999999999" g2="0" b2="0.00011644859999999999" node1="21" voltageLevelId1="_04806326-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04876804-c766-11e1-8775-005056c00008" p1="13.585148148189912" q1="0.88916800035628019" p2="-13.499946811432292" q2="-4.2108901205106148">
         <iidm:alias>_045115c7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0472a784-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9571,7 +9694,7 @@
             <iidm:temporaryLimit name="_e7c9dfab-fb45-4470-964f-4ba9e391f60b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044b7078-c766-11e1-8775-005056c00008" name="105-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="49" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="23" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="26.836439264212075" q1="1.3482655756945727" p2="-26.41964291153247" q2="-4.2162131443206396">
+    <iidm:line id="_044b7078-c766-11e1-8775-005056c00008" name="105-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="49" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="23" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="26.836266732010976" q1="1.3483421698663096" p2="-26.419475805693658" q2="-4.2163131845367996">
         <iidm:alias>_0452c378-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0481c2b7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9579,7 +9702,7 @@
             <iidm:temporaryLimit name="_fff133bf-25fd-46b2-b144-a227c31ee882" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048ac367-c766-11e1-8775-005056c00008" name="100-101" r="4.8264480000000001" x="21.9890881" g1="0" b1="9.4123049999999997e-05" g2="0" b2="9.4123049999999997e-05" node1="77" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046ed6f7-c766-11e1-8775-005056c00008" p1="-19.395066788713571" q1="23.623279019857364" p2="19.667502318113101" q2="-25.690052388262846">
+    <iidm:line id="_048ac367-c766-11e1-8775-005056c00008" name="100-101" r="4.8264480000000001" x="21.9890881" g1="0" b1="9.4123049999999997e-05" g2="0" b2="9.4123049999999997e-05" node1="77" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046ed6f7-c766-11e1-8775-005056c00008" p1="-19.426604213200154" q1="23.651495933724863" p2="19.699750196415369" q2="-25.714955900936999">
         <iidm:alias>_044afb45-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b5fa2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9587,7 +9710,7 @@
             <iidm:temporaryLimit name="_217e3c95-24b5-438f-a721-d2257e1a43b4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0481c2b1-c766-11e1-8775-005056c00008" name="56-57" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="57" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="-31.216220051153954" q1="-5.2758376060338241" p2="31.590163742574472" q2="4.0901997469139868">
+    <iidm:line id="_0481c2b1-c766-11e1-8775-005056c00008" name="56-57" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="57" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="-31.230742310635396" q1="-5.2687943969114803" p2="31.605005560332302" q2="4.0840586814518769">
         <iidm:alias>_045e0e12-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0487dd35-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9595,7 +9718,7 @@
             <iidm:temporaryLimit name="_f5547027-3d48-4a53-937b-bd5ba63ef70d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047a6fb7-c766-11e1-8775-005056c00008" name="47-69" r="14.705855400000001" x="48.403869999999998" g1="0" b1="0.00020351240000000001" g2="0" b2="0.00020351240000000001" node1="31" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="57" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-85.461028313686811" q1="26.84055486661034" p2="92.214564355161272" q2="-12.058587731854356">
+    <iidm:line id="_047a6fb7-c766-11e1-8775-005056c00008" name="47-69" r="14.705855400000001" x="48.403869999999998" g1="0" b1="0.00020351240000000001" g2="0" b2="0.00020351240000000001" node1="31" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="57" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-85.274865887025726" q1="26.735316549944528" p2="91.996772422751391" q2="-12.057629714846392">
         <iidm:alias>_04758db9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0485ba56-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9603,7 +9726,7 @@
             <iidm:temporaryLimit name="_e9fec217-cf6f-4d39-9495-26ed10c05100" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0453fbf0-c766-11e1-8775-005056c00008" name="110-111" r="3.8332799999999998" x="13.1551189" g1="0" b1="5.7392100000000002e-05" g2="0" b2="5.7392100000000002e-05" node1="40" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_046a1c00-c766-11e1-8775-005056c00008" p1="-37.712001170342312" q1="-21.127829941309926" p2="38.153639638377413" q2="20.771011568024417">
+    <iidm:line id="_0453fbf0-c766-11e1-8775-005056c00008" name="110-111" r="3.8332799999999998" x="13.1551189" g1="0" b1="5.7392100000000002e-05" g2="0" b2="5.7392100000000002e-05" node1="40" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_046a1c00-c766-11e1-8775-005056c00008" p1="-37.705906172510346" q1="-21.130017628729881" p2="38.147454611733664" q2="20.772887961222423">
         <iidm:alias>_0447c6f5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04812675-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9611,7 +9734,7 @@
             <iidm:temporaryLimit name="_ea48fee0-31b6-4990-a332-25d08b7d731f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04778984-c766-11e1-8775-005056c00008" name="41-42" r="7.14384" x="23.522401800000001" g1="0" b1="9.8714400000000005e-05" g2="0" b2="9.8714400000000005e-05" node1="21" voltageLevelId1="_048c4a08-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="-12.423460887835756" q1="-9.8672253657769193" p2="12.538769742938245" q2="7.4209483190911714">
+    <iidm:line id="_04778984-c766-11e1-8775-005056c00008" name="41-42" r="7.14384" x="23.522401800000001" g1="0" b1="9.8714400000000005e-05" g2="0" b2="9.8714400000000005e-05" node1="21" voltageLevelId1="_048c4a08-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="-12.242640581664949" q1="-9.9974347227187437" p2="12.356905123220105" q2="7.5494308388767219">
         <iidm:alias>_044d1e2a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046512f1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9619,7 +9742,7 @@
             <iidm:temporaryLimit name="_063af52c-fe10-4c1e-85d4-dd80dcc1d2f9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04653a08-c766-11e1-8775-005056c00008" name="80-99" r="7.9104960000000002" x="35.893439999999998" g1="0" b1="0.00015668044999999999" g2="0" b2="0.00015668044999999999" node1="78" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04644fa4-c766-11e1-8775-005056c00008" p1="10.047751470412731" q1="4.9160859086123709" p2="-9.9793844666620064" q2="-10.399831082571001">
+    <iidm:line id="_04653a08-c766-11e1-8775-005056c00008" name="80-99" r="7.9104960000000002" x="35.893439999999998" g1="0" b1="0.00015668044999999999" g2="0" b2="0.00015668044999999999" node1="78" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04644fa4-c766-11e1-8775-005056c00008" p1="10.056566714123436" q1="4.9142432640281886" p2="-9.9881375500235023" q2="-10.397713941440188">
         <iidm:alias>_04773b69-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0477b092-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9627,7 +9750,7 @@
             <iidm:temporaryLimit name="_c05229ce-6abb-4209-ad4f-0dcd4a070f28" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04581aa5-c766-11e1-8775-005056c00008" name="54-59" r="8.7642720000000001" x="39.953229999999998" g1="0" b1="0.0001716024" g2="0" b2="0.0001716024" node1="58" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-19.775837511986634" q1="-10.485090741780725" p2="20.024723170627801" q2="5.9917428059470241">
+    <iidm:line id="_04581aa5-c766-11e1-8775-005056c00008" name="54-59" r="8.7642720000000001" x="39.953229999999998" g1="0" b1="0.0001716024" g2="0" b2="0.0001716024" node1="58" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-19.760771952069771" q1="-10.489126162763501" p2="20.009363379122348" q2="5.9944312526343637">
         <iidm:alias>_0457cc82-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045cae81-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9635,7 +9758,7 @@
             <iidm:temporaryLimit name="_ac528cbe-6fc1-41dd-ba9d-d8b7a4c77576" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04690a93-c766-11e1-8775-005056c00008" name="92-94" r="8.3809430000000003" x="27.529920000000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="67" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="59.237578863444142" q1="-15.489424464188348" p2="-57.427272039726951" q2="17.462245544742778">
+    <iidm:line id="_04690a93-c766-11e1-8775-005056c00008" name="92-94" r="8.3809430000000003" x="27.529920000000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="67" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="59.291764795781333" q1="-15.426350258368931" p2="-57.478959359468774" q2="17.408253189819838">
         <iidm:alias>_044c33c1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0483706b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9643,7 +9766,7 @@
             <iidm:temporaryLimit name="_6ac84228-6b04-4b10-b560-29655c8e93b4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046009e3-c766-11e1-8775-005056c00008" name="37-39" r="5.5931040000000003" x="18.469439999999999" g1="0" b1="7.7479350000000006e-05" g2="0" b2="7.7479350000000006e-05" node1="57" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046bf0c7-c766-11e1-8775-005056c00008" p1="64.960878020006945" q1="18.951007005761745" p2="-63.327443277514227" q2="-15.906617410034036">
+    <iidm:line id="_046009e3-c766-11e1-8775-005056c00008" name="37-39" r="5.5931040000000003" x="18.469439999999999" g1="0" b1="7.7479350000000006e-05" g2="0" b2="7.7479350000000006e-05" node1="57" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046bf0c7-c766-11e1-8775-005056c00008" p1="65.16338371001514" q1="18.875856534439663" p2="-63.520273553675466" q2="-15.797432164606251">
         <iidm:alias>_044c33c9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04789afa-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9651,7 +9774,7 @@
             <iidm:temporaryLimit name="_2ccdc288-c132-40d1-a928-3887bec4ff67" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0458b6e8-c766-11e1-8775-005056c00008" name="46-47" r="6.6211200000000003" x="22.12848" g1="0" b1="9.0679499999999998e-05" g2="0" b2="9.0679499999999998e-05" node1="33" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_0457f396-c766-11e1-8775-005056c00008" p1="-33.745468417280996" q1="1.853545275950385" p2="34.178377280662588" q2="-3.6282387140415415">
+    <iidm:line id="_0458b6e8-c766-11e1-8775-005056c00008" name="46-47" r="6.6211200000000003" x="22.12848" g1="0" b1="9.0679499999999998e-05" g2="0" b2="9.0679499999999998e-05" node1="33" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_0457f396-c766-11e1-8775-005056c00008" p1="-33.649512593103346" q1="1.8017649198724159" p2="34.079854673712845" q2="-3.5851132520420221">
         <iidm:alias>_04507980-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0464c4da-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9659,7 +9782,7 @@
             <iidm:temporaryLimit name="_06ca3245-2668-448f-a5c6-961924217a5c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044f8f22-c766-11e1-8775-005056c00008" name="82-83" r="1.9514879999999999" x="6.3858959999999998" g1="0" b1="0.0001089302" g2="0" b2="0.0001089302" node1="31" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728074-c766-11e1-8775-005056c00008" p1="-56.806391806701399" q1="33.666223835426599" p2="57.326093212824858" q2="-35.6126016512736">
+    <iidm:line id="_044f8f22-c766-11e1-8775-005056c00008" name="82-83" r="1.9514879999999999" x="6.3858959999999998" g1="0" b1="0.0001089302" g2="0" b2="0.0001089302" node1="31" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728074-c766-11e1-8775-005056c00008" p1="-56.438173811480006" q1="35.008823368534479" p2="56.965116290174997" q2="-36.923608378986046">
         <iidm:alias>_047a48a6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b3891-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9667,7 +9790,7 @@
             <iidm:temporaryLimit name="_dfbd2f07-76ab-41e3-910f-dc706979ea4b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045cfca6-c766-11e1-8775-005056c00008" name="108-109" r="1.82952" x="5.0181120000000004" g1="0" b1="2.1809000000000001e-05" g2="0" b2="2.1809000000000001e-05" node1="21" voltageLevelId1="_046c65f4-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b7b99-c766-11e1-8775-005056c00008" p1="21.617276720990755" q1="-0.82607893372498398" p2="-21.563921681474248" q2="0.27476414657827791">
+    <iidm:line id="_045cfca6-c766-11e1-8775-005056c00008" name="108-109" r="1.82952" x="5.0181120000000004" g1="0" b1="2.1809000000000001e-05" g2="0" b2="2.1809000000000001e-05" node1="21" voltageLevelId1="_046c65f4-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b7b99-c766-11e1-8775-005056c00008" p1="21.620352037412459" q1="-0.82716469119354186" p2="-21.566981757405937" q2="0.2758910256151384">
         <iidm:alias>_04481514-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04716f00-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9675,7 +9798,7 @@
             <iidm:temporaryLimit name="_11451cec-81c7-4f83-a7db-df7dcaffa94e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04784cd5-c766-11e1-8775-005056c00008" name="70-74" r="6.9870239999999999" x="23.051952400000001" g1="0" b1="9.6648299999999994e-05" g2="0" b2="9.6648299999999994e-05" node1="48" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047dcb11-c766-11e1-8775-005056c00008" p1="20.065735494045299" q1="10.146680110675105" p2="-19.841200999374614" q2="-12.583865592177949">
+    <iidm:line id="_04784cd5-c766-11e1-8775-005056c00008" name="70-74" r="6.9870239999999999" x="23.051952400000001" g1="0" b1="9.6648299999999994e-05" g2="0" b2="9.6648299999999994e-05" node1="48" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047dcb11-c766-11e1-8775-005056c00008" p1="19.801903873688069" q1="10.271845817892668" p2="-19.580518125283415" q2="-12.719425380512689">
         <iidm:alias>_045e5c33-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046ab84b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9683,7 +9806,7 @@
             <iidm:temporaryLimit name="_37a5cc00-bd7f-4ec7-a77c-e140e23450d2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04747c40-c766-11e1-8775-005056c00008" name="77-82" r="5.1923519999999996" x="14.8626719" g1="0" b1="0.0002345615" g2="0" b2="0.0002345615" node1="69" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_046512f8-c766-11e1-8775-005056c00008" p1="-16.596995477632387" q1="24.936191888312546" p2="16.928585363821668" q2="-32.050167114960871">
+    <iidm:line id="_04747c40-c766-11e1-8775-005056c00008" name="77-82" r="5.1923519999999996" x="14.8626719" g1="0" b1="0.0002345615" g2="0" b2="0.0002345615" node1="69" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_046512f8-c766-11e1-8775-005056c00008" p1="-16.409098345083102" q1="25.625149383854495" p2="16.750928948805072" q2="-32.702255049883192">
         <iidm:alias>_0451b202-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0452ea84-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9691,7 +9814,7 @@
             <iidm:temporaryLimit name="_e9798d58-b518-4fab-984c-c72076dfc2ae" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045e3524-c766-11e1-8775-005056c00008" name="23-24" r="2.3522400000000001" x="8.5726080000000007" g1="0" b1="0.00014290635" g2="0" b2="0.00014290635" node1="39" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_048c22fa-c766-11e1-8775-005056c00008" p1="35.003160403710979" q1="-7.6622154678599026" p2="-34.835124619799728" q2="3.276227548745267">
+    <iidm:line id="_045e3524-c766-11e1-8775-005056c00008" name="23-24" r="2.3522400000000001" x="8.5726080000000007" g1="0" b1="0.00014290635" g2="0" b2="0.00014290635" node1="39" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_048c22fa-c766-11e1-8775-005056c00008" p1="33.648947484504994" q1="-7.2325996995175839" p2="-33.494235761780388" q2="2.7895657629756969">
         <iidm:alias>_046cb413-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f9fd3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9699,7 +9822,7 @@
             <iidm:temporaryLimit name="_e8ec73b8-1ecf-4d18-9ef9-80eabf3a4969" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0474f177-c766-11e1-8775-005056c00008" name="15-17" r="2.2999679999999998" x="7.6142880000000002" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="48" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-139.65507073118474" q1="-21.259492628959489" p2="142.54376396868759" q2="26.661350626950529">
+    <iidm:line id="_0474f177-c766-11e1-8775-005056c00008" name="15-17" r="2.2999679999999998" x="7.6142880000000002" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="48" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-148.16062538447821" q1="-17.808736038012604" p2="151.39144772258493" q2="24.348580384380348">
         <iidm:alias>_044c5ad2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046931a7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9707,7 +9830,7 @@
             <iidm:temporaryLimit name="_2ceac3d1-f73d-43db-8d37-9e329f1787bb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0483be84-c766-11e1-8775-005056c00008" name="8-30" r="2.0860400000000001" x="24.393599999999999" g1="0" b1="0.00053099175999999997" g2="0" b2="0.00053099175999999997" node1="30" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="38" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="75.757934004164582" q1="26.404449242207289" p2="-75.397224563920716" q2="-72.882989572847862">
+    <iidm:line id="_0483be84-c766-11e1-8775-005056c00008" name="8-30" r="2.0860400000000001" x="24.393599999999999" g1="0" b1="0.00053099175999999997" g2="0" b2="0.00053099175999999997" node1="30" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="38" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="90.723713999085462" q1="20.901910911008741" p2="-90.281778382587305" q2="-66.755449402617728">
         <iidm:alias>_0454e651-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04801506-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9715,7 +9838,7 @@
             <iidm:temporaryLimit name="_ca795ad3-97e5-4416-aaba-53cce27f6434" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0488eea6-c766-11e1-8775-005056c00008" name="49-69" r="17.16264" x="56.453762099999999" g1="0" b1="0.00023760329999999999" g2="0" b2="0.00023760329999999999" node1="115" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-76.957741724842577" q1="27.558607904295812" p2="83.464836016237669" q2="-14.939022778838559">
+    <iidm:line id="_0488eea6-c766-11e1-8775-005056c00008" name="49-69" r="17.16264" x="56.453762099999999" g1="0" b1="0.00023760329999999999" g2="0" b2="0.00023760329999999999" node1="115" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-76.781185059183628" q1="27.447204177546382" p2="83.256172063772354" q2="-14.933239497369325">
         <iidm:alias>_04492681-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046735d6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9723,7 +9846,7 @@
             <iidm:temporaryLimit name="_c42dc3ef-3a2e-4070-8efb-78e5c0cd5554" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047566a0-c766-11e1-8775-005056c00008" name="13-15" r="12.9634562" x="42.584255200000001" g1="0" b1="0.00017986685000000001" g2="0" b2="0.00017986685000000001" node1="21" voltageLevelId1="_04851e1b-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="10.953170963518613" q1="-1.0155896529341906" p2="-10.854588451195585" q2="-4.4304146542286178">
+    <iidm:line id="_047566a0-c766-11e1-8775-005056c00008" name="13-15" r="12.9634562" x="42.584255200000001" g1="0" b1="0.00017986685000000001" g2="0" b2="0.00017986685000000001" node1="21" voltageLevelId1="_04851e1b-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="7.0801725522273689" q1="0.41412688886452226" p2="-7.0313299003175525" q2="-6.0219485499033105">
         <iidm:alias>_04662461-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04865694-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9731,7 +9854,7 @@
             <iidm:temporaryLimit name="_ad988fd9-9270-4230-95a2-1858f32259df" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0476c63a-c766-11e1-8775-005056c00008" name="69-70" r="5.2271999999999998" x="22.12848" g1="0" b1="0.00035009184999999998" g2="0" b2="0.00035009184999999998" node1="59" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="89.437356763032227" q1="18.913643092532688" p2="-87.015836466907132" q2="-21.093705068810259">
+    <iidm:line id="_0476c63a-c766-11e1-8775-005056c00008" name="69-70" r="5.2271999999999998" x="22.12848" g1="0" b1="0.00035009184999999998" g2="0" b2="0.00035009184999999998" node1="59" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="90.213434943273185" q1="18.786784044875336" p2="-87.754675068473802" q2="-20.809627172162081">
         <iidm:alias>_047e193a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b1184-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9739,7 +9862,7 @@
             <iidm:temporaryLimit name="_519e3ecb-3561-4d11-ac6b-172a0b4b09b2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04520028-c766-11e1-8775-005056c00008" name="19-20" r="4.3908480000000001" x="20.38608" g1="0" b1="8.5514249999999999e-05" g2="0" b2="8.5514249999999999e-05" node1="39" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b2d70-c766-11e1-8775-005056c00008" p1="-14.282790425628511" q1="2.3148688808843421" p2="14.344167125394822" q2="-4.6868935953796456">
+    <iidm:line id="_04520028-c766-11e1-8775-005056c00008" name="19-20" r="4.3908480000000001" x="20.38608" g1="0" b1="8.5514249999999999e-05" g2="0" b2="8.5514249999999999e-05" node1="39" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b2d70-c766-11e1-8775-005056c00008" p1="-12.421918632802152" q1="1.3156842283975934" p2="12.467529637231669" q2="-3.7600015066400547">
         <iidm:alias>_0472f5a9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04745537-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9747,7 +9870,7 @@
             <iidm:temporaryLimit name="_b88528bf-cb1c-4c00-ad79-d5937197d40c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04862f83-c766-11e1-8775-005056c00008" name="94-95" r="2.2999679999999998" x="7.5620159999999998" g1="0" b1="3.1852600000000001e-05" g2="0" b2="3.1852600000000001e-05" node1="51" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f4108-c766-11e1-8775-005056c00008" p1="49.966284549831336" q1="7.9757919096812273" p2="-49.619067618253851" q2="-7.9072145913181933">
+    <iidm:line id="_04862f83-c766-11e1-8775-005056c00008" name="94-95" r="2.2999679999999998" x="7.5620159999999998" g1="0" b1="3.1852600000000001e-05" g2="0" b2="3.1852600000000001e-05" node1="51" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f4108-c766-11e1-8775-005056c00008" p1="50.024673902002256" q1="8.1562111324536311" p2="-49.676129505475885" q2="-8.082804651346267">
         <iidm:alias>_044ca8f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04837060-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9755,7 +9878,7 @@
             <iidm:temporaryLimit name="_b70e76a1-6e79-4fb6-b487-dffa9bfeab7b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047b0bf6-c766-11e1-8775-005056c00008" name="12-16" r="3.6938879999999998" x="14.5316162" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="68" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046f7338-c766-11e1-8775-005056c00008" p1="13.328358611601987" q1="7.3842450372144235" p2="-13.274550784073947" q2="-9.2490858841850407">
+    <iidm:line id="_047b0bf6-c766-11e1-8775-005056c00008" name="12-16" r="3.6938879999999998" x="14.5316162" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="68" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046f7338-c766-11e1-8775-005056c00008" p1="7.1572138997454573" q1="9.2554081496247615" p2="-7.1231674737256947" q2="-11.197374857409439">
         <iidm:alias>_0450798a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045c8772-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9763,7 +9886,7 @@
             <iidm:temporaryLimit name="_af73f526-c58b-40e7-8e1c-14f05a39f6a2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04524e47-c766-11e1-8775-005056c00008" name="100-103" r="2.7878400000000001" x="9.1476000000000006" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="78" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0475b4c0-c766-11e1-8775-005056c00008" p1="118.10733849375723" q1="-21.289031134011012" p2="-115.89639461727199" q2="23.037923822369315">
+    <iidm:line id="_04524e47-c766-11e1-8775-005056c00008" name="100-103" r="2.7878400000000001" x="9.1476000000000006" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="78" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0475b4c0-c766-11e1-8775-005056c00008" p1="118.11747704558621" q1="-21.291444653568629" p2="-115.90615182236657" q2="23.041581223618863">
         <iidm:alias>_04684744-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048aea71-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9771,7 +9894,7 @@
             <iidm:temporaryLimit name="_1631e50b-21a3-470b-803b-f9665b6fcd60" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04682038-c766-11e1-8775-005056c00008" name="27-32" r="3.9900959999999999" x="13.1551189" g1="0" b1="5.5268600000000001e-05" g2="0" b2="5.5268600000000001e-05" node1="40" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="15.825043344014892" q1="-3.0764378029113963" p2="-15.762768088089762" q2="1.478331130916485">
+    <iidm:line id="_04682038-c766-11e1-8775-005056c00008" name="27-32" r="3.9900959999999999" x="13.1551189" g1="0" b1="5.5268600000000001e-05" g2="0" b2="5.5268600000000001e-05" node1="40" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="14.000821498776428" q1="-1.8940180712691361" p2="-13.952873777459477" q2="0.24458766542647348">
         <iidm:alias>_0455347a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479ac63-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9779,7 +9902,7 @@
             <iidm:temporaryLimit name="_52eb4b09-42bb-4106-ac26-fe1059639d3a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0482fb31-c766-11e1-8775-005056c00008" name="59-61" r="5.7150720000000002" x="26.1360016" g1="0" b1="0.0001113407" g2="0" b2="0.0001113407" node1="68" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-104.66950273210094" q1="23.814209885072891" p2="108.59647890726885" q2="-9.6583634993659651">
+    <iidm:line id="_0482fb31-c766-11e1-8775-005056c00008" name="59-61" r="5.7150720000000002" x="26.1360016" g1="0" b1="0.0001113407" g2="0" b2="0.0001113407" node1="68" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-104.65394286155163" q1="23.807890351426948" p2="108.57970411916951" q2="-9.6576039217967899">
         <iidm:alias>_044a10e9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0473b8f5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9787,7 +9910,7 @@
             <iidm:temporaryLimit name="_b5a7dea0-bfce-4548-a04d-7bb7b6d9f80a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047d55e3-c766-11e1-8775-005056c00008" name="100-104" r="7.8582239999999999" x="35.544960000000003" g1="0" b1="0.00015524565000000001" g2="0" b2="0.00015524565000000001" node1="79" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="55.587401831240001" q1="10.930074264984601" p2="-54.157856441317129" q2="-9.8096373790360758">
+    <iidm:line id="_047d55e3-c766-11e1-8775-005056c00008" name="100-104" r="7.8582239999999999" x="35.544960000000003" g1="0" b1="0.00015524565000000001" g2="0" b2="0.00015524565000000001" node1="79" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="55.589630851476976" q1="10.929903895399702" p2="-54.159981305655371" q2="-9.8090024810867078">
         <iidm:alias>_04636547-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048aea76-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9795,7 +9918,7 @@
             <iidm:temporaryLimit name="_17a10cd0-b653-4dcf-bdc3-4d5005ea9591" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04653a02-c766-11e1-8775-005056c00008" name="75-77" r="10.4718237" x="34.830577900000002" g1="0" b1="0.00014284895" g2="0" b2="0.00014284895" node1="49" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-36.429256531120316" q1="-7.4779017603841842" p2="37.299218099916295" q2="5.5405047642128755">
+    <iidm:line id="_04653a02-c766-11e1-8775-005056c00008" name="75-77" r="10.4718237" x="34.830577900000002" g1="0" b1="0.00014284895" g2="0" b2="0.00014284895" node1="49" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-36.577776320264448" q1="-7.3742702445806092" p2="37.454129870370245" q2="5.4591374845723504">
         <iidm:alias>_04642894-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04720b47-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9803,7 +9926,7 @@
             <iidm:temporaryLimit name="_6f81df11-7e71-4b6e-a6ee-a8c5f72f4ba5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04483c2a-c766-11e1-8775-005056c00008" name="23-32" r="5.5234079999999999" x="20.089872400000001" g1="0" b1="0.00033660465000000001" g2="0" b2="0.00033660465000000001" node1="40" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="88.405448277326073" q1="5.5972972666702896" p2="-85.900357103385758" q2="-7.8648510105118126">
+    <iidm:line id="_04483c2a-c766-11e1-8775-005056c00008" name="23-32" r="5.5234079999999999" x="20.089872400000001" g1="0" b1="0.00033660465000000001" g2="0" b2="0.00033660465000000001" node1="40" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="84.963824922444033" q1="6.2197676019510943" p2="-82.646119810979741" q2="-9.1886707535738719">
         <iidm:alias>_044b978a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0461dea6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9811,7 +9934,7 @@
             <iidm:temporaryLimit name="_a8f6a7d2-e58d-4671-a776-97be7291355e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048719e5-c766-11e1-8775-005056c00008" name="96-97" r="3.0143520000000001" x="15.42024" g1="0" b1="6.8870549999999994e-05" g2="0" b2="6.8870549999999994e-05" node1="50" voltageLevelId1="_045a1672-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="-3.6708040484717035" q1="-23.230477367327378" p2="3.7591677914596491" q2="21.284548625218058">
+    <iidm:line id="_048719e5-c766-11e1-8775-005056c00008" name="96-97" r="3.0143520000000001" x="15.42024" g1="0" b1="6.8870549999999994e-05" g2="0" b2="6.8870549999999994e-05" node1="50" voltageLevelId1="_045a1672-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="-3.707081360727206" q1="-23.410169039788958" p2="3.7969717277900168" q2="21.473363332994143">
         <iidm:alias>_0451b207-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04828601-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9819,7 +9942,7 @@
             <iidm:temporaryLimit name="_ea6d39aa-df95-4d3e-b7b6-a800e552e72a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048481d0-c766-11e1-8775-005056c00008" name="25-27" r="5.5408330000000001" x="28.401121100000001" g1="0" b1="0.000506198385" g2="0" b2="0.000506198385" node1="30" voltageLevelId1="_04728079-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0476c639-c766-11e1-8775-005056c00008" p1="150.4921405327124" q1="29.88046447756841" p2="-143.50727224631069" q2="-12.076999497740371">
+    <iidm:line id="_048481d0-c766-11e1-8775-005056c00008" name="25-27" r="5.5408330000000001" x="28.401121100000001" g1="0" b1="0.000506198385" g2="0" b2="0.000506198385" node1="30" voltageLevelId1="_04728079-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0476c639-c766-11e1-8775-005056c00008" p1="145.46900150836308" q1="28.854961318159443" p2="-138.93606254965636" q2="-13.391081061005581">
         <iidm:alias>_046d2947-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04725960-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9827,7 +9950,7 @@
             <iidm:temporaryLimit name="_d9d53af2-5ffa-4f2a-a4e6-ed22371332d6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04885268-c766-11e1-8775-005056c00008" name="110-112" r="4.3037280000000004" x="11.1513615" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="41" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="13" voltageLevelId2="_04784cd1-c766-11e1-8775-005056c00008" p1="69.353436206731871" q1="11.007651943559345" p2="-67.998975831522614" q2="-12.999663044305143">
+    <iidm:line id="_04885268-c766-11e1-8775-005056c00008" name="110-112" r="4.3037280000000004" x="11.1513615" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="41" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="13" voltageLevelId2="_04784cd1-c766-11e1-8775-005056c00008" p1="69.353533353635129" q1="11.00766877891234" p2="-67.999070639009034" q2="-12.999679694685943">
         <iidm:alias>_04611b55-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0481c2ba-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9835,7 +9958,7 @@
             <iidm:temporaryLimit name="_d50299b9-a055-408a-aa1e-2e93a715120f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0484a8e4-c766-11e1-8775-005056c00008" name="89-92" r="1.7249760000000001" x="8.7991200000000003" g1="0" b1="0.00015725434999999999" g2="0" b2="0.00015725434999999999" node1="57" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="68" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="216.55591763335852" q1="-4.0906648924525228" p2="-211.9590821003718" q2="22.084358775099446">
+    <iidm:line id="_0484a8e4-c766-11e1-8775-005056c00008" name="89-92" r="1.7249760000000001" x="8.7991200000000003" g1="0" b1="0.00015725434999999999" g2="0" b2="0.00015725434999999999" node1="57" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="68" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="216.67704958620337" q1="-4.0033759818635879" p2="-212.0750986971326" q2="22.023425287206432">
         <iidm:alias>_04481517-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04808a3c-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9843,7 +9966,7 @@
             <iidm:temporaryLimit name="_eee9ca2b-764f-4ab8-a745-405338044743" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04689568-c766-11e1-8775-005056c00008" name="49-54" r="15.1414566" x="50.703842199999997" g1="0" b1="0.00020948120000000001" g2="0" b2="0.00020948120000000001" node1="116" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="47.044216908759182" q1="9.539140074912158" p2="-45.065713550854191" q2="-10.077447480975623">
+    <iidm:line id="_04689568-c766-11e1-8775-005056c00008" name="49-54" r="15.1414566" x="50.703842199999997" g1="0" b1="0.00020948120000000001" g2="0" b2="0.00020948120000000001" node1="116" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="47.061091892664102" q1="9.5363837007785488" p2="-45.081337674687902" q2="-10.070509000976966">
         <iidm:alias>_046030f0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04605808-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9851,7 +9974,7 @@
             <iidm:temporaryLimit name="_690202a4-aad2-4ad3-8842-961b39e37709" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046c8d04-c766-11e1-8775-005056c00008" name="40-41" r="2.5264799999999998" x="8.4854880000000001" g1="0" b1="3.5066600000000001e-05" g2="0" b2="3.5066600000000001e-05" node1="40" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048c4a08-c766-11e1-8775-005056c00008" p1="24.727946897670503" q1="-0.46897380500994512" p2="-24.618711731826497" q2="-0.15173551081632264">
+    <iidm:line id="_046c8d04-c766-11e1-8775-005056c00008" name="40-41" r="2.5264799999999998" x="8.4854880000000001" g1="0" b1="3.5066600000000001e-05" g2="0" b2="3.5066600000000001e-05" node1="40" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048c4a08-c766-11e1-8775-005056c00008" p1="24.911289135319986" q1="-0.59220869576987334" p2="-24.800335233926972" q2="-0.021954190617122504">
         <iidm:alias>_045cae80-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a2194-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9859,7 +9982,7 @@
             <iidm:temporaryLimit name="_34f2ef7c-32da-4444-b989-d02f5f931c50" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046735d5-c766-11e1-8775-005056c00008" name="39-40" r="3.206016" x="10.54152" g1="0" b1="4.4536249999999999e-05" g2="0" b2="4.4536249999999999e-05" node1="22" voltageLevelId1="_046bf0c7-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="36.289039475419358" q1="4.8805919495256038" p2="-35.990716555087381" q2="-5.1744602823141461">
+    <iidm:line id="_046735d5-c766-11e1-8775-005056c00008" name="39-40" r="3.206016" x="10.54152" g1="0" b1="4.4536249999999999e-05" g2="0" b2="4.4536249999999999e-05" node1="22" voltageLevelId1="_046bf0c7-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="36.481222695271335" q1="4.7708954765716767" p2="-36.179802908083794" q2="-5.0534899042044268">
         <iidm:alias>_045115c1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048badc2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9867,7 +9990,7 @@
             <iidm:temporaryLimit name="_38d58455-5205-46bb-8e44-c66873f62938" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0470d2c4-c766-11e1-8775-005056c00008" name="89-92" r="6.8476319999999999" x="27.5473423" g1="0" b1="0.00011880164999999999" g2="0" b2="0.00011880164999999999" node1="58" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="68.300185833594114" q1="-5.9308236389431892" p2="-66.479334712186557" q2="9.1349562895884944">
+    <iidm:line id="_0470d2c4-c766-11e1-8775-005056c00008" name="89-92" r="6.8476319999999999" x="27.5473423" g1="0" b1="0.00011880164999999999" g2="0" b2="0.00011880164999999999" node1="58" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="68.339781325034735" q1="-5.9052011032683813" p2="-66.516903961488183" q2="9.1176830131737159">
         <iidm:alias>_04690a97-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04690a98-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9875,7 +9998,7 @@
             <iidm:temporaryLimit name="_0cce41c7-b99f-4fec-93d2-73ea24433fa1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0479ac60-c766-11e1-8775-005056c00008" name="33-37" r="7.2309599999999996" x="24.742080000000001" g1="0" b1="0.00010502754999999999" g2="0" b2="0.00010502754999999999" node1="21" voltageLevelId1="_0456bb11-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="25.124165265060029" q1="-15.894536135024625" p2="-24.733811100035201" q2="13.941908433711719">
+    <iidm:line id="_0479ac60-c766-11e1-8775-005056c00008" name="33-37" r="7.2309599999999996" x="24.742080000000001" g1="0" b1="0.00010502754999999999" g2="0" b2="0.00010502754999999999" node1="21" voltageLevelId1="_0456bb11-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="26.046226946134325" q1="-16.23048347511476" p2="-25.628709164467502" q2="14.374371265139835">
         <iidm:alias>_04716f08-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0483be89-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9883,7 +10006,7 @@
             <iidm:temporaryLimit name="_343677c6-7477-4bf6-a12c-2c7e4a684d6f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048c4a00-c766-11e1-8775-005056c00008" name="105-108" r="4.5476640000000002" x="12.249072099999999" g1="0" b1="5.2915499999999998e-05" g2="0" b2="5.2915499999999998e-05" node1="50" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_046c65f4-c766-11e1-8775-005056c00008" p1="23.775593017416359" q1="-1.1070269703190916" p2="-23.61724009729695" q2="-0.17388981442877025">
+    <iidm:line id="_048c4a00-c766-11e1-8775-005056c00008" name="105-108" r="4.5476640000000002" x="12.249072099999999" g1="0" b1="5.2915499999999998e-05" g2="0" b2="5.2915499999999998e-05" node1="50" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_046c65f4-c766-11e1-8775-005056c00008" p1="23.778712624294428" q1="-1.1080014191081795" p2="-23.620318197229352" q2="-0.17280538282639066">
         <iidm:alias>_046adf53-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04795e46-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9891,7 +10014,7 @@
             <iidm:temporaryLimit name="_74cf84b9-e14f-4f81-9e8b-3a791cd474a0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04631724-c766-11e1-8775-005056c00008" name="34-37" r="0.44605400000000001" x="1.637856" g1="0" b1="2.8236900000000001e-05" g2="0" b2="2.8236900000000001e-05" node1="41" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-66.671897755815422" q1="-30.907666246191702" p2="66.824717817223828" q2="30.578569074320082">
+    <iidm:line id="_04631724-c766-11e1-8775-005056c00008" name="34-37" r="0.44605400000000001" x="1.637856" g1="0" b1="2.8236900000000001e-05" g2="0" b2="2.8236900000000001e-05" node1="41" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-65.974580318944803" q1="-31.238925882344681" p2="66.125487118607793" q2="30.903609753105783">
         <iidm:alias>_04592c19-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04719611-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9899,7 +10022,7 @@
             <iidm:temporaryLimit name="_8e90bf2e-3be4-41be-a84e-c1d4e709f8a1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04814d85-c766-11e1-8775-005056c00008" name="61-62" r="1.435738" x="6.5514239999999999" g1="0" b1="2.812215e-05" g2="0" b2="2.812215e-05" node1="40" voltageLevelId1="_0448d867-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="59.530596933508548" q1="-18.064634075079685" p2="-59.209916625408688" q2="18.555753568150848">
+    <iidm:line id="_04814d85-c766-11e1-8775-005056c00008" name="61-62" r="1.435738" x="6.5514239999999999" g1="0" b1="2.812215e-05" g2="0" b2="2.812215e-05" node1="40" voltageLevelId1="_0448d867-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="59.511834247704044" q1="-18.06119800390832" p2="-59.191350224364236" q2="18.551420753974629">
         <iidm:alias>_045a3d85-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047abdd8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9907,7 +10030,7 @@
             <iidm:temporaryLimit name="_39a23399-348e-44d9-8032-8fc62e6c7d63" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046a4318-c766-11e1-8775-005056c00008" name="101-102" r="4.2863040000000003" x="19.5148811" g1="0" b1="8.4366399999999999e-05" g2="0" b2="8.4366399999999999e-05" node1="22" voltageLevelId1="_046ed6f7-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="-41.672595660543813" q1="10.684250652703778" p2="42.144114078473763" q2="-11.420750070419164">
+    <iidm:line id="_046a4318-c766-11e1-8775-005056c00008" name="101-102" r="4.2863040000000003" x="19.5148811" g1="0" b1="8.4366399999999999e-05" g2="0" b2="8.4366399999999999e-05" node1="22" voltageLevelId1="_046ed6f7-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="-41.704873685300186" q1="10.709118819586774" p2="42.177239600572804" q2="-11.441566676079077">
         <iidm:alias>_04878f1b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04885261-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9915,7 +10038,7 @@
             <iidm:temporaryLimit name="_0501dacc-29fc-44a2-8cad-31a20b011d25" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c81e3-c766-11e1-8775-005056c00008" name="26-30" r="3.8671600000000002" x="41.624000000000002" g1="0" b1="0.00093801650000000002" g2="0" b2="0.00093801650000000002" node1="21" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="221.13775692271926" q1="-3.7661278434886647" p2="-217.20168580617622" q2="-44.118398170041495">
+    <iidm:line id="_044c81e3-c766-11e1-8775-005056c00008" name="26-30" r="3.8671600000000002" x="41.624000000000002" g1="0" b1="0.00093801650000000002" g2="0" b2="0.00093801650000000002" node1="21" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="233.28352774514025" q1="-7.7296160753076215" p2="-228.9446236232595" q2="-36.211164781841234">
         <iidm:alias>_0463654b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04747c4a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9923,7 +10046,7 @@
             <iidm:temporaryLimit name="_c95a66fd-913c-48c7-b8ef-cf3007c60af6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048915b9-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="41" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="117" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-55.588141863258933" q1="-17.527404370481381" p2="58.388938618149233" q2="22.057473863830243">
+    <iidm:line id="_048915b9-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="41" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="117" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-55.405603254013954" q1="-17.658049593437735" p2="58.193598682995272" q2="22.131992900938329">
         <iidm:alias>_044bbe98-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0456e224-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9931,7 +10054,7 @@
             <iidm:temporaryLimit name="_6cd83bc2-204f-44d5-afd4-fbfef8d2146f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c5ad6-c766-11e1-8775-005056c00008" name="105-106" r="2.4393600000000002" x="9.5309279999999994" g1="0" b1="4.1150150000000001e-05" g2="0" b2="4.1150150000000001e-05" node1="51" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="9.242603044450135" q1="6.2806684914226212" p2="-9.2225134453539255" q2="-7.5311088975918485">
+    <iidm:line id="_044c5ad6-c766-11e1-8775-005056c00008" name="105-106" r="2.4393600000000002" x="9.5309279999999994" g1="0" b1="4.1150150000000001e-05" g2="0" b2="4.1150150000000001e-05" node1="51" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="9.2411693204466943" q1="6.2812023026156805" p2="-9.2210826097600993" q2="-7.5316553920360576">
         <iidm:alias>_04505270-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04531190-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9939,7 +10062,7 @@
             <iidm:temporaryLimit name="_487e1317-48f9-4747-b931-f3f79e95f55a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048badc5-c766-11e1-8775-005056c00008" name="60-61" r="0.45999400000000001" x="2.3522400000000001" g1="0" b1="4.1781450000000003e-05" g2="0" b2="4.1781450000000003e-05" node1="30" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-172.24715250132374" q1="16.079012045699301" p2="173.04999531355185" q2="-13.411307956397767">
+    <iidm:line id="_048badc5-c766-11e1-8775-005056c00008" name="60-61" r="0.45999400000000001" x="2.3522400000000001" g1="0" b1="4.1781450000000003e-05" g2="0" b2="4.1781450000000003e-05" node1="30" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-172.22493365808739" q1="16.075933771718994" p2="173.02756730817984" q2="-13.409301103250801">
         <iidm:alias>_04793734-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048a4e31-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9947,7 +10070,7 @@
             <iidm:temporaryLimit name="_3c55a929-a755-409b-af5f-bae188892af1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044cd003-c766-11e1-8775-005056c00008" name="23-25" r="2.7181440000000001" x="13.9391994" g1="0" b1="0.00024793390000000002" g2="0" b2="0.00024793390000000002" node1="41" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="-188.77529073867575" q1="-13.277356575627131" p2="194.31529725805774" q2="32.580145587251778">
+    <iidm:line id="_044cd003-c766-11e1-8775-005056c00008" name="23-25" r="2.7181440000000001" x="13.9391994" g1="0" b1="0.00024793390000000002" g2="0" b2="0.00024793390000000002" node1="41" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="-181.95695003697401" q1="-14.579212290146712" p2="187.09977384887932" q2="31.837616776455874">
         <iidm:alias>_045ed161-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0473b8f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9955,7 +10078,7 @@
             <iidm:temporaryLimit name="_9658628a-596f-41a9-96a7-c5a8aaf5400c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0457a574-c766-11e1-8775-005056c00008" name="19-34" r="13.102848099999999" x="43.037277199999998" g1="0" b1="0.00018135905000000001" g2="0" b2="0.00018135905000000001" node1="40" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0483be8b-c766-11e1-8775-005056c00008" p1="37.43591519659681" q1="-13.544873806769193" p2="-36.15757614707794" q2="12.080298255483664">
+    <iidm:line id="_0457a574-c766-11e1-8775-005056c00008" name="19-34" r="13.102848099999999" x="43.037277199999998" g1="0" b1="0.00018135905000000001" g2="0" b2="0.00018135905000000001" node1="40" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0483be8b-c766-11e1-8775-005056c00008" p1="38.535063192578512" q1="-13.766176140905456" p2="-37.180776662636916" q2="12.556722103951506">
         <iidm:alias>_04502b61-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04686e5b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9963,7 +10086,7 @@
             <iidm:temporaryLimit name="_b69ab61b-751d-487a-a538-2d47eea7572e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04595326-c766-11e1-8775-005056c00008" name="59-60" r="5.5234079999999999" x="25.264800000000001" g1="0" b1="0.00010789715" g2="0" b2="0.00010789715" node1="69" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_045cfca4-c766-11e1-8775-005056c00008" p1="-92.917022922044723" q1="20.585697465026549" p2="95.901936233737814" q2="-10.607925752732614">
+    <iidm:line id="_04595326-c766-11e1-8775-005056c00008" name="59-60" r="5.5234079999999999" x="25.264800000000001" g1="0" b1="0.00010789715" g2="0" b2="0.00010789715" node1="69" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_045cfca4-c766-11e1-8775-005056c00008" p1="-92.902800527744532" q1="20.580140515175028" p2="95.886765928732672" q2="-10.606709406233355">
         <iidm:alias>_04611b57-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0463b366-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9971,7 +10094,7 @@
             <iidm:temporaryLimit name="_a38d4859-b54a-482f-a2ad-0b4ce4c4da2a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045a8ba1-c766-11e1-8775-005056c00008" name="15-19" r="2.0908799999999998" x="6.865056" g1="0" b1="2.8983e-05" g2="0" b2="2.8983e-05" node1="50" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="27.210078548434662" q1="11.829645369855527" p2="-27.092292360117504" q2="-12.352034819035477">
+    <iidm:line id="_045a8ba1-c766-11e1-8775-005056c00008" name="15-19" r="2.0908799999999998" x="6.865056" g1="0" b1="2.8983e-05" g2="0" b2="2.8983e-05" node1="50" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="26.612712418343378" q1="11.845030283786819" p2="-26.498990419245239" q2="-12.379729849704907">
         <iidm:alias>_047629f1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0481e9c1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9979,7 +10102,7 @@
             <iidm:temporaryLimit name="_15d16bd2-d87c-4584-93d2-b294dc1be116" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04513cd6-c766-11e1-8775-005056c00008" name="90-91" r="4.4256960000000003" x="14.566463499999999" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="31" voltageLevelId1="_047d07c3-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044f8f29-c766-11e1-8775-005056c00008" p1="2.3927368629889414" q1="-16.047740526936074" p2="-2.3283431281090197" q2="14.269573866720375">
+    <iidm:line id="_04513cd6-c766-11e1-8775-005056c00008" name="90-91" r="4.4256960000000003" x="14.566463499999999" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="31" voltageLevelId1="_047d07c3-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044f8f29-c766-11e1-8775-005056c00008" p1="2.4153712994169818" q1="-16.037584664851483" p2="-2.3510302098999776" q2="14.259326542685939">
         <iidm:alias>_045f94b9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04627ae1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9987,7 +10110,7 @@
             <iidm:temporaryLimit name="_7d2a67fb-9d8c-4745-a67e-ce6ade5e520e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0487b623-c766-11e1-8775-005056c00008" name="22-23" r="5.9590079999999999" x="27.704158799999998" g1="0" b1="0.00011593205" g2="0" b2="0.00011593205" node1="21" voltageLevelId1="_04773b6a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_047f9fdb-c766-11e1-8775-005056c00008" p1="-57.131551379277681" q1="-10.535845734953094" p2="58.359952917546835" q2="12.337481308660083">
+    <iidm:line id="_0487b623-c766-11e1-8775-005056c00008" name="22-23" r="5.9590079999999999" x="27.704158799999998" g1="0" b1="0.00011593205" g2="0" b2="0.00011593205" node1="21" voltageLevelId1="_04773b6a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_047f9fdb-c766-11e1-8775-005056c00008" p1="-55.187831300625469" q1="-11.157240342643703" p2="56.337865462475975" q2="12.587534637774944">
         <iidm:alias>_045e0e18-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0477b095-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9995,7 +10118,7 @@
             <iidm:temporaryLimit name="_6477d99a-dd64-4083-8f56-1396610879f0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048b1189-c766-11e1-8775-005056c00008" name="83-85" r="7.4923200000000003" x="25.787520000000001" g1="0" b1="9.9862250000000004e-05" g2="0" b2="9.9862250000000004e-05" node1="32" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-48.836382964149202" q1="16.576678395976863" p2="50.060727634265533" q2="-15.675029615531214">
+    <iidm:line id="_048b1189-c766-11e1-8775-005056c00008" name="83-85" r="7.4923200000000003" x="25.787520000000001" g1="0" b1="9.9862250000000004e-05" g2="0" b2="9.9862250000000004e-05" node1="32" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-48.676560785360387" q1="17.340497571596273" p2="49.90999134314989" q2="-16.394438149701799">
         <iidm:alias>_0455d0b1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0462c906-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10003,7 +10126,7 @@
             <iidm:temporaryLimit name="_38cb3e5b-af1a-4684-aa2f-242826ed460c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045868c5-c766-11e1-8775-005056c00008" name="17-31" r="8.2589760000000005" x="27.233711199999998" g1="0" b1="0.00011449725" g2="0" b2="0.00011449725" node1="60" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="13.115578699421935" q1="4.294187267147028" p2="-13.012217251940983" q2="-7.7468109503417137">
+    <iidm:line id="_045868c5-c766-11e1-8775-005056c00008" name="17-31" r="8.2589760000000005" x="27.233711199999998" g1="0" b1="0.00011449725" g2="0" b2="0.00011449725" node1="60" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="17.153533100179917" q1="2.745103335825779" p2="-16.998301040027105" q2="-6.0240612370950251">
         <iidm:alias>_04544a16-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0467f924-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10011,7 +10134,7 @@
             <iidm:temporaryLimit name="_9066b19a-f404-42c3-88ce-51d375f6fdb5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0488c796-c766-11e1-8775-005056c00008" name="89-90" r="9.0256319999999999" x="32.75712" g1="0" b1="0.00015151515000000001" g2="0" b2="0.00015151515000000001" node1="59" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="58.985599347184646" q1="9.2150904096727189" p2="-57.128810821802425" q2="-7.5658207823089043">
+    <iidm:line id="_0488c796-c766-11e1-8775-005056c00008" name="89-90" r="9.0256319999999999" x="32.75712" g1="0" b1="0.00015151515000000001" g2="0" b2="0.00015151515000000001" node1="59" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="58.994141712323731" q1="9.220614942879843" p2="-57.136771562220488" q2="-7.5691750029314733">
         <iidm:alias>_0459ef61-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04837069-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10019,7 +10142,7 @@
             <iidm:temporaryLimit name="_924b4a0b-bef5-432a-ad87-ab5c10d9c019" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0462c907-c766-11e1-8775-005056c00008" name="70-75" r="7.4574720000000001" x="24.56784" g1="0" b1="0.0001033058" g2="0" b2="0.0001033058" node1="50" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="4.6496823282151318" q1="8.1292289255301196" p2="-4.5969847898536944" q2="-11.378856536066873">
+    <iidm:line id="_0462c907-c766-11e1-8775-005056c00008" name="70-75" r="7.4574720000000001" x="24.56784" g1="0" b1="0.0001033058" g2="0" b2="0.0001033058" node1="50" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="4.3233276723233063" q1="8.2910003975029127" p2="-4.2705040039645317" q2="-11.540143497944248">
         <iidm:alias>_04649dc9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04784cdb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10027,7 +10150,7 @@
             <iidm:temporaryLimit name="_d432d118-553c-4f4c-a734-e98e0762ec40" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045fbbc3-c766-11e1-8775-005056c00008" name="50-57" r="8.2589760000000005" x="23.34816" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="22" voltageLevelId1="_044d1e26-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="44.563011994072149" q1="6.6187294283896883" p2="-43.58991724573751" q2="-7.0900960560535351">
+    <iidm:line id="_045fbbc3-c766-11e1-8775-005056c00008" name="50-57" r="8.2589760000000005" x="23.34816" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="22" voltageLevelId1="_044d1e26-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="44.578486518640069" q1="6.6143532790161732" p2="-43.604770847126169" q2="-7.0839576347875202">
         <iidm:alias>_04500455-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0468e383-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10035,7 +10158,7 @@
             <iidm:temporaryLimit name="_2f32bda4-7275-4485-9901-12f8cff9e4a1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044b9789-c766-11e1-8775-005056c00008" name="5-6" r="2.0734560000000002" x="9.4089600000000004" g1="0" b1="4.0920549999999999e-05" g2="0" b2="4.0920549999999999e-05" node1="49" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f6818-c766-11e1-8775-005056c00008" p1="93.768362370495666" q1="19.37830151649101" p2="-92.696672953771582" q2="-15.941981390973147">
+    <iidm:line id="_044b9789-c766-11e1-8775-005056c00008" name="5-6" r="2.0734560000000002" x="9.4089600000000004" g1="0" b1="4.0920549999999999e-05" g2="0" b2="4.0920549999999999e-05" node1="49" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f6818-c766-11e1-8775-005056c00008" p1="89.777823955123196" q1="20.804668378362329" p2="-88.786322112086125" q2="-17.734245956444269">
         <iidm:alias>_044a5f01-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0455d0b2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10043,7 +10166,7 @@
             <iidm:temporaryLimit name="_b3b0e81b-a434-4e9c-ad94-1161ff47b077" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04720b41-c766-11e1-8775-005056c00008" name="55-59" r="8.2572340000000004" x="37.600994100000001" g1="0" b1="0.00016201790000000001" g2="0" b2="0.00016201790000000001" node1="30" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-24.272049291467113" q1="-11.518381042149393" p2="24.622651641169906" q2="7.8213816536334244">
+    <iidm:line id="_04720b41-c766-11e1-8775-005056c00008" name="55-59" r="8.2572340000000004" x="37.600994100000001" g1="0" b1="0.00016201790000000001" g2="0" b2="0.00016201790000000001" node1="30" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-24.257421673695191" q1="-11.522524412300998" p2="24.607691003897283" q2="7.8240045154128506">
         <iidm:alias>_04656113-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04675ce4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10051,7 +10174,7 @@
             <iidm:temporaryLimit name="_6db0d250-4a2e-4169-abf0-f842aeca485d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048963d9-c766-11e1-8775-005056c00008" name="1-2" r="5.2794720000000002" x="17.4065762" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="22" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_045d4ac5-c766-11e1-8775-005056c00008" p1="-10.932135417582693" q1="-10.384180951406414" p2="10.999275840640482" q2="8.2305987257317348">
+    <iidm:line id="_048963d9-c766-11e1-8775-005056c00008" name="1-2" r="5.2794720000000002" x="17.4065762" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="22" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_045d4ac5-c766-11e1-8775-005056c00008" p1="-11.811024777682789" q1="-9.9014622941025809" p2="11.881831263953755" q2="7.7588401487396652">
         <iidm:alias>_044b9786-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04845acb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10059,7 +10182,7 @@
             <iidm:temporaryLimit name="_9f39cb45-314c-445e-b177-909854a9ce45" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0484f709-c766-11e1-8775-005056c00008" name="11-12" r="1.0367280000000001" x="3.4151039999999999" g1="0" b1="1.4405399999999999e-05" g2="0" b2="1.4405399999999999e-05" node1="40" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="38.762257205420461" q1="-24.890084939778941" p2="-38.63349370903228" q2="24.823527050655372">
+    <iidm:line id="_0484f709-c766-11e1-8775-005056c00008" name="11-12" r="1.0367280000000001" x="3.4151039999999999" g1="0" b1="1.4405399999999999e-05" g2="0" b2="1.4405399999999999e-05" node1="40" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="34.074561323214148" q1="-21.569265288006363" p2="-33.976029255617853" q2="21.402929665090173">
         <iidm:alias>_0456e227-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04880440-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10067,7 +10190,7 @@
             <iidm:temporaryLimit name="_70fad3e1-4529-4a7f-9e6c-8ab249d65460" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044bbe91-c766-11e1-8775-005056c00008" name="8-9" r="1.18096" x="14.762" g1="0" b1="0.001200413215" g2="0" b2="0.001200413215" node1="31" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_045c8779-c766-11e1-8775-005056c00008" p1="-466.3174788220058" q1="-90.337344054262104" p2="471.56873762388159" q2="34.434817609723687">
+    <iidm:line id="_044bbe91-c766-11e1-8775-005056c00008" name="8-9" r="1.18096" x="14.762" g1="0" b1="0.001200413215" g2="0" b2="0.001200413215" node1="31" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_045c8779-c766-11e1-8775-005056c00008" p1="-466.27201642439485" q1="-87.784212915567835" p2="471.49763540778366" q2="31.200700319082454">
         <iidm:alias>_04745535-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048a7548-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="2000">
@@ -10075,7 +10198,7 @@
             <iidm:temporaryLimit name="_205e5d8a-f05a-479d-adaa-3514f48f6857" acceptableDuration="60" value="2400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04566cf8-c766-11e1-8775-005056c00008" name="64-65" r="1.30196" x="14.6168" g1="0" b1="0.000392562" g2="0" b2="0.000392562" node1="35" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-171.60546280233584" q1="-33.044099731776143" p2="172.41160162771959" q2="4.1046981851684761">
+    <iidm:line id="_04566cf8-c766-11e1-8775-005056c00008" name="64-65" r="1.30196" x="14.6168" g1="0" b1="0.000392562" g2="0" b2="0.000392562" node1="35" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-171.57506175750942" q1="-33.046076253360475" p2="172.38091644039972" q2="4.1034191582085064">
         <iidm:alias>_044a10e2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04793738-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10083,7 +10206,7 @@
             <iidm:temporaryLimit name="_8cee2b62-2953-439b-ba4b-4a48d55116c0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046783f3-c766-11e1-8775-005056c00008" name="54-56" r="0.47915999999999997" x="1.6639919999999999" g1="0" b1="2.1005500000000001e-05" g2="0" b2="2.1005500000000001e-05" node1="60" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="28.710785937922385" q1="3.0713145524052043" p2="-28.685581197570386" q2="-3.650574911514969">
+    <iidm:line id="_046783f3-c766-11e1-8775-005056c00008" name="54-56" r="0.47915999999999997" x="1.6639919999999999" g1="0" b1="2.1005500000000001e-05" g2="0" b2="2.1005500000000001e-05" node1="60" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="28.721130126588601" q1="3.0707359118523474" p2="-28.695907616348453" q2="-3.649935048353123">
         <iidm:alias>_0460f444-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d2949-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10091,7 +10214,7 @@
             <iidm:temporaryLimit name="_640627c7-0672-413e-8dc8-c9965709a5cb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04670ec6-c766-11e1-8775-005056c00008" name="84-85" r="5.2620480000000001" x="11.1687832" g1="0" b1="3.541095e-05" g2="0" b2="3.541095e-05" node1="21" voltageLevelId1="_047b0bf4-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-40.299574924618668" q1="12.341070329698026" p2="40.874687078936788" q2="-12.286338200054887">
+    <iidm:line id="_04670ec6-c766-11e1-8775-005056c00008" name="84-85" r="5.2620480000000001" x="11.1687832" g1="0" b1="3.541095e-05" g2="0" b2="3.541095e-05" node1="21" voltageLevelId1="_047b0bf4-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-40.106635658378075" q1="12.835916152810128" p2="40.683503945728376" q2="-12.771816736698472">
         <iidm:alias>_0453fbf5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046512f7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10099,7 +10222,7 @@
             <iidm:temporaryLimit name="_8b888209-5038-4b98-80fc-062b5ea55747" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0460cd36-c766-11e1-8775-005056c00008" name="34-36" r="1.51763" x="4.669632" g1="0" b1="1.6299349999999998e-05" g2="0" b2="1.6299349999999998e-05" node1="43" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="33.508342193514025" q1="11.714250450263872" p2="-33.385828220150565" q2="-11.845098874809722">
+    <iidm:line id="_0460cd36-c766-11e1-8775-005056c00008" name="34-36" r="1.51763" x="4.669632" g1="0" b1="1.6299349999999998e-05" g2="0" b2="1.6299349999999998e-05" node1="43" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="33.58547264097119" q1="11.682758276930342" p2="-33.462417513388957" q2="-11.811469968544468">
         <iidm:alias>_046a6a26-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0487b620-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10107,7 +10230,7 @@
             <iidm:temporaryLimit name="_c0a08025-3a61-4d24-9944-f3ef0b079f64" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04549836-c766-11e1-8775-005056c00008" name="24-70" r="0.38507000000000002" x="71.699759999999998" g1="0" b1="0.00029264234999999998" g2="0" b2="0.00029264234999999998" node1="32" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="7.1464248548378855" q1="-0.74974221786969519" p2="-7.1448790747618869" q2="-8.9989813620623593">
+    <iidm:line id="_04549836-c766-11e1-8775-005056c00008" name="24-70" r="0.38507000000000002" x="71.699759999999998" g1="0" b1="0.00029264234999999998" g2="0" b2="0.00029264234999999998" node1="32" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="6.4364944553361596" q1="-0.57772670621464917" p2="-6.4351282701173531" q2="-9.2132577221103613">
         <iidm:alias>_04549834-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04854522-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10115,7 +10238,7 @@
             <iidm:temporaryLimit name="_32793450-bbfd-4dcd-a911-89e199600780" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0452273a-c766-11e1-8775-005056c00008" name="85-86" r="6.0983999999999998" x="21.431519999999999" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="50" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0484f70a-c766-11e1-8775-005056c00008" p1="21.243100629201116" q1="12.290392764986191" p2="-21.008504985815421" q2="-14.020630260239523">
+    <iidm:line id="_0452273a-c766-11e1-8775-005056c00008" name="85-86" r="6.0983999999999998" x="21.431519999999999" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="50" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0484f70a-c766-11e1-8775-005056c00008" p1="21.292004681049438" q1="16.372781930271742" p2="-21.008163531103317" q2="-17.902749262162001">
         <iidm:alias>_044afb43-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479fa85-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10123,7 +10246,7 @@
             <iidm:temporaryLimit name="_2ec4bef5-7abb-4f52-bb62-49ee474d672b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0450eeb5-c766-11e1-8775-005056c00008" name="16-17" r="7.9104960000000002" x="31.380622899999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="22" voltageLevelId1="_046f7338-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-11.734040715114833" q1="-0.75661790804426232" p2="11.80015418860568" q2="-3.4709359304179261">
+    <iidm:line id="_0450eeb5-c766-11e1-8775-005056c00008" name="16-17" r="7.9104960000000002" x="31.380622899999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="22" voltageLevelId1="_046f7338-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-17.884574860357873" q1="1.1922165420331732" p2="18.041402122653352" q2="-5.0555110188295318">
         <iidm:alias>_044ef2ea-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04837066-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10131,7 +10254,7 @@
             <iidm:temporaryLimit name="_9280074c-8555-49ff-9e62-8ed8f7d95060" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048a4e33-c766-11e1-8775-005056c00008" name="62-66" r="8.3983679999999996" x="37.984317799999999" g1="0" b1="0.00016586315" g2="0" b2="0.00016586315" node1="41" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-16.119868329403786" q1="-21.40247643499935" p2="16.412363917075982" q2="16.692864140697811">
+    <iidm:line id="_048a4e33-c766-11e1-8775-005056c00008" name="62-66" r="8.3983679999999996" x="37.984317799999999" g1="0" b1="0.00016586315" g2="0" b2="0.00016586315" node1="41" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-16.132792040915987" q1="-21.399280416627683" p2="16.425431913000288" q2="16.69031390413852">
         <iidm:alias>_046e13a9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a96c7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10139,7 +10262,7 @@
             <iidm:temporaryLimit name="_ace48562-0a49-4b76-ae82-c896a00b04f9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0478e913-c766-11e1-8775-005056c00008" name="76-77" r="7.736256" x="25.787520000000001" g1="0" b1="0.00010560145" g2="0" b2="0.00010560145" node1="21" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-62.351998073822877" q1="-21.611915651700102" p2="64.516160420150186" q2="25.356583936582432">
+    <iidm:line id="_0478e913-c766-11e1-8775-005056c00008" name="76-77" r="7.736256" x="25.787520000000001" g1="0" b1="0.00010560145" g2="0" b2="0.00010560145" node1="21" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-62.462751522856493" q1="-21.534067849512418" p2="64.632815464919474" q2="25.299314087843666">
         <iidm:alias>_044b9785-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04725965-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10147,7 +10270,7 @@
             <iidm:temporaryLimit name="_3f744dba-88dc-4d89-90d4-a6f196054b28" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048badc1-c766-11e1-8775-005056c00008" name="60-62" r="2.1431520000000002" x="9.7748640000000009" g1="0" b1="4.2125800000000002e-05" g2="0" b2="4.2125800000000002e-05" node1="32" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="-1.6528819459948669" q1="-8.4709608640979397" p2="1.6607203946268925" q2="7.0541983323032316">
+    <iidm:line id="_048badc1-c766-11e1-8775-005056c00008" name="60-62" r="2.1431520000000002" x="9.7748640000000009" g1="0" b1="4.2125800000000002e-05" g2="0" b2="4.2125800000000002e-05" node1="32" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="-1.6600118263745547" q1="-8.4690996262502178" p2="1.6678496091777746" q2="7.0523320861227496">
         <iidm:alias>_045b7600-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04720b44-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10155,7 +10278,7 @@
             <iidm:temporaryLimit name="_43f91aaf-c5f4-4995-85a2-37afac616331" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0472a780-c766-11e1-8775-005056c00008" name="27-28" r="3.3332109999999999" x="14.89752" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="42" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04819ba0-c766-11e1-8775-005056c00008" p1="34.018585669955172" q1="-0.51816667354446577" p2="-33.782582413389697" q2="-0.43972159310099768">
+    <iidm:line id="_0472a780-c766-11e1-8775-005056c00008" name="27-28" r="3.3332109999999999" x="14.89752" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="42" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04819ba0-c766-11e1-8775-005056c00008" p1="32.277264889987038" q1="-0.91863161997032849" p2="-32.065438191307337" q2="-0.15431626260024622">
         <iidm:alias>_04531198-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0475188b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10163,7 +10286,7 @@
             <iidm:temporaryLimit name="_2c20e8bd-84e6-4a1e-b88e-071f631327cb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c81e1-c766-11e1-8775-005056c00008" name="45-46" r="6.9695999999999998" x="23.626943600000001" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="31" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="34" voltageLevelId2="_048a7544-c766-11e1-8775-005056c00008" p1="-34.794670509926831" q1="-6.4380532709870417" p2="35.305377678885627" q2="4.8882706370353182">
+    <iidm:line id="_044c81e1-c766-11e1-8775-005056c00008" name="45-46" r="6.9695999999999998" x="23.626943600000001" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="31" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="34" voltageLevelId2="_048a7544-c766-11e1-8775-005056c00008" p1="-34.669516888213593" q1="-6.500645664382362" p2="35.17690608511748" q2="4.9397008105798719">
         <iidm:alias>_04561ed6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045c877a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10171,7 +10294,7 @@
             <iidm:temporaryLimit name="_6ad31f7e-233f-4801-898f-9ffc883ec724" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c1249-c766-11e1-8775-005056c00008" name="18-19" r="1.949746" x="8.5900320000000008" g1="0" b1="3.2770900000000002e-05" g2="0" b2="3.2770900000000002e-05" node1="22" voltageLevelId1="_04689563-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="41.347653749328302" q1="1.3973813531726067" p2="-41.135284119549098" q2="-1.4865987441605859">
+    <iidm:line id="_045c1249-c766-11e1-8775-005056c00008" name="18-19" r="1.949746" x="8.5900320000000008" g1="0" b1="3.2770900000000002e-05" g2="0" b2="3.2770900000000002e-05" node1="22" voltageLevelId1="_04689563-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="44.937499236753347" q1="0.31810732912572537" p2="-44.686738371883983" q2="-0.23688716815013847">
         <iidm:alias>_046b066b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047ae4e0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10179,7 +10302,7 @@
             <iidm:temporaryLimit name="_a025c9d8-58f9-4320-a1fe-73ecc68d4147" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044a5f09-c766-11e1-8775-005056c00008" name="9-10" r="1.2487200000000001" x="15.584800700000001" g1="0" b1="0.0012706611300000001" g2="0" b2="0.0012706611300000001" node1="21" voltageLevelId1="_045c8779-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_044f4102-c766-11e1-8775-005056c00008" p1="-471.56873762388199" q1="-34.434817609723709" p2="476.92008767834488" q2="-32.816443409052034">
+    <iidm:line id="_044a5f09-c766-11e1-8775-005056c00008" name="9-10" r="1.2487200000000001" x="15.584800700000001" g1="0" b1="0.0012706611300000001" g2="0" b2="0.0012706611300000001" node1="21" voltageLevelId1="_045c8779-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_044f4102-c766-11e1-8775-005056c00008" p1="-471.49763540778372" q1="-31.200700319082163" p2="476.8418565143383" q2="-36.274973948032674">
         <iidm:alias>_04614262-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04834957-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="2000">
@@ -10187,7 +10310,7 @@
             <iidm:temporaryLimit name="_b7fac0a3-c5af-48b9-af49-261fd8d46e00" acceptableDuration="60" value="2400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0480b14b-c766-11e1-8775-005056c00008" name="85-88" r="3.4847999999999999" x="17.772480000000002" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="51" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0470f9d2-c766-11e1-8775-005056c00008" p1="-57.788093501622519" q1="3.9239877943534065" p2="58.497486734642834" q2="-2.9483872768682891">
+    <iidm:line id="_0480b14b-c766-11e1-8775-005056c00008" name="85-88" r="3.4847999999999999" x="17.772480000000002" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="51" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0470f9d2-c766-11e1-8775-005056c00008" p1="-57.698386515067781" q1="2.4871180818394176" p2="58.406539374039077" q2="-1.5082070393522162">
         <iidm:alias>_047602e2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04765105-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10195,7 +10318,7 @@
             <iidm:temporaryLimit name="_51646744-d343-42b5-8ba7-fcedc7cc3a98" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04486330-c766-11e1-8775-005056c00008" name="69-77" r="5.3840159999999999" x="17.598240000000001" g1="0" b1="0.00029786500000000002" g2="0" b2="0.00029786500000000002" node1="60" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="42.074651487400658" q1="15.083018538855647" p2="-41.441090656286306" q2="-23.791982862246385">
+    <iidm:line id="_04486330-c766-11e1-8775-005056c00008" name="69-77" r="5.3840159999999999" x="17.598240000000001" g1="0" b1="0.00029786500000000002" g2="0" b2="0.00029786500000000002" node1="60" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="42.173863174921458" q1="15.206632968326819" p2="-41.536415409996955" q2="-23.901363164304911">
         <iidm:alias>_046205b9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479d379-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10203,7 +10326,7 @@
             <iidm:temporaryLimit name="_76311a15-b79a-4439-a7ce-47afa8fa6fe2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04553477-c766-11e1-8775-005056c00008" name="11-13" r="3.8768400000000001" x="12.7369442" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="41" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04851e1b-c766-11e1-8775-005056c00008" p1="45.505082008383837" q1="14.953274177509215" p2="-44.975054876262824" q2="-15.001504647094317">
+    <iidm:line id="_04553477-c766-11e1-8775-005056c00008" name="11-13" r="3.8768400000000001" x="12.7369442" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="41" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04851e1b-c766-11e1-8775-005056c00008" p1="41.560934913265754" q1="16.1516075386773" p2="-41.100625640712813" q2="-16.430153818920974">
         <iidm:alias>_0479fa89-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0485452a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10211,7 +10334,7 @@
             <iidm:temporaryLimit name="_efbf8de7-4b84-4834-bb7c-6250b6072211" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04488a45-c766-11e1-8775-005056c00008" name="103-105" r="9.3218399999999999" x="28.314" g1="0" b1="0.0001170799" g2="0" b2="0.0001170799" node1="42" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="43.764720066845882" q1="12.558804082871616" p2="-42.647795121891207" q2="-13.148160198050284">
+    <iidm:line id="_04488a45-c766-11e1-8775-005056c00008" name="103-105" r="9.3218399999999999" x="28.314" g1="0" b1="0.0001170799" g2="0" b2="0.0001170799" node1="42" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="43.764667296695961" q1="12.558911811019586" p2="-42.647744592814973" q2="-13.148279740581437">
         <iidm:alias>_044f8f24-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04611b58-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10219,7 +10342,7 @@
             <iidm:temporaryLimit name="_22b6919a-a7a0-49fc-9e90-329069c55055" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046009e6-c766-11e1-8775-005056c00008" name="45-49" r="11.918016400000001" x="32.408639999999998" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="32" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="118" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-42.273027627250045" q1="-7.2265089608842414" p2="43.555939615513509" q2="6.2370478641896288">
+    <iidm:line id="_046009e6-c766-11e1-8775-005056c00008" name="45-49" r="11.918016400000001" x="32.408639999999998" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="32" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="118" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-42.150811746688397" q1="-7.2960705373169041" p2="43.426995636970489" q2="6.2884281442952492">
         <iidm:alias>_044ca8f9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047dcb1b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10227,7 +10350,7 @@
             <iidm:temporaryLimit name="_8b91f4fd-4038-45b7-870c-fbc08592b95a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046a6a27-c766-11e1-8775-005056c00008" name="88-89" r="2.4219360000000001" x="12.4058876" g1="0" b1="5.549815e-05" g2="0" b2="5.549815e-05" node1="22" voltageLevelId1="_0470f9d2-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-106.51228093708775" q1="-7.0567772824911721" p2="108.15097695772928" q2="13.540347735789499">
+    <iidm:line id="_046a6a27-c766-11e1-8775-005056c00008" name="88-89" r="2.4219360000000001" x="12.4058876" g1="0" b1="5.549815e-05" g2="0" b2="5.549815e-05" node1="22" voltageLevelId1="_0470f9d2-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-106.42124472559243" q1="-8.4969378725940015" p2="108.06346216306537" q2="15.000517561388346">
         <iidm:alias>_045ef879-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04649dc1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10235,7 +10358,7 @@
             <iidm:temporaryLimit name="_970bc323-73bf-440d-a3c5-00aebc3a1992" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048a7540-c766-11e1-8775-005056c00008" name="80-98" r="4.1469120000000004" x="18.817920000000001" g1="0" b1="8.20707e-05" g2="0" b2="8.20707e-05" node1="79" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04773b62-c766-11e1-8775-005056c00008" p1="19.417061566537448" q1="10.191059426710854" p2="-19.30378344580722" q2="-12.721761924162445">
+    <iidm:line id="_048a7540-c766-11e1-8775-005056c00008" name="80-98" r="4.1469120000000004" x="18.817920000000001" g1="0" b1="8.20707e-05" g2="0" b2="8.20707e-05" node1="79" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04773b62-c766-11e1-8775-005056c00008" p1="19.425849167654313" q1="10.189199446422956" p2="-19.312505671009092" q2="-12.719609213970461">
         <iidm:alias>_045338a2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04887972-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10243,7 +10366,7 @@
             <iidm:temporaryLimit name="_cb084dc7-1b26-415f-9495-4695df661912" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04640183-c766-11e1-8775-005056c00008" name="91-92" r="6.7430880000000002" x="22.163329999999998" g1="0" b1="9.3778700000000004e-05" g2="0" b2="9.3778700000000004e-05" node1="22" voltageLevelId1="_044f8f29-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="-7.673764767591372" q1="-14.269578386381667" p2="7.7645319472288348" q2="11.426022788095469">
+    <iidm:line id="_04640183-c766-11e1-8775-005056c00008" name="91-92" r="6.7430880000000002" x="22.163329999999998" g1="0" b1="9.3778700000000004e-05" g2="0" b2="9.3778700000000004e-05" node1="22" voltageLevelId1="_044f8f29-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="-7.651093923359011" q1="-14.259333715184235" p2="7.7416172101184486" q2="11.415220864306969">
         <iidm:alias>_04492680-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_044c5ad5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10251,7 +10374,7 @@
             <iidm:temporaryLimit name="_3a165a76-f6ba-461b-84d6-159a5e0b5077" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0474a358-c766-11e1-8775-005056c00008" name="7-12" r="1.501949" x="5.9241599999999996" g1="0" b1="2.5080350000000001e-05" g2="0" b2="2.5080350000000001e-05" node1="22" voltageLevelId1="_047eb571-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="21.598318495441919" q1="-7.8894667537156407" p2="-21.552327498876391" q2="7.2148805946059245">
+    <iidm:line id="_0474a358-c766-11e1-8775-005056c00008" name="7-12" r="1.501949" x="5.9241599999999996" g1="0" b1="2.5080350000000001e-05" g2="0" b2="2.5080350000000001e-05" node1="22" voltageLevelId1="_047eb571-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="17.70397917993791" q1="-6.0279216869859917" p2="-17.67363003712606" q2="5.2913699359309039">
         <iidm:alias>_046ab848-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0477feb7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10259,7 +10382,7 @@
             <iidm:temporaryLimit name="_b19bc945-cc51-4d77-8eaa-3f6afe2d9316" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04765108-c766-11e1-8775-005056c00008" name="99-100" r="3.13632" x="14.165711399999999" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_04644fa4-c766-11e1-8775-005056c00008" node2="80" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-32.022395913659288" q1="10.399827666688841" p2="32.22271900238556" q2="-11.736054880466645">
+    <iidm:line id="_04765108-c766-11e1-8775-005056c00008" name="99-100" r="3.13632" x="14.165711399999999" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_04644fa4-c766-11e1-8775-005056c00008" node2="80" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-32.013695759767693" q1="10.397708347711177" p2="32.213913766038345" q2="-11.734413267589257">
         <iidm:alias>_0471e436-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047e4040-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10267,7 +10390,7 @@
             <iidm:temporaryLimit name="_a9e283ed-fcad-4f4c-ab57-8531875bb098" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047b8128-c766-11e1-8775-005056c00008" name="114-115" r="0.400752" x="1.8120959999999999" g1="0" b1="7.9201000000000006e-06" g2="0" b2="7.9201000000000006e-06" node1="22" voltageLevelId1="_04791027-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="-0.53195671367915598" q1="2.6647684764207744" p2="0.53215736050291873" q2="-2.9194688367603736">
+    <iidm:line id="_047b8128-c766-11e1-8775-005056c00008" name="114-115" r="0.400752" x="1.8120959999999999" g1="0" b1="7.9201000000000006e-06" g2="0" b2="7.9201000000000006e-06" node1="22" voltageLevelId1="_04791027-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="0.46266481378130159" q1="2.0929295385944897" p2="-0.46253730611110522" q2="-2.3485378422514605">
         <iidm:alias>_046c17d3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d0233-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10275,7 +10398,7 @@
             <iidm:temporaryLimit name="_c59e4022-b1c0-4811-a32e-f54656bff32d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046931a5-c766-11e1-8775-005056c00008" name="83-84" r="10.890000000000001" x="22.999680000000001" g1="0" b1="7.4035799999999993e-05" g2="0" b2="7.4035799999999993e-05" node1="33" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b0bf4-c766-11e1-8775-005056c00008" p1="-28.504110343812016" q1="18.569625598929733" p2="29.292894636467015" q2="-19.348174903915215">
+    <iidm:line id="_046931a5-c766-11e1-8775-005056c00008" name="83-84" r="10.890000000000001" x="22.999680000000001" g1="0" b1="7.4035799999999993e-05" g2="0" b2="7.4035799999999993e-05" node1="33" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b0bf4-c766-11e1-8775-005056c00008" p1="-28.302915775547575" q1="19.090740465264886" p2="29.099995929519618" q2="-19.842989106628224">
         <iidm:alias>_0465d645-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479102b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10283,7 +10406,7 @@
             <iidm:temporaryLimit name="_1268eb09-e233-44ce-b8af-22dc30eb16ad" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047ae4ea-c766-11e1-8775-005056c00008" name="14-15" r="10.367279999999999" x="33.976799999999997" g1="0" b1="0.0001440542" g2="0" b2="0.0001440542" node1="21" voltageLevelId1="_047b8129-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="16.241345702668017" q1="5.8253483253910705" p2="-16.0354724253766" q2="-9.834985946345725">
+    <iidm:line id="_047ae4ea-c766-11e1-8775-005056c00008" name="14-15" r="10.367279999999999" x="33.976799999999997" g1="0" b1="0.0001440542" g2="0" b2="0.0001440542" node1="21" voltageLevelId1="_047b8129-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="11.861971426965239" q1="7.3105307720430739" p2="-11.715965686194393" q2="-11.513422942758082">
         <iidm:alias>_0449e9d9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046ed6fa-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10291,7 +10414,7 @@
             <iidm:temporaryLimit name="_9c0c454b-ecc3-40f6-b505-f32fec412522" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046e3ab2-c766-11e1-8775-005056c00008" name="80-96" r="6.2029439999999996" x="31.711680000000001" g1="0" b1="0.0001417585" g2="0" b2="0.0001417585" node1="80" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="11.487447464854284" q1="24.066291325248137" p2="-11.208705884096938" q2="-27.730425842717583">
+    <iidm:line id="_046e3ab2-c766-11e1-8775-005056c00008" name="80-96" r="6.2029439999999996" x="31.711680000000001" g1="0" b1="0.0001417585" g2="0" b2="0.0001417585" node1="80" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="11.526149553097103" q1="24.26617640795639" p2="-11.243583750177262" q2="-27.908992542869456">
         <iidm:alias>_045338a4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04865695-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10299,7 +10422,7 @@
             <iidm:temporaryLimit name="_1432f4d6-9299-4b0d-bd7f-16e059f9de66" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04893cc4-c766-11e1-8775-005056c00008" name="56-59" r="13.9914722" x="41.643360000000001" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="59" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-20.212272537888133" q1="-7.6506771304083676" p2="20.596828810620071" q2="3.7567652035418524">
+    <iidm:line id="_04893cc4-c766-11e1-8775-005056c00008" name="56-59" r="13.9914722" x="41.643360000000001" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="59" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-20.199171029502917" q1="-7.6558934802387526" p2="20.58330782840293" q2="3.7607291811840775">
         <iidm:alias>_046b5484-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04798557-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10307,7 +10430,7 @@
             <iidm:temporaryLimit name="_193f6952-4267-4cc8-a541-726c095028ba" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c1243-c766-11e1-8775-005056c00008" name="92-100" r="11.290752400000001" x="51.400799999999997" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="71" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="34.294343989240083" q1="-16.735136180212901" p2="-33.379903138335429" q2="16.142533579105603">
+    <iidm:line id="_045c1243-c766-11e1-8775-005056c00008" name="92-100" r="11.290752400000001" x="51.400799999999997" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="71" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="34.328514286078637" q1="-16.754298101148979" p2="-33.412063774753854" q2="16.171070154063361">
         <iidm:alias>_045e8348-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045ed164-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10315,7 +10438,7 @@
             <iidm:temporaryLimit name="_579249ce-1c81-4d29-8d3f-5fc627a18f99" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0474a356-c766-11e1-8775-005056c00008" name="43-44" r="10.593792000000001" x="42.7584953" g1="0" b1="0.00017412765" g2="0" b2="0.00017412765" node1="22" voltageLevelId1="_045e8349-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04544a15-c766-11e1-8775-005056c00008" p1="-7.8483865303270086" q1="-9.7876552844617084" p2="7.9228538668552364" q2="4.4480313094794139">
+    <iidm:line id="_0474a356-c766-11e1-8775-005056c00008" name="43-44" r="10.593792000000001" x="42.7584953" g1="0" b1="0.00017412765" g2="0" b2="0.00017412765" node1="22" voltageLevelId1="_045e8349-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04544a15-c766-11e1-8775-005056c00008" p1="-7.6043151244375036" q1="-9.9293928435580376" p2="7.6776690143421149" q2="4.5876181771662621">
         <iidm:alias>_04642899-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047b0bf2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10323,7 +10446,7 @@
             <iidm:temporaryLimit name="_3d2cb4b5-ee82-4866-9855-4a5f4803cd3b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04627ae6-c766-11e1-8775-005056c00008" name="109-110" r="4.8438720000000002" x="13.2770882" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="22" voltageLevelId1="_046b7b99-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="13.564071048821235" q1="-3.2746685269551565" p2="-13.506549086980113" q2="1.5861530300526925">
+    <iidm:line id="_04627ae6-c766-11e1-8775-005056c00008" name="109-110" r="4.8438720000000002" x="13.2770882" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="22" voltageLevelId1="_046b7b99-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="13.567119991758018" q1="-3.2757993432297843" p2="-13.509571364759832" q2="1.5873550421709754">
         <iidm:alias>_0466e7b5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a6fbb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10331,7 +10454,7 @@
             <iidm:temporaryLimit name="_6fc48d8d-05f8-4104-a6a2-3686d430a091" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0478c207-c766-11e1-8775-005056c00008" name="68-81" r="0.84699999999999998" x="9.7767990000000005" g1="0" b1="0.00083471078000000004" g2="0" b2="0.00083471078000000004" node1="38" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_048a272b-c766-11e1-8775-005056c00008" p1="-96.890330282739114" q1="-9.6637992708968596" p2="97.07157561445996" q2="-68.448192794821566">
+    <iidm:line id="_0478c207-c766-11e1-8775-005056c00008" name="68-81" r="0.84699999999999998" x="9.7767990000000005" g1="0" b1="0.00083471078000000004" g2="0" b2="0.00083471078000000004" node1="38" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_048a272b-c766-11e1-8775-005056c00008" p1="-96.332118442330597" q1="-9.7085111646907745" p2="96.511421710804314" q2="-68.42603095404418">
         <iidm:alias>_044a37f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045b4ef6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10339,7 +10462,7 @@
             <iidm:temporaryLimit name="_191836a1-39cd-402b-8dcf-4f3867c45bd0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0467d215-c766-11e1-8775-005056c00008" name="85-89" r="4.1643359999999996" x="30.143518400000001" g1="0" b1="0.00013487144999999999" g2="0" b2="0.00013487144999999999" node1="52" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-78.400793951139718" q1="-3.2638472420212006" p2="79.94870690056463" q2="9.864172200993643">
+    <iidm:line id="_0467d215-c766-11e1-8775-005056c00008" name="85-89" r="4.1643359999999996" x="30.143518400000001" g1="0" b1="0.00013487144999999999" g2="0" b2="0.00013487144999999999" node1="52" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-78.197368089946522" q1="-4.7043700864942917" p2="79.746613739828419" q2="11.325953844839463">
         <iidm:alias>_047629f9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0478e915-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10347,7 +10470,7 @@
             <iidm:temporaryLimit name="_66cbdeeb-a4e4-4bfc-aec1-9fb7a2d2b6bc" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044a37f2-c766-11e1-8775-005056c00008" name="89-90" r="4.1469120000000004" x="17.371727" g1="0" b1="0.00030417815" g2="0" b2="0.00030417815" node1="62" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="111.37105827916862" q1="21.111818054335991" p2="-108.28328653337596" q2="-18.394775635281725">
+    <iidm:line id="_044a37f2-c766-11e1-8775-005056c00008" name="89-90" r="4.1469120000000004" x="17.371727" g1="0" b1="0.00030417815" g2="0" b2="0.00030417815" node1="62" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="111.38693708821484" q1="21.122882699779634" p2="-108.29819812167749" q2="-18.401669276913253">
         <iidm:alias>_045386c2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048719e9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10355,7 +10478,7 @@
             <iidm:temporaryLimit name="_8489e809-6588-4ed2-a9a4-43c44a0d47da" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04658820-c766-11e1-8775-005056c00008" name="98-100" r="6.9173280000000004" x="31.188960999999999" g1="0" b1="0.0001365932" g2="0" b2="0.0001365932" node1="22" voltageLevelId1="_04773b62-c766-11e1-8775-005056c00008" node2="82" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-14.697891852712598" q1="4.7211050836089674" p2="14.799483241415597" q2="-9.2179138109556522">
+    <iidm:line id="_04658820-c766-11e1-8775-005056c00008" name="98-100" r="6.9173280000000004" x="31.188960999999999" g1="0" b1="0.0001365932" g2="0" b2="0.0001365932" node1="22" voltageLevelId1="_04773b62-c766-11e1-8775-005056c00008" node2="82" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-14.689209883789633" q1="4.7189408367138848" p2="14.790692629175584" q2="-9.2162461753846578">
         <iidm:alias>_046f4c22-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046fe865-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10363,7 +10486,7 @@
             <iidm:temporaryLimit name="_620beaaf-63c8-4020-bea5-c3609c0eaadf" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c5ada-c766-11e1-8775-005056c00008" name="28-29" r="4.1294880000000003" x="16.430831900000001" g1="0" b1="6.8296599999999999e-05" g2="0" b2="6.8296599999999999e-05" node1="22" voltageLevelId1="_04819ba0-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04588fd5-c766-11e1-8775-005056c00008" p1="16.778226690040217" q1="-6.5632571901549337" p2="-16.698484848411532" q2="4.6750572962859058">
+    <iidm:line id="_044c5ada-c766-11e1-8775-005056c00008" name="28-29" r="4.1294880000000003" x="16.430831900000001" g1="0" b1="6.8296599999999999e-05" g2="0" b2="6.8296599999999999e-05" node1="22" voltageLevelId1="_04819ba0-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04588fd5-c766-11e1-8775-005056c00008" p1="15.061164109172392" q1="-4.6356444227510938" p2="-15.000129568465558" q2="2.6672624654524286">
         <iidm:alias>_0461697a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04697fc1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10371,7 +10494,13 @@
             <iidm:temporaryLimit name="_6748d0d0-aec8-4b7b-a9ab-be6aecda7c5d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0468e382-c766-11e1-8775-005056c00008" name="3-5" r="4.1991839999999998" x="18.817920000000001" g1="0" b1="8.1496799999999995e-05" g2="0" b2="8.1496799999999995e-05" node1="31" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-71.33941590128947" q1="-16.686744249150259" p2="72.694780247963479" q2="19.966013593107995">
+    <iidm:line id="_044c5ada-c766-11e1-8775-005056c00008-1" name="28-29-open-ended" r="4.1294880000000003" x="16.430831900000001" g1="0" b1="6.8296599999999999e-05" g2="0" b2="6.8296599999999999e-05" node1="25" voltageLevelId1="_04819ba0-c766-11e1-8775-005056c00008" node2="25" voltageLevelId2="_04588fd5-c766-11e1-8775-005056c00008" p1="0.00031255796762683389" q1="-2.2127580258973918" p2="0" q2="0">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_accb8136-1faf-4399-9787-3cd567284fd2-1" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_6748d0d0-aec8-4b7b-a9ab-be6aecda7c5d-1" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0468e382-c766-11e1-8775-005056c00008" name="3-5" r="4.1991839999999998" x="18.817920000000001" g1="0" b1="8.1496799999999995e-05" g2="0" b2="8.1496799999999995e-05" node1="31" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-69.297155069254785" q1="-17.757472514401723" p2="70.586933106643869" q2="20.739078639229497">
         <iidm:alias>_046b0668-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04742e24-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10379,7 +10508,7 @@
             <iidm:temporaryLimit name="_828ca44c-560b-4f94-b825-21e237285fae" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0447c6f1-c766-11e1-8775-005056c00008" name="82-96" r="2.8226879999999999" x="9.2347199999999994" g1="0" b1="0.00015610649999999999" g2="0" b2="0.00015610649999999999" node1="33" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="-14.152221138812907" q1="-9.2973101840349486" p2="14.193218401018722" q2="4.1387331672761611">
+    <iidm:line id="_0447c6f1-c766-11e1-8775-005056c00008" name="82-96" r="2.8226879999999999" x="9.2347199999999994" g1="0" b1="0.00015610649999999999" g2="0" b2="0.00015610649999999999" node1="33" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="-14.342706273729974" q1="-10.018865074949682" p2="14.386392344004866" q2="4.8752590861561114">
         <iidm:alias>_0478e91a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0480d856-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10387,7 +10516,7 @@
             <iidm:temporaryLimit name="_233b7735-85f4-4a6f-9d87-15129fe42ef5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0483e594-c766-11e1-8775-005056c00008" name="38-65" r="4.3608399999999996" x="47.7224" g1="0" b1="0.0010805785" g2="0" b2="0.0010805785" node1="29" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-182.22879372948157" q1="-91.086058311105106" p2="186.01213864808096" q2="35.555331342208177">
+    <iidm:line id="_0483e594-c766-11e1-8775-005056c00008" name="38-65" r="4.3608399999999996" x="47.7224" g1="0" b1="0.0010805785" g2="0" b2="0.0010805785" node1="29" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-180.95707518829138" q1="-91.586972002675054" p2="184.6977573123836" q2="35.606428963612366">
         <iidm:alias>_04638c56-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d5054-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10395,7 +10524,7 @@
             <iidm:temporaryLimit name="_990ce3c5-c90c-41b9-abee-fb803d9df3a5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04784cd4-c766-11e1-8775-005056c00008" name="106-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_04479fe8-c766-11e1-8775-005056c00008" node2="24" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="23.909571937879257" q1="-0.71422611853027773" p2="-23.579607348460307" q2="-2.4295966224002483">
+    <iidm:line id="_04784cd4-c766-11e1-8775-005056c00008" name="106-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_04479fe8-c766-11e1-8775-005056c00008" node2="24" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="23.909813703980536" q1="-0.71429918498597433" p2="-23.579842900603509" q2="-2.4295063616257337">
         <iidm:alias>_04483c21-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f0395-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10403,7 +10532,7 @@
             <iidm:temporaryLimit name="_1372c3b0-62d7-47d7-a8c0-ed8e10bc1f1a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046f9a43-c766-11e1-8775-005056c00008" name="27-115" r="2.8575360000000001" x="12.9111843" g1="0" b1="5.6588600000000002e-05" g2="0" b2="5.6588600000000002e-05" node1="43" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="22.633999981555643" q1="2.6626032994777025" p2="-22.542204338422941" q2="-4.0858398385502213">
+    <iidm:line id="_046f9a43-c766-11e1-8775-005056c00008" name="27-115" r="2.8575360000000001" x="12.9111843" g1="0" b1="5.6588600000000002e-05" g2="0" b2="5.6588600000000002e-05" node1="43" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="21.631144381042063" q1="3.195540096722413" p2="-21.546622118195998" q2="-4.6563196019554871">
         <iidm:alias>_046d0238-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048c22f4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10411,7 +10540,7 @@
             <iidm:temporaryLimit name="_64cfd0fb-1d8e-45d2-a52f-469238dfc0c6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04529c61-c766-11e1-8775-005056c00008" name="12-14" r="3.7461600000000002" x="12.3187675" g1="0" b1="5.2112050000000002e-05" g2="0" b2="5.2112050000000002e-05" node1="71" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b8129-c766-11e1-8775-005056c00008" p1="30.460972924132001" q1="5.7674750611753787" p2="-30.247707813455708" q2="-6.8260945937875395">
+    <iidm:line id="_04529c61-c766-11e1-8775-005056c00008" name="12-14" r="3.7461600000000002" x="12.3187675" g1="0" b1="5.2112050000000002e-05" g2="0" b2="5.2112050000000002e-05" node1="71" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b8129-c766-11e1-8775-005056c00008" p1="26.030523652479477" q1="7.0860763996233427" p2="-25.867928995033871" q2="-8.3112383477259417">
         <iidm:alias>_045fbbc1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047bf65b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10419,7 +10548,7 @@
             <iidm:temporaryLimit name="_efe2501d-bcee-42ff-a037-3d8a280487b0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0463da77-c766-11e1-8775-005056c00008" name="76-118" r="2.8575360000000001" x="9.4786560000000009" g1="0" b1="3.8911849999999999e-05" g2="0" b2="3.8911849999999999e-05" node1="22" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="-5.6401656916927738" q1="-14.381135937647038" p2="5.6815244605373003" q2="13.314075000524033">
+    <iidm:line id="_0463da77-c766-11e1-8775-005056c00008" name="76-118" r="2.8575360000000001" x="9.4786560000000009" g1="0" b1="3.8911849999999999e-05" g2="0" b2="3.8911849999999999e-05" node1="22" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="-5.5286887327877032" q1="-14.458296607210947" p2="5.5702230631507117" q2="13.392052080881395">
         <iidm:alias>_046931a0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04806320-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10427,7 +10556,7 @@
             <iidm:temporaryLimit name="_2ae204bf-78cc-49cb-b886-a933b33057e4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046931a3-c766-11e1-8775-005056c00008" name="74-75" r="2.1431520000000002" x="7.0741440000000004" g1="0" b1="2.9671699999999999e-05" g2="0" b2="2.9671699999999999e-05" node1="23" voltageLevelId1="_047dcb11-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="-48.140843813328836" q1="-3.3535725812076986" p2="48.451629837833799" q2="3.4200650226192244">
+    <iidm:line id="_046931a3-c766-11e1-8775-005056c00008" name="74-75" r="2.1431520000000002" x="7.0741440000000004" g1="0" b1="2.9671699999999999e-05" g2="0" b2="2.9671699999999999e-05" node1="23" voltageLevelId1="_047dcb11-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="-48.400135437698218" q1="-3.2178238723927013" p2="48.714186916867178" q2="3.29518453249492">
         <iidm:alias>_044f4103-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04638c58-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10435,7 +10564,7 @@
             <iidm:temporaryLimit name="_e822432e-79af-4bba-8f40-5250468f81a0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045ed162-c766-11e1-8775-005056c00008" name="3-12" r="8.4332159999999998" x="27.878398900000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="32" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-8.011387337167541" q1="-9.7902405511501041" p2="8.0758451628234784" q2="6.0917266468831244">
+    <iidm:line id="_045ed162-c766-11e1-8775-005056c00008" name="3-12" r="8.4332159999999998" x="27.878398900000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="32" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-9.1660203133469125" q1="-9.1754260810319703" p2="9.2357912998326555" q2="5.4928047866050562">
         <iidm:alias>_047a48a1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047b5a14-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10443,7 +10572,7 @@
             <iidm:temporaryLimit name="_c437e52c-43d7-4ae9-87ad-dc19396dc6ff" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04499bb6-c766-11e1-8775-005056c00008" name="49-51" r="8.468064" x="23.8708782" g1="0" b1="9.81405e-05" g2="0" b2="9.81405e-05" node1="119" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04542300-c766-11e1-8775-005056c00008" p1="77.400889161549827" q1="18.579298761634927" p2="-74.437556827984878" q2="-13.616924995951758">
+    <iidm:line id="_04499bb6-c766-11e1-8775-005056c00008" name="49-51" r="8.468064" x="23.8708782" g1="0" b1="9.81405e-05" g2="0" b2="9.81405e-05" node1="119" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04542300-c766-11e1-8775-005056c00008" p1="77.42024944590878" q1="18.576258316340795" p2="-74.455590461457959" q2="-13.610139890485929">
         <iidm:alias>_0487dd38-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b1180-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10451,7 +10580,7 @@
             <iidm:temporaryLimit name="_90dcdbe1-437b-443f-b0b5-c2353f7c6954" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04839779-c766-11e1-8775-005056c00008" name="40-42" r="9.6703209999999995" x="31.885919999999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="42" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="-2.5380479731857997" q1="-8.343393013356188" p2="2.5709185323184167" q2="4.6072797511485808">
+    <iidm:line id="_04839779-c766-11e1-8775-005056c00008" name="40-42" r="9.6703209999999995" x="31.885919999999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="42" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="-2.3527386239054517" q1="-8.471158246010253" p2="2.3861695389141202" q2="4.739375321959244">
         <iidm:alias>_044974a9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04616975-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10459,7 +10588,7 @@
             <iidm:temporaryLimit name="_9b8510fa-bd0e-4e63-8f4c-0e5443a3eb63" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0484a8e1-c766-11e1-8775-005056c00008" name="32-113" r="10.71576" x="35.370719999999999" g1="0" b1="0.00014864555000000001" g2="0" b2="0.00014864555000000001" node1="52" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="4.9492850191954405" q1="-10.7769461407054" p2="-4.8872032582344671" q2="6.0680868333082545">
+    <iidm:line id="_0484a8e1-c766-11e1-8775-005056c00008" name="32-113" r="10.71576" x="35.370719999999999" g1="0" b1="0.00014864555000000001" g2="0" b2="0.00014864555000000001" node1="52" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="1.2295863427078977" q1="-9.08785426605567" p2="-1.1994220372621922" q2="4.2717820450279671">
         <iidm:alias>_04723258-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0482860a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10467,7 +10596,7 @@
             <iidm:temporaryLimit name="_336bfd86-a922-4154-9e06-cd87382cdc5f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04898ae4-c766-11e1-8775-005056c00008" name="51-58" r="4.4431200000000004" x="12.5278568" g1="0" b1="5.1308550000000002e-05" g2="0" b2="5.1308550000000002e-05" node1="31" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="25.631545875101569" q1="0.35455550906548539" p2="-25.45149374140696" q2="-1.5012464578771187">
+    <iidm:line id="_04898ae4-c766-11e1-8775-005056c00008" name="51-58" r="4.4431200000000004" x="12.5278568" g1="0" b1="5.1308550000000002e-05" g2="0" b2="5.1308550000000002e-05" node1="31" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="25.643603142476017" q1="0.34955420992085484" p2="-25.463384447313725" q2="-1.4957699997036187">
         <iidm:alias>_044778d4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04789af1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10475,7 +10604,7 @@
             <iidm:temporaryLimit name="_2be10dec-f0ac-470d-83f7-a2a4e70f3491" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046efe04-c766-11e1-8775-005056c00008" name="29-31" r="1.8817919999999999" x="5.7673439999999996" g1="0" b1="2.3817700000000001e-05" g2="0" b2="2.3817700000000001e-05" node1="22" voltageLevelId1="_04588fd5-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="-7.3030632947047396" q1="-8.6754839567347357" p2="7.317268995750517" q2="7.9458372299341633">
+    <iidm:line id="_046efe04-c766-11e1-8775-005056c00008" name="29-31" r="1.8817919999999999" x="5.7673439999999996" g1="0" b1="2.3817700000000001e-05" g2="0" b2="2.3817700000000001e-05" node1="22" voltageLevelId1="_04588fd5-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="-9.0012802843575077" q1="-6.6676540858887483" p2="9.0152879759768361" q2="5.937001223178159">
         <iidm:alias>_04492688-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047cb9a5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10483,7 +10612,7 @@
             <iidm:temporaryLimit name="_f0e21213-6535-44a7-89b6-3063f8738d6b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044a10e4-c766-11e1-8775-005056c00008" name="65-68" r="0.66791999999999996" x="7.7439999999999998" g1="0" b1="0.00065909092999999995" g2="0" b2="0.00065909092999999995" node1="41" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0449e9d2-c766-11e1-8775-005056c00008" p1="-235.65138859901467" q1="33.902947368861746" p2="236.46985556029105" q2="-88.434385513954794">
+    <iidm:line id="_044a10e4-c766-11e1-8775-005056c00008" name="65-68" r="0.66791999999999996" x="7.7439999999999998" g1="0" b1="0.00065909092999999995" g2="0" b2="0.00065909092999999995" node1="41" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0449e9d2-c766-11e1-8775-005056c00008" p1="-234.21274912101077" q1="33.711310478954381" p2="235.02163384680205" q2="-88.354029096153013">
         <iidm:alias>_0461dea7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047629f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10491,7 +10620,7 @@
             <iidm:temporaryLimit name="_ab31cd46-6d0c-4d9c-95f1-396a45a237e1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046b7b92-c766-11e1-8775-005056c00008" name="49-54" r="12.719519999999999" x="50.355361899999998" g1="0" b1="0.00021177684999999999" g2="0" b2="0.00021177684999999999" node1="120" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="47.304830899094547" q1="11.78651983871381" p2="-45.579521727075566" q2="-12.198366273022627">
+    <iidm:line id="_046b7b92-c766-11e1-8775-005056c00008" name="49-54" r="12.719519999999999" x="50.355361899999998" g1="0" b1="0.00021177684999999999" g2="0" b2="0.00021177684999999999" node1="120" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="47.322128325030114" q1="11.784449303260764" p2="-45.59572836873464" q2="-12.191984119650103">
         <iidm:alias>_0462f017-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047120e1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10499,7 +10628,7 @@
             <iidm:temporaryLimit name="_1bf78539-b6fa-4d8b-ba8e-9b5970019be6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04607f15-c766-11e1-8775-005056c00008" name="70-71" r="1.536797" x="6.1855200000000004" g1="0" b1="2.5195149999999999e-05" g2="0" b2="2.5195149999999999e-05" node1="52" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04664b78-c766-11e1-8775-005056c00008" p1="3.4646744768574198" q1="-8.1734012805859457" p2="-3.458100423843165" q2="7.3489730839114475">
+    <iidm:line id="_04607f15-c766-11e1-8775-005056c00008" name="70-71" r="1.536797" x="6.1855200000000004" g1="0" b1="2.5195149999999999e-05" g2="0" b2="2.5195149999999999e-05" node1="52" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04664b78-c766-11e1-8775-005056c00008" p1="4.0860774681431709" q1="-8.52901354128214" p2="-4.0785614934571415" q2="7.7082525093397161">
         <iidm:alias>_04486336-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f51b4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10507,7 +10636,7 @@
             <iidm:temporaryLimit name="_08ff3ae4-d1dd-49f7-9eda-32ffc8eb0010" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c5ad7-c766-11e1-8775-005056c00008" name="55-56" r="0.85029100000000002" x="2.631024" g1="0" b1="1.0732300000000001e-05" g2="0" b2="1.0732300000000001e-05" node1="31" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="-28.706582231634826" q1="-6.9829886353327266" p2="28.753525726237271" q2="6.7888911198232176">
+    <iidm:line id="_044c5ad7-c766-11e1-8775-005056c00008" name="55-56" r="0.85029100000000002" x="2.631024" g1="0" b1="1.0732300000000001e-05" g2="0" b2="1.0732300000000001e-05" node1="31" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="-28.717438296186408" q1="-6.9794817478885882" p2="28.764412810461295" q2="6.7854800540129876">
         <iidm:alias>_04558294-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045868c2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10515,7 +10644,7 @@
             <iidm:temporaryLimit name="_94316214-afd8-4c0d-bca4-916acb92af85" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048a2725-c766-11e1-8775-005056c00008" name="35-37" r="1.9166399999999999" x="8.6597279999999994" g1="0" b1="3.7821399999999997e-05" g2="0" b2="3.7821399999999997e-05" node1="21" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-30.715375215250091" q1="-13.988309804060917" p2="30.854352136838127" q2="13.431212221844">
+    <iidm:line id="_048a2725-c766-11e1-8775-005056c00008" name="35-37" r="1.9166399999999999" x="8.6597279999999994" g1="0" b1="3.7821399999999997e-05" g2="0" b2="3.7821399999999997e-05" node1="21" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-30.640338609002466" q1="-14.023473573763537" p2="30.778993040196369" q2="13.465993829171152">
         <iidm:alias>_0471bd29-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04808a30-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10523,7 +10652,7 @@
             <iidm:temporaryLimit name="_4ea6b532-d914-4b0c-97ee-9f02a14a40b3" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04614263-c766-11e1-8775-005056c00008" name="4-5" r="0.30666199999999999" x="1.3904350000000001" g1="0" b1="6.0261499999999999e-06" g2="0" b2="6.0261499999999999e-06" node1="22" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-110.56672640292658" q1="-19.754634526245411" p2="110.78559552400758" q2="20.533302199084165">
+    <iidm:line id="_04614263-c766-11e1-8775-005056c00008" name="4-5" r="0.30666199999999999" x="1.3904350000000001" g1="0" b1="6.0261499999999999e-06" g2="0" b2="6.0261499999999999e-06" node1="22" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-106.38844155262971" q1="-21.490142930940344" p2="106.59247332272568" q2="22.201168198530922">
         <iidm:alias>_04529c66-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04753f92-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10531,7 +10660,7 @@
             <iidm:temporaryLimit name="_2a95fb2b-6661-46e7-a9f6-fe63c1b7433c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0451b208-c766-11e1-8775-005056c00008" name="20-21" r="3.1885919999999999" x="14.7929754" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_046b2d70-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0460f448-c766-11e1-8775-005056c00008" p1="-32.372239472464159" q1="1.6791525646589138" p2="32.588882234351871" q2="-2.6078013851901685">
+    <iidm:line id="_0451b208-c766-11e1-8775-005056c00008" name="20-21" r="3.1885919999999999" x="14.7929754" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_046b2d70-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0460f448-c766-11e1-8775-005056c00008" p1="-30.49455687567303" q1="0.75250624184505233" p2="30.686053457636568" q2="-1.799424183712282">
         <iidm:alias>_046c65f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048c22f6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10539,7 +10668,7 @@
             <iidm:temporaryLimit name="_4b67f5f5-f0e1-4bfb-9d57-4d3474720a45" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047d55e4-c766-11e1-8775-005056c00008" name="104-105" r="1.731946" x="6.5862720000000001" g1="0" b1="2.8294300000000001e-05" g2="0" b2="2.8294300000000001e-05" node1="32" voltageLevelId1="_0483977a-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="48.454458456935882" q1="0.75366197980188954" p2="-48.206551666889283" q2="-0.73469123916168333">
+    <iidm:line id="_047d55e4-c766-11e1-8775-005056c00008" name="104-105" r="1.731946" x="6.5862720000000001" g1="0" b1="2.8294300000000001e-05" g2="0" b2="2.8294300000000001e-05" node1="32" voltageLevelId1="_0483977a-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="48.456081185891833" q1="0.75325253637278444" p2="-48.208158185006958" q2="-0.73422119802283359">
         <iidm:alias>_0451d910-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046c65f2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10547,7 +10676,7 @@
             <iidm:temporaryLimit name="_1ca40dc7-6736-4fa8-b4cb-ca696949e421" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046dc589-c766-11e1-8775-005056c00008" name="44-45" r="3.9029759999999998" x="15.699023199999999" g1="0" b1="6.4279149999999996e-05" g2="0" b2="6.4279149999999996e-05" node1="23" voltageLevelId1="_04544a15-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_045d23b4-c766-11e1-8775-005056c00008" p1="-23.928011416780549" q1="-2.9317677177929271" p2="24.063558537013186" q2="1.3283130608090377">
+    <iidm:line id="_046dc589-c766-11e1-8775-005056c00008" name="44-45" r="3.9029759999999998" x="15.699023199999999" g1="0" b1="6.4279149999999996e-05" g2="0" b2="6.4279149999999996e-05" node1="23" voltageLevelId1="_04544a15-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_045d23b4-c766-11e1-8775-005056c00008" p1="-23.682975792404303" q1="-3.0733697532895383" p2="23.815933205133" q2="1.4597680666375525">
         <iidm:alias>_04518afa-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04667287-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10555,7 +10684,7 @@
             <iidm:temporaryLimit name="_ba738481-ddba-4ebe-a218-8aad0b537f5b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04642896-c766-11e1-8775-005056c00008" name="4-11" r="3.641616" x="11.9877129" g1="0" b1="5.0160700000000002e-05" g2="0" b2="5.0160700000000002e-05" node1="23" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="71.546158550540653" q1="7.7441336805116094" p2="-70.475837796322438" q2="-5.9592168810608959">
+    <iidm:line id="_04642896-c766-11e1-8775-005056c00008" name="4-11" r="3.641616" x="11.9877129" g1="0" b1="5.0160700000000002e-05" g2="0" b2="5.0160700000000002e-05" node1="23" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="67.368739199848463" q1="9.4800466386646587" p2="-66.412809108879316" q2="-8.0738361420799354">
         <iidm:alias>_0455f7c5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04803c17-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10563,7 +10692,7 @@
             <iidm:temporaryLimit name="_b1d87c24-e527-4174-aa04-cd0b9de271ea" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047d07c0-c766-11e1-8775-005056c00008" name="92-93" r="4.4953919999999998" x="14.775551800000001" g1="0" b1="6.2557400000000005e-05" g2="0" b2="6.2557400000000005e-05" node1="72" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04789af0-c766-11e1-8775-005056c00008" p1="64.68414943069925" q1="-11.890466442055914" p2="-63.552709525562598" q2="13.483825388313909">
+    <iidm:line id="_047d07c0-c766-11e1-8775-005056c00008" name="92-93" r="4.4953919999999998" x="14.775551800000001" g1="0" b1="6.2557400000000005e-05" g2="0" b2="6.2557400000000005e-05" node1="72" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04789af0-c766-11e1-8775-005056c00008" p1="64.738590159663104" q1="-11.826855702706609" p2="-63.60554519249294" q2="13.425844421973354">
         <iidm:alias>_044a5f07-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047602e5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10571,7 +10700,7 @@
             <iidm:temporaryLimit name="_4e1daf8e-7708-4b96-8d3f-67f58f2505f9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044f4109-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="43" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="121" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-55.588141863258933" q1="-17.527404370481381" p2="58.388938618149233" q2="22.057473863830243">
+    <iidm:line id="_044f4109-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="43" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="121" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-55.405603254013954" q1="-17.658049593437735" p2="58.193598682995272" q2="22.131992900938329">
         <iidm:alias>_046958b0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04758db0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10579,7 +10708,7 @@
             <iidm:temporaryLimit name="_c58940cb-bd36-4dfc-9615-11716dd652a7" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046e61c8-c766-11e1-8775-005056c00008" name="69-75" r="7.0567200000000003" x="21.257280000000002" g1="0" b1="0.00035583104999999999" g2="0" b2="0.00035583104999999999" node1="61" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="97.381629972415539" q1="23.374090845584782" p2="-93.455687171846265" q2="-23.987174771971798">
+    <iidm:line id="_046e61c8-c766-11e1-8775-005056c00008" name="69-75" r="7.0567200000000003" x="21.257280000000002" g1="0" b1="0.00035583104999999999" g2="0" b2="0.00035583104999999999" node1="61" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="97.734355445943805" q1="23.343856181403119" p2="-93.783082866569771" q2="-23.879979195845127">
         <iidm:alias>_046d294a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048ac362-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10587,7 +10716,7 @@
             <iidm:temporaryLimit name="_3c9a454c-10ee-4c72-a059-77f723f5b7c7" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0463da71-c766-11e1-8775-005056c00008" name="79-80" r="2.7181440000000001" x="12.2664957" g1="0" b1="5.3661600000000001e-05" g2="0" b2="5.3661600000000001e-05" node1="23" voltageLevelId1="_04481510-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-66.85537546063054" q1="-31.929844886688961" p2="67.690404448013879" q2="33.738479872262893">
+    <iidm:line id="_0463da71-c766-11e1-8775-005056c00008" name="79-80" r="2.7181440000000001" x="12.2664957" g1="0" b1="5.3661600000000001e-05" g2="0" b2="5.3661600000000001e-05" node1="23" voltageLevelId1="_04481510-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-66.937469645916195" q1="-32.046559684500991" p2="67.775468228071404" q2="33.868780601828341">
         <iidm:alias>_0464ebe9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04662468-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10595,7 +10724,7 @@
             <iidm:temporaryLimit name="_270a7d04-9ff9-4178-8b72-b610735a72ac" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044fdd41-c766-11e1-8775-005056c00008" name="51-52" r="3.5370720000000002" x="10.2453117" g1="0" b1="4.0059699999999999e-05" g2="0" b2="4.0059699999999999e-05" node1="32" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04806326-c766-11e1-8775-005056c00008" p1="31.806542349673855" q1="5.2627888934180742" p2="-31.578684320453927" q2="-5.8909168563136589">
+    <iidm:line id="_044fdd41-c766-11e1-8775-005056c00008" name="51-52" r="3.5370720000000002" x="10.2453117" g1="0" b1="4.0059699999999999e-05" g2="0" b2="4.0059699999999999e-05" node1="32" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04806326-c766-11e1-8775-005056c00008" p1="31.812501654252106" q1="5.2609977635067819" p2="-31.584564775588614" q2="-5.8888919163623221">
         <iidm:alias>_045115c2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0464ebe5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10603,7 +10732,7 @@
             <iidm:temporaryLimit name="_9d1eb182-ceb5-426e-9440-5f4d426a31cb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c3958-c766-11e1-8775-005056c00008" name="53-54" r="4.5825120000000004" x="21.257280000000002" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="22" voltageLevelId1="_04876804-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="-9.5054514979275044" q1="-6.7864822484975305" p2="9.5406289435127842" q2="4.1508852186626033">
+    <iidm:line id="_045c3958-c766-11e1-8775-005056c00008" name="53-54" r="4.5825120000000004" x="21.257280000000002" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="22" voltageLevelId1="_04876804-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="-9.4996782184632789" q1="-6.7887998733475063" p2="9.5348308126779102" q2="4.1530886381332941">
         <iidm:alias>_044f6817-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0455f7c6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10611,7 +10740,7 @@
             <iidm:temporaryLimit name="_735ac8df-6a6a-43f0-86f2-49d3280c9a3b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044ef2e1-c766-11e1-8775-005056c00008" name="54-55" r="2.9446560000000002" x="12.3187675" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="63" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04767817-c766-11e1-8775-005056c00008" p1="10.041110488061582" q1="1.7470354842574649" p2="-10.021108431492282" q2="-3.4984734127433805">
+    <iidm:line id="_044ef2e1-c766-11e1-8775-005056c00008" name="54-55" r="2.9446560000000002" x="12.3187675" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="63" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04767817-c766-11e1-8775-005056c00008" p1="10.044958166619654" q1="1.7464766068876862" p2="-10.024942360307557" q2="-3.4978583425627945">
         <iidm:alias>_04640181-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047dcb17-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10619,7 +10748,7 @@
             <iidm:temporaryLimit name="_52aadf8d-53f2-4827-8c70-421bdf1ba822" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0456e226-c766-11e1-8775-005056c00008" name="80-97" r="3.1885919999999999" x="16.2740154" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="82" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="18.977338326668512" q1="28.712891542097495" p2="-18.76325107760038" q2="-30.288641340857016">
+    <iidm:line id="_0456e226-c766-11e1-8775-005056c00008" name="80-97" r="3.1885919999999999" x="16.2740154" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="82" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="19.017460240388363" q1="28.913992734184209" p2="-18.801061076561957" q2="-30.477465003001569">
         <iidm:alias>_04479fe9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047df222-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10627,7 +10756,7 @@
             <iidm:temporaryLimit name="_fece5807-6af8-4161-8de8-8f8473d92f11" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0487b624-c766-11e1-8775-005056c00008" name="103-110" r="6.8058139999999998" x="31.5897121" g1="0" b1="0.00013228879999999999" g2="0" b2="0.00013228879999999999" node1="43" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="58.615055791314994" q1="18.417900645685204" p2="-57.134335774067324" q2="-15.998609515115797">
+    <iidm:line id="_0487b624-c766-11e1-8775-005056c00008" name="103-110" r="6.8058139999999998" x="31.5897121" g1="0" b1="0.00013228879999999999" g2="0" b2="0.00013228879999999999" node1="43" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="58.618425712596732" q1="18.417634768524255" p2="-57.137560611047924" q2="-15.997675674317978">
         <iidm:alias>_046a9139-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b3895-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10635,7 +10764,7 @@
             <iidm:temporaryLimit name="_3eacc034-737e-41de-a7b6-b610d3bd0921" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045338a8-c766-11e1-8775-005056c00008" name="56-58" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="61" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="-13.384104958691553" q1="-0.52254334693138982" p2="13.451765367617927" q2="-1.4986393252453527">
+    <iidm:line id="_045338a8-c766-11e1-8775-005056c00008" name="56-58" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="61" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="-13.395862530614902" q1="-0.51672049259482711" p2="13.463644165137628" q2="-1.5041184283278657">
         <iidm:alias>_0451d915-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04817494-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10643,7 +10772,7 @@
             <iidm:temporaryLimit name="_0d0c3ec5-798a-48a4-9bc8-d19c57128a13" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04854529-c766-11e1-8775-005056c00008" name="15-33" r="6.6211200000000003" x="21.675455100000001" g1="0" b1="9.1655200000000003e-05" g2="0" b2="9.1655200000000003e-05" node1="52" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456bb11-c766-11e1-8775-005056c00008" p1="49.19738148042417" q1="-6.38085544700506" p2="-48.174433848559687" q2="6.8618995607419926">
+    <iidm:line id="_04854529-c766-11e1-8775-005056c00008" name="15-33" r="6.6211200000000003" x="21.675455100000001" g1="0" b1="9.1655200000000003e-05" g2="0" b2="9.1655200000000003e-05" node1="52" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456bb11-c766-11e1-8775-005056c00008" p1="50.16169901043218" q1="-6.5749799068733736" p2="-49.096560688029733" q2="7.1977061268586997">
         <iidm:alias>_0448d862-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047d2ed5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10651,7 +10780,7 @@
             <iidm:temporaryLimit name="_5b0395f4-534d-4975-a1af-e0b6ef439193" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04649dc2-c766-11e1-8775-005056c00008" name="35-36" r="0.39029799999999998" x="1.7772479999999999" g1="0" b1="7.6905500000000004e-06" g2="0" b2="7.6905500000000004e-06" node1="22" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="-2.3362182343613149" q1="4.9649204077405136" p2="2.3370071177042124" q2="-5.1994291618503512">
+    <iidm:line id="_04649dc2-c766-11e1-8775-005056c00008" name="35-36" r="0.39029799999999998" x="1.7772479999999999" g1="0" b1="7.6905500000000004e-06" g2="0" b2="7.6905500000000004e-06" node1="22" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="-2.4120588621484473" q1="4.9996365042200033" p2="2.4128664666840631" q2="-5.2338385082221963">
         <iidm:alias>_044c0cb5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0456e225-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10659,7 +10788,7 @@
             <iidm:temporaryLimit name="_74c4b341-7b99-4a81-b88a-2ed3b0c4b1de" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0470d2c9-c766-11e1-8775-005056c00008" name="37-40" r="10.3324327" x="29.272320000000001" g1="0" b1="0.0001205234" g2="0" b2="0.0001205234" node1="61" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="54.320962282581235" q1="11.218552613377778" p2="-52.284242340443576" q2="-9.0624837325793361">
+    <iidm:line id="_0470d2c9-c766-11e1-8775-005056c00008" name="37-40" r="10.3324327" x="29.272320000000001" g1="0" b1="0.0001205234" g2="0" b2="0.0001205234" node1="61" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="54.516233582437813" q1="11.132841911616906" p2="-52.465326485154172" q2="-8.9334828535508386">
         <iidm:alias>_045b9d10-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046a4317-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10667,7 +10796,7 @@
             <iidm:temporaryLimit name="_e98d56fe-a54b-45e4-acff-0ac310beb3dd" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044e56a2-c766-11e1-8775-005056c00008" name="48-49" r="3.1188959999999999" x="8.7991200000000003" g1="0" b1="3.6099649999999999e-05" g2="0" b2="3.6099649999999999e-05" node1="23" voltageLevelId1="_044778d3-c766-11e1-8775-005056c00008" node2="122" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-29.493082246934303" q1="1.5236252664931214" p2="29.643319908858601" q2="-2.4160490857073995">
+    <iidm:line id="_044e56a2-c766-11e1-8775-005056c00008" name="48-49" r="3.1188959999999999" x="8.7991200000000003" g1="0" b1="3.6099649999999999e-05" g2="0" b2="3.6099649999999999e-05" node1="23" voltageLevelId1="_044778d3-c766-11e1-8775-005056c00008" node2="122" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-29.463676771309043" q1="1.5143068819018588" p2="29.613609301646242" q2="-2.4075937174372437">
         <iidm:alias>_0454bf49-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0460a623-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10675,7 +10804,7 @@
             <iidm:temporaryLimit name="_f2e58700-2366-46e0-8408-9472d85acd23" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047eb573-c766-11e1-8775-005056c00008" name="56-59" r="14.3748007" x="43.734237700000001" g1="0" b1="0.0001632805" g2="0" b2="0.0001632805" node1="62" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-19.254924806054106" q1="-7.6891025754943474" p2="19.614710442476209" q2="3.4350379094694947">
+    <iidm:line id="_047eb573-c766-11e1-8775-005056c00008" name="56-59" r="14.3748007" x="43.734237700000001" g1="0" b1="0.0001632805" g2="0" b2="0.0001632805" node1="62" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-19.242389949917555" q1="-7.6939982510813909" p2="19.601783132308121" q2="3.4387354588911254">
         <iidm:alias>_0468bc78-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048915b0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10683,7 +10812,7 @@
             <iidm:temporaryLimit name="_89654167-95a6-4c76-aad7-63a881116e17" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046f9a4b-c766-11e1-8775-005056c00008" name="94-100" r="3.1014719999999998" x="10.105919999999999" g1="0" b1="0.00017332415000000001" g2="0" b2="0.00017332415000000001" node1="52" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-1.8209163465241873" q1="-51.264108446409182" p2="2.2469284440089305" q2="46.57900138137186">
+    <iidm:line id="_046f9a4b-c766-11e1-8775-005056c00008" name="94-100" r="3.1014719999999998" x="10.105919999999999" g1="0" b1="0.00017332415000000001" g2="0" b2="0.00017332415000000001" node1="52" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-1.8395371193714871" q1="-51.537315657872121" p2="2.2705515093374165" q2="46.869511745460166">
         <iidm:alias>_04812676-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048a2722-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10691,7 +10820,7 @@
             <iidm:temporaryLimit name="_216c0f3b-03e8-4b7d-96fc-a5f891331f7f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046735d0-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="123" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-100.51393133775829" q1="-0.28063039755960845" p2="102.24503110145619" q2="6.4603077773302733">
+    <iidm:line id="_046735d0-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="123" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-100.42334463525837" q1="-0.30680661164199374" p2="102.15131530468149" q2="6.4705056267606951">
         <iidm:alias>_04570934-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b3894-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10699,7 +10828,7 @@
             <iidm:temporaryLimit name="_32655e4f-e7da-46b0-a908-b601224ddb73" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046d294b-c766-11e1-8775-005056c00008" name="21-22" r="3.641616" x="16.901281399999998" g1="0" b1="7.0592299999999998e-05" g2="0" b2="7.0592299999999998e-05" node1="22" voltageLevelId1="_0460f448-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04773b6a-c766-11e1-8775-005056c00008" p1="-46.609377089873064" q1="-5.411643361579686" p2="47.118524165741427" q2="5.5250264139418244">
+    <iidm:line id="_046d294b-c766-11e1-8775-005056c00008" name="21-22" r="3.641616" x="16.901281399999998" g1="0" b1="7.0592299999999998e-05" g2="0" b2="7.0592299999999998e-05" node1="22" voltageLevelId1="_0460f448-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04773b6a-c766-11e1-8775-005056c00008" p1="-44.70559367017696" q1="-6.2191680292905058" p2="45.175513162933164" q2="6.1469802218517078">
         <iidm:alias>_044a37f0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_044be5a2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10707,7 +10836,7 @@
             <iidm:temporaryLimit name="_bafaeace-e459-4dc2-87a0-467a9ea25f8d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_6a131803-f462-47e2-bc21-bda919364fe9" name="reactor1" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="36" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="37" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="-6.9388939039072284e-15" q1="-83.151415555460858" p2="8.3266726846886741e-15" q2="92.151058359018947">
+    <iidm:line id="_6a131803-f462-47e2-bc21-bda919364fe9" name="reactor1" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="36" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="37" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="1.1102230246251565e-14" q1="-83.15150181653344" p2="-1.1102230246251565e-14" q2="92.151153956298671">
         <iidm:alias>_04531196-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_ca0adad2-ffe3-4efa-b56b-7d333b8ae18f</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10715,7 +10844,7 @@
             <iidm:temporaryLimit name="_ae4eadea-f3fc-4ac6-8899-c1698ece7a89" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_9803b364-2a93-4f21-94b7-8bdbe27a16f2" name="reactor2" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="38" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="7.1577068924688625e-07" q1="27.746694052874883" p2="-7.1577068785910747e-07" q2="-26.843858118096836">
+    <iidm:line id="_9803b364-2a93-4f21-94b7-8bdbe27a16f2" name="reactor2" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="38" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="1.3188794821994594e-06" q1="27.746120683951524" p2="-1.3188794821994594e-06" q2="-26.843322976725069">
         <iidm:alias>_0461b792-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_afe0e60b-3870-44fb-ba93-a056228f9636</iidm:alias>
     </iidm:line>

--- a/tests/main_sa/reference/launch/generator_contingency/outputIIDM.xml
+++ b/tests/main_sa/reference/launch/generator_contingency/outputIIDM.xml
@@ -31,8 +31,8 @@
                     <iidm:alias>_bea273f1-1e21-476d-b0d0-92dd6cb9a2d4</iidm:alias>
                     <iidm:alias>_c94e6b68-da6c-43d1-94fd-09ad60c74134</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_047abdd7-c766-11e1-8775-005056c00008-BREAKER" name="BREAKER-Jay LD" kind="BREAKER" retained="true" open="false" node1="0" node2="8"/>
                 <iidm:internalConnection node1="7" node2="0"/>
-                <iidm:internalConnection node1="8" node2="0"/>
                 <iidm:internalConnection node1="9" node2="1"/>
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="4"/>
@@ -47,9 +47,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="124.45625564054723" angle="8.4303226345426907" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.56671265733297" angle="-3.998114729652424" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047abdd7-c766-11e1-8775-005056c00008" name="Jay LD" loadType="UNDEFINED" p0="14" q0="8" node="8" p="13.988079340520954" q="7.9886502135476256">
+            <iidm:load id="_047abdd7-c766-11e1-8775-005056c00008" name="Jay LD" loadType="UNDEFINED" p0="14" q0="8" node="8" p="13.98857870690548" q="7.9891255362311471">
                 <iidm:alias>_04590500-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -139,12 +139,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="127.65828356623288" angle="12.023671363186587" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="127.85612470472809" angle="-0.60062243571454899" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045b00d5-c766-11e1-8775-005056c00008" name="Madison LD" loadType="UNDEFINED" p0="62" q0="13" node="14" p="61.987286271796094" q="12.995557334165269">
+            <iidm:load id="_045b00d5-c766-11e1-8775-005056c00008" name="Madison LD" loadType="UNDEFINED" p0="62" q0="13" node="14" p="61.988610293641379" q="12.996019970009485">
                 <iidm:alias>_045b27e3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_04689566-c766-11e1-8775-005056c00008" name="Madison NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="15" p="8.9981544588091094" q="0">
+            <iidm:load id="_04689566-c766-11e1-8775-005056c00008" name="Madison NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="15" p="8.9983466555285876" q="0">
                 <iidm:alias>_04765100-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -272,7 +272,7 @@
                 <iidm:internalConnection node1="61" node2="12"/>
                 <iidm:internalConnection node1="62" node2="15"/>
                 <iidm:internalConnection node1="63" node2="18"/>
-                <iidm:bus v="124.67349935314789" angle="-9.9671452437733308" nodes="0,1,4,7,10,13,16,19,20,21,22,24,26,28,30,32,34,35,38,39,42,43,46,47,50,51,54,55"/>
+                <iidm:bus v="124.6733248417102" angle="-22.4273737730345" nodes="0,1,4,7,10,13,16,19,20,21,22,24,26,28,30,32,34,35,38,39,42,43,46,47,50,51,54,55"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="_046c3ee7-c766-11e1-8775-005056c00008" name="Torrey SM" energySource="THERMAL" minP="20" maxP="80" ratedS="100" voltageRegulatorOn="true" targetP="48" targetV="126.06" targetQ="0" node="21" p="-0" q="-0">
                 <iidm:alias>_047147f3-c766-11e1-8775-005056c00008</iidm:alias>
@@ -281,7 +281,7 @@
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-30" maxQ="85"/>
             </iidm:generator>
-            <iidm:load id="_044afb44-c766-11e1-8775-005056c00008" name="Torrey LD" loadType="UNDEFINED" p0="113" q0="32" node="20" p="112.51509857612999" q="31.771465488769991">
+            <iidm:load id="_044afb44-c766-11e1-8775-005056c00008" name="Torrey LD" loadType="UNDEFINED" p0="113" q0="32" node="20" p="112.51527464771824" q="31.771548352542332">
                 <iidm:alias>_04522737-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -332,9 +332,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="123.82959720781369" angle="8.6187447174492835" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="123.82026910831102" angle="-3.8973991721074741" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04481515-c766-11e1-8775-005056c00008" name="Darrah LD" loadType="UNDEFINED" p0="68" q0="36" node="8" p="67.998023213387256" q="35.998255793419972">
+            <iidm:load id="_04481515-c766-11e1-8775-005056c00008" name="Darrah LD" loadType="UNDEFINED" p0="68" q0="36" node="8" p="67.998220875462508" q="35.998430197922339">
                 <iidm:alias>_044e7db8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -385,9 +385,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.42263909760896" angle="23.666842427305461" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.4166231911716" angle="11.173302819888432" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044c0cb3-c766-11e1-8775-005056c00008" name="Smythe LD" loadType="UNDEFINED" p0="5" q0="3" node="8" p="4.9993535935007269" q="2.9993536213572183">
+            <iidm:load id="_044c0cb3-c766-11e1-8775-005056c00008" name="Smythe LD" loadType="UNDEFINED" p0="5" q0="3" node="8" p="4.9993447220666321" q="2.9993447506929933">
                 <iidm:alias>_045163e8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -514,9 +514,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="124.6624590588476" angle="-10.004775141570061" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="124.66230872949399" angle="-22.465101538537652" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0450a093-c766-11e1-8775-005056c00008" name="Sunnysde LD" loadType="UNDEFINED" p0="84" q0="18" node="20" p="83.675064349832923" q="17.884101253931227">
+            <iidm:load id="_0450a093-c766-11e1-8775-005056c00008" name="Sunnysde LD" loadType="UNDEFINED" p0="84" q0="18" node="20" p="83.675209216841012" q="17.884152858666688">
                 <iidm:alias>_045f4695-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -568,12 +568,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="126.73812359733816" angle="8.4565560846852286" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="126.74265454380064" angle="-4.0769039656687385" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044b2251-c766-11e1-8775-005056c00008" name="Bellefnt LD" loadType="UNDEFINED" p0="68" q0="27" node="8" p="68.00108197568585" q="27.000716017119103">
+            <iidm:load id="_044b2251-c766-11e1-8775-005056c00008" name="Bellefnt LD" loadType="UNDEFINED" p0="68" q0="27" node="8" p="68.001532122192955" q="27.001013912007206">
                 <iidm:alias>_04622cc1-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0449e9d5-c766-11e1-8775-005056c00008" name="Bellefnt SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.40300000000001" targetDeadband="1" node="9" q="-11.067098309379196">
+            <iidm:shunt id="_0449e9d5-c766-11e1-8775-005056c00008" name="Bellefnt SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.40300000000001" targetDeadband="1" node="9" q="-11.067889631277529">
                 <iidm:alias>_047bcf48-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_6cc38790-c6a6-4309-99f4-a3258e24e785"/>
                 <iidm:shuntLinearModel bPerSection="0.00013779999999999999" gPerSection="0" maximumSectionCount="10"/>
@@ -665,12 +665,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="126.06763089070738" angle="9.2687699168890969" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="126.06748727011355" angle="-3.231509544323564" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04682035-c766-11e1-8775-005056c00008" name="Fieldale LD" loadType="UNDEFINED" p0="39" q0="30" node="14" p="39.000261253998993" q="30.000334941772248">
+            <iidm:load id="_04682035-c766-11e1-8775-005056c00008" name="Fieldale LD" loadType="UNDEFINED" p0="39" q0="30" node="14" p="39.000203758550199" q="30.00026122936546">
                 <iidm:alias>_0478c20a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_045c6067-c766-11e1-8775-005056c00008" name="Fieldale SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.066" targetDeadband="1" node="15" q="-5.4672083600880992">
+            <iidm:shunt id="_045c6067-c766-11e1-8775-005056c00008" name="Fieldale SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.066" targetDeadband="1" node="15" q="-5.4671959032304835">
                 <iidm:alias>_0451b209-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_2d222dd9-7306-4afd-baa5-fd303b0eeb40"/>
                 <iidm:shuntLinearModel bPerSection="6.8800000000000005e-05" gPerSection="0" maximumSectionCount="10"/>
@@ -780,7 +780,7 @@
                 <iidm:internalConnection node1="51" node2="9"/>
                 <iidm:internalConnection node1="52" node2="12"/>
                 <iidm:internalConnection node1="53" node2="15"/>
-                <iidm:bus v="138.02506053608593" angle="3.6946909871601479" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
+                <iidm:bus v="138.02514618080164" angle="-8.7674984164388494" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="_047f0391-c766-11e1-8775-005056c00008" name="Muskngum SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="392" targetV="138.59999099999999" targetQ="0" node="18" p="-0" q="-0">
                 <iidm:alias>_047eb572-c766-11e1-8775-005056c00008</iidm:alias>
@@ -789,7 +789,7 @@
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
-            <iidm:load id="_047e1936-c766-11e1-8775-005056c00008" name="Muskngum LD" loadType="UNDEFINED" p0="39" q0="18" node="17" p="39.000847479092499" q="18.000651911716243">
+            <iidm:load id="_047e1936-c766-11e1-8775-005056c00008" name="Muskngum LD" loadType="UNDEFINED" p0="39" q0="18" node="17" p="39.000886751412018" q="18.00068212164058">
                 <iidm:alias>_046e88d5-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -876,9 +876,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="221.1000041221603" angle="9.1915883316198457" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="221.10006438850994" angle="-3.2737837107312808" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0458ddf1-c766-11e1-8775-005056c00008" name="Muskngum SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="391" targetV="221.09999999999999" targetQ="0" node="14" p="-439.22871027471427" q="-166.13137435606848">
+            <iidm:generator id="_0458ddf1-c766-11e1-8775-005056c00008" name="Muskngum SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="391" targetV="221.09999999999999" targetQ="0" node="14" p="-439.15044190592153" q="-166.04930846953732">
                 <iidm:alias>_04522732-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_5036c3a5-56f9-489c-9ecb-8c15aa7c70c5"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_12b01822-ca11-4cf8-a6b4-2f8ff805ca20"/>
@@ -886,7 +886,7 @@
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045cae83-c766-11e1-8775-005056c00008" name="65-66" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="42" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="290.9814551078307" q1="98.859947622957165" p2="-290.9814551078307" q2="-68.614162451864146">
+        <iidm:twoWindingsTransformer id="_045cae83-c766-11e1-8775-005056c00008" name="65-66" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="42" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="290.81375676011089" q1="98.842790851646939" p2="-290.81375676011089" q2="-68.629354235625129">
             <iidm:alias>_044b2254-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_044b4964-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_045645e1-c766-11e1-8775-005056c00008</iidm:alias>
@@ -961,9 +961,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="123.82859700713152" angle="6.5680321325035518" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="123.88064444806245" angle="-5.7354022689304625" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0453d4e2-c766-11e1-8775-005056c00008" name="Adams LD" loadType="UNDEFINED" p0="18" q0="3" node="8" p="17.983189646010768" q="2.9953319110180834">
+            <iidm:load id="_0453d4e2-c766-11e1-8775-005056c00008" name="Adams LD" loadType="UNDEFINED" p0="18" q0="3" node="8" p="17.983765121806091" q="2.9954916675680074">
                 <iidm:alias>_0448ff77-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1053,16 +1053,16 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="133.32013365980657" angle="14.976597828429767" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="133.32000838076164" angle="2.4767371492517363" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_046bf0c4-c766-11e1-8775-005056c00008" name="Claytor SM" energySource="THERMAL" minP="0" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="40" targetV="133.31999200000001" targetQ="0" node="15" p="-44.93388340406284" q="-82.742133760890468">
+            <iidm:generator id="_046bf0c4-c766-11e1-8775-005056c00008" name="Claytor SM" energySource="THERMAL" minP="0" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="40" targetV="133.31999200000001" targetQ="0" node="15" p="-44.92587640981295" q="-82.746235654162831">
                 <iidm:alias>_0460a627-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e56da2eb-bb6a-4133-953c-40073c5bc5f4"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_d41be6b4-155e-4c8f-b46b-16b50c49f0f4"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-60" maxQ="170"/>
             </iidm:generator>
-            <iidm:load id="_048433b6-c766-11e1-8775-005056c00008" name="Claytor LD" loadType="UNDEFINED" p0="23" q0="16" node="14" p="23.000036658152702" q="16.000042502228613">
+            <iidm:load id="_048433b6-c766-11e1-8775-005056c00008" name="Claytor LD" loadType="UNDEFINED" p0="23" q0="16" node="14" p="23.000004238946349" q="16.000004914720709">
                 <iidm:alias>_0480ff6b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1133,12 +1133,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="129.73614489064039" angle="-5.1091072896522318" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="129.73036015085023" angle="-17.54977356033012" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0449e9d7-c766-11e1-8775-005056c00008" name="N.Newark LD" loadType="UNDEFINED" p0="53" q0="22" node="11" p="52.996607222626437" q="21.997652845613246">
+            <iidm:load id="_0449e9d7-c766-11e1-8775-005056c00008" name="N.Newark LD" loadType="UNDEFINED" p0="53" q0="22" node="11" p="52.996531085914867" q="21.997600174689723">
                 <iidm:alias>_04531191-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_04684741-c766-11e1-8775-005056c00008" name="N.Newark SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.32300000000001" targetDeadband="1" node="12" q="-9.6612622250829219">
+            <iidm:shunt id="_04684741-c766-11e1-8775-005056c00008" name="N.Newark SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.32300000000001" targetDeadband="1" node="12" q="-9.6604006819549877">
                 <iidm:alias>_04607f19-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_eae61817-d3cb-488f-a1f3-13bc8e31431b"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -1191,9 +1191,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.82708497489793" angle="11.764492478267226" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.92076052459137" angle="-0.89199749687617125" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0448d86a-c766-11e1-8775-005056c00008" name="Hillsbro NegG LD" loadType="UNDEFINED" p0="12" q0="0" node="8" p="11.99544539214142" q="0">
+            <iidm:load id="_0448d86a-c766-11e1-8775-005056c00008" name="Hillsbro NegG LD" loadType="UNDEFINED" p0="12" q0="0" node="8" p="11.995730189701302" q="0">
                 <iidm:alias>_044ef2e8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1244,9 +1244,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="125.08638026089025" angle="-6.2206981249171056" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="125.03591143894121" angle="-18.600034829057364" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047dcb12-c766-11e1-8775-005056c00008" name="S.Kenton LD" loadType="UNDEFINED" p0="18" q0="7" node="8" p="17.982461344678384" q="6.9886360455292094">
+            <iidm:load id="_047dcb12-c766-11e1-8775-005056c00008" name="S.Kenton LD" loadType="UNDEFINED" p0="18" q0="7" node="8" p="17.982283962836892" q="6.9885211508890528">
                 <iidm:alias>_0451b205-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1281,6 +1281,9 @@
                     <iidm:alias>_8ef85f09-3622-4a12-87bf-fefcecc01e4a</iidm:alias>
                     <iidm:alias>_a0244ab3-80e5-4c20-b201-a142d50e6ec1</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_dffdb415-95a8-496a-ad1a-93cdeb444fae-1" name="DISCONNECTOR723-1" kind="DISCONNECTOR" retained="false" open="false" node1="24" node2="25"/>
+                <iidm:switch id="_aa063f2e-1205-4d1a-a549-3ccc5b31e65d-1" name="BREAKER362-1" kind="BREAKER" retained="false" open="false" node1="23" node2="24"/>
+                <iidm:switch id="_28b3e895-483c-478d-a5a3-7b9d7c9e11f3-1" name="DISCONNECTOR724-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="23"/>
                 <iidm:internalConnection node1="7" node2="0"/>
                 <iidm:internalConnection node1="8" node2="0"/>
                 <iidm:internalConnection node1="9" node2="1"/>
@@ -1297,9 +1300,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="125.1463224738247" angle="22.119687804119117" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.11675305277313" angle="9.7225234891900527" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044afb49-c766-11e1-8775-005056c00008" name="Hazard LD" loadType="UNDEFINED" p0="21" q0="10" node="8" p="20.994099065337291" q="9.9953171571978654">
+            <iidm:load id="_044afb49-c766-11e1-8775-005056c00008" name="Hazard LD" loadType="UNDEFINED" p0="21" q0="10" node="8" p="20.993685702018652" q="9.9949891546846352">
                 <iidm:alias>_045e5c31-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1320,6 +1323,9 @@
                     <iidm:alias>_2a61ce12-8d9c-4aae-8bc7-c8f820ecae6c</iidm:alias>
                     <iidm:alias>_a3d5e8cc-be34-4d4a-a586-ce582737826b</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_83a05cd7-017e-4e7a-bc5e-a01ee9681f9f-1" name="DISCONNECTOR725-1" kind="DISCONNECTOR" retained="false" open="false" node1="14" node2="15"/>
+                <iidm:switch id="_cf4393c0-21c2-4e35-b330-c1acda2647ba-1" name="BREAKER363-1" kind="BREAKER" retained="false" open="true" node1="13" node2="14"/>
+                <iidm:switch id="_b9ab29b9-3d90-4536-8d1a-7757d8c22ae4-1" name="DISCONNECTOR726-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="13"/>
                 <iidm:internalConnection node1="4" node2="0"/>
                 <iidm:internalConnection node1="5" node2="0"/>
                 <iidm:internalConnection node1="6" node2="1"/>
@@ -1329,14 +1335,14 @@
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="3"/>
-                <iidm:bus v="31.286580618456178" angle="22.119687804119113" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="31.029188263193287" angle="9.7225234891900527" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13"/>
             </iidm:nodeBreakerTopology>
             <iidm:staticVarCompensator id="_047fc6e6-c766-11e1-8775-005056c00008" name="Pinevlle SVC" bMin="-10" bMax="10" voltageSetpoint="33.494999999999997" regulationMode="VOLTAGE" node="5" p="0" q="0">
                 <iidm:alias>_046ab846-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_98f667da-02d1-4a31-b826-44314a1fbbfe"/>
             </iidm:staticVarCompensator>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045e3525-c766-11e1-8775-005056c00008" name="86-87" r="0.30796918750000002" x="2.2585859312499998" g="0" b="-0.0040863184000000004" ratedU1="132" ratedU2="33" node1="22" voltageLevelId1="_0484f70a-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_04555b88-c766-11e1-8775-005056c00008" p1="-2.8969882048812678e-14" q1="3.9998932839653571" p2="2.4456412044883519e-14" q2="-4.2620356328813162e-15">
+        <iidm:twoWindingsTransformer id="_045e3525-c766-11e1-8775-005056c00008" name="86-87" r="0.30796918750000002" x="2.2585859312499998" g="0" b="-0.0040863184000000004" ratedU1="132" ratedU2="33" node1="22" voltageLevelId1="_0484f70a-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_04555b88-c766-11e1-8775-005056c00008" p1="-9.7144514654701197e-15" q1="3.9343503610490784" p2="2.7630251235949682e-14" q2="-3.7631130630172811e-14">
             <iidm:alias>_0452755a-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04682034-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_048c7110-c766-11e1-8775-005056c00008</iidm:alias>
@@ -1412,6 +1418,82 @@
                 <iidm:temporaryLimit name="_257d56c1-d70a-4a96-b85c-d928ade03ad4" acceptableDuration="60" value="12246"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
+        <iidm:twoWindingsTransformer id="_045e3525-c766-11e1-8775-005056c00008-1" name="86-87-open-ended" r="0.30796918750000002" x="2.2585859312499998" g="0" b="-0.0040863184000000004" ratedU1="132" ratedU2="33" node1="25" voltageLevelId1="_0484f70a-c766-11e1-8775-005056c00008" node2="15" voltageLevelId2="_04555b88-c766-11e1-8775-005056c00008" p1="0" q1="3.9343503610491473" p2="0" q2="0">
+            <iidm:alias>_0452755a-c766-11e1-8775-005056c00008-1</iidm:alias>
+            <iidm:alias>_04682034-c766-11e1-8775-005056c00008-1</iidm:alias>
+            <iidm:alias>_048c7110-c766-11e1-8775-005056c00008-1</iidm:alias>
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="31" loadTapChangingCapabilities="false">
+                <iidm:step r="-78.460970487743992" x="-78.460970487743992" g="364.27347129590328" b="364.27347129590328" rho="0.4641016"/>
+                <iidm:step r="-76.770985444658564" x="-76.770985444658564" g="330.49609255595948" b="330.49609255595948" rho="0.48196488000000004"/>
+                <iidm:step r="-75.017181047101431" x="-75.017181047101431" g="300.27508580410921" b="300.27508580410921" rho="0.49982816000000002"/>
+                <iidm:step r="-73.199557295072623" x="-73.199557295072623" g="273.1281647135425" b="273.1281647135425" rho="0.51769144000000011"/>
+                <iidm:step r="-71.318114188572153" x="-71.318114188572153" g="248.65210975826625" b="248.65210975826625" rho="0.53555472000000004"/>
+                <iidm:step r="-69.372851727600008" x="-69.372851727600008" g="226.50770848984379" b="226.50770848984379" rho="0.55341799999999997"/>
+                <iidm:step r="-67.363769912156158" x="-67.363769912156158" g="206.40793906293555" b="206.40793906293555" rho="0.57128128"/>
+                <iidm:step r="-65.290868742240633" x="-65.290868742240633" g="188.10862264852744" b="188.10862264852744" rho="0.58914456000000004"/>
+                <iidm:step r="-63.154148217853432" x="-63.154148217853432" g="171.40097232995538" b="171.40097232995538" rho="0.60700784000000008"/>
+                <iidm:step r="-60.953608338994556" x="-60.953608338994556" g="156.10561116167679" b="156.10561116167679" rho="0.62487112"/>
+                <iidm:step r="-58.689249105663997" x="-58.689249105663997" g="142.06773741726079" b="142.06773741726079" rho="0.64273440000000004"/>
+                <iidm:step r="-56.361070517861769" x="-56.361070517861769" g="129.15319231405709" b="129.15319231405709" rho="0.66059767999999996"/>
+                <iidm:step r="-53.969072575587838" x="-53.969072575587838" g="117.24524269951107" b="117.24524269951107" rho="0.67846096"/>
+                <iidm:step r="-51.51325527884223" x="-51.51325527884223" g="106.24193390397649" b="106.24193390397649" rho="0.69632424000000004"/>
+                <iidm:step r="-48.993618627624947" x="-48.993618627624947" g="96.053900138385018" b="96.053900138385018" rho="0.71418752000000008"/>
+                <iidm:step r="-46.410162621936003" x="-46.410162621936003" g="86.602544237115268" b="86.602544237115268" rho="0.7320508"/>
+                <iidm:step r="-43.762887261775354" x="-43.762887261775354" g="77.81851722275475" b="77.81851722275475" rho="0.74991407999999993"/>
+                <iidm:step r="-41.051792547143037" x="-41.051792547143037" g="69.640442552852292" b="69.640442552852292" rho="0.76777735999999996"/>
+                <iidm:step r="-38.276878478039045" x="-38.276878478039045" g="62.013841060226049" b="62.013841060226049" rho="0.78564064"/>
+                <iidm:step r="-35.438145054463355" x="-35.438145054463355" g="54.890221299184191" b="54.890221299184191" rho="0.80350392000000004"/>
+                <iidm:step r="-32.53559227641599" x="-32.53559227641599" g="48.2263068397802" b="48.2263068397802" rho="0.82136720000000008"/>
+                <iidm:step r="-29.569220143896956" x="-29.569220143896956" g="41.983377444222199" b="41.983377444222199" rho="0.83923048"/>
+                <iidm:step r="-26.53902865690624" x="-26.53902865690624" g="36.126705339843348" b="36.126705339843348" rho="0.85709376000000004"/>
+                <iidm:step r="-23.445017815443848" x="-23.445017815443848" g="30.625071218648301" b="30.625071218648301" rho="0.87495704000000007"/>
+                <iidm:step r="-20.287187619509762" x="-20.287187619509762" g="25.450347332714429" b="25.450347332714429" rho="0.89282032000000011"/>
+                <iidm:step r="-17.06553806910399" x="-17.06553806910399" g="20.577137262099331" b="20.577137262099331" rho="0.91068360000000004"/>
+                <iidm:step r="-13.780069164226571" x="-13.780069164226571" g="15.982463718828566" b="15.982463718828566" rho="0.92854687999999996"/>
+                <iidm:step r="-10.430780904877434" x="-10.430780904877434" g="11.645497203453271" b="11.645497203453271" rho="0.94641016"/>
+                <iidm:step r="-7.0176732910566368" x="-7.0176732910566368" g="7.5473195169912355" b="7.5473195169912355" rho="0.96427344000000004"/>
+                <iidm:step r="-3.5407463227641656" x="-3.5407463227641656" g="3.6707171036300279" b="3.6707171036300279" rho="0.98213671999999985"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1"/>
+                <iidm:step r="3.6045656772358381" x="3.6045656772358381" g="-3.4791571719583358" b="-3.4791571719583358" rho="1.01786328"/>
+                <iidm:step r="7.272950708943382" x="7.272950708943382" g="-6.7798551833225922" b="-6.7798551833225922" rho="1.0357265600000001"/>
+                <iidm:step r="11.005155095122543" x="11.005155095122543" g="-9.9140937064517427" b="-9.9140937064517427" rho="1.0535898399999999"/>
+                <iidm:step r="14.801178835773431" x="14.801178835773431" g="-12.892880531259154" b="-12.892880531259154" rho="1.0714531199999999"/>
+                <iidm:step r="18.661021930895984" x="18.661021930895984" g="-15.726328348801433" b="-15.726328348801433" rho="1.0893164"/>
+                <iidm:step r="22.584684380490238" x="22.584684380490238" g="-18.423740693731116" b="-18.423740693731116" rho="1.10717968"/>
+                <iidm:step r="26.572166184556178" x="26.572166184556178" g="-20.993688411566747" b="-20.993688411566747" rho="1.12504296"/>
+                <iidm:step r="30.623467343093779" x="30.623467343093779" g="-23.444077826121855" b="-23.444077826121855" rho="1.1429062400000001"/>
+                <iidm:step r="34.738587856103067" x="34.738587856103067" g="-25.782211620922489" b="-25.782211620922489" rho="1.1607695200000001"/>
+                <iidm:step r="38.917527723583987" x="38.917527723583987" g="-28.014843311220961" b="-28.014843311220961" rho="1.1786327999999999"/>
+                <iidm:step r="43.16028694553664" x="43.16028694553664" g="-30.148226066322692" b="-30.148226066322692" rho="1.19649608"/>
+                <iidm:step r="47.466865521960955" x="47.466865521960955" g="-32.188156542116317" b="-32.188156542116317" rho="1.21435936"/>
+                <iidm:step r="51.837263452856973" x="51.837263452856973" g="-34.140014298236885" b="-34.140014298236885" rho="1.23222264"/>
+                <iidm:step r="56.271480738224653" x="56.271480738224653" g="-36.0087973009527" b="-36.0087973009527" rho="1.2500859200000001"/>
+                <iidm:step r="60.769517378063973" x="60.769517378063973" g="-37.799153949786998" b="-37.799153949786998" rho="1.2679491999999999"/>
+                <iidm:step r="65.331373372375026" x="65.331373372375026" g="-39.515412011505823" b="-39.515412011505823" rho="1.2858124799999999"/>
+                <iidm:step r="69.957048721157761" x="69.957048721157761" g="-41.161604798123854" b="-41.161604798123854" rho="1.30367576"/>
+                <iidm:step r="74.646543424412172" x="74.646543424412172" g="-42.741494884907091" b="-42.741494884907091" rho="1.32153904"/>
+                <iidm:step r="79.399857482138245" x="79.399857482138245" g="-44.258595629064871" b="-44.258595629064871" rho="1.33940232"/>
+                <iidm:step r="84.216990894335964" x="84.216990894335964" g="-45.716190719151165" b="-45.716190719151165" rho="1.3572655999999998"/>
+                <iidm:step r="89.097943661005473" x="89.097943661005473" g="-47.11735195848069" b="-47.11735195848069" rho="1.3751288800000001"/>
+                <iidm:step r="94.04271578214653" x="94.04271578214653" g="-48.464955462553469" b="-48.464955462553469" rho="1.3929921599999999"/>
+                <iidm:step r="99.051307257759348" x="99.051307257759348" g="-49.761696430103783" b="-49.761696430103783" rho="1.41085544"/>
+                <iidm:step r="104.12371808784383" x="104.12371808784383" g="-51.010102629540867" b="-51.010102629540867" rho="1.42871872"/>
+                <iidm:step r="109.25994827240002" x="109.25994827240002" g="-52.212546726893493" b="-52.212546726893493" rho="1.446582"/>
+                <iidm:step r="114.45999781142788" x="114.45999781142788" g="-53.371257567609966" b="-53.371257567609966" rho="1.4644452800000001"/>
+                <iidm:step r="119.72386670492732" x="119.72386670492732" g="-54.488330512455207" b="-54.488330512455207" rho="1.4823085599999999"/>
+                <iidm:step r="125.05155495289854" x="125.05155495289854" g="-55.565736917068101" b="-55.565736917068101" rho="1.5001718399999999"/>
+                <iidm:step r="130.44306255534144" x="130.44306255534144" g="-56.605332835313817" b="-56.605332835313817" rho="1.51803512"/>
+                <iidm:step r="135.89838951225599" x="135.89838951225599" g="-57.608867018227542" b="-57.608867018227542" rho="1.5358984"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="2186">
+                <iidm:temporaryLimit name="_580d3b53-5508-4d8d-97cc-4ea463e0cdb9-1" acceptableDuration="900" value="2514"/>
+                <iidm:temporaryLimit name="_a867e68a-58d1-49cb-955f-bb8e59cf2a11-1" acceptableDuration="60" value="3061"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="8747">
+                <iidm:temporaryLimit name="_1a7f23f9-e2c0-46a6-a93c-687f2209e33d-1" acceptableDuration="900" value="10059"/>
+                <iidm:temporaryLimit name="_257d56c1-d70a-4a96-b85c-d928ade03ad4-1" acceptableDuration="60" value="12246"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
     </iidm:substation>
     <iidm:substation id="_045beb3a-c766-11e1-8775-005056c00008" name="Minas Tirith" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
         <iidm:voltageLevel id="_048a9c58-c766-11e1-8775-005056c00008" name="MNT132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -1460,12 +1542,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="132.66523968887759" angle="13.55402582686728" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="132.78650943650371" angle="0.27628726456767011" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0447ee05-c766-11e1-8775-005056c00008" name="NwCarlsl NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="8" p="8.9978779327459151" q="0">
+            <iidm:load id="_0447ee05-c766-11e1-8775-005056c00008" name="NwCarlsl NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="8" p="8.997949982318918" q="0">
                 <iidm:alias>_04731cb7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_047a48a8-c766-11e1-8775-005056c00008" name="NwCarlsl LD" loadType="UNDEFINED" p0="30" q0="12" node="9" p="29.992926442486382" q="11.995284665631861">
+            <iidm:load id="_047a48a8-c766-11e1-8775-005056c00008" name="NwCarlsl LD" loadType="UNDEFINED" p0="30" q0="12" node="9" p="29.993166607729727" q="11.995444751052645">
                 <iidm:alias>_044c0cb9-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1516,9 +1598,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.62408894856145" angle="10.266520918753304" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.62394201530159" angle="-2.2334974124725466" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044ecbd1-c766-11e1-8775-005056c00008" name="Blaine LD" loadType="UNDEFINED" p0="2" q0="1" node="8" p="2.0000163708137659" q="1.0000136423820276">
+            <iidm:load id="_044ecbd1-c766-11e1-8775-005056c00008" name="Blaine LD" loadType="UNDEFINED" p0="2" q0="1" node="8" p="2.000013498166755" q="1.0000112484976016">
                 <iidm:alias>_04700f74-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1569,9 +1651,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="133.14723153205568" angle="15.922877382709368" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="133.12237879886962" angle="3.4243665726955932" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046b7b95-c766-11e1-8775-005056c00008" name="Sundial LD" loadType="UNDEFINED" p0="15" q0="9" node="8" p="14.998224428677757" q="8.9982244987376454">
+            <iidm:load id="_046b7b95-c766-11e1-8775-005056c00008" name="Sundial LD" loadType="UNDEFINED" p0="15" q0="9" node="8" p="14.998204175581668" q="8.9982042472489621">
                 <iidm:alias>_046efe07-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1622,9 +1704,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.67067061650999" angle="8.7131083331945884" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.72012036785607" angle="-4.3941758779251945" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045645e2-c766-11e1-8775-005056c00008" name="Riversde LD" loadType="UNDEFINED" p0="51" q0="27" node="8" p="50.994928216105748" q="26.995525044910355">
+            <iidm:load id="_045645e2-c766-11e1-8775-005056c00008" name="Riversde LD" loadType="UNDEFINED" p0="51" q0="27" node="8" p="50.9951086925849" q="26.995684278492693">
                 <iidm:alias>_0476ed4b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1675,9 +1757,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.62099870575845" angle="11.292900908188049" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.77185274894404" angle="-1.2783430157412383" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04887973-c766-11e1-8775-005056c00008" name="Randolph LD" loadType="UNDEFINED" p0="10" q0="5" node="8" p="9.9928620024051327" q="4.9940530840890434">
+            <iidm:load id="_04887973-c766-11e1-8775-005056c00008" name="Randolph LD" loadType="UNDEFINED" p0="10" q0="5" node="8" p="9.9932155881675975" q="4.9943476021317306">
                 <iidm:alias>_0462f018-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1728,9 +1810,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="125.43672908594141" angle="-8.8492486873135885" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="125.43642895100604" angle="-21.308745570936896" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0477627b-c766-11e1-8775-005056c00008" name="WNwPhil2 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="11.960954758751512" q="2.9837488008990847">
+            <iidm:load id="_0477627b-c766-11e1-8775-005056c00008" name="WNwPhil2 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="11.960975167620052" q="2.983757286143073">
                 <iidm:alias>_045841b6-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1800,9 +1882,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="126.73284975905013" angle="10.977904996509016" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="126.7327041072712" angle="-1.5218785995228774" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0476781a-c766-11e1-8775-005056c00008" name="Cloverdl LD" loadType="UNDEFINED" p0="43" q0="16" node="11" p="43.000365619738169" q="16.000226741565537">
+            <iidm:load id="_0476781a-c766-11e1-8775-005056c00008" name="Cloverdl LD" loadType="UNDEFINED" p0="43" q0="16" node="11" p="43.000305309769438" q="16.000189339840013">
                 <iidm:alias>_0481749a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1872,9 +1954,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="128.11825264755186" angle="12.348543382599798" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="128.11811735581838" angle="-0.15125722399105027" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046b0665-c766-11e1-8775-005056c00008" name="Hancock LD" loadType="UNDEFINED" p0="38" q0="25" node="11" p="38.000208233509433" q="25.000228326633554">
+            <iidm:load id="_046b0665-c766-11e1-8775-005056c00008" name="Hancock LD" loadType="UNDEFINED" p0="38" q0="25" node="11" p="38.000154924399723" q="25.000169873476164">
                 <iidm:alias>_0464c4d5-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1926,12 +2008,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="128.60386809484552" angle="-6.0901611750059006" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="128.5863002974377" angle="-18.51486520097982" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044bbe92-c766-11e1-8775-005056c00008" name="WMVernon LD" loadType="UNDEFINED" p0="16" q0="8" node="8" p="15.99533217365286" q="7.9961105229973333">
+            <iidm:load id="_044bbe92-c766-11e1-8775-005056c00008" name="WMVernon LD" loadType="UNDEFINED" p0="16" q0="8" node="8" p="15.995262854483009" q="7.9960527683414977">
                 <iidm:alias>_04500452-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_047825c8-c766-11e1-8775-005056c00008" name="WMVernon SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.21199999999999" targetDeadband="1" node="9" q="-9.4933601062609902">
+            <iidm:shunt id="_047825c8-c766-11e1-8775-005056c00008" name="WMVernon SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.21199999999999" targetDeadband="1" node="9" q="-9.4907666222809475">
                 <iidm:alias>_047084aa-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_2a6c1dcd-201b-4911-83b2-c16acc50a0f4"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -1965,9 +2047,9 @@
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="3"/>
-                <iidm:bus v="231.00024830877891" angle="36.480608195136078" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="231.00001921910166" angle="22.888361924769416" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_045868c0-c766-11e1-8775-005056c00008" name="Breed SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="450" targetV="230.99998500000001" targetQ="0" node="5" p="-505.50618829570692" q="20.143422364614562">
+            <iidm:generator id="_045868c0-c766-11e1-8775-005056c00008" name="Breed SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="450" targetV="230.99998500000001" targetQ="0" node="5" p="-505.41610961039567" q="23.850560719145044">
                 <iidm:alias>_045b7606-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_f26d4eb3-ebdb-4025-8080-f856ce656b42"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_7566f2a7-61eb-42fe-a59a-8276257fdbc6"/>
@@ -2041,9 +2123,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="126.59919081321758" angle="-7.4790231665465292" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="126.59883478005656" angle="-19.93790411259209" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044d1e22-c766-11e1-8775-005056c00008" name="Newcmrst LD" loadType="UNDEFINED" p0="17" q0="8" node="11" p="16.954096460096192" q="7.9640296383335727">
+            <iidm:load id="_044d1e22-c766-11e1-8775-005056c00008" name="Newcmrst LD" loadType="UNDEFINED" p0="17" q0="8" node="11" p="16.954124487751155" q="7.9640515812308061">
                 <iidm:alias>_048a754b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2113,9 +2195,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="138.60009391518719" angle="25.77132003914711" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="138.59999588143162" angle="12.628959095472402" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_045ab2b0-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="220" targetV="138.59999099999999" targetQ="0" node="11" p="-247.13635872234562" q="-50.045074695774694">
+            <iidm:generator id="_045ab2b0-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="220" targetV="138.59999099999999" targetQ="0" node="11" p="-247.09232025397125" q="-47.199744487163805">
                 <iidm:alias>_046ba2a5-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_56975783-9739-40fc-8ec1-e1de8cb06c9a"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b8449cd9-5a17-497e-bf04-70f728b0f9f2"/>
@@ -2168,9 +2250,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="223.30018037713171" angle="28.238997238303693" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="223.3000107501764" angle="14.834475255862095" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0483224a-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="314" targetV="223.30000000000001" targetQ="0" node="8" p="-352.73098472189332" q="-24.974418729285087">
+            <iidm:generator id="_0483224a-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="314" targetV="223.30000000000001" targetQ="0" node="8" p="-352.66812981703168" q="-20.372645750171458">
                 <iidm:alias>_045cd594-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_05df66ba-3f64-40cb-8b18-c66d26c4e2c1"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_c1d29442-5f57-41d1-bb60-4b74b4994c20"/>
@@ -2178,7 +2260,7 @@
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045b7604-c766-11e1-8775-005056c00008" name="26-25" r="0" x="6.6559680000000006" g="0" b="0" ratedU1="220" ratedU2="132" node1="22" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="125.127521314002" q1="22.877176849246101" p2="-125.12752131400194" q2="-17.348024337134966">
+        <iidm:twoWindingsTransformer id="_045b7604-c766-11e1-8775-005056c00008" name="26-25" r="0" x="6.6559680000000006" g="0" b="0" ratedU1="220" ratedU2="132" node1="22" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="111.84101925048529" q1="22.334856185886718" p2="-111.84101925048525" q2="-17.889981867666304">
             <iidm:alias>_0447c6f3-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0463b364-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04803c1c-c766-11e1-8775-005056c00008</iidm:alias>
@@ -2321,9 +2403,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="136.62002184632331" angle="14.884480256512051" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="136.62001043689571" angle="2.3867448520942371" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_048aea70-c766-11e1-8775-005056c00008" name="Sporn SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="513.43743900000004" targetV="136.62" targetQ="-62.132553100000003" node="20" p="-576.76845048266568" q="47.176086808456944">
+            <iidm:generator id="_048aea70-c766-11e1-8775-005056c00008" name="Sporn SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="513.43743900000004" targetV="136.62" targetQ="-62.132553100000003" node="20" p="-576.66567321712193" q="47.464310569270218">
                 <iidm:alias>_04555b84-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_27799004-aa1e-4889-ba95-ee6fdae64895"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_827a9c80-183d-4e33-9e73-ef0aab3dfb13"/>
@@ -2413,9 +2495,9 @@
                 <iidm:internalConnection node1="39" node2="9"/>
                 <iidm:internalConnection node1="40" node2="12"/>
                 <iidm:internalConnection node1="41" node2="3"/>
-                <iidm:bus v="219.68632352805005" angle="10.942958276943603" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41"/>
+                <iidm:bus v="219.68738797366487" angle="-1.5366067803709351" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41"/>
             </iidm:nodeBreakerTopology>
-            <iidm:danglingLine id="_0482fb33-c766-11e1-8775-005056c00008" name="68-116" p0="184" q0="0" r="0.16456000000000001" x="1.9601999999999999" g="0" b="0.00033884300000000002" ucteXnodeCode="XWE_BR21" node="41" p="184.11562277193514" q="-14.976375140975652">
+            <iidm:danglingLine id="_0482fb33-c766-11e1-8775-005056c00008" name="68-116" p0="184" q0="0" r="0.16456000000000001" x="1.9601999999999999" g="0" b="0.00033884300000000002" ucteXnodeCode="XWE_BR21" node="41" p="184.11564366029788" q="-14.976548874570703">
                 <iidm:alias>_0459c855-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_04684742-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_5631ccc0-d9d2-11e2-bb49-005056c00008</iidm:alias>
@@ -2428,7 +2510,7 @@
                 </iidm:currentLimits>
             </iidm:danglingLine>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_044f6815-c766-11e1-8775-005056c00008" name="68-69" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-205.35540932274094" q1="102.30135749871042" p2="205.35540932274085" q2="-85.226757350426283">
+        <iidm:twoWindingsTransformer id="_044f6815-c766-11e1-8775-005056c00008" name="68-69" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-204.41118137824895" q1="102.25206362424066" p2="204.41118137824884" q2="-85.306408371831395">
             <iidm:alias>_047e8e67-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04840ca7-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0487dd39-c766-11e1-8775-005056c00008</iidm:alias>
@@ -2535,9 +2617,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="131.59931408756208" angle="2.2055443334027967" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="131.59941245532556" angle="-10.258377484057227" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04547126-c766-11e1-8775-005056c00008" name="Natrium LD" loadType="UNDEFINED" p0="77" q0="14" node="14" p="76.998478596207491" q="13.999538971584164">
+            <iidm:load id="_04547126-c766-11e1-8775-005056c00008" name="Natrium LD" loadType="UNDEFINED" p0="77" q0="14" node="14" p="76.998557141259809" q="13.999562772809737">
                 <iidm:alias>_047b3307-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2588,9 +2670,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="123.48299725812052" angle="-4.9775618137376032" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="123.41331590442222" angle="-17.325324524645531" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045d4ac9-c766-11e1-8775-005056c00008" name="Sterling LD" loadType="UNDEFINED" p0="31" q0="17" node="8" p="30.957015391588392" q="16.960731153569387">
+            <iidm:load id="_045d4ac9-c766-11e1-8775-005056c00008" name="Sterling LD" loadType="UNDEFINED" p0="31" q0="17" node="8" p="30.956674526948792" q="16.960419899818568">
                 <iidm:alias>_0477b094-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2698,9 +2780,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="130.23585029009604" angle="18.736840129974606" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="130.21321975651892" angle="6.2397046426349991" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0466246a-c766-11e1-8775-005056c00008" name="Switchbk LD" loadType="UNDEFINED" p0="30" q0="16" node="17" p="29.994386479270862" q="15.995010515028621">
+            <iidm:load id="_0466246a-c766-11e1-8775-005056c00008" name="Switchbk LD" loadType="UNDEFINED" p0="30" q0="16" node="17" p="29.994331118144004" q="15.994961311307227">
                 <iidm:alias>_04882b59-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2751,9 +2833,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="135.07716971505684" angle="15.777746467162524" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="135.07711995321188" angle="3.2790805441024213" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046adf5a-c766-11e1-8775-005056c00008" name="Bradley LD" loadType="UNDEFINED" p0="34" q0="8" node="8" p="33.999083167123381" q="7.9996404609272185">
+            <iidm:load id="_046adf5a-c766-11e1-8775-005056c00008" name="Bradley LD" loadType="UNDEFINED" p0="34" q0="8" node="8" p="33.999053429013586" q="7.9996287991364285">
                 <iidm:alias>_04555b85-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2788,6 +2870,9 @@
                     <iidm:alias>_7f359893-b7c5-41b0-ada8-8df06cf7a8e6</iidm:alias>
                     <iidm:alias>_a4edf081-2fb2-4da4-94db-98a2a596247f</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_312f25f3-55bc-4417-848c-236d31d823f4-1" name="DISCONNECTOR524-1" kind="DISCONNECTOR" retained="false" open="false" node1="24" node2="25"/>
+                <iidm:switch id="_686e884a-a0b1-454e-b7d1-33c7ad46f89f-1" name="BREAKER262-1" kind="BREAKER" retained="false" open="false" node1="23" node2="24"/>
+                <iidm:switch id="_346a5319-3ec2-40a2-aefd-38dfacbbe97c-1" name="DISCONNECTOR523-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="23"/>
                 <iidm:internalConnection node1="7" node2="0"/>
                 <iidm:internalConnection node1="8" node2="0"/>
                 <iidm:internalConnection node1="9" node2="1"/>
@@ -2804,9 +2889,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.85439098272886" angle="10.186228810845478" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.13156800997238" angle="-2.3347519808466544" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047a48a2-c766-11e1-8775-005056c00008" name="Mullin LD" loadType="UNDEFINED" p0="17" q0="7" node="8" p="16.997859962345675" q="6.9985314083356078">
+            <iidm:load id="_047a48a2-c766-11e1-8775-005056c00008" name="Mullin LD" loadType="UNDEFINED" p0="17" q0="7" node="8" p="16.998118707783217" q="6.9987089647322875">
                 <iidm:alias>_0474553a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2972,16 +3057,16 @@
                 <iidm:internalConnection node1="81" node2="18"/>
                 <iidm:internalConnection node1="82" node2="21"/>
                 <iidm:internalConnection node1="83" node2="24"/>
-                <iidm:bus v="134.24412342151908" angle="18.488163018671578" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
+                <iidm:bus v="134.24400210719344" angle="5.9886642139874038" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_044cd00a-c766-11e1-8775-005056c00008" name="Glen Lyn SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="252" targetV="134.243988" targetQ="0" node="27" p="-283.08346544559583" q="-84.454482916643371">
+            <iidm:generator id="_044cd00a-c766-11e1-8775-005056c00008" name="Glen Lyn SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="252" targetV="134.243988" targetQ="0" node="27" p="-283.03302138182158" q="-84.808231324169682">
                 <iidm:alias>_045e5c30-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e54b499b-436c-4b89-9803-b1d75e2fa364"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_32c8ab65-80f7-4c17-b3f5-ff075cce0ba5"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
-            <iidm:load id="_04566cf5-c766-11e1-8775-005056c00008" name="Glen Lyn LD" loadType="UNDEFINED" p0="37" q0="18" node="26" p="37.000055986836472" q="18.000045394755166">
+            <iidm:load id="_04566cf5-c766-11e1-8775-005056c00008" name="Glen Lyn LD" loadType="UNDEFINED" p0="37" q0="18" node="26" p="37.000005832285424" q="18.00000472888032">
                 <iidm:alias>_04577e64-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3032,9 +3117,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.52194989873934" angle="11.173712481409233" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.59654329404719" angle="-1.9771086737264369" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044ea4c0-c766-11e1-8775-005056c00008" name="Kankakee LD" loadType="UNDEFINED" p0="52" q0="22" node="8" p="51.99302710199489" q="21.995083432719255">
+            <iidm:load id="_044ea4c0-c766-11e1-8775-005056c00008" name="Kankakee LD" loadType="UNDEFINED" p0="52" q0="22" node="8" p="51.993293854141065" q="21.995271510687655">
                 <iidm:alias>_047e6758-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3143,12 +3228,12 @@
                 <iidm:internalConnection node1="51" node2="9"/>
                 <iidm:internalConnection node1="52" node2="12"/>
                 <iidm:internalConnection node1="53" node2="15"/>
-                <iidm:bus v="127.42398968165867" angle="11.249889279026199" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
+                <iidm:bus v="127.42385645439246" angle="-1.2499559067304071" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0484cffb-c766-11e1-8775-005056c00008" name="Roanoke LD" loadType="UNDEFINED" p0="31" q0="26" node="17" p="31.000154479231369" q="26.0002159390692">
+            <iidm:load id="_0484cffb-c766-11e1-8775-005056c00008" name="Roanoke LD" loadType="UNDEFINED" p0="31" q0="26" node="17" p="31.000110792992331" q="26.000154872109267">
                 <iidm:alias>_0454983a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0489d903-c766-11e1-8775-005056c00008" name="Roanoke SC" sectionCount="5" voltageRegulatorOn="true" targetV="127.423" targetDeadband="1" node="18" q="-18.639930372057389">
+            <iidm:shunt id="_0489d903-c766-11e1-8775-005056c00008" name="Roanoke SC" sectionCount="5" voltageRegulatorOn="true" targetV="127.423" targetDeadband="1" node="18" q="-18.639891394378637">
                 <iidm:alias>_0476c638-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_5be38d1a-9d01-42d8-b8bb-e9a26cfbcf1a"/>
                 <iidm:shuntLinearModel bPerSection="0.0002296" gPerSection="0" maximumSectionCount="10"/>
@@ -3240,12 +3325,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="120.44650663284354" angle="-10.807344649560132" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="120.4099957139169" angle="-23.222347295707419" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047a219a-c766-11e1-8775-005056c00008" name="Howard LD" loadType="UNDEFINED" p0="37" q0="23" node="14" p="36.971132987741129" q="22.970100513499762">
+            <iidm:load id="_047a219a-c766-11e1-8775-005056c00008" name="Howard LD" loadType="UNDEFINED" p0="37" q0="23" node="14" p="36.970795975115514" q="22.9697515389649">
                 <iidm:alias>_04882b51-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_04488a49-c766-11e1-8775-005056c00008" name="Howard NegG LD" loadType="UNDEFINED" p0="59" q0="0" node="15" p="58.953968818289901" q="0">
+            <iidm:load id="_04488a49-c766-11e1-8775-005056c00008" name="Howard NegG LD" loadType="UNDEFINED" p0="59" q0="0" node="15" p="58.953431419778802" q="0">
                 <iidm:alias>_046d9e74-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3295,7 +3380,7 @@
                 <iidm:internalConnection node1="19" node2="6"/>
                 <iidm:internalConnection node1="20" node2="3"/>
                 <iidm:internalConnection node1="21" node2="6"/>
-                <iidm:bus v="218.76065421931335" angle="12.915037397575029" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
+                <iidm:bus v="218.76133569587898" angle="0.4284182263646733" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_046efe09-c766-11e1-8775-005056c00008" name="CRI132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -3458,20 +3543,20 @@
                 <iidm:internalConnection node1="81" node2="18"/>
                 <iidm:internalConnection node1="82" node2="21"/>
                 <iidm:internalConnection node1="83" node2="24"/>
-                <iidm:bus v="137.28005902306359" angle="16.105451073921898" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
+                <iidm:bus v="137.28000004030994" angle="3.6072759818948632" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_045868c1-c766-11e1-8775-005056c00008" name="CabinCrk SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="477" targetV="137.28" targetQ="0" node="27" p="-535.83655959344924" q="-143.83085812726969">
+            <iidm:generator id="_045868c1-c766-11e1-8775-005056c00008" name="CabinCrk SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="477" targetV="137.28" targetQ="0" node="27" p="-535.7410761870193" q="-144.65441026897574">
                 <iidm:alias>_0487dd36-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_a6ec9760-88da-48df-a23f-7877e7c85ccd"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_e6131af8-c298-413b-84e3-4e21c3b6b06f"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-225" maxQ="640"/>
             </iidm:generator>
-            <iidm:load id="_04747c44-c766-11e1-8775-005056c00008" name="CabinCrk LD" loadType="UNDEFINED" p0="130" q0="26" node="26" p="130.000083839588" q="26.000027946535337">
+            <iidm:load id="_04747c44-c766-11e1-8775-005056c00008" name="CabinCrk LD" loadType="UNDEFINED" p0="130" q0="26" node="26" p="130.00000005725846" q="26.000000019086155">
                 <iidm:alias>_046a9138-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_0488c79b-c766-11e1-8775-005056c00008" name="81-80" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="21" voltageLevelId1="_048a272b-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-166.36678958228364" q1="72.159946691913362" p2="166.36678958228381" q2="-61.402002541126166">
+        <iidm:twoWindingsTransformer id="_0488c79b-c766-11e1-8775-005056c00008" name="81-80" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="21" voltageLevelId1="_048a272b-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-165.7652611435411" q1="72.137482639382455" p2="165.76526114354107" q2="-61.446023533490312">
             <iidm:alias>_044974a0-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_045a3d83-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_046adf57-c766-11e1-8775-005056c00008</iidm:alias>
@@ -3551,12 +3636,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="134.75108211532816" angle="-2.0080363945091446" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="134.75131037415019" angle="-14.464352708343867" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04524e4a-c766-11e1-8775-005056c00008" name="Zanesvll LD" loadType="UNDEFINED" p0="20" q0="11" node="8" p="20.000217258284504" q="11.000199154148591">
+            <iidm:load id="_04524e4a-c766-11e1-8775-005056c00008" name="Zanesvll LD" loadType="UNDEFINED" p0="20" q0="11" node="8" p="20.000245114053673" q="11.000224688800433">
                 <iidm:alias>_045c1240-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_048b5fa9-c766-11e1-8775-005056c00008" name="Zanesvll SC" sectionCount="5" voltageRegulatorOn="true" targetV="134.72300000000001" targetDeadband="1" node="9" q="-15.633912407007905">
+            <iidm:shunt id="_048b5fa9-c766-11e1-8775-005056c00008" name="Zanesvll SC" sectionCount="5" voltageRegulatorOn="true" targetV="134.72300000000001" targetDeadband="1" node="9" q="-15.633965372541029">
                 <iidm:alias>_04736ad5-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_99c6c4ad-5247-4058-96d4-ee8495103e85"/>
                 <iidm:shuntLinearModel bPerSection="0.00017220000000000001" gPerSection="0" maximumSectionCount="10"/>
@@ -3609,9 +3694,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.7105530021349" angle="21.581148116613587" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.69481097078801" angle="9.0865304440157004" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044ca8f2-c766-11e1-8775-005056c00008" name="Tazewell LD" loadType="UNDEFINED" p0="12" q0="7" node="8" p="11.997568699973044" q="6.997636395727926">
+            <iidm:load id="_044ca8f2-c766-11e1-8775-005056c00008" name="Tazewell LD" loadType="UNDEFINED" p0="12" q0="7" node="8" p="11.997546073901592" q="6.9976144011436423">
                 <iidm:alias>_04542305-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3662,9 +3747,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="119.50884278093848" angle="-8.6442953210078688" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="119.44383713392378" angle="-21.016373423606698" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04778989-c766-11e1-8775-005056c00008" name="NwLibrty LD" loadType="UNDEFINED" p0="27" q0="11" node="8" p="26.961805353583724" q="10.974077594656096">
+            <iidm:load id="_04778989-c766-11e1-8775-005056c00008" name="NwLibrty LD" loadType="UNDEFINED" p0="27" q0="11" node="8" p="26.96145951195329" q="10.973842986438379">
                 <iidm:alias>_0483e592-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3697,12 +3782,12 @@
                 <iidm:internalConnection node1="11" node2="2"/>
                 <iidm:internalConnection node1="12" node2="3"/>
                 <iidm:internalConnection node1="13" node2="3"/>
-                <iidm:bus v="122.60703079019027" angle="6.6216659865788943" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13"/>
+                <iidm:bus v="122.60688981430019" angle="-5.8786142935026033" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0463da70-c766-11e1-8775-005056c00008" name="Danville LD" loadType="UNDEFINED" p0="25" q0="13" node="5" p="25.00017519447789" q="13.000151835568849">
+            <iidm:load id="_0463da70-c766-11e1-8775-005056c00008" name="Danville LD" loadType="UNDEFINED" p0="25" q0="13" node="5" p="25.000138311200352" q="13.000119869928032">
                 <iidm:alias>_0488eeab-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_0448b150-c766-11e1-8775-005056c00008" name="Danville NegG LD" loadType="UNDEFINED" p0="43" q0="0" node="6" p="43.00030133450197" q="0">
+            <iidm:load id="_0448b150-c766-11e1-8775-005056c00008" name="Danville NegG LD" loadType="UNDEFINED" p0="43" q0="0" node="6" p="43.000237895264611" q="0">
                 <iidm:alias>_0457cc88-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3753,9 +3838,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.55130104498272" angle="27.503744780034705" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.4143053838728" angle="15.026577364841941" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045cae82-c766-11e1-8775-005056c00008" name="Fremont LD" loadType="UNDEFINED" p0="48" q0="10" node="8" p="47.993153895345067" q="9.9976229933438976">
+            <iidm:load id="_045cae82-c766-11e1-8775-005056c00008" name="Fremont LD" loadType="UNDEFINED" p0="48" q0="10" node="8" p="47.992955309458615" q="9.9975540465627741">
                 <iidm:alias>_045f4693-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3901,9 +3986,9 @@
                 <iidm:internalConnection node1="70" node2="15"/>
                 <iidm:internalConnection node1="71" node2="18"/>
                 <iidm:internalConnection node1="72" node2="21"/>
-                <iidm:bus v="132.33122525511521" angle="13.768947495722804" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
+                <iidm:bus v="132.3125368971148" angle="1.2668503708435628" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0448d863-c766-11e1-8775-005056c00008" name="Turner LD" loadType="UNDEFINED" p0="61" q0="28" node="23" p="60.99604350614657" q="27.996973239542218">
+            <iidm:load id="_0448d863-c766-11e1-8775-005056c00008" name="Turner LD" loadType="UNDEFINED" p0="61" q0="28" node="23" p="60.996025293311675" q="27.996959306829773">
                 <iidm:alias>_046e3ab3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3938,6 +4023,9 @@
                     <iidm:alias>_0b877750-4384-4ec3-bb38-08ee5ccf16d3</iidm:alias>
                     <iidm:alias>_1ed822d3-f3ab-4432-80f0-4c55ae3b4b78</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_3be2355e-0065-43df-a264-57a295042faa-1" name="DISCONNECTOR526-1" kind="DISCONNECTOR" retained="false" open="false" node1="24" node2="25"/>
+                <iidm:switch id="_2463ff2c-7690-4dd6-bf44-039f9f475bb1-1" name="BREAKER263-1" kind="BREAKER" retained="false" open="true" node1="23" node2="24"/>
+                <iidm:switch id="_ddcf7aac-e7c3-45e9-bd81-6146e951addd-1" name="DISCONNECTOR525-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="23"/>
                 <iidm:internalConnection node1="7" node2="0"/>
                 <iidm:internalConnection node1="8" node2="0"/>
                 <iidm:internalConnection node1="9" node2="1"/>
@@ -3954,9 +4042,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.1291974113649" angle="9.0695355065259946" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.19805747548519" angle="-3.3092981081298198" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047d7cf6-c766-11e1-8775-005056c00008" name="Grant LD" loadType="UNDEFINED" p0="24" q0="4" node="8" p="23.999260700033766" q="3.999794641006936">
+            <iidm:load id="_047d7cf6-c766-11e1-8775-005056c00008" name="Grant LD" loadType="UNDEFINED" p0="24" q0="4" node="8" p="23.999340692890659" q="3.9998168608133282">
                 <iidm:alias>_0481e9c0-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4026,9 +4114,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="220.79528077415375" angle="19.626524572716711" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="221.26096830446153" angle="6.0638009542878439" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04867dab-c766-11e1-8775-005056c00008" name="Olive NegG LD" loadType="UNDEFINED" p0="28" q0="0" node="11" p="27.987584544497967" q="0">
+            <iidm:load id="_04867dab-c766-11e1-8775-005056c00008" name="Olive NegG LD" loadType="UNDEFINED" p0="28" q0="0" node="11" p="27.9879796212035" q="0">
                 <iidm:alias>_048433b8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4134,15 +4222,15 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="133.11604993289507" angle="14.050519288508625" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="133.24526976590832" angle="0.74947103892766787" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:shunt id="_0447c6f6-c766-11e1-8775-005056c00008" name="Olive SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.67599999999999" targetDeadband="1" node="17" q="-40.684850793396173">
+            <iidm:shunt id="_0447c6f6-c766-11e1-8775-005056c00008" name="Olive SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.67599999999999" targetDeadband="1" node="17" q="-40.763877196816303">
                 <iidm:alias>_045e8340-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_c701959a-91c1-4a35-9a37-71fb790426ca"/>
                 <iidm:shuntLinearModel bPerSection="0.00045919999999999999" gPerSection="0" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_04575750-c766-11e1-8775-005056c00008" name="8-5" r="0" x="4.6522079999999999" g="0" b="0" ratedU1="220" ratedU2="132" node1="32" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="373.93049621931465" q1="58.063020841385338" p2="-373.93049621931453" q2="-21.235000414935968">
+        <iidm:twoWindingsTransformer id="_04575750-c766-11e1-8775-005056c00008" name="8-5" r="0" x="4.6522079999999999" g="0" b="0" ratedU1="220" ratedU2="132" node1="32" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="357.53247330481037" q1="61.00470765850212" p2="-357.53247330481048" q2="-27.313717568367064">
             <iidm:alias>_045eaa55-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_046b2d74-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04745533-c766-11e1-8775-005056c00008</iidm:alias>
@@ -4213,9 +4301,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.74883828376821" angle="20.529946268796202" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.74523959693491" angle="8.0334696203007052" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047b0bf0-c766-11e1-8775-005056c00008" name="Wythe LD" loadType="UNDEFINED" p0="22" q0="15" node="8" p="21.998065245615958" q="14.997801479923629">
+            <iidm:load id="_047b0bf0-c766-11e1-8775-005056c00008" name="Wythe LD" loadType="UNDEFINED" p0="22" q0="15" node="8" p="21.998029965162058" q="14.997761390870723">
                 <iidm:alias>_0479d376-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4266,9 +4354,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="123.55279336224719" angle="-5.0098852262886435" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="123.48341099643243" angle="-17.358279762999381" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0458ddf5-c766-11e1-8775-005056c00008" name="WestLima LD" loadType="UNDEFINED" p0="33" q0="9" node="8" p="32.95439820680312" q="8.9792814615082239">
+            <iidm:load id="_0458ddf5-c766-11e1-8775-005056c00008" name="WestLima LD" loadType="UNDEFINED" p0="33" q0="9" node="8" p="32.954036527561243" q="8.9791172139415227">
                 <iidm:alias>_04492686-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4376,9 +4464,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="128.38809290392584" angle="23.446893578389062" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="128.05292702339679" angle="10.978696238915585" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044b2257-c766-11e1-8775-005056c00008" name="BeaverCk LD" loadType="UNDEFINED" p0="24" q0="15" node="17" p="23.994601260503028" q="14.994376734712599">
+            <iidm:load id="_044b2257-c766-11e1-8775-005056c00008" name="BeaverCk LD" loadType="UNDEFINED" p0="24" q0="15" node="17" p="23.994413549813849" q="14.994181232578557">
                 <iidm:alias>_045868c4-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4437,6 +4525,9 @@
                     <iidm:alias>_2b636cdd-aa2f-4a65-92fc-12b4fc392e5f</iidm:alias>
                     <iidm:alias>_c96e50b9-ea15-4421-b6c8-bd9c9158a69a</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_e5318967-afcc-4fcc-b0de-d5f2522a95a6-1" name="DISCONNECTOR699-1" kind="DISCONNECTOR" retained="false" open="false" node1="43" node2="44"/>
+                <iidm:switch id="_e9f91b69-a29b-44ea-aa0f-cff86ee80320-1" name="BREAKER350-1" kind="BREAKER" retained="true" open="true" node1="42" node2="43"/>
+                <iidm:switch id="_ad86e83d-6334-4dd8-b642-b4c16d65329a-1" name="DISCONNECTOR700-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="42"/>
                 <iidm:internalConnection node1="13" node2="0"/>
                 <iidm:internalConnection node1="14" node2="1"/>
                 <iidm:internalConnection node1="15" node2="2"/>
@@ -4466,7 +4557,7 @@
                 <iidm:internalConnection node1="39" node2="9"/>
                 <iidm:internalConnection node1="40" node2="12"/>
                 <iidm:internalConnection node1="41" node2="3"/>
-                <iidm:bus v="214.32101496669407" angle="17.052254476796598" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41"/>
+                <iidm:bus v="215.34364639614398" angle="3.0132310137638409" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_047bcf46-c766-11e1-8775-005056c00008" name="STN132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -4546,6 +4637,9 @@
                     <iidm:alias>_4aab41d6-d1b6-4dbe-a6aa-cb7ccd941912</iidm:alias>
                     <iidm:alias>_e9315b98-af75-40bb-bf8e-05bd03d43db5</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_b8b0b9a9-af8b-41d2-a4f8-940637e63f70-1" name="DISCONNECTOR701-1" kind="DISCONNECTOR" retained="false" open="false" node1="64" node2="65"/>
+                <iidm:switch id="_0b78ffaa-9859-4658-af17-c8d355633556-1" name="BREAKER351-1" kind="BREAKER" retained="true" open="false" node1="63" node2="64"/>
+                <iidm:switch id="_9dfeeaef-5c49-4c2c-97b1-03876970bee4-1" name="DISCONNECTOR702-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="63"/>
                 <iidm:internalConnection node1="19" node2="0"/>
                 <iidm:internalConnection node1="20" node2="0"/>
                 <iidm:internalConnection node1="21" node2="1"/>
@@ -4590,9 +4684,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="129.20624387015121" angle="10.219825380370358" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="129.15427141324494" angle="-1.6471212437673368" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045dbff4-c766-11e1-8775-005056c00008" name="Sorenson LD" loadType="UNDEFINED" p0="11" q0="3" node="20" p="10.99320528370002" q="2.996912128559774">
+            <iidm:load id="_045dbff4-c766-11e1-8775-005056c00008" name="Sorenson LD" loadType="UNDEFINED" p0="11" q0="3" node="20" p="10.993639787979706" q="2.9971095517662065">
                 <iidm:alias>_044d4536-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4613,6 +4707,9 @@
                     <iidm:alias>_340082f1-db9c-446d-97df-80e45aa0058b</iidm:alias>
                     <iidm:alias>_90c04b95-703a-4bae-82b8-7edf3075aa24</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_4d08a684-cdcb-484a-a767-03b10f4ada7f-1" name="DISCONNECTOR735-1" kind="DISCONNECTOR" retained="false" open="false" node1="14" node2="15"/>
+                <iidm:switch id="_f468d841-1bf6-470e-85d4-55d34fab8bff-1" name="BREAKER368-1" kind="BREAKER" retained="true" open="false" node1="13" node2="14"/>
+                <iidm:switch id="_f193bd8f-badf-4600-82ac-f212d1f33534-1" name="DISCONNECTOR736-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="13"/>
                 <iidm:internalConnection node1="4" node2="0"/>
                 <iidm:internalConnection node1="5" node2="1"/>
                 <iidm:internalConnection node1="6" node2="2"/>
@@ -4622,13 +4719,13 @@
                 <iidm:internalConnection node1="10" node2="3"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="0"/>
-                <iidm:bus v="383.8454908078977" angle="16.828923459253485" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="388.68952567490555" angle="0" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15"/>
             </iidm:nodeBreakerTopology>
             <iidm:lccConverterStation id="_7393a68e-c4e6-48dd-9347-543858363fdb" name="Conv1" lossFactor="0" powerFactor="0.80000000000000004" node="12" p="10" q="6">
                 <iidm:alias>_739658a7-e08b-4395-8d79-93e87b7855e3</iidm:alias>
             </iidm:lccConverterStation>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_047120e9-c766-11e1-8775-005056c00008" name="30-17" r="0" x="6.7605125399999997" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_047b8123-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="304.55896252952385" q1="112.18452510316929" p2="-304.55896252952385" q2="-72.493741386785445">
+        <iidm:twoWindingsTransformer id="_047120e9-c766-11e1-8775-005056c00008" name="30-17" r="0" x="6.7605125399999997" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_047b8123-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="208.90958588621831" q1="116.71222789770322" p2="-208.90958588621831" q2="-95.340265551413552">
             <iidm:alias>_044f6811-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0463b36a-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_047d2ed8-c766-11e1-8775-005056c00008</iidm:alias>
@@ -4647,7 +4744,7 @@
                 <iidm:temporaryLimit name="_f62f2fc6-4b6c-4571-a8c5-40d6a89ac703" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_b08e9e50-4e0c-4ac0-9f21-4a27429caeb2" name="PowTrans1" r="0.4840000000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_3bbfa58a-a1ad-4b23-a526-3d76b096c1f4" node2="41" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="-10.000008671236857" q1="-6.0000104912239838" p2="10.001448865806841" q2="6.0540177876023265">
+        <iidm:twoWindingsTransformer id="_b08e9e50-4e0c-4ac0-9f21-4a27429caeb2" name="PowTrans1" r="0.4840000000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_3bbfa58a-a1ad-4b23-a526-3d76b096c1f4" node2="41" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="-134.46510626161506" q1="20.754134110224136" p2="134.65628185528493" q2="-13.585049347604036">
             <iidm:alias>_046ba2aa-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_a5bf9702-545a-437d-9663-773550202828</iidm:alias>
             <iidm:alias>_ee9505e1-96d7-49b3-9d1a-924397ffb27e</iidm:alias>
@@ -4667,6 +4764,32 @@
                 <iidm:temporaryLimit name="_611bb05e-9b9a-469c-b1d1-80a944c3ce2f" acceptableDuration="60" value="1400"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
+        <iidm:threeWindingsTransformer id="_86d83c7d-7826-4c16-b161-4ce17174e77f-1" name="T422" r1="-1.5199999809265099" x1="23.199999999999999" g1="0" b1="0" ratedU1="400" r2="2.0000000630528461" x2="19.999999999999996" g2="0" b2="0" ratedU2="220" r3="1.2000000564689806" x3="12" g3="0" b3="0" ratedU3="132" ratedU0="400" node1="15" voltageLevelId1="_3bbfa58a-a1ad-4b23-a526-3d76b096c1f4" node2="44" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" node3="65" voltageLevelId3="_047bcf46-c766-11e1-8775-005056c00008" p1="124.46510672674826" q1="-26.754133831146127" p2="0" q2="0" p3="-124.49943532870789" q3="30.530280938164179">
+            <iidm:alias>_1b2d419c-ac88-4dae-8dfe-2eb92d18c40a-1</iidm:alias>
+            <iidm:alias>_206474da-93c8-46b1-863f-9a308bfc2117-1</iidm:alias>
+            <iidm:alias>_9ac069ea-557b-4b8c-b12e-f9f2aecc3bf5-1</iidm:alias>
+            <iidm:alias>_ae46e10e-1fbe-4139-b493-ed8e2844ee8d-1</iidm:alias>
+            <iidm:ratioTapChanger1 lowTapPosition="1" tapPosition="11" targetDeadband="0" loadTapChangingCapabilities="true" regulating="false" targetV="220">
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.95238095238095233"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.96385542168674687"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.97560975609756106"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.98765432098765438"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0126582278481011"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0256410256410258"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0389610389610389"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0526315789473684"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0666666666666667"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0810810810810809"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.095890410958904"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.1111111111111112"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.1267605633802817"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.1428571428571428"/>
+            </iidm:ratioTapChanger1>
+            <iidm:currentLimits1 permanentLimit="500">
+                <iidm:temporaryLimit name="_3fd18f6e-749a-4fa7-af1b-b0c2d3952638-1" acceptableDuration="1800" value="533"/>
+            </iidm:currentLimits1>
+        </iidm:threeWindingsTransformer>
     </iidm:substation>
     <iidm:substation id="_04642898-c766-11e1-8775-005056c00008" name="Rómenna" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
         <iidm:voltageLevel id="_0457f394-c766-11e1-8775-005056c00008" name="RÓM132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -4905,16 +5028,16 @@
                 <iidm:internalConnection node1="121" node2="30"/>
                 <iidm:internalConnection node1="122" node2="33"/>
                 <iidm:internalConnection node1="123" node2="36"/>
-                <iidm:bus v="135.30001821315705" angle="-1.2236370683602391" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123"/>
+                <iidm:bus v="135.30014746802956" angle="-13.680901625080741" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04859346-c766-11e1-8775-005056c00008" name="Philo SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="204" targetV="135.30000000000001" targetQ="0" node="39" p="-229.16280536072045" q="-195.63979498763845">
+            <iidm:generator id="_04859346-c766-11e1-8775-005056c00008" name="Philo SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="204" targetV="135.30000000000001" targetQ="0" node="39" p="-229.12196969004603" q="-195.65447879474561">
                 <iidm:alias>_048719e2-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e3753d6d-b894-4cce-b6fa-307c50dc107f"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_dff93c01-9c84-4c1f-8529-66c054ed9e37"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
-            <iidm:load id="_045163e2-c766-11e1-8775-005056c00008" name="Philo LD" loadType="UNDEFINED" p0="87" q0="30" node="38" p="87.000017567014581" q="30.000010095986067">
+            <iidm:load id="_045163e2-c766-11e1-8775-005056c00008" name="Philo LD" loadType="UNDEFINED" p0="87" q0="30" node="38" p="87.000142236386552" q="30.000081745094288">
                 <iidm:alias>_04513cd3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4965,9 +5088,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.71531384994692" angle="21.377358008558254" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.4291195048515" angle="8.8981710515181369" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04524e46-c766-11e1-8775-005056c00008" name="BetsyLne LD" loadType="UNDEFINED" p0="11" q0="7" node="8" p="10.996784179156666" q="6.9965896133060941">
+            <iidm:load id="_04524e46-c766-11e1-8775-005056c00008" name="BetsyLne LD" loadType="UNDEFINED" p0="11" q0="7" node="8" p="10.996703315447411" q="6.9965038656923255">
                 <iidm:alias>_04549830-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5020,15 +5143,15 @@
                 <iidm:internalConnection node1="22" node2="6"/>
                 <iidm:internalConnection node1="23" node2="3"/>
                 <iidm:internalConnection node1="24" node2="6"/>
-                <iidm:bus v="124.76090630192363" angle="8.2728198015245731" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24"/>
+                <iidm:bus v="124.76076828873408" angle="-4.2269955212173445" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04566cf3-c766-11e1-8775-005056c00008" name="Reusens NegG LD" loadType="UNDEFINED" p0="22" q0="0" node="8" p="22.00015174748577" q="0">
+            <iidm:load id="_04566cf3-c766-11e1-8775-005056c00008" name="Reusens NegG LD" loadType="UNDEFINED" p0="22" q0="0" node="8" p="22.0001207930124" q="0">
                 <iidm:alias>_0483be81-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_0482fb36-c766-11e1-8775-005056c00008" name="Reusens LD" loadType="UNDEFINED" p0="28" q0="12" node="9" p="28.000193133163716" q="12.000137952576972">
+            <iidm:load id="_0482fb36-c766-11e1-8775-005056c00008" name="Reusens LD" loadType="UNDEFINED" p0="28" q0="12" node="9" p="28.000153736561234" q="12.000109812030429">
                 <iidm:alias>_0486cbc1-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_04558293-c766-11e1-8775-005056c00008" name="Reusens SC" sectionCount="5" voltageRegulatorOn="true" targetV="124.76300000000001" targetDeadband="1" node="10" q="-5.3544576069994152">
+            <iidm:shunt id="_04558293-c766-11e1-8775-005056c00008" name="Reusens SC" sectionCount="5" voltageRegulatorOn="true" targetV="124.76300000000001" targetDeadband="1" node="10" q="-5.3544457605743485">
                 <iidm:alias>_04893ccc-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_99303cd3-6b53-4ee2-a5ce-fe8d5feeb304"/>
                 <iidm:shuntLinearModel bPerSection="6.8800000000000005e-05" gPerSection="0" maximumSectionCount="10"/>
@@ -5101,12 +5224,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="126.41048134333508" angle="25.815889558220373" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="126.40852288259231" angle="13.326609274729673" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045c8777-c766-11e1-8775-005056c00008" name="Holston NegG LD" loadType="UNDEFINED" p0="85" q0="0" node="11" p="84.996214857753245" q="0">
+            <iidm:load id="_045c8777-c766-11e1-8775-005056c00008" name="Holston NegG LD" loadType="UNDEFINED" p0="85" q0="0" node="11" p="84.996060286955782" q="0">
                 <iidm:alias>_0487dd31-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_0451d918-c766-11e1-8775-005056c00008" name="Holston LD" loadType="UNDEFINED" p0="78" q0="42" node="12" p="77.996526575350032" q="41.996882870302713">
+            <iidm:load id="_0451d918-c766-11e1-8775-005056c00008" name="Holston LD" loadType="UNDEFINED" p0="78" q0="42" node="12" p="77.996384733912379" q="41.996755580561015">
                 <iidm:alias>_0485ba54-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5214,9 +5337,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="127.73792142857062" angle="9.537404627295766" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="127.73760130897837" angle="-2.9880068047529309" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04742e27-c766-11e1-8775-005056c00008" name="SthPoint LD" loadType="UNDEFINED" p0="47" q0="11" node="17" p="47.000967627162687" q="11.000377445809727">
+            <iidm:load id="_04742e27-c766-11e1-8775-005056c00008" name="SthPoint LD" loadType="UNDEFINED" p0="47" q0="11" node="17" p="47.001199549224701" q="11.000467913252743">
                 <iidm:alias>_047b3303-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5268,12 +5391,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="132.90849626074638" angle="13.795182037593401" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="132.89593419954696" angle="1.2943564590465682" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04716f06-c766-11e1-8775-005056c00008" name="CapitlHl LD" loadType="UNDEFINED" p0="39" q0="32" node="8" p="38.998288268388613" q="31.997659204692908">
+            <iidm:load id="_04716f06-c766-11e1-8775-005056c00008" name="CapitlHl LD" loadType="UNDEFINED" p0="39" q0="32" node="8" p="38.99827100425879" q="31.997635596320773">
                 <iidm:alias>_04700f70-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0466c0a0-c766-11e1-8775-005056c00008" name="CapitlHl SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.00200000000001" targetDeadband="1" node="9" q="-20.279039298280171">
+            <iidm:shunt id="_0466c0a0-c766-11e1-8775-005056c00008" name="CapitlHl SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.00200000000001" targetDeadband="1" node="9" q="-20.27520606713232">
                 <iidm:alias>_045e8346-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_99931a87-ee15-4fd0-b251-9556df7fe598"/>
                 <iidm:shuntLinearModel bPerSection="0.0002296" gPerSection="0" maximumSectionCount="10"/>
@@ -5326,9 +5449,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="132.04262405882486" angle="13.47274327754465" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="132.02601042320242" angle="0.97096167033554115" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046efe03-c766-11e1-8775-005056c00008" name="Chemical LD" loadType="UNDEFINED" p0="71" q0="26" node="8" p="70.995952486850868" q="25.997529733752589">
+            <iidm:load id="_046efe03-c766-11e1-8775-005056c00008" name="Chemical LD" loadType="UNDEFINED" p0="71" q0="26" node="8" p="70.995927716893362" q="25.997514616514465">
                 <iidm:alias>_045d71d5-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5379,9 +5502,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.49512059036388" angle="10.621162455958766" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.54045359367259" angle="-2.4718839755647299" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046a4319-c766-11e1-8775-005056c00008" name="JacksnRd LD" loadType="UNDEFINED" p0="19" q0="2" node="8" p="18.998429823361608" q="1.9997245380027364">
+            <iidm:load id="_046a4319-c766-11e1-8775-005056c00008" name="JacksnRd LD" loadType="UNDEFINED" p0="19" q0="2" node="8" p="18.998485771385081" q="1.9997343529143068">
                 <iidm:alias>_046c8d06-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5527,9 +5650,9 @@
                 <iidm:internalConnection node1="70" node2="15"/>
                 <iidm:internalConnection node1="71" node2="18"/>
                 <iidm:internalConnection node1="72" node2="21"/>
-                <iidm:bus v="130.56373050741684" angle="25.392039837588911" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
+                <iidm:bus v="130.55681165638785" angle="12.900020873422177" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0458ddf4-c766-11e1-8775-005056c00008" name="Saltvlle LD" loadType="UNDEFINED" p0="65" q0="10" node="23" p="64.991417330743786" q="9.99779941243699">
+            <iidm:load id="_0458ddf4-c766-11e1-8775-005056c00008" name="Saltvlle LD" loadType="UNDEFINED" p0="65" q0="10" node="23" p="64.991297936629451" q="9.9977688012751855">
                 <iidm:alias>_045645e4-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5599,9 +5722,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="131.42703891148727" angle="14.878436261072769" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="131.5695809410511" angle="2.1307406548862602" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0476ed42-c766-11e1-8775-005056c00008" name="Trenton NegG LD" loadType="UNDEFINED" p0="13" q0="0" node="11" p="12.992782186768933" q="0">
+            <iidm:load id="_0476ed42-c766-11e1-8775-005056c00008" name="Trenton NegG LD" loadType="UNDEFINED" p0="13" q0="0" node="11" p="12.993141818439554" q="0">
                 <iidm:alias>_0471e432-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5671,9 +5794,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="128.31138026093876" angle="9.6499317917115395" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="128.37282576944844" angle="-3.487317215963881" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044a5f08-c766-11e1-8775-005056c00008" name="HickryCk LD" loadType="UNDEFINED" p0="39" q0="10" node="11" p="38.995253806806254" q="9.997971794590498">
+            <iidm:load id="_044a5f08-c766-11e1-8775-005056c00008" name="HickryCk LD" loadType="UNDEFINED" p0="39" q0="10" node="11" p="38.995421978228038" q="9.9980436569918805">
                 <iidm:alias>_047d7cf3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5802,9 +5925,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="124.99795716608583" angle="-4.1659394741136904" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="124.93059973644252" angle="-16.516286510265331" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:shunt id="_0450eeb7-c766-11e1-8775-005056c00008" name="EastLima SC" sectionCount="5" voltageRegulatorOn="true" targetV="131.565" targetDeadband="1" node="20" q="-22.421142139321784">
+            <iidm:shunt id="_0450eeb7-c766-11e1-8775-005056c00008" name="EastLima SC" sectionCount="5" voltageRegulatorOn="true" targetV="131.565" targetDeadband="1" node="20" q="-22.396984566977849">
                 <iidm:alias>_044aad27-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_6c36f421-303e-4932-93a9-5b0ff86cb7d4"/>
                 <iidm:shuntLinearModel bPerSection="0.00028699999999999998" gPerSection="0" maximumSectionCount="10"/>
@@ -5892,16 +6015,16 @@
                 <iidm:internalConnection node1="41" node2="7"/>
                 <iidm:internalConnection node1="42" node2="12"/>
                 <iidm:internalConnection node1="43" node2="11"/>
-                <iidm:bus v="218.82961073733659" angle="6.2251042750532628" nodes="0,1,2,3,8,9,10,13,17,18,21,22,23,24,25,26,31,32,33,34,35,39,40"/>
-                <iidm:bus v="237.93779524620135" angle="-6.6758143422100362" nodes="11,15,37,43"/>
-                <iidm:bus v="226.19467202131392" angle="6.2251042950812741" nodes="12,16,38,42"/>
-                <iidm:bus v="214.70035006853155" angle="-6.6758143422100371" nodes="4,5,6,7,14,19,20,27,28,29,30,36,41"/>
+                <iidm:bus v="218.82987440818277" angle="-6.2397370737056299" nodes="0,1,2,3,8,9,10,13,17,18,21,22,23,24,25,26,31,32,33,34,35,39,40"/>
+                <iidm:bus v="237.93812601588891" angle="-19.138554750820514" nodes="11,15,37,43"/>
+                <iidm:bus v="226.19478020476433" angle="-6.2397361320809788" nodes="12,16,38,42"/>
+                <iidm:bus v="214.70064853463967" angle="-19.138554750820514" nodes="4,5,6,7,14,19,20,27,28,29,30,36,41"/>
             </iidm:nodeBreakerTopology>
-            <iidm:vscConverterStation id="_b46bfb8e-7af6-459e-acf3-53a42c943a7c" name="VSC2" voltageRegulatorOn="true" lossFactor="0.32362458" voltageSetpoint="218.47" reactivePowerSetpoint="0" node="42" p="-0" q="-27.7656270205567">
+            <iidm:vscConverterStation id="_b46bfb8e-7af6-459e-acf3-53a42c943a7c" name="VSC2" voltageRegulatorOn="true" lossFactor="0.32362458" voltageSetpoint="218.47" reactivePowerSetpoint="0" node="42" p="-0" q="-27.765027575642577">
                 <iidm:alias>_a168e701-bd48-4f66-8f0b-0f69b2545530</iidm:alias>
                 <iidm:minMaxReactiveLimits minQ="-1.7976931348623157e+308" maxQ="1.7976931348623157e+308"/>
             </iidm:vscConverterStation>
-            <iidm:vscConverterStation id="_b48ce7cf-abf5-413f-bc51-9e1d3103c9bd" name="VSC1" voltageRegulatorOn="true" lossFactor="0.32467531999999999" voltageSetpoint="213.53999999999999" reactivePowerSetpoint="0" node="43" p="-0" q="-92.151020935018536">
+            <iidm:vscConverterStation id="_b48ce7cf-abf5-413f-bc51-9e1d3103c9bd" name="VSC1" voltageRegulatorOn="true" lossFactor="0.32467531999999999" voltageSetpoint="213.53999999999999" reactivePowerSetpoint="0" node="43" p="-0" q="-92.151020935102736">
                 <iidm:alias>_071bb138-ff00-4874-8acc-a884aa5cf4a9</iidm:alias>
                 <iidm:minMaxReactiveLimits minQ="-1.7976931348623157e+308" maxQ="1.7976931348623157e+308"/>
             </iidm:vscConverterStation>
@@ -5969,7 +6092,7 @@
                 <iidm:internalConnection node1="29" node2="6"/>
                 <iidm:internalConnection node1="30" node2="9"/>
                 <iidm:internalConnection node1="31" node2="3"/>
-                <iidm:bus v="201.48841440435797" angle="-0.26192869944810759" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
+                <iidm:bus v="201.43476364394064" angle="-12.641073154750728" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_0448d867-c766-11e1-8775-005056c00008" name="EDO132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -6055,9 +6178,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="131.34000285669475" angle="3.5869530583510665" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="131.34008940246602" angle="-8.8774207629573407" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0472a789-c766-11e1-8775-005056c00008" name="W.Kammer SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="160" targetV="131.34" targetQ="0" node="14" p="-179.73553361625136" q="92.508163953254893">
+            <iidm:generator id="_0472a789-c766-11e1-8775-005056c00008" name="W.Kammer SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="160" targetV="131.34" targetQ="0" node="14" p="-179.7035056392518" q="92.505958498323054">
                 <iidm:alias>_04697fc0-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_17852426-f663-4add-9a2b-0a635d51f101"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b512ea0a-96d0-4a48-9de1-a5cf499bf0dd"/>
@@ -6206,16 +6329,16 @@
                 <iidm:internalConnection node1="71" node2="15"/>
                 <iidm:internalConnection node1="72" node2="18"/>
                 <iidm:internalConnection node1="73" node2="21"/>
-                <iidm:bus v="130.02006133644289" angle="-6.6758143422100362" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
+                <iidm:bus v="130.02024208408335" angle="-19.138554750820511" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04839777-c766-11e1-8775-005056c00008" name="Tidd SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="155" targetV="130.02000000000001" targetQ="0" node="24" p="-174.11879819074349" q="-113.83369208584297">
+            <iidm:generator id="_04839777-c766-11e1-8775-005056c00008" name="Tidd SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="155" targetV="130.02000000000001" targetQ="0" node="24" p="-174.08777108802519" q="-113.83869574980558">
                 <iidm:alias>_045fe2d8-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_d2a96d8d-65be-4fd6-a012-ceeeabd2bee6"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_29df1e0b-36ca-4536-97b4-6f98b84d49d8"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-90" maxQ="255"/>
             </iidm:generator>
-            <iidm:load id="_04798556-c766-11e1-8775-005056c00008" name="Tidd LD" loadType="UNDEFINED" p0="277" q0="113" node="23" p="277.00019601057551" q="113.00013326835294">
+            <iidm:load id="_04798556-c766-11e1-8775-005056c00008" name="Tidd LD" loadType="UNDEFINED" p0="277" q0="113" node="23" p="277.00077361931585" q="113.00052598714845">
                 <iidm:alias>_04502b62-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6245,13 +6368,13 @@
                 <iidm:internalConnection node1="10" node2="3"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="0"/>
-                <iidm:bus v="360.39513455569403" angle="0" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="360.2984350950145" angle="-12.379004335383375" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
             </iidm:nodeBreakerTopology>
             <iidm:lccConverterStation id="_9793118d-5ba1-4a9c-b2e0-db1d15be5913" name="Conv2" lossFactor="0" powerFactor="-0.75741000000000003" node="12" p="-10" q="8.6206896551724146">
                 <iidm:alias>_453bdc57-5855-4eb5-8712-d6a0255e0da8</iidm:alias>
             </iidm:lccConverterStation>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045c1248-c766-11e1-8775-005056c00008" name="38-37" r="0" x="6.5340005399999992" g="0" b="0" ratedU1="220" ratedU2="132" node1="30" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="168.40917049604053" q1="90.818378277178354" p2="-168.40917049604059" q2="-76.509847989471965">
+        <iidm:twoWindingsTransformer id="_045c1248-c766-11e1-8775-005056c00008" name="38-37" r="0" x="6.5340005399999992" g="0" b="0" ratedU1="220" ratedU2="132" node1="30" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="167.03425399505713" q1="91.358280404018799" p2="-167.0342539950573" q2="-77.18401889002709">
             <iidm:alias>_0453d4e8-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0477d7aa-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_047df228-c766-11e1-8775-005056c00008</iidm:alias>
@@ -6275,7 +6398,7 @@
                 <iidm:temporaryLimit name="_c97df399-5a91-4c8b-b72c-496cade334b5" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_0485ba57-c766-11e1-8775-005056c00008" name="64-61" r="0" x="4.669632" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="172.56751814970025" q1="59.843530826225219" p2="-172.56751814970033" q2="-51.076008895210279">
+        <iidm:twoWindingsTransformer id="_0485ba57-c766-11e1-8775-005056c00008" name="64-61" r="0" x="4.669632" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="172.53727930164294" q1="59.844311795263124" p2="-172.53727930164283" q2="-51.079528983936662">
             <iidm:alias>_04549831-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0472ce92-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0489d905-c766-11e1-8775-005056c00008</iidm:alias>
@@ -6301,7 +6424,7 @@
                 <iidm:temporaryLimit name="_f6b1a81c-eda7-4a08-b290-bd29a5ed9fa4" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_044cd007-c766-11e1-8775-005056c00008" name="63-59" r="0" x="6.7256646120000001" g="0" b="0" ratedU1="220" ratedU2="132" node1="41" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="73" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-3.7470027081099033e-14" q1="83.151460239066495" p2="7.4940054162198066e-14" q2="-80.568906249556477">
+        <iidm:twoWindingsTransformer id="_044cd007-c766-11e1-8775-005056c00008" name="63-59" r="0" x="6.7256646120000001" g="0" b="0" ratedU1="220" ratedU2="132" node1="41" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="73" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-2.4980018054066022e-13" q1="83.151691425554716" p2="6.6613381477509392e-14" q2="-80.569130255755198">
             <iidm:alias>_044e7db4-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_046eafe5-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0488797a-c766-11e1-8775-005056c00008</iidm:alias>
@@ -6347,7 +6470,7 @@
                 <iidm:temporaryLimit name="_f2daef4d-6f1a-44d1-9c9b-228acff12575" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_ffd940c8-03c8-4dcf-ad46-62018a0d813d" name="PowTrans2" r="0.3932500000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_04f97116-552a-4a34-afd9-4862f62ac7aa" node2="31" voltageLevelId2="_04742e21-c766-11e1-8775-005056c00008" p1="9.9999977010815702" q1="-8.6206876733460778" p2="-9.9982963360703287" q2="8.6992122123272519">
+        <iidm:twoWindingsTransformer id="_ffd940c8-03c8-4dcf-ad46-62018a0d813d" name="PowTrans2" r="0.3932500000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_04f97116-552a-4a34-afd9-4862f62ac7aa" node2="31" voltageLevelId2="_04742e21-c766-11e1-8775-005056c00008" p1="9.9999988518423208" q1="-8.6207045741944537" p2="-9.9982965703892912" q2="8.6992714104908018">
             <iidm:alias>_04479fea-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_c089eb25-9f67-4d82-88a8-635dd4808bae</iidm:alias>
             <iidm:alias>_ea8cd467-31f0-40dc-95d7-4064463724c4</iidm:alias>
@@ -6414,9 +6537,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="123.53711436267221" angle="-10.377311263723575" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="123.53682529054528" angle="-22.837085370563528" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0481c2b3-c766-11e1-8775-005056c00008" name="Wooster LD" loadType="UNDEFINED" p0="23" q0="11" node="8" p="22.909154362961765" q="10.927682192406413">
+            <iidm:load id="_0481c2b3-c766-11e1-8775-005056c00008" name="Wooster LD" loadType="UNDEFINED" p0="23" q0="11" node="8" p="22.909195379210264" q="10.927714800389865">
                 <iidm:alias>_04614268-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6486,9 +6609,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="124.36481928834716" angle="-10.249390274451716" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="124.36468306108367" angle="-22.709845461721411" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044974a8-c766-11e1-8775-005056c00008" name="Wagenhls LD" loadType="UNDEFINED" p0="63" q0="22" node="11" p="62.763309839874303" q="21.862416410296255">
+            <iidm:load id="_044974a8-c766-11e1-8775-005056c00008" name="Wagenhls LD" loadType="UNDEFINED" p0="63" q0="22" node="11" p="62.763423343804767" q="21.862482305261917">
                 <iidm:alias>_048481d4-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6539,9 +6662,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.17560816418592" angle="8.6122865927924153" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.23497603041227" angle="-4.2511323779114853" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047fedf2-c766-11e1-8775-005056c00008" name="Concord LD" loadType="UNDEFINED" p0="34" q0="16" node="8" p="33.988157110678955" q="15.99071253786013">
+            <iidm:load id="_047fedf2-c766-11e1-8775-005056c00008" name="Concord LD" loadType="UNDEFINED" p0="34" q0="16" node="8" p="33.988783966514895" q="15.991204078343236">
                 <iidm:alias>_046d9e75-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6649,9 +6772,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="127.36727010216482" angle="11.122579219367028" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="127.49735094099954" angle="-1.3903836829656711" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045f94ba-c766-11e1-8775-005056c00008" name="Delaware LD" loadType="UNDEFINED" p0="59" q0="23" node="17" p="58.98560408585822" q="22.990647483199592">
+            <iidm:load id="_045f94ba-c766-11e1-8775-005056c00008" name="Delaware LD" loadType="UNDEFINED" p0="59" q0="23" node="17" p="58.986832187787698" q="22.991445278269655">
                 <iidm:alias>_0463654a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6759,9 +6882,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="125.01718124131092" angle="6.1583114110210877" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="124.96383255437782" angle="-5.9910682144886467" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04697fc9-c766-11e1-8775-005056c00008" name="FtWayne LD" loadType="UNDEFINED" p0="90" q0="30" node="17" p="89.917574902288493" q="29.954222259683501">
+            <iidm:load id="_04697fc9-c766-11e1-8775-005056c00008" name="FtWayne LD" loadType="UNDEFINED" p0="90" q0="30" node="17" p="89.919811445470714" q="29.955464035222494">
                 <iidm:alias>_044d1e25-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6812,9 +6935,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.06946157238093" angle="-7.7967681869770935" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.06918273921374" angle="-20.256079692251387" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0474f170-c766-11e1-8775-005056c00008" name="WNwPhil1 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="11.965363345305954" q="2.9855819503933825">
+            <iidm:load id="_0474f170-c766-11e1-8775-005056c00008" name="WNwPhil1 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="11.965382455824187" q="2.9855898977838393">
                 <iidm:alias>_0466c0a7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6885,12 +7008,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="129.53648881396452" angle="15.984904471718176" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="129.43217519927296" angle="3.4863952222142025" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044a5f05-c766-11e1-8775-005056c00008" name="Logan LD" loadType="UNDEFINED" p0="54" q0="27" node="11" p="53.986264434232197" q="26.988554665723846">
+            <iidm:load id="_044a5f05-c766-11e1-8775-005056c00008" name="Logan LD" loadType="UNDEFINED" p0="54" q0="27" node="11" p="53.986094985036139" q="26.98841348215446">
                 <iidm:alias>_04767811-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0475dbd6-c766-11e1-8775-005056c00008" name="Logan SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.41900000000001" targetDeadband="1" node="12" q="-19.263097820519416">
+            <iidm:shunt id="_0475dbd6-c766-11e1-8775-005056c00008" name="Logan SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.41900000000001" targetDeadband="1" node="12" q="-19.232085797383956">
                 <iidm:alias>_04577e67-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_a7768441-642e-48a2-b4a8-0ae06bebf676"/>
                 <iidm:shuntLinearModel bPerSection="0.0002296" gPerSection="0" maximumSectionCount="10"/>
@@ -6964,19 +7087,19 @@
                 <iidm:internalConnection node1="32" node2="3"/>
                 <iidm:internalConnection node1="33" node2="6"/>
                 <iidm:internalConnection node1="34" node2="9"/>
-                <iidm:bus v="132.66001167755797" angle="-2.6246452800429729" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34"/>
+                <iidm:bus v="132.66012572175944" angle="-15.077381207478807" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04633e31-c766-11e1-8775-005056c00008" name="W.Lancst SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="19" targetV="132.66" targetQ="0" node="13" p="-21.343594616929849" q="1.1765137166370496">
+            <iidm:generator id="_04633e31-c766-11e1-8775-005056c00008" name="W.Lancst SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="19" targetV="132.66" targetQ="0" node="13" p="-21.339791294661151" q="1.1757799988303266">
                 <iidm:alias>_047bcf42-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_83fae784-1da1-4055-8108-ba978276d1b6"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_5f711f63-f631-45d3-b26c-33821ab2ee56"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-15" maxQ="45"/>
             </iidm:generator>
-            <iidm:load id="_048a9c51-c766-11e1-8775-005056c00008" name="W.Lancst LD" loadType="UNDEFINED" p0="28" q0="10" node="11" p="28.000003697101217" q="10.000002200655581">
+            <iidm:load id="_048a9c51-c766-11e1-8775-005056c00008" name="W.Lancst LD" loadType="UNDEFINED" p0="28" q0="10" node="11" p="28.000039803370637" q="10.00002369249375">
                 <iidm:alias>_044e7db6-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_045b00d9-c766-11e1-8775-005056c00008" name="W.Lancst SC" sectionCount="5" voltageRegulatorOn="true" targetV="132.66" targetDeadband="1" node="12" q="-10.101641572818359">
+            <iidm:shunt id="_045b00d9-c766-11e1-8775-005056c00008" name="W.Lancst SC" sectionCount="5" voltageRegulatorOn="true" targetV="132.66" targetDeadband="1" node="12" q="-10.101658941038476">
                 <iidm:alias>_04758db6-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_be267a3c-f7a7-4bdf-bb17-71b773247fbf"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -7086,9 +7209,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="129.88514917938545" angle="10.111105156106598" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="129.90458103469695" angle="-2.4485239189991264" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045dbff2-c766-11e1-8775-005056c00008" name="Portsmth LD" loadType="UNDEFINED" p0="66" q0="20" node="17" p="65.999993612927611" q="19.999996774205965">
+            <iidm:load id="_045dbff2-c766-11e1-8775-005056c00008" name="Portsmth LD" loadType="UNDEFINED" p0="66" q0="20" node="17" p="66.000712037177493" q="20.000359616029336">
                 <iidm:alias>_0454bf45-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7159,16 +7282,16 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="127.64405028967209" angle="9.1418199707745753" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="127.64400007568942" angle="-3.185179141103009" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04856c34-c766-11e1-8775-005056c00008" name="DeerCrk SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="7" targetV="127.64400000000001" targetQ="0" node="12" p="-7.863429595710997" q="-40.86291761023358">
+            <iidm:generator id="_04856c34-c766-11e1-8775-005056c00008" name="DeerCrk SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="7" targetV="127.64400000000001" targetQ="0" node="12" p="-7.8620283717172672" q="-38.587244420139818">
                 <iidm:alias>_0477d7a5-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e5a479a8-ab8d-4a54-bb52-376874ae2784"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b55d80d5-720f-46f9-897f-ff8c5eaf8b44"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-15" maxQ="45"/>
             </iidm:generator>
-            <iidm:load id="_04791028-c766-11e1-8775-005056c00008" name="DeerCrk LD" loadType="UNDEFINED" p0="43" q0="27" node="11" p="43.000025411959584" q="27.000026593916427">
+            <iidm:load id="_04791028-c766-11e1-8775-005056c00008" name="DeerCrk LD" loadType="UNDEFINED" p0="43" q0="27" node="11" p="43.000000038246746" q="27.000000040025661">
                 <iidm:alias>_04486337-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7219,9 +7342,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.79099795307187" angle="10.956251744135848" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.95651701496745" angle="-1.6098449598259263" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0462c904-c766-11e1-8775-005056c00008" name="Medford LD" loadType="UNDEFINED" p0="22" q0="7" node="8" p="21.994962575669284" q="6.9973288425083062">
+            <iidm:load id="_0462c904-c766-11e1-8775-005056c00008" name="Medford LD" loadType="UNDEFINED" p0="22" q0="7" node="8" p="21.995439273161203" q="6.9975815998685009">
                 <iidm:alias>_0489b1f7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7310,9 +7433,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="131.90166335954262" angle="16.635220353808528" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="132.04530140308344" angle="3.8397148546911959" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046205b5-c766-11e1-8775-005056c00008" name="CollCrnr LD" loadType="UNDEFINED" p0="7" q0="3" node="14" p="6.9970691636785443" q="2.9979068376683888">
+            <iidm:load id="_046205b5-c766-11e1-8775-005056c00008" name="CollCrnr LD" loadType="UNDEFINED" p0="7" q0="3" node="14" p="6.9972467754583114" q="2.9980336688843958">
                 <iidm:alias>_04486334-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7363,9 +7486,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.85960965026851" angle="17.248788595097786" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.82534238531005" angle="4.7508765680141885" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0483be82-c766-11e1-8775-005056c00008" name="Caldwell LD" loadType="UNDEFINED" p0="42" q0="31" node="8" p="41.990741771769059" q="30.988611746584006">
+            <iidm:load id="_0483be82-c766-11e1-8775-005056c00008" name="Caldwell LD" loadType="UNDEFINED" p0="42" q0="31" node="8" p="41.990657216508055" q="30.9885077455477">
                 <iidm:alias>_045841b9-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7416,9 +7539,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.33370644356562" angle="9.8974807979160229" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.33355853772689" angle="-2.6026089611997434" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045f94b4-c766-11e1-8775-005056c00008" name="Franklin LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="8.0000664408704818" q="3.0000415256590092">
+            <iidm:load id="_045f94b4-c766-11e1-8775-005056c00008" name="Franklin LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="8.0000548655082149" q="3.0000342910210254">
                 <iidm:alias>_047da403-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7469,9 +7592,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="124.67985798852997" angle="6.985054733556102" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.61378003367359" angle="-5.0150526320011526" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045f6da2-c766-11e1-8775-005056c00008" name="McKinley LD" loadType="UNDEFINED" p0="60" q0="34" node="8" p="59.947605714047491" q="33.950530912733051">
+            <iidm:load id="_045f6da2-c766-11e1-8775-005056c00008" name="McKinley LD" loadType="UNDEFINED" p0="60" q0="34" node="8" p="59.94935979970267" q="33.952186600767817">
                 <iidm:alias>_0465d641-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7618,19 +7741,19 @@
                 <iidm:internalConnection node1="71" node2="18"/>
                 <iidm:internalConnection node1="72" node2="21"/>
                 <iidm:internalConnection node1="73" node2="12"/>
-                <iidm:bus v="130.68007069497577" angle="10.084853700266075" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
+                <iidm:bus v="130.68000807767825" angle="-2.9131225891398147" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_044ca8f0-c766-11e1-8775-005056c00008" name="TwinBrch SM" energySource="THERMAL" minP="50" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="85" targetV="130.68000799999999" targetQ="0" node="24" p="-95.484502233633535" q="-94.127317332801823">
+            <iidm:generator id="_044ca8f0-c766-11e1-8775-005056c00008" name="TwinBrch SM" energySource="THERMAL" minP="50" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="85" targetV="130.68000799999999" targetQ="0" node="24" p="-95.46748737085251" q="-90.112911619880776">
                 <iidm:alias>_04633e38-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_0f6ab5a4-6b72-42f4-92bc-1993e1ae58a3"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_668eb671-5c36-4351-a95d-53ca850581db"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-60" maxQ="170"/>
             </iidm:generator>
-            <iidm:load id="_048740f1-c766-11e1-8775-005056c00008" name="TwinBrch LD" loadType="UNDEFINED" p0="47" q0="10" node="23" p="47.000033823049066" q="10.000011993991908">
+            <iidm:load id="_048740f1-c766-11e1-8775-005056c00008" name="TwinBrch LD" loadType="UNDEFINED" p0="47" q0="10" node="23" p="47.000000041906318" q="10.000000014860397">
                 <iidm:alias>_044ecbda-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:danglingLine id="_045338a1-c766-11e1-8775-005056c00008" name="12-117" p0="20" q0="8" r="5.7324960000000003" x="24.393599999999999" g="0" b="0.00020546369999999999" ucteXnodeCode="XMO_TE32" node="73" p="20.161812956683772" q="5.1797305059402756">
+            <iidm:danglingLine id="_045338a1-c766-11e1-8775-005056c00008" name="12-117" p0="20" q0="8" r="5.7324960000000003" x="24.393599999999999" g="0" b="0.00020546369999999999" ucteXnodeCode="XMO_TE32" node="73" p="20.161793639906307" q="5.1797255300584091">
                 <iidm:alias>_044afb42-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_0457f391-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_5631f3d0-d9d2-11e2-bb49-005056c00008</iidm:alias>
@@ -7728,9 +7851,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="123.84168428393286" angle="5.3469717626516999" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="123.79361708699713" angle="-6.7864462493466542" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0479fa87-c766-11e1-8775-005056c00008" name="Lincoln LD" loadType="UNDEFINED" p0="45" q0="25" node="14" p="44.954462373658579" q="24.95784975550453">
+            <iidm:load id="_0479fa87-c766-11e1-8775-005056c00008" name="Lincoln LD" loadType="UNDEFINED" p0="45" q0="25" node="14" p="44.955493893691532" q="24.958804229489715">
                 <iidm:alias>_047fc6e2-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7781,9 +7904,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="134.63802944843752" angle="16.43063381038689" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="134.63795369946973" angle="3.9315158313898153" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044c81e4-c766-11e1-8775-005056c00008" name="Hinton NegG LD" loadType="UNDEFINED" p0="42" q0="0" node="8" p="41.999042789458684" q="0">
+            <iidm:load id="_044c81e4-c766-11e1-8775-005056c00008" name="Hinton NegG LD" loadType="UNDEFINED" p0="42" q0="0" node="8" p="41.998995673199005" q="0">
                 <iidm:alias>_04494d96-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7834,9 +7957,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.19588676564075" angle="9.3397996044337006" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.17342413998551" angle="-3.3032214686918135" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_048bfbe0-c766-11e1-8775-005056c00008" name="N. E. LD" loadType="UNDEFINED" p0="25" q0="10" node="8" p="24.99506670743779" q="9.9967113546288306">
+            <iidm:load id="_048bfbe0-c766-11e1-8775-005056c00008" name="N. E. LD" loadType="UNDEFINED" p0="25" q0="10" node="8" p="24.995458754910931" q="9.9969726865923825">
                 <iidm:alias>_0480b140-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7887,9 +8010,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="125.13107182009907" angle="-8.6919164218642901" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="125.13068302824166" angle="-21.151040367747651" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04854525-c766-11e1-8775-005056c00008" name="SCoshoct LD" loadType="UNDEFINED" p0="18" q0="5" node="8" p="17.943281599618903" q="4.9737690713636376">
+            <iidm:load id="_04854525-c766-11e1-8775-005056c00008" name="SCoshoct LD" loadType="UNDEFINED" p0="18" q0="5" node="8" p="17.94331294763013" q="4.9737835538370749">
                 <iidm:alias>_04747c42-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7940,9 +8063,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="125.04903281223538" angle="8.6468128793382135" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="125.04452741687948" angle="-3.8743393735709115" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044aad24-c766-11e1-8775-005056c00008" name="WHuntngd LD" loadType="UNDEFINED" p0="33" q0="15" node="8" p="32.999964583404491" q="14.999973169255421">
+            <iidm:load id="_044aad24-c766-11e1-8775-005056c00008" name="WHuntngd LD" loadType="UNDEFINED" p0="33" q0="15" node="8" p="33.000098040501044" q="15.000074273180401">
                 <iidm:alias>_04784cd2-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7974,9 +8097,9 @@
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="3"/>
-                <iidm:bus v="129.36015301916555" angle="10.854338134348614" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="129.36002144591825" angle="-1.6463023616094941" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0452ea80-c766-11e1-8775-005056c00008" name="DanRiver SM" energySource="THERMAL" minP="20" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="36" targetV="129.36000000000001" targetQ="0" node="5" p="-40.440495063656549" q="-20.106957981626927">
+            <iidm:generator id="_0452ea80-c766-11e1-8775-005056c00008" name="DanRiver SM" energySource="THERMAL" minP="20" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="36" targetV="129.36000000000001" targetQ="0" node="5" p="-40.433288768831652" q="-20.109036932705237">
                 <iidm:alias>_046a4316-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_fec62959-21c5-4921-90b2-7c85e9f3bfab"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_9db08c95-4586-4a2b-87e3-5a17c944b43a"/>
@@ -8049,9 +8172,9 @@
                 <iidm:internalConnection node1="29" node2="3"/>
                 <iidm:internalConnection node1="30" node2="9"/>
                 <iidm:internalConnection node1="31" node2="6"/>
-                <iidm:bus v="130.12114776899594" angle="10.263937355502478" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
+                <iidm:bus v="130.15369247613222" angle="-2.3115716811944562" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
             </iidm:nodeBreakerTopology>
-            <iidm:danglingLine id="_044ef2e7-c766-11e1-8775-005056c00008" name="71-73" p0="6" q0="0" r="1.508918" x="7.9104960000000002" g="0" b="6.76079e-05" ucteXnodeCode="XMO_TE31" node="31" p="6.0032149538031927" q="-1.1278662182152039">
+            <iidm:danglingLine id="_044ef2e7-c766-11e1-8775-005056c00008" name="71-73" p0="6" q0="0" r="1.508918" x="7.9104960000000002" g="0" b="6.76079e-05" ucteXnodeCode="XMO_TE31" node="31" p="6.0032104196091094" q="-1.1284476775407031">
                 <iidm:alias>_04670ec2-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_046b2d7a-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_26a070b9-db0c-47cd-9991-0a461576aec2</iidm:alias>
@@ -8111,9 +8234,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="134.29689793193583" angle="2.2093006158207538" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="134.29696229479273" angle="-10.253673371689409" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0453add4-c766-11e1-8775-005056c00008" name="Summerfl LD" loadType="UNDEFINED" p0="28" q0="7" node="8" p="27.999924698935448" q="6.9999686245845609">
+            <iidm:load id="_0453add4-c766-11e1-8775-005056c00008" name="Summerfl LD" loadType="UNDEFINED" p0="28" q0="7" node="8" p="27.999952856500204" q="6.9999803568861081">
                 <iidm:alias>_04851e16-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8240,9 +8363,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="132.66019677245268" angle="32.169654609511653" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="132.66003823021853" angle="19.681316925263861" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0489b1fa-c766-11e1-8775-005056c00008" name="ClinchRv SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="607" targetV="132.66" targetQ="0" node="20" p="-681.87168065665355" q="-46.947752888022364">
+            <iidm:generator id="_0489b1fa-c766-11e1-8775-005056c00008" name="ClinchRv SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="607" targetV="132.66" targetQ="0" node="20" p="-681.75017451891154" q="-49.996605073042339">
                 <iidm:alias>_04840caa-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_2621b09a-22e3-4630-b3bd-32c102e36741"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b0d662e5-64c9-4d59-b8e0-9b1ed175769b"/>
@@ -8297,9 +8420,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.46041446276624" angle="9.162254393572379" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.47790511619431" angle="-3.8766437054942311" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0485e168-c766-11e1-8775-005056c00008" name="Pokagon LD" loadType="UNDEFINED" p0="20" q0="9" node="8" p="19.999272693451672" q="8.9994545267009638">
+            <iidm:load id="_0485e168-c766-11e1-8775-005056c00008" name="Pokagon LD" loadType="UNDEFINED" p0="20" q0="9" node="8" p="19.999289510464166" q="8.9994671391580905">
                 <iidm:alias>_0462c902-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8350,9 +8473,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.97309113472988" angle="8.6168742482300136" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.9809036309442" angle="-4.1624615537841425" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04812679-c766-11e1-8775-005056c00008" name="GoshenJt LD" loadType="UNDEFINED" p0="14" q0="1" node="8" p="13.996337630962149" q="0.9995640417056324">
+            <iidm:load id="_04812679-c766-11e1-8775-005056c00008" name="GoshenJt LD" loadType="UNDEFINED" p0="14" q0="1" node="8" p="13.996517388668536" q="0.99958543779193709">
                 <iidm:alias>_045b9d17-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8403,9 +8526,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="117.74547391591948" angle="-11.325661908262775" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="117.69107172580715" angle="-23.718803629074515" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0489b1f2-c766-11e1-8775-005056c00008" name="S.Tiffin LD" loadType="UNDEFINED" p0="37" q0="10" node="8" p="36.955001890784651" q="9.9797387995319156">
+            <iidm:load id="_0489b1f2-c766-11e1-8775-005056c00008" name="S.Tiffin LD" loadType="UNDEFINED" p0="37" q0="10" node="8" p="36.954546124377231" q="9.9795336666780692">
                 <iidm:alias>_046476b8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8456,9 +8579,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="123.21309525528297" angle="0.41518946555534803" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="123.13112870391731" angle="-11.828987828101038" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045cfca7-c766-11e1-8775-005056c00008" name="Haviland LD" loadType="UNDEFINED" p0="23" q0="9" node="8" p="22.966165443465226" q="8.9779448068386039">
+            <iidm:load id="_045cfca7-c766-11e1-8775-005056c00008" name="Haviland LD" loadType="UNDEFINED" p0="23" q0="9" node="8" p="22.966165711757768" q="8.9779449816403609">
                 <iidm:alias>_0482ad17-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8528,9 +8651,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="130.98593760841615" angle="2.1737067792029858" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="130.98606848002319" angle="-10.290474283867471" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04555b82-c766-11e1-8775-005056c00008" name="SWKammer LD" loadType="UNDEFINED" p0="78" q0="3" node="11" p="77.995057020458759" q="2.9996831490303988">
+            <iidm:load id="_04555b82-c766-11e1-8775-005056c00008" name="SWKammer LD" loadType="UNDEFINED" p0="78" q0="3" node="11" p="77.995141978608345" q="2.9996885948375205">
                 <iidm:alias>_0474ca6b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8638,9 +8761,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="130.32829502990825" angle="16.439013656920618" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="130.28026079176698" angle="3.940473938977302" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04817492-c766-11e1-8775-005056c00008" name="Baileysv LD" loadType="UNDEFINED" p0="38" q0="15" node="17" p="37.991188632036049" q="14.994203495465808">
+            <iidm:load id="_04817492-c766-11e1-8775-005056c00008" name="Baileysv LD" loadType="UNDEFINED" p0="38" q0="15" node="17" p="37.991110196853398" q="14.994151901384708">
                 <iidm:alias>_0474f17b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8691,9 +8814,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.02051407659241" angle="25.313767952660143" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.0165668279605" angle="12.823365836578073" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0461b790-c766-11e1-8775-005056c00008" name="HolstonT NegG LD" loadType="UNDEFINED" p0="10" q0="0" node="8" p="9.9991888459462821" q="0">
+            <iidm:load id="_0461b790-c766-11e1-8775-005056c00008" name="HolstonT NegG LD" loadType="UNDEFINED" p0="10" q0="0" node="8" p="9.999170529934549" q="0">
                 <iidm:alias>_0464ebe7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8744,9 +8867,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.82715113853662" angle="10.93896388755889" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.98756619264191" angle="-1.6192897216803732" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044c81e5-c766-11e1-8775-005056c00008" name="WMedford LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="7.9981491628041717" q="2.9988433159631902">
+            <iidm:load id="_044c81e5-c766-11e1-8775-005056c00008" name="WMedford LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="7.9983218182349951" q="2.9989512097395719">
                 <iidm:alias>_04570939-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8836,12 +8959,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="124.32756716646965" angle="-4.4372921100099774" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="124.25804261719938" angle="-16.782831300976017" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04854520-c766-11e1-8775-005056c00008" name="Rockhill LD" loadType="UNDEFINED" p0="59" q0="26" node="14" p="58.919399483173486" q="25.940828841447335">
+            <iidm:load id="_04854520-c766-11e1-8775-005056c00008" name="Rockhill LD" loadType="UNDEFINED" p0="59" q0="26" node="14" p="58.918764132299565" q="25.940362626324724">
                 <iidm:alias>_0461b799-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0460cd38-c766-11e1-8775-005056c00008" name="Rockhill SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.81399999999999" targetDeadband="1" node="15" q="-12.412247197899021">
+            <iidm:shunt id="_0460cd38-c766-11e1-8775-005056c00008" name="Rockhill SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.81399999999999" targetDeadband="1" node="15" q="-12.398369107511362">
                 <iidm:alias>_048b86b4-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_069d84c6-bd26-4c26-ac6c-e801a0202a00"/>
                 <iidm:shuntLinearModel bPerSection="0.0001606" gPerSection="0" maximumSectionCount="10"/>
@@ -8914,12 +9037,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="128.60923803350533" angle="17.803016059628654" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="128.43273775622578" angle="5.3085942062449938" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047a48a5-c766-11e1-8775-005056c00008" name="Sprigg LD" loadType="UNDEFINED" p0="20" q0="10" node="11" p="19.993481972867837" q="9.9945689008095329">
+            <iidm:load id="_047a48a5-c766-11e1-8775-005056c00008" name="Sprigg LD" loadType="UNDEFINED" p0="20" q0="10" node="11" p="19.993384056902606" q="9.9944873220342831">
                 <iidm:alias>_0472ce97-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_04553478-c766-11e1-8775-005056c00008" name="Sprigg SC" sectionCount="5" voltageRegulatorOn="true" targetV="129.935" targetDeadband="1" node="12" q="-9.4941529257387707">
+            <iidm:shunt id="_04553478-c766-11e1-8775-005056c00008" name="Sprigg SC" sectionCount="5" voltageRegulatorOn="true" targetV="129.935" targetDeadband="1" node="12" q="-9.4681117052191333">
                 <iidm:alias>_045bc428-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_f4cdc674-4a66-4ab8-8d4f-552cb066e259"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -9011,12 +9134,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="118.17361575273553" angle="-10.311726490600272" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="118.11358589664793" angle="-22.695756094805422" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04819ba4-c766-11e1-8775-005056c00008" name="West End NegG LD" loadType="UNDEFINED" p0="46" q0="0" node="14" p="45.938511372947438" q="0">
+            <iidm:load id="_04819ba4-c766-11e1-8775-005056c00008" name="West End NegG LD" loadType="UNDEFINED" p0="46" q0="0" node="14" p="45.937920509826249" q="0">
                 <iidm:alias>_04627ae0-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_04555b89-c766-11e1-8775-005056c00008" name="West End LD" loadType="UNDEFINED" p0="20" q0="23" node="15" p="19.973265814324972" q="22.948782312076073">
+            <iidm:load id="_04555b89-c766-11e1-8775-005056c00008" name="West End LD" loadType="UNDEFINED" p0="20" q0="23" node="15" p="19.973008917315759" q="22.948290367133282">
                 <iidm:alias>_04592c18-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9067,9 +9190,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.00300347573739" angle="10.227115269885877" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.97608753400183" angle="-1.7222247456335322" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046d0232-c766-11e1-8775-005056c00008" name="Deer Crk NegG LD" loadType="UNDEFINED" p0="6" q0="0" node="8" p="5.9965741201806715" q="0">
+            <iidm:load id="_046d0232-c766-11e1-8775-005056c00008" name="Deer Crk NegG LD" loadType="UNDEFINED" p0="6" q0="0" node="8" p="5.9967991926146276" q="0">
                 <iidm:alias>_0480150a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9139,9 +9262,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="133.84633440942298" angle="-0.22328119919940945" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="133.8497765967459" angle="-12.68446468420608" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046c3ee3-c766-11e1-8775-005056c00008" name="Crooksvl LD" loadType="UNDEFINED" p0="34" q0="0" node="11" p="33.992423208870669" q="0">
+            <iidm:load id="_046c3ee3-c766-11e1-8775-005056c00008" name="Crooksvl LD" loadType="UNDEFINED" p0="34" q0="0" node="11" p="33.992490096846012" q="0">
                 <iidm:alias>_047e4047-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9192,9 +9315,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="131.66205165499213" angle="-3.9464691387122715" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="131.66191081003262" angle="-16.404437338966698" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046dc585-c766-11e1-8775-005056c00008" name="WCambrdg LD" loadType="UNDEFINED" p0="17" q0="4" node="8" p="16.980374360486543" q="3.9923066328332557">
+            <iidm:load id="_046dc585-c766-11e1-8775-005056c00008" name="WCambrdg LD" loadType="UNDEFINED" p0="17" q0="4" node="8" p="16.980399271742684" q="3.9923163944380011">
                 <iidm:alias>_045dbff8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9283,9 +9406,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="130.19692021938346" angle="10.651472083806528" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="130.25578741668011" angle="-2.4185911050633289" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_048b5fa5-c766-11e1-8775-005056c00008" name="SouthBnd LD" loadType="UNDEFINED" p0="70" q0="23" node="14" p="69.990558717477839" q="22.99483000630595">
+            <iidm:load id="_048b5fa5-c766-11e1-8775-005056c00008" name="SouthBnd LD" loadType="UNDEFINED" p0="70" q0="23" node="14" p="69.991000130551868" q="22.995071711285497">
                 <iidm:alias>_04522734-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9335,11 +9458,11 @@
                 <iidm:internalConnection node1="19" node2="6"/>
                 <iidm:internalConnection node1="20" node2="3"/>
                 <iidm:internalConnection node1="21" node2="6"/>
-                <iidm:bus v="227.58311274554265" angle="27.927591437655007" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
+                <iidm:bus v="227.83280864260047" angle="14.34124088762721" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:line id="_044cd006-c766-11e1-8775-005056c00008" name="31-32" r="5.1923519999999996" x="17.16264" g1="0" b1="7.20271e-05" g2="0" b2="7.20271e-05" node1="31" voltageLevelId1="_04636548-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="-29.268439497795551" q1="10.305785930089224" p2="29.583433965940685" q2="-11.606604712632265">
+    <iidm:line id="_044cd006-c766-11e1-8775-005056c00008" name="31-32" r="5.1923519999999996" x="17.16264" g1="0" b1="7.20271e-05" g2="0" b2="7.20271e-05" node1="31" voltageLevelId1="_04636548-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="-26.777184070694055" q1="8.483453593769946" p2="27.035407582154409" q2="-9.9743083352734416">
         <iidm:alias>_04682030-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0471bd25-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9347,7 +9470,7 @@
             <iidm:temporaryLimit name="_de6da3cb-8cb5-4900-9c33-8ad45632b535" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045a3d89-c766-11e1-8775-005056c00008" name="2-12" r="3.2582879999999999" x="10.7331839" g1="0" b1="4.5110200000000001e-05" g2="0" b2="4.5110200000000001e-05" node1="21" voltageLevelId1="_045d4ac5-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-30.386662298012968" q1="-17.883143338256659" p2="30.626972311719253" q2="17.159981189203165">
+    <iidm:line id="_045a3d89-c766-11e1-8775-005056c00008" name="2-12" r="3.2582879999999999" x="10.7331839" g1="0" b1="4.5110200000000001e-05" g2="0" b2="4.5110200000000001e-05" node1="21" voltageLevelId1="_045d4ac5-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-31.350091437810367" q1="-17.36596252716636" p2="31.598628931599116" q2="16.669700677348686">
         <iidm:alias>_046adf51-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046fe868-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9355,7 +9478,7 @@
             <iidm:temporaryLimit name="_6bd63dd1-1344-4183-b7bd-af326919f4eb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04513cd7-c766-11e1-8775-005056c00008" name="32-114" r="2.3522400000000001" x="10.6634884" g1="0" b1="4.6717149999999997e-05" g2="0" b2="4.6717149999999997e-05" node1="49" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04791027-c766-11e1-8775-005056c00008" p1="5.9880575596713923" q1="4.3803293133497494" p2="-5.9790302101393022" q2="-5.8487218820677631">
+    <iidm:line id="_04513cd7-c766-11e1-8775-005056c00008" name="32-114" r="2.3522400000000001" x="10.6634884" g1="0" b1="4.6717149999999997e-05" g2="0" b2="4.6717149999999997e-05" node1="49" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04791027-c766-11e1-8775-005056c00008" p1="7.0691437379367255" q1="3.7885435483753978" p2="-7.0589194579871517" q2="-5.2549609677168947">
         <iidm:alias>_046d0237-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0470d2c7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9363,7 +9486,7 @@
             <iidm:temporaryLimit name="_5f05650a-c63d-46e5-a426-2db4f036929f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045d71d4-c766-11e1-8775-005056c00008" name="24-72" r="8.5029120000000002" x="34.151040000000002" g1="0" b1="0.00014003675" g2="0" b2="0.00014003675" node1="30" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="26.468837161239545" q1="-5.9568066415803314" p2="-26.117795509863349" q2="2.551033259312987">
+    <iidm:line id="_045d71d4-c766-11e1-8775-005056c00008" name="24-72" r="8.5029120000000002" x="34.151040000000002" g1="0" b1="0.00014003675" g2="0" b2="0.00014003675" node1="30" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="25.795246145617124" q1="-5.6452173376062742" p2="-25.46330907398524" q2="2.1540291254182184">
         <iidm:alias>_04667281-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d0234-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9371,7 +9494,7 @@
             <iidm:temporaryLimit name="_d2074163-ab09-4251-a1d7-6983091dc4f1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045f94b8-c766-11e1-8775-005056c00008" name="17-18" r="2.1431520000000002" x="8.7991200000000003" g1="0" b1="3.7247499999999999e-05" g2="0" b2="3.7247499999999999e-05" node1="57" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04689563-c766-11e1-8775-005056c00008" p1="113.47458940920451" q1="41.122251479040393" p2="-111.59784505100514" q2="-34.617753039677204">
+    <iidm:line id="_045f94b8-c766-11e1-8775-005056c00008" name="17-18" r="2.1431520000000002" x="8.7991200000000003" g1="0" b1="3.7247499999999999e-05" g2="0" b2="3.7247499999999999e-05" node1="57" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04689563-c766-11e1-8775-005056c00008" p1="117.48707568852711" q1="40.567844341469097" p2="-115.49566697267983" q2="-33.59145575755754">
         <iidm:alias>_045e0e17-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0485ba59-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9379,7 +9502,7 @@
             <iidm:temporaryLimit name="_2b6693c7-4e29-4c2c-91d0-3485bbe8fe87" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048963d8-c766-11e1-8775-005056c00008" name="17-113" r="1.590811" x="5.244624" g1="0" b1="2.2038549999999999e-05" g2="0" b2="2.2038549999999999e-05" node1="58" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="1.0204982417680128" q1="4.3295870187230276" p2="-1.0182962624939136" q2="-5.0570052082759327">
+    <iidm:line id="_048963d8-c766-11e1-8775-005056c00008" name="17-113" r="1.590811" x="5.244624" g1="0" b1="2.2038549999999999e-05" g2="0" b2="2.2038549999999999e-05" node1="58" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="5.0321464807514058" q1="2.4967072673064643" p2="-5.0289491017090091" q2="-3.2203948432431786">
         <iidm:alias>_045841b5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046958b4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9387,7 +9510,7 @@
             <iidm:temporaryLimit name="_786432da-fa4d-4751-a275-87d0e20529f1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0458ddf0-c766-11e1-8775-005056c00008" name="49-50" r="4.6522079999999999" x="13.102848099999999" g1="0" b1="5.3776400000000002e-05" g2="0" b2="5.3776400000000002e-05" node1="112" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044d1e26-c766-11e1-8775-005056c00008" p1="69.682752102505347" q1="13.37501669486049" p2="-68.396354436556521" q2="-11.668548316177105">
+    <iidm:line id="_0458ddf0-c766-11e1-8775-005056c00008" name="49-50" r="4.6522079999999999" x="13.102848099999999" g1="0" b1="5.3776400000000002e-05" g2="0" b2="5.3776400000000002e-05" node1="112" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044d1e26-c766-11e1-8775-005056c00008" p1="69.698696811544266" q1="13.372971615904708" p2="-68.41175172824282" q2="-11.664961333965815">
         <iidm:alias>_0464ebe8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f9fd8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9395,7 +9518,7 @@
             <iidm:temporaryLimit name="_1f0844a5-ea5c-42b2-abcb-6fac2c426092" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04535fb7-c766-11e1-8775-005056c00008" name="1-3" r="2.2476959999999999" x="7.3877759999999997" g1="0" b1="3.1049149999999997e-05" g2="0" b2="3.1049149999999997e-05" node1="21" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_047eb579-c766-11e1-8775-005056c00008" p1="-40.674612557431104" q1="-15.960641056609887" p2="40.939861294253824" q2="15.823081189493948">
+    <iidm:line id="_04535fb7-c766-11e1-8775-005056c00008" name="1-3" r="2.2476959999999999" x="7.3877759999999997" g1="0" b1="3.1049149999999997e-05" g2="0" b2="3.1049149999999997e-05" node1="21" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_047eb579-c766-11e1-8775-005056c00008" p1="-39.714803430901398" q1="-16.488060301761493" p2="39.971365252919377" q2="16.321069335159923">
         <iidm:alias>_044ef2e9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047c4474-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9403,7 +9526,7 @@
             <iidm:temporaryLimit name="_4ea43e34-67a3-42b8-9601-2189db7790d4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0478e912-c766-11e1-8775-005056c00008" name="92-102" r="2.1431520000000002" x="9.7400160000000007" g1="0" b1="4.2011000000000001e-05" g2="0" b2="4.2011000000000001e-05" node1="66" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="50.766628500919417" q1="-9.2028435464231286" p2="-50.433559035898298" q2="9.2857828570486198">
+    <iidm:line id="_0478e912-c766-11e1-8775-005056c00008" name="92-102" r="2.1431520000000002" x="9.7400160000000007" g1="0" b1="4.2011000000000001e-05" g2="0" b2="4.2011000000000001e-05" node1="66" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="50.803601199677928" q1="-9.221787560727229" p2="-50.469983621789851" q2="9.307359710726006">
         <iidm:alias>_045a1673-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0468bc79-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9411,7 +9534,7 @@
             <iidm:temporaryLimit name="_23cc194e-9273-46e9-a793-84a9c2911737" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04547127-c766-11e1-8775-005056c00008" name="93-94" r="3.8855520000000001" x="12.7543688" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="21" voltageLevelId1="_04789af0-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="59.107685406833696" q1="-22.623126873425832" p2="-58.191918231063376" q2="23.810303319947366">
+    <iidm:line id="_04547127-c766-11e1-8775-005056c00008" name="93-94" r="3.8855520000000001" x="12.7543688" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="21" voltageLevelId1="_04789af0-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="59.163494893269522" q1="-22.566806862364224" p2="-58.246542806024323" q2="23.758409930156361">
         <iidm:alias>_04500450-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047b0bfb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9419,7 +9542,7 @@
             <iidm:temporaryLimit name="_1a9fe09e-3f63-4904-8e36-aa38c5e16c59" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04791021-c766-11e1-8775-005056c00008" name="46-48" r="10.4718237" x="32.931359999999998" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044778d3-c766-11e1-8775-005056c00008" p1="-7.7288376526874742" q1="-8.3181614960751684" p2="7.7853381264136896" q2="3.6527857555886181">
+    <iidm:line id="_04791021-c766-11e1-8775-005056c00008" name="46-48" r="10.4718237" x="32.931359999999998" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044778d3-c766-11e1-8775-005056c00008" p1="-7.698286878439081" q1="-8.3287116665896921" p2="7.7545813567241479" q2="3.6626756896893653">
         <iidm:alias>_0459ef69-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04640186-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9427,7 +9550,7 @@
             <iidm:temporaryLimit name="_467ba04d-dbad-4fe1-81c8-3bc87b41fcd1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046958b6-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="113" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-99.828422657255516" q1="-0.48107172279121085" p2="101.53592968122378" q2="6.5402867078455635">
+    <iidm:line id="_046958b6-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="113" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-99.733941774635483" q1="-0.50781674624899575" p2="101.43820780268287" q2="6.5504804756321393">
         <iidm:alias>_04776270-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a96c8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9435,7 +9558,7 @@
             <iidm:temporaryLimit name="_d0737ab4-5a3a-46c8-8aeb-789313f0f332" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046f4c26-c766-11e1-8775-005056c00008" name="75-118" r="2.5264799999999998" x="8.3809430000000003" g1="0" b1="3.4377849999999998e-05" g2="0" b2="3.4377849999999998e-05" node1="48" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="38.545178695962974" q1="29.032272339651723" p2="-38.179531596378311" q2="-28.917850767986074">
+    <iidm:line id="_046f4c26-c766-11e1-8775-005056c00008" name="75-118" r="2.5264799999999998" x="8.3809430000000003" g1="0" b1="3.4377849999999998e-05" g2="0" b2="3.4377849999999998e-05" node1="48" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="38.43126476949076" q1="29.128096333860189" p2="-38.066094007815018" q2="-29.015213342370831">
         <iidm:alias>_04619088-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04814d8a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9443,7 +9566,7 @@
             <iidm:temporaryLimit name="_173dc7ff-ae18-4410-b2e1-a4c2abac8ff6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c3954-c766-11e1-8775-005056c00008" name="94-96" r="4.6870560000000001" x="15.1414566" g1="0" b1="6.60009e-05" g2="0" b2="6.60009e-05" node1="49" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="41.044730445140608" q1="-13.7186853161542" p2="-40.535327989699546" q2="13.123779421618698">
+    <iidm:line id="_045c3954-c766-11e1-8775-005056c00008" name="94-96" r="4.6870560000000001" x="15.1414566" g1="0" b1="6.60009e-05" g2="0" b2="6.60009e-05" node1="49" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="41.109452258869382" q1="-13.519114049458178" p2="-40.59977935592476" q2="12.92629705516479">
         <iidm:alias>_046ba2a0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0472ce94-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9451,7 +9574,7 @@
             <iidm:temporaryLimit name="_efde58bf-c92e-496d-b558-d0095a271083" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04518af7-c766-11e1-8775-005056c00008" name="62-67" r="4.4953919999999998" x="20.38608" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="39" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="-3.7161136015905081" q1="-18.13500369466923" p2="3.7911779943413153" q2="15.330396468050164">
+    <iidm:line id="_04518af7-c766-11e1-8775-005056c00008" name="62-67" r="4.4953919999999998" x="20.38608" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="39" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="-3.7297464793704798" q1="-18.131792217333455" p2="3.8048094250003301" q2="15.32717458719446">
         <iidm:alias>_04544a10-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04814d86-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9459,7 +9582,7 @@
             <iidm:temporaryLimit name="_8a81d4ae-2bc8-4038-8650-27a6150946b1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0452c375-c766-11e1-8775-005056c00008" name="47-49" r="3.3279839999999998" x="10.890000000000001" g1="0" b1="4.6028449999999998e-05" g2="0" b2="4.6028449999999998e-05" node1="30" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="114" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="21.629915544001673" q1="-25.048113669433526" p2="-21.433999814545182" q2="24.022005622434737">
+    <iidm:line id="_0452c375-c766-11e1-8775-005056c00008" name="47-49" r="3.3279839999999998" x="10.890000000000001" g1="0" b1="4.6028449999999998e-05" g2="0" b2="4.6028449999999998e-05" node1="30" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="114" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="21.537310443531148" q1="-24.981571145102944" p2="-21.34274575688351" q2="23.950998123213047">
         <iidm:alias>_0465fd54-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0471e431-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9467,7 +9590,7 @@
             <iidm:temporaryLimit name="_8d6a074c-900d-4a37-830c-5da4c1de1ab5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046c17d9-c766-11e1-8775-005056c00008" name="100-106" r="10.54152" x="39.900959999999998" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="76" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="59.238118371456103" q1="10.072380611450351" p2="-57.082328133132961" q2="-7.9762879033981493">
+    <iidm:line id="_046c17d9-c766-11e1-8775-005056c00008" name="100-106" r="10.54152" x="39.900959999999998" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="76" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="59.240056649444575" q1="10.072202877070414" p2="-57.084131037422146" q2="-7.975585399585194">
         <iidm:alias>_045d98e5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0480d851-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9475,7 +9598,7 @@
             <iidm:temporaryLimit name="_3154dc30-b0e5-4570-8e52-9333bae20ef2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046b2d77-c766-11e1-8775-005056c00008" name="77-78" r="0.655142" x="2.1605759999999998" g1="0" b1="3.6271800000000001e-05" g2="0" b2="3.6271800000000001e-05" node1="66" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044fb634-c766-11e1-8775-005056c00008" p1="43.227457656924976" q1="4.0415053940151404" p2="-43.156730877606485" q2="-5.0758409835599618">
+    <iidm:line id="_046b2d77-c766-11e1-8775-005056c00008" name="77-78" r="0.655142" x="2.1605759999999998" g1="0" b1="3.6271800000000001e-05" g2="0" b2="3.6271800000000001e-05" node1="66" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044fb634-c766-11e1-8775-005056c00008" p1="43.140411984853323" q1="3.9382691295305103" p2="-43.069982363544916" q2="-4.9732461878675771">
         <iidm:alias>_046ed6fb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04893cc3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9483,7 +9606,7 @@
             <iidm:temporaryLimit name="_cce754c5-b9d5-4105-a431-32da96e4a6cf" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c8776-c766-11e1-8775-005056c00008" name="6-7" r="0.79976199999999997" x="3.6241919999999999" g1="0" b1="1.5782850000000001e-05" g2="0" b2="1.5782850000000001e-05" node1="21" voltageLevelId1="_044f6818-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047eb571-c766-11e1-8775-005056c00008" p1="43.46674196352091" q1="-8.6760477350363132" p2="-43.374727056465311" q2="8.5553793079598499">
+    <iidm:line id="_045c8776-c766-11e1-8775-005056c00008" name="6-7" r="0.79976199999999997" x="3.6241919999999999" g1="0" b1="1.5782850000000001e-05" g2="0" b2="1.5782850000000001e-05" node1="21" voltageLevelId1="_044f6818-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047eb571-c766-11e1-8775-005056c00008" p1="39.196513344910045" q1="-6.7222401781955075" p2="-39.122517596694578" q2="6.5194221638659418">
         <iidm:alias>_046efe08-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04720b4a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9491,7 +9614,7 @@
             <iidm:temporaryLimit name="_361a9cc3-fb33-4037-9b9a-c20adb90b66b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047ba839-c766-11e1-8775-005056c00008" name="77-80" r="5.1226560000000001" x="18.295200000000001" g1="0" b1="6.5426999999999995e-05" g2="0" b2="6.5426999999999995e-05" node1="67" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="76" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-46.618170344955843" q1="-23.062583421380705" p2="47.394428842123595" q2="23.456181695048901">
+    <iidm:line id="_047ba839-c766-11e1-8775-005056c00008" name="77-80" r="5.1226560000000001" x="18.295200000000001" g1="0" b1="6.5426999999999995e-05" g2="0" b2="6.5426999999999995e-05" node1="67" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="76" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-46.708800087358668" q1="-23.163901602357711" p2="47.489059571390918" q2="23.572113760439741">
         <iidm:alias>_047c6b85-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0480b148-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9499,7 +9622,7 @@
             <iidm:temporaryLimit name="_da00c66f-a882-4938-923b-f2455f7f9a81" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04592c16-c766-11e1-8775-005056c00008" name="78-79" r="0.95135000000000003" x="4.2514560000000001" g1="0" b1="1.8595050000000001e-05" g2="0" b2="1.8595050000000001e-05" node1="22" voltageLevelId1="_044fb634-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04481510-c766-11e1-8775-005056c00008" p1="-27.839230279046706" q1="-20.921691376592321" p2="27.904668617040812" q2="20.561441740922305">
+    <iidm:line id="_04592c16-c766-11e1-8775-005056c00008" name="78-79" r="0.95135000000000003" x="4.2514560000000001" g1="0" b1="1.8595050000000001e-05" g2="0" b2="1.8595050000000001e-05" node1="22" voltageLevelId1="_044fb634-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04481510-c766-11e1-8775-005056c00008" p1="-27.925945019812126" q1="-21.02426711686584" p2="27.991895136475996" q2="20.666448220590937">
         <iidm:alias>_0453add6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045b7605-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9507,7 +9630,7 @@
             <iidm:temporaryLimit name="_ba4abe9d-8490-4c19-b19b-c9d2c3597fc9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047b3301-c766-11e1-8775-005056c00008" name="103-104" r="8.1195839999999997" x="27.599615100000001" g1="0" b1="0.00011679295" g2="0" b2="0.00011679295" node1="40" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="33.096208124163233" q1="13.966087392124942" p2="-32.478269604392317" q2="-15.858607904510233">
+    <iidm:line id="_047b3301-c766-11e1-8775-005056c00008" name="103-104" r="8.1195839999999997" x="27.599615100000001" g1="0" b1="0.00011679295" g2="0" b2="0.00011679295" node1="40" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="33.095557744679965" q1="13.966276333417548" p2="-32.477635017414777" q2="-15.85884257654177">
         <iidm:alias>_0459a142-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045d98e6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9515,7 +9638,7 @@
             <iidm:temporaryLimit name="_2320da74-eda7-4f7f-ade9-1ed0e994f3af" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045e5c32-c766-11e1-8775-005056c00008" name="95-96" r="2.9795039999999999" x="9.5309279999999994" g1="0" b1="4.2298000000000001e-05" g2="0" b2="4.2298000000000001e-05" node1="21" voltageLevelId1="_044f4108-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="17.080961941736632" q1="-25.722972553605807" p2="-16.91627693515008" q2="24.82897099576757">
+    <iidm:line id="_045e5c32-c766-11e1-8775-005056c00008" name="95-96" r="2.9795039999999999" x="9.5309279999999994" g1="0" b1="4.2298000000000001e-05" g2="0" b2="4.2298000000000001e-05" node1="21" voltageLevelId1="_044f4108-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="17.138685330635024" q1="-25.549120533315172" p2="-16.975111203300042" q2="24.65246845119907">
         <iidm:alias>_04597a34-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04801509-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9523,7 +9646,7 @@
             <iidm:temporaryLimit name="_3bc03415-e95f-47a7-8e92-01089d304a9c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045ed169-c766-11e1-8775-005056c00008" name="77-80" r="2.9620799999999998" x="8.4506409999999992" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="68" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="77" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-101.68409065741156" q1="-42.438130930381789" p2="103.70458125524047" q2="43.278036031285446">
+    <iidm:line id="_045ed169-c766-11e1-8775-005056c00008" name="77-80" r="2.9620799999999998" x="8.4506409999999992" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="68" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="77" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-101.88979938999312" q1="-42.640344562874418" p2="103.92070398827558" q2="43.510632271280748">
         <iidm:alias>_0464289a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04828605-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9531,7 +9654,7 @@
             <iidm:temporaryLimit name="_f93b6d4c-39fa-4f6f-a42d-c63a4cf21a67" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047f78c2-c766-11e1-8775-005056c00008" name="5-11" r="3.5370720000000002" x="11.8831682" g1="0" b1="4.987375e-05" g2="0" b2="4.987375e-05" node1="48" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="89.077613894447083" q1="7.8679547125788565" p2="-87.478452789733325" q2="-4.2245823318090858">
+    <iidm:line id="_047f78c2-c766-11e1-8775-005056c00008" name="5-11" r="3.5370720000000002" x="11.8831682" g1="0" b1="4.987375e-05" g2="0" b2="4.987375e-05" node1="48" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="83.923799373858614" q1="9.8872890085466505" p2="-82.497508107413978" q2="-6.8271724513001235">
         <iidm:alias>_045bc426-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0476c633-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9539,7 +9662,7 @@
             <iidm:temporaryLimit name="_3bc4ab96-7a0d-4e18-b9f5-d89f63a82f0a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04845ac7-c766-11e1-8775-005056c00008" name="71-72" r="7.7711040000000002" x="31.363201100000001" g1="0" b1="0.00012752525" g2="0" b2="0.00012752525" node1="29" voltageLevelId1="_04664b78-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="-14.031740187236224" q1="-1.4251327755051022" p2="14.122354536010567" q2="-2.5510417760111093">
+    <iidm:line id="_04845ac7-c766-11e1-8775-005056c00008" name="71-72" r="7.7711040000000002" x="31.363201100000001" g1="0" b1="0.00012752525" g2="0" b2="0.00012752525" node1="29" voltageLevelId1="_04664b78-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="-13.385351228957166" q1="-1.8601786944636538" p2="13.467584491158441" q2="-2.1540279218841487">
         <iidm:alias>_04642891-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046b0661-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9547,7 +9670,7 @@
             <iidm:temporaryLimit name="_bcb69c6e-125e-449c-acb3-a4deb151668d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047343c2-c766-11e1-8775-005056c00008" name="66-67" r="3.9029759999999998" x="17.685359999999999" g1="0" b1="7.6962800000000001e-05" g2="0" b2="7.6962800000000001e-05" node1="50" voltageLevelId1="_047147f4-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="32.104726217313932" q1="20.897184106768748" p2="-31.791102895160357" q2="-22.330365015722638">
+    <iidm:line id="_047343c2-c766-11e1-8775-005056c00008" name="66-67" r="3.9029759999999998" x="17.685359999999999" g1="0" b1="7.6962800000000001e-05" g2="0" b2="7.6962800000000001e-05" node1="50" voltageLevelId1="_047147f4-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="32.118553187814868" q1="20.894687497679598" p2="-31.804771186093905" q2="-22.32715253990883">
         <iidm:alias>_0465af34-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04860874-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9555,7 +9678,7 @@
             <iidm:temporaryLimit name="_b4b8a31d-dc3c-4b51-88ad-a22e070eb96c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04569409-c766-11e1-8775-005056c00008" name="34-43" r="7.1961120000000003" x="29.289743399999999" g1="0" b1="0.0001212695" g2="0" b2="0.0001212695" node1="40" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_045e8349-c766-11e1-8775-005056c00008" p1="14.896793466626757" q1="-8.4982355571629657" p2="-14.773056674119388" q2="5.2299112186067616">
+    <iidm:line id="_04569409-c766-11e1-8775-005056c00008" name="34-43" r="7.1961120000000003" x="29.289743399999999" g1="0" b1="0.0001212695" g2="0" b2="0.0001212695" node1="40" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_045e8349-c766-11e1-8775-005056c00008" p1="15.16064404109553" q1="-8.630422136293495" p2="-15.032235022356414" q2="5.3847414837526495">
         <iidm:alias>_04500454-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04505274-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9563,7 +9686,7 @@
             <iidm:temporaryLimit name="_5585c67a-0839-48e6-8847-4393e1e9b9c7" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04817498-c766-11e1-8775-005056c00008" name="52-53" r="7.0567200000000003" x="28.488240000000001" g1="0" b1="0.00011644859999999999" g2="0" b2="0.00011644859999999999" node1="21" voltageLevelId1="_04806326-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04876804-c766-11e1-8775-005056c00008" p1="16.72544094493712" q1="1.2696783485340639" p2="-16.595054757886746" q2="-4.3438024732490925">
+    <iidm:line id="_04817498-c766-11e1-8775-005056c00008" name="52-53" r="7.0567200000000003" x="28.488240000000001" g1="0" b1="0.00011644859999999999" g2="0" b2="0.00011644859999999999" node1="21" voltageLevelId1="_04806326-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04876804-c766-11e1-8775-005056c00008" p1="16.731092575910058" q1="1.2680098274235865" p2="-16.600625042960569" q2="-4.3417859082995234">
         <iidm:alias>_045115c7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0472a784-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9571,7 +9694,7 @@
             <iidm:temporaryLimit name="_e7c9dfab-fb45-4470-964f-4ba9e391f60b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044b7078-c766-11e1-8775-005056c00008" name="105-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="49" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="23" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="26.913754784384441" q1="1.3213111973272302" p2="-26.494731559873742" q2="-4.1819494283841214">
+    <iidm:line id="_044b7078-c766-11e1-8775-005056c00008" name="105-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="49" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="23" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="26.913462094959336" q1="1.3213936187103152" p2="-26.494446643060087" q2="-4.1820494241721029">
         <iidm:alias>_0452c378-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0481c2b7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9579,7 +9702,7 @@
             <iidm:temporaryLimit name="_fff133bf-25fd-46b2-b144-a227c31ee882" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048ac367-c766-11e1-8775-005056c00008" name="100-101" r="4.8264480000000001" x="21.9890881" g1="0" b1="9.4123049999999997e-05" g2="0" b2="9.4123049999999997e-05" node1="77" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046ed6f7-c766-11e1-8775-005056c00008" p1="-22.557713177493795" q1="25.100638767306059" p2="22.886303194983736" q2="-26.908891869296191">
+    <iidm:line id="_048ac367-c766-11e1-8775-005056c00008" name="100-101" r="4.8264480000000001" x="21.9890881" g1="0" b1="9.4123049999999997e-05" g2="0" b2="9.4123049999999997e-05" node1="77" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046ed6f7-c766-11e1-8775-005056c00008" p1="-22.592330853912578" q1="25.130937082983571" p2="22.921775143057367" q2="-26.935206521467741">
         <iidm:alias>_044afb45-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b5fa2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9587,7 +9710,7 @@
             <iidm:temporaryLimit name="_217e3c95-24b5-438f-a721-d2257e1a43b4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0481c2b1-c766-11e1-8775-005056c00008" name="56-57" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="57" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="-37.600848022332983" q1="-4.8568069076892817" p2="38.150044046282076" q2="4.2030098719064108">
+    <iidm:line id="_0481c2b1-c766-11e1-8775-005056c00008" name="56-57" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="57" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="-37.615022854416388" q1="-4.8501579157104953" p2="38.164610923367142" q2="4.1974725305540428">
         <iidm:alias>_045e0e12-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0487dd35-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9595,7 +9718,7 @@
             <iidm:temporaryLimit name="_f5547027-3d48-4a53-937b-bd5ba63ef70d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047a6fb7-c766-11e1-8775-005056c00008" name="47-69" r="14.705855400000001" x="48.403869999999998" g1="0" b1="0.00020351240000000001" g2="0" b2="0.00020351240000000001" node1="31" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="57" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-88.644231598231087" q1="28.672956537753926" p2="95.951918523405467" q2="-12.064387616190208">
+    <iidm:line id="_047a6fb7-c766-11e1-8775-005056c00008" name="47-69" r="14.705855400000001" x="48.403869999999998" g1="0" b1="0.00020351240000000001" g2="0" b2="0.00020351240000000001" node1="31" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="57" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-88.448260861745524" q1="28.560175490191121" p2="95.721121510815848" q2="-12.066423077633203">
         <iidm:alias>_04758db9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0485ba56-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9603,7 +9726,7 @@
             <iidm:temporaryLimit name="_e9fec217-cf6f-4d39-9495-26ed10c05100" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0453fbf0-c766-11e1-8775-005056c00008" name="110-111" r="3.8332799999999998" x="13.1551189" g1="0" b1="5.7392100000000002e-05" g2="0" b2="5.7392100000000002e-05" node1="40" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_046a1c00-c766-11e1-8775-005056c00008" p1="-39.964308096740794" q1="-20.345024340941876" p2="40.440610487169032" q2="20.107069808532962">
+    <iidm:line id="_0453fbf0-c766-11e1-8775-005056c00008" name="110-111" r="3.8332799999999998" x="13.1551189" g1="0" b1="5.7392100000000002e-05" g2="0" b2="5.7392100000000002e-05" node1="40" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_046a1c00-c766-11e1-8775-005056c00008" p1="-39.95712219944479" q1="-20.347412814364681" p2="40.433309567111678" q2="20.109067576720236">
         <iidm:alias>_0447c6f5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04812675-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9611,7 +9734,7 @@
             <iidm:temporaryLimit name="_ea48fee0-31b6-4990-a332-25d08b7d731f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04778984-c766-11e1-8775-005056c00008" name="41-42" r="7.14384" x="23.522401800000001" g1="0" b1="9.8714400000000005e-05" g2="0" b2="9.8714400000000005e-05" node1="21" voltageLevelId1="_048c4a08-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="-8.7461321720929188" q1="-12.208162643878772" p2="8.8460920912279271" q2="9.7366374467090484">
+    <iidm:line id="_04778984-c766-11e1-8775-005056c00008" name="41-42" r="7.14384" x="23.522401800000001" g1="0" b1="9.8714400000000005e-05" g2="0" b2="9.8714400000000005e-05" node1="21" voltageLevelId1="_048c4a08-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="-8.5555928118025069" q1="-12.35008980034123" p2="8.6555565150578246" q2="9.8807095069436226">
         <iidm:alias>_044d1e2a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046512f1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9619,7 +9742,7 @@
             <iidm:temporaryLimit name="_063af52c-fe10-4c1e-85d4-dd80dcc1d2f9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04653a08-c766-11e1-8775-005056c00008" name="80-99" r="7.9104960000000002" x="35.893439999999998" g1="0" b1="0.00015668044999999999" g2="0" b2="0.00015668044999999999" node1="78" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04644fa4-c766-11e1-8775-005056c00008" p1="-0.66160011745022473" q1="7.3061859049073528" p2="0.70596074234471762" q2="-12.897881753739709">
+    <iidm:line id="_04653a08-c766-11e1-8775-005056c00008" name="80-99" r="7.9104960000000002" x="35.893439999999998" g1="0" b1="0.00015668044999999999" g2="0" b2="0.00015668044999999999" node1="78" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04644fa4-c766-11e1-8775-005056c00008" p1="-0.65351338431549266" q1="7.3044179704419214" p2="0.69785433668418306" q2="-12.896197349074527">
         <iidm:alias>_04773b69-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0477b092-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9627,7 +9750,7 @@
             <iidm:temporaryLimit name="_c05229ce-6abb-4209-ad4f-0dcd4a070f28" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04581aa5-c766-11e1-8775-005056c00008" name="54-59" r="8.7642720000000001" x="39.953229999999998" g1="0" b1="0.0001716024" g2="0" b2="0.0001716024" node1="58" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-25.576213015254389" q1="-13.071450224232118" p2="26.00608999926078" q2="9.4628336095885839">
+    <iidm:line id="_04581aa5-c766-11e1-8775-005056c00008" name="54-59" r="8.7642720000000001" x="39.953229999999998" g1="0" b1="0.0001716024" g2="0" b2="0.0001716024" node1="58" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-25.559710938008312" q1="-13.077168769318915" p2="25.989180516765636" q2="9.4666943390845546">
         <iidm:alias>_0457cc82-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045cae81-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9635,7 +9758,7 @@
             <iidm:temporaryLimit name="_ac528cbe-6fc1-41dd-ba9d-d8b7a4c77576" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04690a93-c766-11e1-8775-005056c00008" name="92-94" r="8.3809430000000003" x="27.529920000000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="67" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="67.104311291648273" q1="-16.697599130844718" p2="-64.784053614465364" q2="20.357071330383334">
+    <iidm:line id="_04690a93-c766-11e1-8775-005056c00008" name="92-94" r="8.3809430000000003" x="27.529920000000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="67" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="67.161838266952387" q1="-16.635023910716431" p2="-64.838437186297909" q2="20.305718820246334">
         <iidm:alias>_044c33c1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0483706b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9643,7 +9766,7 @@
             <iidm:temporaryLimit name="_6ac84228-6b04-4b10-b560-29655c8e93b4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046009e3-c766-11e1-8775-005056c00008" name="37-39" r="5.5931040000000003" x="18.469439999999999" g1="0" b1="7.7479350000000006e-05" g2="0" b2="7.7479350000000006e-05" node1="57" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046bf0c7-c766-11e1-8775-005056c00008" p1="68.839087876340201" q1="17.561634173446254" p2="-67.016583518414478" q2="-13.860558999098632">
+    <iidm:line id="_046009e3-c766-11e1-8775-005056c00008" name="37-39" r="5.5931040000000003" x="18.469439999999999" g1="0" b1="7.7479350000000006e-05" g2="0" b2="7.7479350000000006e-05" node1="57" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046bf0c7-c766-11e1-8775-005056c00008" p1="69.052243112138171" q1="17.483774094188977" p2="-67.218302934568186" q2="-13.74242793953308">
         <iidm:alias>_044c33c9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04789afa-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9651,7 +9774,7 @@
             <iidm:temporaryLimit name="_2ccdc288-c132-40d1-a928-3887bec4ff67" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0458b6e8-c766-11e1-8775-005056c00008" name="46-47" r="6.6211200000000003" x="22.12848" g1="0" b1="9.0679499999999998e-05" g2="0" b2="9.0679499999999998e-05" node1="33" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_0457f396-c766-11e1-8775-005056c00008" p1="-32.617403083615557" q1="1.7563537045904538" p2="33.021898177694212" q2="-3.6248367525248049">
+    <iidm:line id="_0458b6e8-c766-11e1-8775-005056c00008" name="46-47" r="6.6211200000000003" x="22.12848" g1="0" b1="9.0679499999999998e-05" g2="0" b2="9.0679499999999998e-05" node1="33" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_0457f396-c766-11e1-8775-005056c00008" p1="-32.516566410262321" q1="1.7012914348695076" p2="32.91845204611581" q2="-3.5785818682193637">
         <iidm:alias>_04507980-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0464c4da-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9659,7 +9782,7 @@
             <iidm:temporaryLimit name="_06ca3245-2668-448f-a5c6-961924217a5c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044f8f22-c766-11e1-8775-005056c00008" name="82-83" r="1.9514879999999999" x="6.3858959999999998" g1="0" b1="0.0001089302" g2="0" b2="0.0001089302" node1="31" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728074-c766-11e1-8775-005056c00008" p1="-70.075512099897125" q1="39.70920223845885" p2="70.847270848346753" q2="-40.813317956121168">
+    <iidm:line id="_044f8f22-c766-11e1-8775-005056c00008" name="82-83" r="1.9514879999999999" x="6.3858959999999998" g1="0" b1="0.0001089302" g2="0" b2="0.0001089302" node1="31" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728074-c766-11e1-8775-005056c00008" p1="-69.674959834843236" q1="41.040743270434803" p2="70.454505005873472" q2="-42.111494731713755">
         <iidm:alias>_047a48a6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b3891-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9667,7 +9790,7 @@
             <iidm:temporaryLimit name="_dfbd2f07-76ab-41e3-910f-dc706979ea4b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045cfca6-c766-11e1-8775-005056c00008" name="108-109" r="1.82952" x="5.0181120000000004" g1="0" b1="2.1809000000000001e-05" g2="0" b2="2.1809000000000001e-05" node1="21" voltageLevelId1="_046c65f4-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b7b99-c766-11e1-8775-005056c00008" p1="20.50283981026627" q1="-0.43120531184573163" p2="-20.454873159184856" q2="-0.13498322463477777">
+    <iidm:line id="_045cfca6-c766-11e1-8775-005056c00008" name="108-109" r="1.82952" x="5.0181120000000004" g1="0" b1="2.1809000000000001e-05" g2="0" b2="2.1809000000000001e-05" node1="21" voltageLevelId1="_046c65f4-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b7b99-c766-11e1-8775-005056c00008" p1="20.50631867873248" q1="-0.43243135366868962" p2="-20.458335614458729" q2="-0.13371053722199439">
         <iidm:alias>_04481514-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04716f00-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9675,7 +9798,7 @@
             <iidm:temporaryLimit name="_11451cec-81c7-4f83-a7db-df7dcaffa94e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04784cd5-c766-11e1-8775-005056c00008" name="70-74" r="6.9870239999999999" x="23.051952400000001" g1="0" b1="9.6648299999999994e-05" g2="0" b2="9.6648299999999994e-05" node1="48" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047dcb11-c766-11e1-8775-005056c00008" p1="23.888540432101919" q1="9.1584275137809321" p2="-23.603983207986616" q2="-11.402491394815971">
+    <iidm:line id="_04784cd5-c766-11e1-8775-005056c00008" name="70-74" r="6.9870239999999999" x="23.051952400000001" g1="0" b1="9.6648299999999994e-05" g2="0" b2="9.6648299999999994e-05" node1="48" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047dcb11-c766-11e1-8775-005056c00008" p1="23.614863295624446" q1="9.3182254672264797" p2="-23.334331329520825" q2="-11.576168589450091">
         <iidm:alias>_045e5c33-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046ab84b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9683,7 +9806,7 @@
             <iidm:temporaryLimit name="_37a5cc00-bd7f-4ec7-a77c-e140e23450d2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04747c40-c766-11e1-8775-005056c00008" name="77-82" r="5.1923519999999996" x="14.8626719" g1="0" b1="0.0002345615" g2="0" b2="0.0002345615" node1="69" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_046512f8-c766-11e1-8775-005056c00008" p1="-31.728376815603713" q1="32.722625441619506" p2="32.429074814320757" q2="-38.760344453075533">
+    <iidm:line id="_04747c40-c766-11e1-8775-005056c00008" name="77-82" r="5.1923519999999996" x="14.8626719" g1="0" b1="0.0002345615" g2="0" b2="0.0002345615" node1="69" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_046512f8-c766-11e1-8775-005056c00008" p1="-31.518164578714231" q1="33.41107362508474" p2="32.230272676710349" q2="-39.408635666152733">
         <iidm:alias>_0451b202-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0452ea84-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9691,7 +9814,7 @@
             <iidm:temporaryLimit name="_e9798d58-b518-4fab-984c-c72076dfc2ae" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045e3524-c766-11e1-8775-005056c00008" name="23-24" r="2.3522400000000001" x="8.5726080000000007" g1="0" b1="0.00014290635" g2="0" b2="0.00014290635" node1="39" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_048c22fa-c766-11e1-8775-005056c00008" p1="59.759343973247155" q1="-10.630411840617779" p2="-59.267548200939771" q2="7.4680116651273307">
+    <iidm:line id="_045e3524-c766-11e1-8775-005056c00008" name="23-24" r="2.3522400000000001" x="8.5726080000000007" g1="0" b1="0.00014290635" g2="0" b2="0.00014290635" node1="39" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_048c22fa-c766-11e1-8775-005056c00008" p1="58.306598582223224" q1="-10.261446517756143" p2="-57.839815216574806" q2="6.9971147487152399">
         <iidm:alias>_046cb413-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f9fd3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9699,7 +9822,7 @@
             <iidm:temporaryLimit name="_e8ec73b8-1ecf-4d18-9ef9-80eabf3a4969" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0474f177-c766-11e1-8775-005056c00008" name="15-17" r="2.2999679999999998" x="7.6142880000000002" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="48" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-155.25450564910065" q1="-18.546723594614253" p2="158.84191731688392" q2="26.304872472463931">
+    <iidm:line id="_0474f177-c766-11e1-8775-005056c00008" name="15-17" r="2.2999679999999998" x="7.6142880000000002" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="48" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-164.47696986390565" q1="-14.991213479793819" p2="168.48627026896247" q2="24.149479754638325">
         <iidm:alias>_044c5ad2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046931a7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9707,7 +9830,7 @@
             <iidm:temporaryLimit name="_2ceac3d1-f73d-43db-8d37-9e329f1787bb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0483be84-c766-11e1-8775-005056c00008" name="8-30" r="2.0860400000000001" x="24.393599999999999" g1="0" b1="0.00053099175999999997" g2="0" b2="0.00053099175999999997" node1="30" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="38" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="91.637830762150116" q1="26.83595046652346" p2="-91.159561322724116" q2="-71.519646339866512">
+    <iidm:line id="_0483be84-c766-11e1-8775-005056c00008" name="8-30" r="2.0860400000000001" x="24.393599999999999" g1="0" b1="0.00053099175999999997" g2="0" b2="0.00053099175999999997" node1="30" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="38" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="107.9844024872948" q1="21.210814196887341" p2="-107.39258750017146" q2="-64.909360195159479">
         <iidm:alias>_0454e651-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04801506-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9715,7 +9838,7 @@
             <iidm:temporaryLimit name="_ca795ad3-97e5-4416-aaba-53cce27f6434" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0488eea6-c766-11e1-8775-005056c00008" name="49-69" r="17.16264" x="56.453762099999999" g1="0" b1="0.00023760329999999999" g2="0" b2="0.00023760329999999999" node1="115" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-80.462917565268882" q1="29.803515566311507" p2="87.626370618764682" q2="-15.024942671023734">
+    <iidm:line id="_0488eea6-c766-11e1-8775-005056c00008" name="49-69" r="17.16264" x="56.453762099999999" g1="0" b1="0.00023760329999999999" g2="0" b2="0.00023760329999999999" node1="115" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-80.277307603011806" q1="29.683334323835986" p2="87.405093349549887" q2="-15.022090905776253">
         <iidm:alias>_04492681-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046735d6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9723,7 +9846,7 @@
             <iidm:temporaryLimit name="_c42dc3ef-3a2e-4070-8efb-78e5c0cd5554" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047566a0-c766-11e1-8775-005056c00008" name="13-15" r="12.9634562" x="42.584255200000001" g1="0" b1="0.00017986685000000001" g2="0" b2="0.00017986685000000001" node1="21" voltageLevelId1="_04851e1b-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="16.521444269964999" q1="-1.1501237207105466" p2="-16.300183587759008" q2="-3.8433398637363099">
+    <iidm:line id="_047566a0-c766-11e1-8775-005056c00008" name="13-15" r="12.9634562" x="42.584255200000001" g1="0" b1="0.00017986685000000001" g2="0" b2="0.00017986685000000001" node1="21" voltageLevelId1="_04851e1b-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="12.313688528016662" q1="0.29762404699928169" p2="-12.18402189595529" q2="-5.5922870939455089">
         <iidm:alias>_04662461-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04865694-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9731,7 +9854,7 @@
             <iidm:temporaryLimit name="_ad988fd9-9270-4230-95a2-1858f32259df" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0476c63a-c766-11e1-8775-005056c00008" name="69-70" r="5.2271999999999998" x="22.12848" g1="0" b1="0.00035009184999999998" g2="0" b2="0.00035009184999999998" node1="59" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="73.128861464347068" q1="20.553019394658669" p2="-71.425700843366926" q2="-25.783550493665295">
+    <iidm:line id="_0476c63a-c766-11e1-8775-005056c00008" name="69-70" r="5.2271999999999998" x="22.12848" g1="0" b1="0.00035009184999999998" g2="0" b2="0.00035009184999999998" node1="59" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="73.94549364701497" q1="20.313048333517429" p2="-72.212321474126156" q2="-25.418296770462646">
         <iidm:alias>_047e193a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b1184-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9739,7 +9862,7 @@
             <iidm:temporaryLimit name="_519e3ecb-3561-4d11-ac6b-172a0b4b09b2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04520028-c766-11e1-8775-005056c00008" name="19-20" r="4.3908480000000001" x="20.38608" g1="0" b1="8.5514249999999999e-05" g2="0" b2="8.5514249999999999e-05" node1="39" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b2d70-c766-11e1-8775-005056c00008" p1="-15.267880034701692" q1="2.2272766895202212" p2="15.338203166874964" q2="-4.5235227839108392">
+    <iidm:line id="_04520028-c766-11e1-8775-005056c00008" name="19-20" r="4.3908480000000001" x="20.38608" g1="0" b1="8.5514249999999999e-05" g2="0" b2="8.5514249999999999e-05" node1="39" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b2d70-c766-11e1-8775-005056c00008" p1="-13.269788942350907" q1="1.1457120397618767" p2="13.321969669450912" q2="-3.5262753452561397">
         <iidm:alias>_0472f5a9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04745537-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9747,7 +9870,7 @@
             <iidm:temporaryLimit name="_b88528bf-cb1c-4c00-ad79-d5937197d40c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04862f83-c766-11e1-8775-005056c00008" name="94-95" r="2.2999679999999998" x="7.5620159999999998" g1="0" b1="3.1852600000000001e-05" g2="0" b2="3.1852600000000001e-05" node1="51" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f4108-c766-11e1-8775-005056c00008" p1="59.558124818664396" q1="5.7958323110096854" p2="-59.071683596871779" q2="-5.2656425044297528">
+    <iidm:line id="_04862f83-c766-11e1-8775-005056c00008" name="94-95" r="2.2999679999999998" x="7.5620159999999998" g1="0" b1="3.1852600000000001e-05" g2="0" b2="3.1852600000000001e-05" node1="51" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f4108-c766-11e1-8775-005056c00008" p1="59.617205973851007" q1="5.9747612422600431" p2="-59.129328977410452" q2="-5.4393817767086432">
         <iidm:alias>_044ca8f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04837060-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9755,7 +9878,7 @@
             <iidm:temporaryLimit name="_b70e76a1-6e79-4fb6-b487-dffa9bfeab7b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047b0bf6-c766-11e1-8775-005056c00008" name="12-16" r="3.6938879999999998" x="14.5316162" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="68" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046f7338-c766-11e1-8775-005056c00008" p1="17.401001344733341" q1="7.9732293164590571" p2="-17.317899380703206" q2="-9.7200396972704279">
+    <iidm:line id="_047b0bf6-c766-11e1-8775-005056c00008" name="12-16" r="3.6938879999999998" x="14.5316162" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="68" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046f7338-c766-11e1-8775-005056c00008" p1="10.670256483488934" q1="9.8142909706982948" p2="-10.620104332316773" q2="-11.690367268953644">
         <iidm:alias>_0450798a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045c8772-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9763,7 +9886,7 @@
             <iidm:temporaryLimit name="_af73f526-c58b-40e7-8e1c-14f05a39f6a2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04524e47-c766-11e1-8775-005056c00008" name="100-103" r="2.7878400000000001" x="9.1476000000000006" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="78" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0475b4c0-c766-11e1-8775-005056c00008" p1="114.45797567421612" q1="-20.421018450559718" p2="-112.38318305123131" q2="21.723158131771779">
+    <iidm:line id="_04524e47-c766-11e1-8775-005056c00008" name="100-103" r="2.7878400000000001" x="9.1476000000000006" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="78" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0475b4c0-c766-11e1-8775-005056c00008" p1="114.46928127053559" q1="-20.423662882922571" p2="-112.39407005238226" q2="21.72718622733683">
         <iidm:alias>_04684744-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048aea71-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9771,7 +9894,7 @@
             <iidm:temporaryLimit name="_1631e50b-21a3-470b-803b-f9665b6fcd60" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04682038-c766-11e1-8775-005056c00008" name="27-32" r="3.9900959999999999" x="13.1551189" g1="0" b1="5.5268600000000001e-05" g2="0" b2="5.5268600000000001e-05" node1="40" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="18.626807853177237" q1="-3.5735460520013951" p2="-18.540108897289397" q2="2.0621047075790426">
+    <iidm:line id="_04682038-c766-11e1-8775-005056c00008" name="27-32" r="3.9900959999999999" x="13.1551189" g1="0" b1="5.5268600000000001e-05" g2="0" b2="5.5268600000000001e-05" node1="40" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="16.642269050698292" q1="-2.346593919236752" p2="-16.574157826609195" q2="0.76924366584931048">
         <iidm:alias>_0455347a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479ac63-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9779,7 +9902,7 @@
             <iidm:temporaryLimit name="_52eb4b09-42bb-4106-ac26-fe1059639d3a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0482fb31-c766-11e1-8775-005056c00008" name="59-61" r="5.7150720000000002" x="26.1360016" g1="0" b1="0.0001113407" g2="0" b2="0.0001113407" node1="68" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-110.2853816726599" q1="26.120588681263701" p2="114.66232494105546" q2="-9.9069661653617285">
+    <iidm:line id="_0482fb31-c766-11e1-8775-005056c00008" name="59-61" r="5.7150720000000002" x="26.1360016" g1="0" b1="0.0001113407" g2="0" b2="0.0001113407" node1="68" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-110.26870885980158" q1="26.114100209343206" p2="114.64427407195062" q2="-9.9067875447225155">
         <iidm:alias>_044a10e9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0473b8f5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9787,7 +9910,7 @@
             <iidm:temporaryLimit name="_b5a7dea0-bfce-4548-a04d-7bb7b6d9f80a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047d55e3-c766-11e1-8775-005056c00008" name="100-104" r="7.8582239999999999" x="35.544960000000003" g1="0" b1="0.00015524565000000001" g2="0" b2="0.00015524565000000001" node1="79" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="54.800619683018226" q1="10.998204270105308" p2="-53.408129577514366" q2="-10.045583106740331">
+    <iidm:line id="_047d55e3-c766-11e1-8775-005056c00008" name="100-104" r="7.8582239999999999" x="35.544960000000003" g1="0" b1="0.00015524565000000001" g2="0" b2="0.00015524565000000001" node1="79" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="54.803002067148924" q1="10.997981674960702" p2="-53.410398323811734" q2="-10.044836057250349">
         <iidm:alias>_04636547-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048aea76-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9795,7 +9918,7 @@
             <iidm:temporaryLimit name="_17a10cd0-b653-4dcf-bdc3-4d5005ea9591" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04653a02-c766-11e1-8775-005056c00008" name="75-77" r="10.4718237" x="34.830577900000002" g1="0" b1="0.00014284895" g2="0" b2="0.00014284895" node1="49" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-37.121312814908642" q1="-6.6928870900030315" p2="38.017884423111518" q2="4.8426249455635046">
+    <iidm:line id="_04653a02-c766-11e1-8775-005056c00008" name="75-77" r="10.4718237" x="34.830577900000002" g1="0" b1="0.00014284895" g2="0" b2="0.00014284895" node1="49" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-37.274617430384041" q1="-6.5649592025988763" p2="38.177807474669336" q2="4.7374289721393721">
         <iidm:alias>_04642894-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04720b47-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9803,7 +9926,7 @@
             <iidm:temporaryLimit name="_6f81df11-7e71-4b6e-a6ee-a8c5f72f4ba5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04483c2a-c766-11e1-8775-005056c00008" name="23-32" r="5.5234079999999999" x="20.089872400000001" g1="0" b1="0.00033660465000000001" g2="0" b2="0.00033660465000000001" node1="40" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="83.286536098174452" q1="4.8838647114991973" p2="-81.047718420641317" q2="-8.0575898524175997">
+    <iidm:line id="_04483c2a-c766-11e1-8775-005056c00008" name="23-32" r="5.5234079999999999" x="20.089872400000001" g1="0" b1="0.00033660465000000001" g2="0" b2="0.00033660465000000001" node1="40" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="79.553337180948816" q1="5.640341421948003" p2="-77.506542231474967" q2="-9.5364173355714499">
         <iidm:alias>_044b978a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0461dea6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9811,7 +9934,7 @@
             <iidm:temporaryLimit name="_a8f6a7d2-e58d-4671-a776-97be7291355e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048719e5-c766-11e1-8775-005056c00008" name="96-97" r="3.0143520000000001" x="15.42024" g1="0" b1="6.8870549999999994e-05" g2="0" b2="6.8870549999999994e-05" node1="50" voltageLevelId1="_045a1672-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="5.2867336765257598" q1="-25.982588828047408" p2="-5.1725119148408583" q2="24.176154313618401">
+    <iidm:line id="_048719e5-c766-11e1-8775-005056c00008" name="96-97" r="3.0143520000000001" x="15.42024" g1="0" b1="6.8870549999999994e-05" g2="0" b2="6.8870549999999994e-05" node1="50" voltageLevelId1="_045a1672-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="5.2455380608337405" q1="-26.160775703637256" p2="-5.1297253933948808" q2="24.3637975212174">
         <iidm:alias>_0451b207-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04828601-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9819,7 +9942,7 @@
             <iidm:temporaryLimit name="_ea6d39aa-df95-4d3e-b7b6-a800e552e72a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048481d0-c766-11e1-8775-005056c00008" name="25-27" r="5.5408330000000001" x="28.401121100000001" g1="0" b1="0.000506198385" g2="0" b2="0.000506198385" node1="30" voltageLevelId1="_04728079-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0476c639-c766-11e1-8775-005056c00008" p1="156.01102129272709" q1="31.083832677067662" p2="-148.51034804143003" q2="-10.61038637825914">
+    <iidm:line id="_048481d0-c766-11e1-8775-005056c00008" name="25-27" r="5.5408330000000001" x="28.401121100000001" g1="0" b1="0.000506198385" g2="0" b2="0.000506198385" node1="30" voltageLevelId1="_04728079-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0476c639-c766-11e1-8775-005056c00008" p1="150.52333469212564" q1="29.900156303949206" p2="-143.53530766995161" q2="-12.079999791663527">
         <iidm:alias>_046d2947-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04725960-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9827,7 +9950,7 @@
             <iidm:temporaryLimit name="_d9d53af2-5ffa-4f2a-a4e6-ed22371332d6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04885268-c766-11e1-8775-005056c00008" name="110-112" r="4.3037280000000004" x="11.1513615" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="41" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="13" voltageLevelId2="_04784cd1-c766-11e1-8775-005056c00008" p1="69.354888698848043" q1="11.007320130972595" p2="-68.000515225633279" q2="-13.000143283911092">
+    <iidm:line id="_04885268-c766-11e1-8775-005056c00008" name="110-112" r="4.3037280000000004" x="11.1513615" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="41" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="13" voltageLevelId2="_04784cd1-c766-11e1-8775-005056c00008" p1="69.354752539733227" q1="11.007302183363993" p2="-68.000381277735215" q2="-13.000118472726601">
         <iidm:alias>_04611b55-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0481c2ba-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9835,7 +9958,7 @@
             <iidm:temporaryLimit name="_d50299b9-a055-408a-aa1e-2e93a715120f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0484a8e4-c766-11e1-8775-005056c00008" name="89-92" r="1.7249760000000001" x="8.7991200000000003" g1="0" b1="0.00015725434999999999" g2="0" b2="0.00015725434999999999" node1="57" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="68" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="232.27476247442274" q1="-2.938971993521089" p2="-226.98658442970992" q2="24.465847864751378">
+    <iidm:line id="_0484a8e4-c766-11e1-8775-005056c00008" name="89-92" r="1.7249760000000001" x="8.7991200000000003" g1="0" b1="0.00015725434999999999" g2="0" b2="0.00015725434999999999" node1="57" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="68" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="232.40548685455832" q1="-2.8485246921961971" p2="-227.11134434307036" q2="24.406116087734148">
         <iidm:alias>_04481517-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04808a3c-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9843,7 +9966,7 @@
             <iidm:temporaryLimit name="_eee9ca2b-764f-4ab8-a745-405338044743" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04689568-c766-11e1-8775-005056c00008" name="49-54" r="15.1414566" x="50.703842199999997" g1="0" b1="0.00020948120000000001" g2="0" b2="0.00020948120000000001" node1="116" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="55.265663175108735" q1="11.883883279204815" p2="-52.535012504944667" q2="-9.8306670114824293">
+    <iidm:line id="_04689568-c766-11e1-8775-005056c00008" name="49-54" r="15.1414566" x="50.703842199999997" g1="0" b1="0.00020948120000000001" g2="0" b2="0.00020948120000000001" node1="116" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="55.282206423564482" q1="11.882388236645786" p2="-52.550086989977409" q2="-9.8242517666987581">
         <iidm:alias>_046030f0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04605808-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9851,7 +9974,7 @@
             <iidm:temporaryLimit name="_690202a4-aad2-4ad3-8842-961b39e37709" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046c8d04-c766-11e1-8775-005056c00008" name="40-41" r="2.5264799999999998" x="8.4854880000000001" g1="0" b1="3.5066600000000001e-05" g2="0" b2="3.5066600000000001e-05" node1="40" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048c4a08-c766-11e1-8775-005056c00008" p1="28.355093474853572" q1="-2.7128891843038967" p2="-28.208741503871472" q2="2.2285615275388007">
+    <iidm:line id="_046c8d04-c766-11e1-8775-005056c00008" name="40-41" r="2.5264799999999998" x="8.4854880000000001" g1="0" b1="3.5066600000000001e-05" g2="0" b2="3.5066600000000001e-05" node1="40" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048c4a08-c766-11e1-8775-005056c00008" p1="28.547470856770897" q1="-2.8466515102182233" p2="-28.398876260914559" q2="2.3708025167238382">
         <iidm:alias>_045cae80-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a2194-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9859,7 +9982,7 @@
             <iidm:temporaryLimit name="_34f2ef7c-32da-4444-b989-d02f5f931c50" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046735d5-c766-11e1-8775-005056c00008" name="39-40" r="3.206016" x="10.54152" g1="0" b1="4.4536249999999999e-05" g2="0" b2="4.4536249999999999e-05" node1="22" voltageLevelId1="_046bf0c7-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="40.054916681988196" q1="2.8866406883834914" p2="-39.6919861568173" q2="-2.9513411389357245">
+    <iidm:line id="_046735d5-c766-11e1-8775-005056c00008" name="39-40" r="3.206016" x="10.54152" g1="0" b1="4.4536249999999999e-05" g2="0" b2="4.4536249999999999e-05" node1="22" voltageLevelId1="_046bf0c7-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="40.256926961800808" q1="2.7688367693531388" p2="-39.890139954470229" q2="-2.8195334301977129">
         <iidm:alias>_045115c1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048badc2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9867,7 +9990,7 @@
             <iidm:temporaryLimit name="_38d58455-5205-46bb-8e44-c66873f62938" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0470d2c4-c766-11e1-8775-005056c00008" name="89-92" r="6.8476319999999999" x="27.5473423" g1="0" b1="0.00011880164999999999" g2="0" b2="0.00011880164999999999" node1="58" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="73.277517239019048" q1="-5.8159118397994982" p2="-71.182818646080094" q2="10.126719597874366">
+    <iidm:line id="_0470d2c4-c766-11e1-8775-005056c00008" name="89-92" r="6.8476319999999999" x="27.5473423" g1="0" b1="0.00011880164999999999" g2="0" b2="0.00011880164999999999" node1="58" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="73.32018879067607" q1="-5.7894398322886644" p2="-71.223127614621333" q2="10.109971658015915">
         <iidm:alias>_04690a97-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04690a98-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9875,7 +9998,7 @@
             <iidm:temporaryLimit name="_0cce41c7-b99f-4fec-93d2-73ea24433fa1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0479ac60-c766-11e1-8775-005056c00008" name="33-37" r="7.2309599999999996" x="24.742080000000001" g1="0" b1="0.00010502754999999999" g2="0" b2="0.00010502754999999999" node1="21" voltageLevelId1="_0456bb11-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="43.947521227605165" q1="-21.338058178403912" p2="-42.841932436848353" q2="21.885562592764749">
+    <iidm:line id="_0479ac60-c766-11e1-8775-005056c00008" name="33-37" r="7.2309599999999996" x="24.742080000000001" g1="0" b1="0.00010502754999999999" g2="0" b2="0.00010502754999999999" node1="21" voltageLevelId1="_0456bb11-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="44.95675887203172" q1="-21.606994767256165" p2="-43.80176446165401" q2="22.327438541407211">
         <iidm:alias>_04716f08-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0483be89-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9883,7 +10006,7 @@
             <iidm:temporaryLimit name="_343677c6-7477-4bf6-a12c-2c7e4a684d6f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048c4a00-c766-11e1-8775-005056c00008" name="105-108" r="4.5476640000000002" x="12.249072099999999" g1="0" b1="5.2915499999999998e-05" g2="0" b2="5.2915499999999998e-05" node1="50" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_046c65f4-c766-11e1-8775-005056c00008" p1="22.64650480652886" q1="-0.75189101641611189" p2="-22.502857301429806" q2="-0.5688077432737304">
+    <iidm:line id="_048c4a00-c766-11e1-8775-005056c00008" name="105-108" r="4.5476640000000002" x="12.249072099999999" g1="0" b1="5.2915499999999998e-05" g2="0" b2="5.2915499999999998e-05" node1="50" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_046c65f4-c766-11e1-8775-005056c00008" p1="22.650024715151392" q1="-0.75299426817045478" p2="-22.506332319397611" q2="-0.56757981350312214">
         <iidm:alias>_046adf53-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04795e46-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9891,7 +10014,7 @@
             <iidm:temporaryLimit name="_74cf84b9-e14f-4f81-9e8b-3a791cd474a0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04631724-c766-11e1-8775-005056c00008" name="34-37" r="0.44605400000000001" x="1.637856" g1="0" b1="2.8236900000000001e-05" g2="0" b2="2.8236900000000001e-05" node1="41" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-54.709284047344589" q1="-36.318972880589058" p2="54.832811446415398" q2="35.894895838411195">
+    <iidm:line id="_04631724-c766-11e1-8775-005056c00008" name="34-37" r="0.44605400000000001" x="1.637856" g1="0" b1="2.8236900000000001e-05" g2="0" b2="2.8236900000000001e-05" node1="41" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-53.958402318508782" q1="-36.662784477946254" p2="54.080427954994647" q2="36.234156514465568">
         <iidm:alias>_04592c19-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04719611-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9899,7 +10022,7 @@
             <iidm:temporaryLimit name="_8e90bf2e-3be4-41be-a84e-c1d4e709f8a1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04814d85-c766-11e1-8775-005056c00008" name="61-62" r="1.435738" x="6.5514239999999999" g1="0" b1="2.812215e-05" g2="0" b2="2.812215e-05" node1="40" voltageLevelId1="_0448d867-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="59.760924938365974" q1="-18.013448029915661" p2="-59.438107235613501" q2="18.51435659839591">
+    <iidm:line id="_04814d85-c766-11e1-8775-005056c00008" name="61-62" r="1.435738" x="6.5514239999999999" g1="0" b1="2.812215e-05" g2="0" b2="2.812215e-05" node1="40" voltageLevelId1="_0448d867-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="59.741001856635513" q1="-18.00982356904224" p2="-59.41839331361988" q2="18.509776352156983">
         <iidm:alias>_045a3d85-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047abdd8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9907,7 +10030,7 @@
             <iidm:temporaryLimit name="_39a23399-348e-44d9-8032-8fc62e6c7d63" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046a4318-c766-11e1-8775-005056c00008" name="101-102" r="4.2863040000000003" x="19.5148811" g1="0" b1="8.4366399999999999e-05" g2="0" b2="8.4366399999999999e-05" node1="22" voltageLevelId1="_046ed6f7-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="-44.884373011836132" q1="11.911092913954976" p2="45.434204877685289" q2="-12.28513658569462">
+    <iidm:line id="_046a4318-c766-11e1-8775-005056c00008" name="101-102" r="4.2863040000000003" x="19.5148811" g1="0" b1="8.4366399999999999e-05" g2="0" b2="8.4366399999999999e-05" node1="22" voltageLevelId1="_046ed6f7-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="-44.919803527576747" q1="11.937444733557669" p2="45.470639589915741" q2="-12.306704675325316">
         <iidm:alias>_04878f1b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04885261-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9915,7 +10038,7 @@
             <iidm:temporaryLimit name="_0501dacc-29fc-44a2-8cad-31a20b011d25" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c81e3-c766-11e1-8775-005056c00008" name="26-30" r="3.8671600000000002" x="41.624000000000002" g1="0" b1="0.00093801650000000002" g2="0" b2="0.00093801650000000002" node1="21" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="227.60373091379904" q1="2.0977448509031493" p2="-223.40085007260672" q2="-46.718896550904077">
+    <iidm:line id="_044c81e3-c766-11e1-8775-005056c00008" name="26-30" r="3.8671600000000002" x="41.624000000000002" g1="0" b1="0.00093801650000000002" g2="0" b2="0.00093801650000000002" node1="21" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="240.82706838393534" q1="-1.9620958892339058" p2="-236.17328024133178" q2="-38.217818354939617">
         <iidm:alias>_0463654b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04747c4a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9923,7 +10046,7 @@
             <iidm:temporaryLimit name="_c95a66fd-913c-48c7-b8ef-cf3007c60af6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048915b9-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="41" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="117" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-51.812088469133698" q1="-19.858392085749081" p2="54.344939826568471" q2="23.202601033047795">
+    <iidm:line id="_048915b9-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="41" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="117" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-51.61973632152224" q1="-20.004248881804351" p2="54.141188343284178" q2="23.299123105994042">
         <iidm:alias>_044bbe98-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0456e224-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9931,7 +10054,7 @@
             <iidm:temporaryLimit name="_6cd83bc2-204f-44d5-afd4-fbfef8d2146f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c5ad6-c766-11e1-8775-005056c00008" name="105-106" r="2.4393600000000002" x="9.5309279999999994" g1="0" b1="4.1150150000000001e-05" g2="0" b2="4.1150150000000001e-05" node1="51" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="9.7727871866379239" q1="6.0898920710004232" p2="-9.7515771186727314" q2="-7.3360924859489156">
+    <iidm:line id="_044c5ad6-c766-11e1-8775-005056c00008" name="105-106" r="2.4393600000000002" x="9.5309279999999994" g1="0" b1="4.1150150000000001e-05" g2="0" b2="4.1150150000000001e-05" node1="51" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="9.7710967696122566" q1="6.0904738778515917" p2="-9.7498904420604084" q2="-7.3366859908022635">
         <iidm:alias>_04505270-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04531190-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9939,7 +10062,7 @@
             <iidm:temporaryLimit name="_487e1317-48f9-4747-b931-f3f79e95f55a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048badc5-c766-11e1-8775-005056c00008" name="60-61" r="0.45999400000000001" x="2.3522400000000001" g1="0" b1="4.1781450000000003e-05" g2="0" b2="4.1781450000000003e-05" node1="30" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-177.03171761253529" q1="16.411102383919747" p2="177.87982605260214" q2="-13.511783746442173">
+    <iidm:line id="_048badc5-c766-11e1-8775-005056c00008" name="60-61" r="0.45999400000000001" x="2.3522400000000001" g1="0" b1="4.1781450000000003e-05" g2="0" b2="4.1781450000000003e-05" node1="30" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-177.00796615078158" q1="16.408301710861963" p2="177.85584487858253" q2="-13.510160119674975">
         <iidm:alias>_04793734-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048a4e31-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9947,7 +10070,7 @@
             <iidm:temporaryLimit name="_3c55a929-a755-409b-af5f-bae188892af1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044cd003-c766-11e1-8775-005056c00008" name="23-25" r="2.7181440000000001" x="13.9391994" g1="0" b1="0.00024793390000000002" g2="0" b2="0.00024793390000000002" node1="41" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="-209.39716637440733" q1="-10.227939066088581" p2="216.25299328519114" q2="36.309651427894309">
+    <iidm:line id="_044cd003-c766-11e1-8775-005056c00008" name="23-25" r="2.7181440000000001" x="13.9391994" g1="0" b1="0.00024793390000000002" g2="0" b2="0.00024793390000000002" node1="41" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="-202.03825455509912" q1="-11.59991185733441" p2="208.40997634928408" q2="35.189640847347817">
         <iidm:alias>_045ed161-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0473b8f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9955,7 +10078,7 @@
             <iidm:temporaryLimit name="_9658628a-596f-41a9-96a7-c5a8aaf5400c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0457a574-c766-11e1-8775-005056c00008" name="19-34" r="13.102848099999999" x="43.037277199999998" g1="0" b1="0.00018135905000000001" g2="0" b2="0.00018135905000000001" node1="40" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0483be8b-c766-11e1-8775-005056c00008" p1="56.699996038365377" q1="-16.238388797426104" p2="-53.798667339390249" q2="20.183228331846877">
+    <iidm:line id="_0457a574-c766-11e1-8775-005056c00008" name="19-34" r="13.102848099999999" x="43.037277199999998" g1="0" b1="0.00018135905000000001" g2="0" b2="0.00018135905000000001" node1="40" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0483be8b-c766-11e1-8775-005056c00008" p1="57.919595817408052" q1="-16.322923212632084" p2="-54.89449090600511" q2="20.679608038453988">
         <iidm:alias>_04502b61-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04686e5b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9963,7 +10086,7 @@
             <iidm:temporaryLimit name="_b69ab61b-751d-487a-a538-2d47eea7572e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04595326-c766-11e1-8775-005056c00008" name="59-60" r="5.5234079999999999" x="25.264800000000001" g1="0" b1="0.00010789715" g2="0" b2="0.00010789715" node1="69" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_045cfca4-c766-11e1-8775-005056c00008" p1="-98.334710404063571" q1="22.727831002220881" p2="101.69102697473636" q2="-11.050844468767995">
+    <iidm:line id="_04595326-c766-11e1-8775-005056c00008" name="59-60" r="5.5234079999999999" x="25.264800000000001" g1="0" b1="0.00010789715" g2="0" b2="0.00010789715" node1="69" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_045cfca4-c766-11e1-8775-005056c00008" p1="-98.319450936310574" q1="22.722151533279856" p2="101.67468669356327" q2="-11.050117554177001">
         <iidm:alias>_04611b57-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0463b366-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9971,7 +10094,7 @@
             <iidm:temporaryLimit name="_a38d4859-b54a-482f-a2ad-0b4ce4c4da2a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045a8ba1-c766-11e1-8775-005056c00008" name="15-19" r="2.0908799999999998" x="6.865056" g1="0" b1="2.8983e-05" g2="0" b2="2.8983e-05" node1="50" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="35.252854201746075" q1="10.442786005442134" p2="-35.070715826821861" q2="-10.74225427756463">
+    <iidm:line id="_045a8ba1-c766-11e1-8775-005056c00008" name="15-19" r="2.0908799999999998" x="6.865056" g1="0" b1="2.8983e-05" g2="0" b2="2.8983e-05" node1="50" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="34.622786991965803" q1="10.520812078638459" p2="-34.446160584229318" q2="-10.837646465912751">
         <iidm:alias>_047629f1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0481e9c1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9979,7 +10102,7 @@
             <iidm:temporaryLimit name="_15d16bd2-d87c-4584-93d2-b294dc1be116" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04513cd6-c766-11e1-8775-005056c00008" name="90-91" r="4.4256960000000003" x="14.566463499999999" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="31" voltageLevelId1="_047d07c3-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044f8f29-c766-11e1-8775-005056c00008" p1="5.0388798572733329" q1="-16.441753254244038" p2="-4.9656475050168094" q2="14.695028474203642">
+    <iidm:line id="_04513cd6-c766-11e1-8775-005056c00008" name="90-91" r="4.4256960000000003" x="14.566463499999999" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="31" voltageLevelId1="_047d07c3-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044f8f29-c766-11e1-8775-005056c00008" p1="5.063292966605534" q1="-16.431476096348483" p2="-4.9900777628878776" q2="14.68478734381906">
         <iidm:alias>_045f94b9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04627ae1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9987,7 +10110,7 @@
             <iidm:temporaryLimit name="_7d2a67fb-9d8c-4745-a67e-ce6ade5e520e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0487b623-c766-11e1-8775-005056c00008" name="22-23" r="5.9590079999999999" x="27.704158799999998" g1="0" b1="0.00011593205" g2="0" b2="0.00011593205" node1="21" voltageLevelId1="_04773b6a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_047f9fdb-c766-11e1-8775-005056c00008" p1="-58.070588302952373" q1="-10.884512718820684" p2="59.354224155500567" q2="12.976577380954007">
+    <iidm:line id="_0487b623-c766-11e1-8775-005056c00008" name="22-23" r="5.9590079999999999" x="27.704158799999998" g1="0" b1="0.00011593205" g2="0" b2="0.00011593205" node1="21" voltageLevelId1="_04773b6a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_047f9fdb-c766-11e1-8775-005056c00008" p1="-55.984191131413098" q1="-11.543063753043874" p2="57.181076170402754" q2="13.222986393626776">
         <iidm:alias>_045e0e18-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0477b095-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9995,7 +10118,7 @@
             <iidm:temporaryLimit name="_6477d99a-dd64-4083-8f56-1396610879f0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048b1189-c766-11e1-8775-005056c00008" name="83-85" r="7.4923200000000003" x="25.787520000000001" g1="0" b1="9.9862250000000004e-05" g2="0" b2="9.9862250000000004e-05" node1="32" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-56.941923739182407" q1="19.099051309557396" p2="58.605682638215569" q2="-16.670460148442075">
+    <iidm:line id="_048b1189-c766-11e1-8775-005056c00008" name="83-85" r="7.4923200000000003" x="25.787520000000001" g1="0" b1="9.9862250000000004e-05" g2="0" b2="9.9862250000000004e-05" node1="32" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-56.763002956647135" q1="19.856728241685882" p2="58.436552238392302" q2="-17.381326212441238">
         <iidm:alias>_0455d0b1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0462c906-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10003,7 +10126,7 @@
             <iidm:temporaryLimit name="_38cb3e5b-af1a-4684-aa2f-242826ed460c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045868c5-c766-11e1-8775-005056c00008" name="17-31" r="8.2589760000000005" x="27.233711199999998" g1="0" b1="0.00011449725" g2="0" b2="0.00011449725" node1="60" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="12.52186115589253" q1="1.8099137395284033" p2="-12.437439453112935" q2="-5.3084860692706171">
+    <iidm:line id="_045868c5-c766-11e1-8775-005056c00008" name="17-31" r="8.2589760000000005" x="27.233711199999998" g1="0" b1="0.00011449725" g2="0" b2="0.00011449725" node1="60" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="16.929276212546039" q1="0.3365370260483741" p2="-16.784876596651973" q2="-3.635795196602519">
         <iidm:alias>_04544a16-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0467f924-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10011,7 +10134,7 @@
             <iidm:temporaryLimit name="_9066b19a-f404-42c3-88ce-51d375f6fdb5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0488c796-c766-11e1-8775-005056c00008" name="89-90" r="9.0256319999999999" x="32.75712" g1="0" b1="0.00015151515000000001" g2="0" b2="0.00015151515000000001" node1="59" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="59.944076181014218" q1="9.2717566424422504" p2="-58.028137750767705" q2="-7.4057845648030804">
+    <iidm:line id="_0488c796-c766-11e1-8775-005056c00008" name="89-90" r="9.0256319999999999" x="32.75712" g1="0" b1="0.00015151515000000001" g2="0" b2="0.00015151515000000001" node1="59" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="59.953061330308302" q1="9.2774260259631554" p2="-58.036496460202549" q2="-7.4090989887884042">
         <iidm:alias>_0459ef61-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04837069-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10019,7 +10142,7 @@
             <iidm:temporaryLimit name="_924b4a0b-bef5-432a-ad87-ab5c10d9c019" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0462c907-c766-11e1-8775-005056c00008" name="70-75" r="7.4574720000000001" x="24.56784" g1="0" b1="0.0001033058" g2="0" b2="0.0001033058" node1="50" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="9.3559429611470701" q1="6.8030632863894365" p2="-9.2849649187153229" q2="-9.9976566184585174">
+    <iidm:line id="_0462c907-c766-11e1-8775-005056c00008" name="70-75" r="7.4574720000000001" x="24.56784" g1="0" b1="0.0001033058" g2="0" b2="0.0001033058" node1="50" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="9.0159441995051175" q1="7.0079722567063536" p2="-8.9461775053983388" q2="-10.207069304983699">
         <iidm:alias>_04649dc9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04784cdb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10027,7 +10150,7 @@
             <iidm:temporaryLimit name="_d432d118-553c-4f4c-a734-e98e0762ec40" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045fbbc3-c766-11e1-8775-005056c00008" name="50-57" r="8.2589760000000005" x="23.34816" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="22" voltageLevelId1="_044d1e26-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="51.416048772401545" q1="7.6763186722456496" p2="-50.115082634897803" q2="-7.1882987339374722">
+    <iidm:line id="_045fbbc3-c766-11e1-8775-005056c00008" name="50-57" r="8.2589760000000005" x="23.34816" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="22" voltageLevelId1="_044d1e26-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="51.431395796812474" q1="7.6727669127178961" p2="-50.129706460277035" q2="-7.1826922031890312">
         <iidm:alias>_04500455-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0468e383-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10035,7 +10158,7 @@
             <iidm:temporaryLimit name="_2f32bda4-7275-4485-9901-12f8cff9e4a1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044b9789-c766-11e1-8775-005056c00008" name="5-6" r="2.0734560000000002" x="9.4089600000000004" g1="0" b1="4.0920549999999999e-05" g2="0" b2="4.0920549999999999e-05" node1="49" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f6818-c766-11e1-8775-005056c00008" p1="96.588253444736651" q1="17.017667836239937" p2="-95.459769097261315" q2="-13.319043489865773">
+    <iidm:line id="_044b9789-c766-11e1-8775-005056c00008" name="5-6" r="2.0734560000000002" x="9.4089600000000004" g1="0" b1="4.0920549999999999e-05" g2="0" b2="4.0920549999999999e-05" node1="49" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f6818-c766-11e1-8775-005056c00008" p1="92.226566303916016" q1="18.553232891625644" p2="-91.189803585236902" q2="-15.273029829771723">
         <iidm:alias>_044a5f01-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0455d0b2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10043,7 +10166,7 @@
             <iidm:temporaryLimit name="_b3b0e81b-a434-4e9c-ad94-1161ff47b077" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04720b41-c766-11e1-8775-005056c00008" name="55-59" r="8.2572340000000004" x="37.600994100000001" g1="0" b1="0.00016201790000000001" g2="0" b2="0.00016201790000000001" node1="30" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-29.314722396049714" q1="-13.93677585658399" p2="29.843268489834408" q2="11.098802927555491">
+    <iidm:line id="_04720b41-c766-11e1-8775-005056c00008" name="55-59" r="8.2572340000000004" x="37.600994100000001" g1="0" b1="0.00016201790000000001" g2="0" b2="0.00016201790000000001" node1="30" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-29.29883803576827" q1="-13.942354995796336" p2="29.826956407232174" q2="11.102432220864387">
         <iidm:alias>_04656113-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04675ce4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10051,7 +10174,7 @@
             <iidm:temporaryLimit name="_6db0d250-4a2e-4169-abf0-f842aeca485d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048963d9-c766-11e1-8775-005056c00008" name="1-2" r="5.2794720000000002" x="17.4065762" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="22" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_045d4ac5-c766-11e1-8775-005056c00008" p1="-10.320317816981198" q1="-11.034887187339287" p2="10.387385896185823" q2="8.8836893985243837">
+    <iidm:line id="_048963d9-c766-11e1-8775-005056c00008" name="1-2" r="5.2794720000000002" x="17.4065762" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="22" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_045d4ac5-c766-11e1-8775-005056c00008" p1="-11.280303277367299" q1="-10.507622957288868" p2="11.350802044830079" q2="8.3664953957047921">
         <iidm:alias>_044b9786-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04845acb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10059,7 +10182,7 @@
             <iidm:temporaryLimit name="_9f39cb45-314c-445e-b177-909854a9ce45" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0484f709-c766-11e1-8775-005056c00008" name="11-12" r="1.0367280000000001" x="3.4151039999999999" g1="0" b1="1.4405399999999999e-05" g2="0" b2="1.4405399999999999e-05" node1="40" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="40.058896345513105" q1="-30.580865487885639" p2="-39.904467013691843" q2="30.599379448734187">
+    <iidm:line id="_0484f709-c766-11e1-8775-005056c00008" name="11-12" r="1.0367280000000001" x="3.4151039999999999" g1="0" b1="1.4405399999999999e-05" g2="0" b2="1.4405399999999999e-05" node1="40" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="34.943995332021821" q1="-26.846989658886905" p2="-34.82613884970975" q2="26.744807721183321">
         <iidm:alias>_0456e227-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04880440-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10067,7 +10190,7 @@
             <iidm:temporaryLimit name="_70fad3e1-4529-4a7f-9e6c-8ab249d65460" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044bbe91-c766-11e1-8775-005056c00008" name="8-9" r="1.18096" x="14.762" g1="0" b1="0.001200413215" g2="0" b2="0.001200413215" node1="31" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_045c8779-c766-11e1-8775-005056c00008" p1="-493.55590143073317" q1="-84.899004520518332" p2="499.47379375121341" q2="38.177556914651277">
+    <iidm:line id="_044bbe91-c766-11e1-8775-005056c00008" name="8-9" r="1.18096" x="14.762" g1="0" b1="0.001200413215" g2="0" b2="0.001200413215" node1="31" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_045c8779-c766-11e1-8775-005056c00008" p1="-493.50483746998395" q1="-82.21552754544274" p2="499.39310701737406" q2="34.740172538630368">
         <iidm:alias>_04745535-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048a7548-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="2000">
@@ -10075,7 +10198,7 @@
             <iidm:temporaryLimit name="_205e5d8a-f05a-479d-adaa-3514f48f6857" acceptableDuration="60" value="2400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04566cf8-c766-11e1-8775-005056c00008" name="64-65" r="1.30196" x="14.6168" g1="0" b1="0.000392562" g2="0" b2="0.000392562" node1="35" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-172.56751786132872" q1="-32.981972595736323" p2="173.38264914435462" q2="4.1444037004523979">
+    <iidm:line id="_04566cf8-c766-11e1-8775-005056c00008" name="64-65" r="1.30196" x="14.6168" g1="0" b1="0.000392562" g2="0" b2="0.000392562" node1="35" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-172.53726574372109" q1="-32.983288287028969" p2="173.35211219077914" q2="4.1424658424607852">
         <iidm:alias>_044a10e2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04793738-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10083,7 +10206,7 @@
             <iidm:temporaryLimit name="_8cee2b62-2953-439b-ba4b-4a48d55116c0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046783f3-c766-11e1-8775-005056c00008" name="54-56" r="0.47915999999999997" x="1.6639919999999999" g1="0" b1="2.1005500000000001e-05" g2="0" b2="2.1005500000000001e-05" node1="60" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="5.8851364716559482" q1="-1.1919702443795481" p2="-5.8840456905209928" q2="0.54281885368864158">
+    <iidm:line id="_046783f3-c766-11e1-8775-005056c00008" name="54-56" r="0.47915999999999997" x="1.6639919999999999" g1="0" b1="2.1005500000000001e-05" g2="0" b2="2.1005500000000001e-05" node1="60" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="5.8993749588430573" q1="-1.1978719137186895" p2="-5.8982786860177461" q2="0.54874129550317075">
         <iidm:alias>_0460f444-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d2949-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10091,7 +10214,7 @@
             <iidm:temporaryLimit name="_640627c7-0672-413e-8dc8-c9965709a5cb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04670ec6-c766-11e1-8775-005056c00008" name="84-85" r="5.2620480000000001" x="11.1687832" g1="0" b1="3.541095e-05" g2="0" b2="3.541095e-05" node1="21" voltageLevelId1="_047b0bf4-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-45.98365598560607" q1="14.351450069663635" p2="46.737700318064526" q2="-13.912270220700378">
+    <iidm:line id="_04670ec6-c766-11e1-8775-005056c00008" name="84-85" r="5.2620480000000001" x="11.1687832" g1="0" b1="3.541095e-05" g2="0" b2="3.541095e-05" node1="21" voltageLevelId1="_047b0bf4-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-45.778402126292924" q1="14.838814624456647" p2="46.53450059148858" q2="-14.389645524759082">
         <iidm:alias>_0453fbf5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046512f7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10099,7 +10222,7 @@
             <iidm:temporaryLimit name="_8b888209-5038-4b98-80fc-062b5ea55747" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0460cd36-c766-11e1-8775-005056c00008" name="34-36" r="1.51763" x="4.669632" g1="0" b1="1.6299349999999998e-05" g2="0" b2="1.6299349999999998e-05" node1="43" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="34.692081055588844" q1="11.10571738466075" p2="-34.561250164134727" q2="-11.203638662444051">
+    <iidm:line id="_0460cd36-c766-11e1-8775-005056c00008" name="34-36" r="1.51763" x="4.669632" g1="0" b1="1.6299349999999998e-05" g2="0" b2="1.6299349999999998e-05" node1="43" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="34.773688061415527" q1="11.072114865043053" p2="-34.642229060824405" q2="-11.167541385224535">
         <iidm:alias>_046a6a26-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0487b620-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10107,7 +10230,7 @@
             <iidm:temporaryLimit name="_c0a08025-3a61-4d24-9944-f3ef0b079f64" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04549836-c766-11e1-8775-005056c00008" name="24-70" r="0.38507000000000002" x="71.699759999999998" g1="0" b1="0.00029264234999999998" g2="0" b2="0.00029264234999999998" node1="32" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="19.805940916055903" q1="-1.5112205042200073" p2="-19.796915950020797" q2="-6.800088950303576">
+    <iidm:line id="_04549836-c766-11e1-8775-005056c00008" name="24-70" r="0.38507000000000002" x="71.699759999999998" g1="0" b1="0.00029264234999999998" g2="0" b2="0.00029264234999999998" node1="32" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="19.051440735093607" q1="-1.3518974228733711" p2="-19.043059992293333" q2="-7.0918138531250507">
         <iidm:alias>_04549834-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04854522-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10115,7 +10238,7 @@
             <iidm:temporaryLimit name="_32793450-bbfd-4dcd-a911-89e199600780" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0452273a-c766-11e1-8775-005056c00008" name="85-86" r="6.0983999999999998" x="21.431519999999999" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="50" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0484f70a-c766-11e1-8775-005056c00008" p1="21.229059914177633" q1="12.27504154897564" p2="-20.994090390162974" q2="-13.995219137768927">
+    <iidm:line id="_0452273a-c766-11e1-8775-005056c00008" name="85-86" r="6.0983999999999998" x="21.431519999999999" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="50" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0484f70a-c766-11e1-8775-005056c00008" p1="21.277810153184788" q1="16.343426309153969" p2="-20.993675276531189" q2="-17.863689778175971">
         <iidm:alias>_044afb43-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479fa85-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10123,7 +10246,7 @@
             <iidm:temporaryLimit name="_2ec4bef5-7abb-4f52-bb62-49ee474d672b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0450eeb5-c766-11e1-8775-005056c00008" name="16-17" r="7.9104960000000002" x="31.380622899999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="22" voltageLevelId1="_046f7338-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-7.6771635763128216" q1="-0.27667764686306362" p2="7.7069079995227163" q2="-4.0698008681463875">
+    <iidm:line id="_0450eeb5-c766-11e1-8775-005056c00008" name="16-17" r="7.9104960000000002" x="31.380622899999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="22" voltageLevelId1="_046f7338-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-14.375351773735852" q1="1.6933966863380625" p2="14.480624448407495" q2="-5.7376859563034861">
         <iidm:alias>_044ef2ea-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04837066-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10131,7 +10254,7 @@
             <iidm:temporaryLimit name="_9280074c-8555-49ff-9e62-8ed8f7d95060" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048a4e33-c766-11e1-8775-005056c00008" name="62-66" r="8.3983679999999996" x="37.984317799999999" g1="0" b1="0.00016586315" g2="0" b2="0.00016586315" node1="41" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-16.506791160013368" q1="-21.3237564251497" p2="16.804022143324655" q2="16.635752920644002">
+    <iidm:line id="_048a4e33-c766-11e1-8775-005056c00008" name="62-66" r="8.3983679999999996" x="37.984317799999999" g1="0" b1="0.00016586315" g2="0" b2="0.00016586315" node1="41" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-16.520502684636206" q1="-21.320325456597157" p2="16.817891360418052" q2="16.633026951340032">
         <iidm:alias>_046e13a9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a96c7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10139,7 +10262,7 @@
             <iidm:temporaryLimit name="_ace48562-0a49-4b76-ae82-c896a00b04f9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0478e913-c766-11e1-8775-005056c00008" name="76-77" r="7.736256" x="25.787520000000001" g1="0" b1="0.00010560145" g2="0" b2="0.00010560145" node1="21" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-62.861932075640766" q1="-21.019404600558389" p2="65.045506200642251" q2="24.829471354291556">
+    <iidm:line id="_0478e913-c766-11e1-8775-005056c00008" name="76-77" r="7.736256" x="25.787520000000001" g1="0" b1="0.00010560145" g2="0" b2="0.00010560145" node1="21" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-62.975997527506436" q1="-20.923476921971496" p2="65.165274840874545" q2="24.753320532926644">
         <iidm:alias>_044b9785-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04725965-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10147,7 +10270,7 @@
             <iidm:temporaryLimit name="_3f744dba-88dc-4d89-90d4-a6f196054b28" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048badc1-c766-11e1-8775-005056c00008" name="60-62" r="2.1431520000000002" x="9.7748640000000009" g1="0" b1="4.2125800000000002e-05" g2="0" b2="4.2125800000000002e-05" node1="32" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="-2.6543666930832996" q1="-8.3599379697630045" p2="2.6625324382283084" q2="6.9448654883166077">
+    <iidm:line id="_048badc1-c766-11e1-8775-005056c00008" name="60-62" r="2.1431520000000002" x="9.7748640000000009" g1="0" b1="4.2125800000000002e-05" g2="0" b2="4.2125800000000002e-05" node1="32" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="-2.661891178587958" q1="-8.3578578593469093" p2="2.6700579331966381" q2="6.942787447120673">
         <iidm:alias>_045b7600-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04720b44-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10155,7 +10278,7 @@
             <iidm:temporaryLimit name="_43f91aaf-c5f4-4995-85a2-37afac616331" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0472a780-c766-11e1-8775-005056c00008" name="27-28" r="3.3332109999999999" x="14.89752" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="42" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04819ba0-c766-11e1-8775-005056c00008" p1="34.779611238020955" q1="-1.3442453275208266" p2="-34.532180112262026" q2="0.44255558935684047">
+    <iidm:line id="_0472a780-c766-11e1-8775-005056c00008" name="27-28" r="3.3332109999999999" x="14.89752" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="42" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04819ba0-c766-11e1-8775-005056c00008" p1="32.875567354076232" q1="-1.6507978726592512" p2="-32.655107487248415" q2="0.62106532459668007">
         <iidm:alias>_04531198-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0475188b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10163,7 +10286,7 @@
             <iidm:temporaryLimit name="_2c20e8bd-84e6-4a1e-b88e-071f631327cb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c81e1-c766-11e1-8775-005056c00008" name="45-46" r="6.9695999999999998" x="23.626943600000001" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="31" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="34" voltageLevelId2="_048a7544-c766-11e1-8775-005056c00008" p1="-33.220052650051777" q1="-7.1744268383195839" p2="33.689872295963816" q2="5.486924415458251">
+    <iidm:line id="_044c81e1-c766-11e1-8775-005056c00008" name="45-46" r="6.9695999999999998" x="23.626943600000001" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="31" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="34" voltageLevelId2="_048a7544-c766-11e1-8775-005056c00008" p1="-33.08815865985504" q1="-7.251528990318187" p2="33.5547573491489" q2="5.5532476384747342">
         <iidm:alias>_04561ed6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045c877a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10171,7 +10294,7 @@
             <iidm:temporaryLimit name="_6ad31f7e-233f-4801-898f-9ffc883ec724" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c1249-c766-11e1-8775-005056c00008" name="18-19" r="1.949746" x="8.5900320000000008" g1="0" b1="3.2770900000000002e-05" g2="0" b2="3.2770900000000002e-05" node1="22" voltageLevelId1="_04689563-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="51.65044702003393" q1="0.66730280782505913" p2="-51.315667433300469" q2="-0.20438354768999578">
+    <iidm:line id="_045c1249-c766-11e1-8775-005056c00008" name="18-19" r="1.949746" x="8.5900320000000008" g1="0" b1="3.2770900000000002e-05" g2="0" b2="3.2770900000000002e-05" node1="22" voltageLevelId1="_04689563-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="55.546424872456804" q1="-0.36055439102337172" p2="-55.159023443532519" q2="1.0562405795674517">
         <iidm:alias>_046b066b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047ae4e0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10179,7 +10302,7 @@
             <iidm:temporaryLimit name="_a025c9d8-58f9-4320-a1fe-73ecc68d4147" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044a5f09-c766-11e1-8775-005056c00008" name="9-10" r="1.2487200000000001" x="15.584800700000001" g1="0" b1="0.0012706611300000001" g2="0" b2="0.0012706611300000001" node1="21" voltageLevelId1="_045c8779-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_044f4102-c766-11e1-8775-005056c00008" p1="-499.47379375121352" q1="-38.177556914650793" p2="505.50685684322821" q2="-20.142680795541821">
+    <iidm:line id="_044a5f09-c766-11e1-8775-005056c00008" name="9-10" r="1.2487200000000001" x="15.584800700000001" g1="0" b1="0.0012706611300000001" g2="0" b2="0.0012706611300000001" node1="21" voltageLevelId1="_045c8779-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_044f4102-c766-11e1-8775-005056c00008" p1="-499.39310701737389" q1="-34.740172538631938" p2="505.41608565439384" q2="-23.85028479259017">
         <iidm:alias>_04614262-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04834957-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="2000">
@@ -10187,7 +10310,7 @@
             <iidm:temporaryLimit name="_b7fac0a3-c5af-48b9-af49-261fd8d46e00" acceptableDuration="60" value="2400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0480b14b-c766-11e1-8775-005056c00008" name="85-88" r="3.4847999999999999" x="17.772480000000002" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="51" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0470f9d2-c766-11e1-8775-005056c00008" p1="-64.902319344750936" q1="5.3624219506858033" p2="65.802249473435154" q2="-3.4075646146976837">
+    <iidm:line id="_0480b14b-c766-11e1-8775-005056c00008" name="85-88" r="3.4847999999999999" x="17.772480000000002" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="51" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0470f9d2-c766-11e1-8775-005056c00008" p1="-64.797434463464185" q1="3.9238479461834577" p2="65.695538273748426" q2="-1.9686876468435366">
         <iidm:alias>_047602e2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04765105-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10195,7 +10318,7 @@
             <iidm:temporaryLimit name="_51646744-d343-42b5-8ba7-fcedc7cc3a98" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04486330-c766-11e1-8775-005056c00008" name="69-77" r="5.3840159999999999" x="17.598240000000001" g1="0" b1="0.00029786500000000002" g2="0" b2="0.00029786500000000002" node1="60" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="27.657602632104737" q1="19.468583424121338" p2="-27.256259459126913" q2="-28.932487810098724">
+    <iidm:line id="_04486330-c766-11e1-8775-005056c00008" name="69-77" r="5.3840159999999999" x="17.598240000000001" g1="0" b1="0.00029786500000000002" g2="0" b2="0.00029786500000000002" node1="60" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="27.767488693153592" q1="19.581455097860779" p2="-27.362755216172669" q2="-29.032803811030274">
         <iidm:alias>_046205b9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479d379-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10203,7 +10326,7 @@
             <iidm:temporaryLimit name="_76311a15-b79a-4439-a7ce-47afa8fa6fe2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04553477-c766-11e1-8775-005056c00008" name="11-13" r="3.8768400000000001" x="12.7369442" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="41" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04851e1b-c766-11e1-8775-005056c00008" p1="51.167887731894467" q1="15.220166000937818" p2="-50.509578109070553" q2="-14.840597776956749">
+    <iidm:line id="_04553477-c766-11e1-8775-005056c00008" name="11-13" r="3.8768400000000001" x="12.7369442" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="41" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04851e1b-c766-11e1-8775-005056c00008" p1="46.872803389446076" q1="16.377739486002053" p2="-46.302460846401885" q2="-16.288816199438859">
         <iidm:alias>_0479fa89-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0485452a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10211,7 +10334,7 @@
             <iidm:temporaryLimit name="_efbf8de7-4b84-4834-bb7c-6250b6072211" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04488a45-c766-11e1-8775-005056c00008" name="103-105" r="9.3218399999999999" x="28.314" g1="0" b1="0.0001170799" g2="0" b2="0.0001170799" node1="42" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="43.807615076931143" q1="12.527660922856901" p2="-42.68919913412261" q2="-13.112622990724725">
+    <iidm:line id="_04488a45-c766-11e1-8775-005056c00008" name="103-105" r="9.3218399999999999" x="28.314" g1="0" b1="0.0001170799" g2="0" b2="0.0001170799" node1="42" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="43.807398646615226" q1="12.527734362121985" p2="-42.688989481545406" q2="-13.112709130416391">
         <iidm:alias>_044f8f24-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04611b58-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10219,7 +10342,7 @@
             <iidm:temporaryLimit name="_22b6919a-a7a0-49fc-9e90-329069c55055" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046009e6-c766-11e1-8775-005056c00008" name="45-49" r="11.918016400000001" x="32.408639999999998" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="32" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="118" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-39.141327136561678" q1="-8.7786042852208261" p2="40.257299156119053" q2="7.3363723240083969">
+    <iidm:line id="_046009e6-c766-11e1-8775-005056c00008" name="45-49" r="11.918016400000001" x="32.408639999999998" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="32" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="118" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-39.012825691631086" q1="-8.8590122331214545" p2="40.122547308348395" q2="7.3999703428772978">
         <iidm:alias>_044ca8f9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047dcb1b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10227,7 +10350,7 @@
             <iidm:temporaryLimit name="_8b91f4fd-4038-45b7-870c-fbc08592b95a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046a6a27-c766-11e1-8775-005056c00008" name="88-89" r="2.4219360000000001" x="12.4058876" g1="0" b1="5.549815e-05" g2="0" b2="5.549815e-05" node1="22" voltageLevelId1="_0470f9d2-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-113.79542317474494" q1="-6.5900759510230884" p2="115.66869693641992" q2="14.277397640035117">
+    <iidm:line id="_046a6a27-c766-11e1-8775-005056c00008" name="88-89" r="2.4219360000000001" x="12.4058876" g1="0" b1="5.549815e-05" g2="0" b2="5.549815e-05" node1="22" voltageLevelId1="_0470f9d2-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-113.68849174413084" q1="-8.0288742778112567" p2="115.56487409183758" q2="15.734090334743382">
         <iidm:alias>_045ef879-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04649dc1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10235,7 +10358,7 @@
             <iidm:temporaryLimit name="_970bc323-73bf-440d-a3c5-00aebc3a1992" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048a7540-c766-11e1-8775-005056c00008" name="80-98" r="4.1469120000000004" x="18.817920000000001" g1="0" b1="8.20707e-05" g2="0" b2="8.20707e-05" node1="79" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04773b62-c766-11e1-8775-005056c00008" p1="8.7558519753687776" q1="12.61036591573162" p2="-8.6948805573106824" q2="-15.377827096173041">
+    <iidm:line id="_048a7540-c766-11e1-8775-005056c00008" name="80-98" r="4.1469120000000004" x="18.817920000000001" g1="0" b1="8.20707e-05" g2="0" b2="8.20707e-05" node1="79" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04773b62-c766-11e1-8775-005056c00008" p1="8.763892791777101" q1="12.608569419463429" p2="-8.7029015233922458" q2="-15.375938090406041">
         <iidm:alias>_045338a2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04887972-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10243,7 +10366,7 @@
             <iidm:temporaryLimit name="_cb084dc7-1b26-415f-9495-4695df661912" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04640183-c766-11e1-8775-005056c00008" name="91-92" r="6.7430880000000002" x="22.163329999999998" g1="0" b1="9.3778700000000004e-05" g2="0" b2="9.3778700000000004e-05" node1="22" voltageLevelId1="_044f8f29-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="-5.033547825826604" q1="-14.695031596660129" p2="5.1152056083529329" q2="11.8278284742764">
+    <iidm:line id="_04640183-c766-11e1-8775-005056c00008" name="91-92" r="6.7430880000000002" x="22.163329999999998" g1="0" b1="9.3778700000000004e-05" g2="0" b2="9.3778700000000004e-05" node1="22" voltageLevelId1="_044f8f29-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="-5.009093670437438" q1="-14.684788635585152" p2="5.090545598577731" q2="11.817173108846598">
         <iidm:alias>_04492680-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_044c5ad5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10251,7 +10374,7 @@
             <iidm:temporaryLimit name="_3a165a76-f6ba-461b-84d6-159a5e0b5077" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0474a358-c766-11e1-8775-005056c00008" name="7-12" r="1.501949" x="5.9241599999999996" g1="0" b1="2.5080350000000001e-05" g2="0" b2="2.5080350000000001e-05" node1="22" voltageLevelId1="_047eb571-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="24.376293445574611" q1="-10.555106896996646" p2="-24.314837693615566" q2="9.9421108703664771">
+    <iidm:line id="_0474a358-c766-11e1-8775-005056c00008" name="7-12" r="1.501949" x="5.9241599999999996" g1="0" b1="2.5080350000000001e-05" g2="0" b2="2.5080350000000001e-05" node1="22" voltageLevelId1="_047eb571-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="20.124032254096178" q1="-8.5191566298791237" p2="-20.082567266970088" q2="7.8270143507260084">
         <iidm:alias>_046ab848-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0477feb7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10259,7 +10382,7 @@
             <iidm:temporaryLimit name="_b19bc945-cc51-4d77-8eaa-3f6afe2d9316" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04765108-c766-11e1-8775-005056c00008" name="99-100" r="3.13632" x="14.165711399999999" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_04644fa4-c766-11e1-8775-005056c00008" node2="80" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-42.705020569802862" q1="12.89787881560761" p2="43.054567244323209" q2="-13.55972739876014">
+    <iidm:line id="_04765108-c766-11e1-8775-005056c00008" name="99-100" r="3.13632" x="14.165711399999999" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_04644fa4-c766-11e1-8775-005056c00008" node2="80" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-42.696850967121378" q1="12.896196623910249" p2="43.046269154639972" q2="-13.558622256802527">
         <iidm:alias>_0471e436-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047e4040-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10267,7 +10390,7 @@
             <iidm:temporaryLimit name="_a9e283ed-fcad-4f4c-ab57-8531875bb098" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047b8128-c766-11e1-8775-005056c00008" name="114-115" r="0.400752" x="1.8120959999999999" g1="0" b1="7.9201000000000006e-06" g2="0" b2="7.9201000000000006e-06" node1="22" voltageLevelId1="_04791027-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="-2.019117167896888" q1="2.8498762314865607" p2="2.0194395853093408" q2="-3.1031373409111862">
+    <iidm:line id="_047b8128-c766-11e1-8775-005056c00008" name="114-115" r="0.400752" x="1.8120959999999999" g1="0" b1="7.9201000000000006e-06" g2="0" b2="7.9201000000000006e-06" node1="22" voltageLevelId1="_04791027-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="-0.93940115741171104" q1="2.2560105267572554" p2="0.9395642987621794" q2="-2.5106469580146324">
         <iidm:alias>_046c17d3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d0233-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10275,7 +10398,7 @@
             <iidm:temporaryLimit name="_c59e4022-b1c0-4811-a32e-f54656bff32d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046931a5-c766-11e1-8775-005056c00008" name="83-84" r="10.890000000000001" x="22.999680000000001" g1="0" b1="7.4035799999999993e-05" g2="0" b2="7.4035799999999993e-05" node1="33" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b0bf4-c766-11e1-8775-005056c00008" p1="-33.898815288116737" q1="21.213844063810768" p2="34.986879588645515" q2="-21.348042121088298">
+    <iidm:line id="_046931a5-c766-11e1-8775-005056c00008" name="83-84" r="10.890000000000001" x="22.999680000000001" g1="0" b1="7.4035799999999993e-05" g2="0" b2="7.4035799999999993e-05" node1="33" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b0bf4-c766-11e1-8775-005056c00008" p1="-33.684875668415934" q1="21.728395159733576" p2="34.781704855853221" q2="-21.83531676086211">
         <iidm:alias>_0465d645-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479102b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10283,7 +10406,7 @@
             <iidm:temporaryLimit name="_1268eb09-e233-44ce-b8af-22dc30eb16ad" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047ae4ea-c766-11e1-8775-005056c00008" name="14-15" r="10.367279999999999" x="33.976799999999997" g1="0" b1="0.0001440542" g2="0" b2="0.0001440542" node1="21" voltageLevelId1="_047b8129-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="22.936616491161057" q1="6.0583131031189712" p2="-22.564178983528208" q2="-9.4853912177884663">
+    <iidm:line id="_047ae4ea-c766-11e1-8775-005056c00008" name="14-15" r="10.367279999999999" x="33.976799999999997" g1="0" b1="0.0001440542" g2="0" b2="0.0001440542" node1="21" voltageLevelId1="_047b8129-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="18.172234655059953" q1="7.5496089956210186" p2="-17.904793463850961" q2="-11.31916186276238">
         <iidm:alias>_0449e9d9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046ed6fa-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10291,7 +10414,7 @@
             <iidm:temporaryLimit name="_9c0c454b-ecc3-40f6-b505-f32fec412522" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046e3ab2-c766-11e1-8775-005056c00008" name="80-96" r="6.2029439999999996" x="31.711680000000001" g1="0" b1="0.0001417585" g2="0" b2="0.0001417585" node1="80" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="2.5079037704464984" q1="26.94167898750759" p2="-2.2171948767603076" q2="-30.534858975427881">
+    <iidm:line id="_046e3ab2-c766-11e1-8775-005056c00008" name="80-96" r="6.2029439999999996" x="31.711680000000001" g1="0" b1="0.0001417585" g2="0" b2="0.0001417585" node1="80" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="2.5516479560835794" q1="27.140772474843857" p2="-2.2569718511641037" q2="-30.711893805027547">
         <iidm:alias>_045338a4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04865695-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10299,7 +10422,7 @@
             <iidm:temporaryLimit name="_1432f4d6-9299-4b0d-bd7f-16e059f9de66" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04893cc4-c766-11e1-8775-005056c00008" name="56-59" r="13.9914722" x="41.643360000000001" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="59" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-24.952901458366178" q1="-9.3881710672949428" p2="25.557564935247051" q2="6.1973159793155927">
+    <iidm:line id="_04893cc4-c766-11e1-8775-005056c00008" name="56-59" r="13.9914722" x="41.643360000000001" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="59" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-24.938775207930345" q1="-9.3948350489048966" p2="25.542889701126274" q2="6.2023445351369322">
         <iidm:alias>_046b5484-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04798557-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10307,7 +10430,7 @@
             <iidm:temporaryLimit name="_193f6952-4267-4cc8-a541-726c095028ba" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c1243-c766-11e1-8775-005056c00008" name="92-100" r="11.290752400000001" x="51.400799999999997" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="71" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="37.661348951416599" q1="-17.457775658883858" p2="-36.569910103436129" q2="17.676669178629659">
+    <iidm:line id="_045c1243-c766-11e1-8775-005056c00008" name="92-100" r="11.290752400000001" x="51.400799999999997" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="71" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="37.698977794623914" q1="-17.477346365120884" p2="-36.605146922074283" q2="17.70737861705733">
         <iidm:alias>_045e8348-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045ed164-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10315,7 +10438,7 @@
             <iidm:temporaryLimit name="_579249ce-1c81-4d29-8d3f-5fc627a18f99" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0474a356-c766-11e1-8775-005056c00008" name="43-44" r="10.593792000000001" x="42.7584953" g1="0" b1="0.00017412765" g2="0" b2="0.00017412765" node1="22" voltageLevelId1="_045e8349-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04544a15-c766-11e1-8775-005056c00008" p1="-3.209360185200147" q1="-12.218497293249255" p2="3.2773619523139645" q2="6.888569470727762">
+    <iidm:line id="_0474a356-c766-11e1-8775-005056c00008" name="43-44" r="10.593792000000001" x="42.7584953" g1="0" b1="0.00017412765" g2="0" b2="0.00017412765" node1="22" voltageLevelId1="_045e8349-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04544a15-c766-11e1-8775-005056c00008" p1="-2.9500305457843421" q1="-12.373169958735975" p2="3.0190399133499319" q2="7.0502938310515724">
         <iidm:alias>_04642899-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047b0bf2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10323,7 +10446,7 @@
             <iidm:temporaryLimit name="_3d2cb4b5-ee82-4866-9855-4a5f4803cd3b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04627ae6-c766-11e1-8775-005056c00008" name="109-110" r="4.8438720000000002" x="13.2770882" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="22" voltageLevelId1="_046b7b99-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="12.454802224588272" q1="-2.8650564759050567" p2="-12.406581025451329" q2="1.1508254716001203">
+    <iidm:line id="_04627ae6-c766-11e1-8775-005056c00008" name="109-110" r="4.8438720000000002" x="13.2770882" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="22" voltageLevelId1="_046b7b99-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="12.458280174221633" q1="-2.8663234868982901" p2="-12.410031070226347" q2="1.1521732353104435">
         <iidm:alias>_0466e7b5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a6fbb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10331,7 +10454,7 @@
             <iidm:temporaryLimit name="_6fc48d8d-05f8-4104-a6a2-3686d430a091" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0478c207-c766-11e1-8775-005056c00008" name="68-81" r="0.84699999999999998" x="9.7767990000000005" g1="0" b1="0.00083471078000000004" g2="0" b2="0.00083471078000000004" node1="38" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_048a272b-c766-11e1-8775-005056c00008" p1="-165.85855584983435" q1="-2.2045695273094248" p2="166.36678958228396" q2="-72.159946691913646">
+    <iidm:line id="_0478c207-c766-11e1-8775-005056c00008" name="68-81" r="0.84699999999999998" x="9.7767990000000005" g1="0" b1="0.00083471078000000004" g2="0" b2="0.00083471078000000004" node1="38" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_048a272b-c766-11e1-8775-005056c00008" p1="-165.26059244306333" q1="-2.2688234939756984" p2="165.76526114354104" q2="-72.13748263938335">
         <iidm:alias>_044a37f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045b4ef6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10339,7 +10462,7 @@
             <iidm:temporaryLimit name="_191836a1-39cd-402b-8dcf-4f3867c45bd0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0467d215-c766-11e1-8775-005056c00008" name="85-89" r="4.1643359999999996" x="30.143518400000001" g1="0" b1="0.00013487144999999999" g2="0" b2="0.00013487144999999999" node1="52" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-85.66471645109101" q1="-2.0491144398557868" p2="87.518683554033203" q2="10.872323159123376">
+    <iidm:line id="_0467d215-c766-11e1-8775-005056c00008" name="85-89" r="4.1643359999999996" x="30.143518400000001" g1="0" b1="0.00013487144999999999" g2="0" b2="0.00013487144999999999" node1="52" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-85.44583300904182" q1="-3.4904833407079949" p2="87.300413998066091" q2="12.329733582511992">
         <iidm:alias>_047629f9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0478e915-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10347,7 +10470,7 @@
             <iidm:temporaryLimit name="_66cbdeeb-a4e4-4bfc-aec1-9fb7a2d2b6bc" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044a37f2-c766-11e1-8775-005056c00008" name="89-90" r="4.1469120000000004" x="17.371727" g1="0" b1="0.00030417815" g2="0" b2="0.00030417815" node1="62" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="113.18972241396439" q1="21.282510956233814" p2="-110.00358652895521" q2="-18.149344145582031">
+    <iidm:line id="_044a37f2-c766-11e1-8775-005056c00008" name="89-90" r="4.1469120000000004" x="17.371727" g1="0" b1="0.00030417815" g2="0" b2="0.00030417815" node1="62" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="113.2064342579429" q1="21.293881171725893" p2="-110.01925662624517" q2="-18.156187000986673">
         <iidm:alias>_045386c2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048719e9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10355,7 +10478,7 @@
             <iidm:temporaryLimit name="_8489e809-6588-4ed2-a9a4-43c44a0d47da" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04658820-c766-11e1-8775-005056c00008" name="98-100" r="6.9173280000000004" x="31.188960999999999" g1="0" b1="0.0001365932" g2="0" b2="0.0001365932" node1="22" voltageLevelId1="_04773b62-c766-11e1-8775-005056c00008" node2="82" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-25.304212094316792" q1="7.3781867483656542" p2="25.583898410650374" q2="-11.071002711498002">
+    <iidm:line id="_04658820-c766-11e1-8775-005056c00008" name="98-100" r="6.9173280000000004" x="31.188960999999999" g1="0" b1="0.0001365932" g2="0" b2="0.0001365932" node1="22" voltageLevelId1="_04773b62-c766-11e1-8775-005056c00008" node2="82" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-25.296151876024194" q1="7.3763090634009929" p2="25.575669709776921" q2="-11.06987839822143">
         <iidm:alias>_046f4c22-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046fe865-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10363,7 +10486,7 @@
             <iidm:temporaryLimit name="_620beaaf-63c8-4020-bea5-c3609c0eaadf" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c5ada-c766-11e1-8775-005056c00008" name="28-29" r="4.1294880000000003" x="16.430831900000001" g1="0" b1="6.8296599999999999e-05" g2="0" b2="6.8296599999999999e-05" node1="22" voltageLevelId1="_04819ba0-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04588fd5-c766-11e1-8775-005056c00008" p1="17.534320029517215" q1="-7.4410893750553697" p2="-17.445100996609817" q2="5.593253633266575">
+    <iidm:line id="_044c5ada-c766-11e1-8775-005056c00008" name="28-29" r="4.1294880000000003" x="16.430831900000001" g1="0" b1="6.8296599999999999e-05" g2="0" b2="6.8296599999999999e-05" node1="22" voltageLevelId1="_04819ba0-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04588fd5-c766-11e1-8775-005056c00008" p1="15.656677474852037" q1="-5.4108549996625435" p2="-15.589306974149872" q2="3.4700819739990347">
         <iidm:alias>_0461697a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04697fc1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10371,7 +10494,13 @@
             <iidm:temporaryLimit name="_6748d0d0-aec8-4b7b-a9ab-be6aecda7c5d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0468e382-c766-11e1-8775-005056c00008" name="3-5" r="4.1991839999999998" x="18.817920000000001" g1="0" b1="8.1496799999999995e-05" g2="0" b2="8.1496799999999995e-05" node1="31" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-72.735765598395204" q1="-15.19607440698578" p2="74.134090077718312" q2="18.676563174657581">
+    <iidm:line id="_044c5ada-c766-11e1-8775-005056c00008-1" name="28-29-open-ended" r="4.1294880000000003" x="16.430831900000001" g1="0" b1="6.8296599999999999e-05" g2="0" b2="6.8296599999999999e-05" node1="25" voltageLevelId1="_04819ba0-c766-11e1-8775-005056c00008" node2="25" voltageLevelId2="_04588fd5-c766-11e1-8775-005056c00008" p1="0.00031201566606058311" q1="-2.2089187952028397" p2="0" q2="0">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_accb8136-1faf-4399-9787-3cd567284fd2-1" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_6748d0d0-aec8-4b7b-a9ab-be6aecda7c5d-1" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0468e382-c766-11e1-8775-005056c00008" name="3-5" r="4.1991839999999998" x="18.817920000000001" g1="0" b1="8.1496799999999995e-05" g2="0" b2="8.1496799999999995e-05" node1="31" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-70.506019582159624" q1="-16.364763643244977" p2="71.830210565318808" q2="19.508945486765963">
         <iidm:alias>_046b0668-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04742e24-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10379,7 +10508,7 @@
             <iidm:temporaryLimit name="_828ca44c-560b-4f94-b825-21e237285fae" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0447c6f1-c766-11e1-8775-005056c00008" name="82-96" r="2.8226879999999999" x="9.2347199999999994" g1="0" b1="0.00015610649999999999" g2="0" b2="0.00015610649999999999" node1="33" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="-16.339805512559803" q1="-8.6743287990912865" p2="16.390885828755824" q2="3.5704814621169314">
+    <iidm:line id="_0447c6f1-c766-11e1-8775-005056c00008" name="82-96" r="2.8226879999999999" x="9.2347199999999994" g1="0" b1="0.00015610649999999999" g2="0" b2="0.00015610649999999999" node1="33" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="-16.541391553332456" q1="-9.3884274913058317" p2="16.595223657164151" q2="4.299754132692299">
         <iidm:alias>_0478e91a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0480d856-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10387,7 +10516,7 @@
             <iidm:temporaryLimit name="_233b7735-85f4-4a6f-9d87-15129fe42ef5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0483e594-c766-11e1-8775-005056c00008" name="38-65" r="4.3608399999999996" x="47.7224" g1="0" b1="0.0010805785" g2="0" b2="0.0010805785" node1="29" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-158.41087415997021" q1="-99.51759048950565" p2="161.43902259694875" q2="35.962636473071406">
+    <iidm:line id="_0483e594-c766-11e1-8775-005056c00008" name="38-65" r="4.3608399999999996" x="47.7224" g1="0" b1="0.0010805785" g2="0" b2="0.0010805785" node1="29" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-157.03595742466777" q1="-100.05755181450957" p2="160.02587874417321" q2="36.107593518985695">
         <iidm:alias>_04638c56-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d5054-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10395,7 +10524,7 @@
             <iidm:temporaryLimit name="_990ce3c5-c90c-41b9-abee-fb803d9df3a5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04784cd4-c766-11e1-8775-005056c00008" name="106-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_04479fe8-c766-11e1-8775-005056c00008" node2="24" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="23.833516467578452" q1="-0.68783695867338923" p2="-23.505640059516811" q2="-2.4637237008819266">
+    <iidm:line id="_04784cd4-c766-11e1-8775-005056c00008" name="106-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_04479fe8-c766-11e1-8775-005056c00008" node2="24" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="23.833713427558308" q1="-0.68791665646169819" p2="-23.505831012592555" q2="-2.4636135975720674">
         <iidm:alias>_04483c21-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f0395-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10403,7 +10532,7 @@
             <iidm:temporaryLimit name="_1372c3b0-62d7-47d7-a8c0-ed8e10bc1f1a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046f9a43-c766-11e1-8775-005056c00008" name="27-115" r="2.8575360000000001" x="12.9111843" g1="0" b1="5.6588600000000002e-05" g2="0" b2="5.6588600000000002e-05" node1="43" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="24.118489708045487" q1="2.5325941767148819" p2="-24.014398320224974" q2="-3.8941986123797796">
+    <iidm:line id="_046f9a43-c766-11e1-8775-005056c00008" name="27-115" r="2.8575360000000001" x="12.9111843" g1="0" b1="5.6588600000000002e-05" g2="0" b2="5.6588600000000002e-05" node1="43" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="23.03052253931039" q1="3.0813730012864085" p2="-22.935000355911413" q2="-4.4869329606652473">
         <iidm:alias>_046d0238-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048c22f4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10411,7 +10540,7 @@
             <iidm:temporaryLimit name="_64cfd0fb-1d8e-45d2-a52f-469238dfc0c6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04529c61-c766-11e1-8775-005056c00008" name="12-14" r="3.7461600000000002" x="12.3187675" g1="0" b1="5.2112050000000002e-05" g2="0" b2="5.2112050000000002e-05" node1="71" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b8129-c766-11e1-8775-005056c00008" p1="37.248781581628002" q1="6.3396788535502253" p2="-36.932953042741204" q2="-7.0578841317083141">
+    <iidm:line id="_04529c61-c766-11e1-8775-005056c00008" name="12-14" r="3.7461600000000002" x="12.3187675" g1="0" b1="5.2112050000000002e-05" g2="0" b2="5.2112050000000002e-05" node1="71" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b8129-c766-11e1-8775-005056c00008" p1="32.415064577208291" q1="7.602299042809296" p2="-32.168749238589029" q2="-8.5491937462672922">
         <iidm:alias>_045fbbc1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047bf65b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10419,7 +10548,7 @@
             <iidm:temporaryLimit name="_efe2501d-bcee-42ff-a037-3d8a280487b0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0463da77-c766-11e1-8775-005056c00008" name="76-118" r="2.8575360000000001" x="9.4786560000000009" g1="0" b1="3.8911849999999999e-05" g2="0" b2="3.8911849999999999e-05" node1="22" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="-5.1360990658597121" q1="-14.978849221618217" p2="5.1795622067876277" q2="13.917879576253112">
+    <iidm:line id="_0463da77-c766-11e1-8775-005056c00008" name="76-118" r="2.8575360000000001" x="9.4786560000000009" g1="0" b1="3.8911849999999999e-05" g2="0" b2="3.8911849999999999e-05" node1="22" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="-5.0222241908866092" q1="-15.074952201754632" p2="5.0659957111351677" q2="14.015139208245753">
         <iidm:alias>_046931a0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04806320-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10427,7 +10556,7 @@
             <iidm:temporaryLimit name="_2ae204bf-78cc-49cb-b886-a933b33057e4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046931a3-c766-11e1-8775-005056c00008" name="74-75" r="2.1431520000000002" x="7.0741440000000004" g1="0" b1="2.9671699999999999e-05" g2="0" b2="2.9671699999999999e-05" node1="23" voltageLevelId1="_047dcb11-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="-44.397108919110742" q1="-4.5311210775389732" p2="44.662297506015477" q2="4.445703357706825">
+    <iidm:line id="_046931a3-c766-11e1-8775-005056c00008" name="74-75" r="2.1431520000000002" x="7.0741440000000004" g1="0" b1="2.9671699999999999e-05" g2="0" b2="2.9671699999999999e-05" node1="23" voltageLevelId1="_047dcb11-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="-44.667200933992156" q1="-4.3569559009808367" p2="44.935395540093715" q2="4.2814288368682156">
         <iidm:alias>_044f4103-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04638c58-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10435,7 +10564,7 @@
             <iidm:temporaryLimit name="_e822432e-79af-4bba-8f40-5250468f81a0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045ed162-c766-11e1-8775-005056c00008" name="3-12" r="8.4332159999999998" x="27.878398900000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="32" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-7.1993534156987904" q1="-10.624986105051477" p2="7.2647341309826139" q2="6.9333840003877336">
+    <iidm:line id="_045ed162-c766-11e1-8775-005056c00008" name="3-12" r="8.4332159999999998" x="27.878398900000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="32" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-8.460765627923875" q1="-9.9543490996057677" p2="8.5304313925894757" q2="6.2750768110704538">
         <iidm:alias>_047a48a1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047b5a14-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10443,7 +10572,7 @@
             <iidm:temporaryLimit name="_c437e52c-43d7-4ae9-87ad-dc19396dc6ff" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04499bb6-c766-11e1-8775-005056c00008" name="49-51" r="8.468064" x="23.8708782" g1="0" b1="9.81405e-05" g2="0" b2="9.81405e-05" node1="119" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04542300-c766-11e1-8775-005056c00008" p1="86.331880363720245" q1="21.166214570519141" p2="-82.640255189202961" q2="-14.129284204051885">
+    <iidm:line id="_04499bb6-c766-11e1-8775-005056c00008" name="49-51" r="8.468064" x="23.8708782" g1="0" b1="9.81405e-05" g2="0" b2="9.81405e-05" node1="119" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04542300-c766-11e1-8775-005056c00008" p1="86.351199085480374" q1="21.16435372717055" p2="-82.658077245011597" q2="-14.123198949948366">
         <iidm:alias>_0487dd38-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b1180-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10451,7 +10580,7 @@
             <iidm:temporaryLimit name="_90dcdbe1-437b-443f-b0b5-c2353f7c6954" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04839779-c766-11e1-8775-005056c00008" name="40-42" r="9.6703209999999995" x="31.885919999999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="42" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="1.2011821738077972" q1="-10.638689896422816" p2="-1.1469082612642703" q2="7.0102200322886716">
+    <iidm:line id="_04839779-c766-11e1-8775-005056c00008" name="40-42" r="9.6703209999999995" x="31.885919999999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="42" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="1.3966976050712863" q1="-10.77679260562889" p2="-1.3403004562450471" q2="7.1583964068366823">
         <iidm:alias>_044974a9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04616975-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10459,7 +10588,7 @@
             <iidm:temporaryLimit name="_9b8510fa-bd0e-4e63-8f4c-0e5443a3eb63" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0484a8e1-c766-11e1-8775-005056c00008" name="32-113" r="10.71576" x="35.370719999999999" g1="0" b1="0.00014864555000000001" g2="0" b2="0.00014864555000000001" node1="52" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="5.0307478575205167" q1="-9.7689039750031466" p2="-4.9782726311287036" q2="5.0569983358385144">
+    <iidm:line id="_0484a8e1-c766-11e1-8775-005056c00008" name="32-113" r="10.71576" x="35.370719999999999" g1="0" b1="0.00014864555000000001" g2="0" b2="0.00014864555000000001" node1="52" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="0.98932650464266059" q1="-8.0384996384193066" p2="-0.96784453224546663" q2="3.2203951744016934">
         <iidm:alias>_04723258-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0482860a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10467,7 +10596,7 @@
             <iidm:temporaryLimit name="_336bfd86-a922-4154-9e06-cd87382cdc5f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04898ae4-c766-11e1-8775-005056c00008" name="51-58" r="4.4431200000000004" x="12.5278568" g1="0" b1="5.1308550000000002e-05" g2="0" b2="5.1308550000000002e-05" node1="31" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="30.739713805399166" q1="0.38516037972515377" p2="-30.477355125519129" q2="-1.2750599562281029">
+    <iidm:line id="_04898ae4-c766-11e1-8775-005056c00008" name="51-58" r="4.4431200000000004" x="12.5278568" g1="0" b1="5.1308550000000002e-05" g2="0" b2="5.1308550000000002e-05" node1="31" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="30.751588115768168" q1="0.38067979907911997" p2="-30.489028538726604" q2="-1.2700044357087756">
         <iidm:alias>_044778d4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04789af1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10475,7 +10604,7 @@
             <iidm:temporaryLimit name="_2be10dec-f0ac-470d-83f7-a2a4e70f3491" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046efe04-c766-11e1-8775-005056c00008" name="29-31" r="1.8817919999999999" x="5.7673439999999996" g1="0" b1="2.3817700000000001e-05" g2="0" b2="2.3817700000000001e-05" node1="22" voltageLevelId1="_04588fd5-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="-6.5541641358492555" q1="-9.5930490063095277" p2="6.5690381987977222" q2="8.8656356976560104">
+    <iidm:line id="_046efe04-c766-11e1-8775-005056c00008" name="29-31" r="1.8817919999999999" x="5.7673439999999996" g1="0" b1="2.3817700000000001e-05" g2="0" b2="2.3817700000000001e-05" node1="22" voltageLevelId1="_04588fd5-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="-8.4100336710836547" q1="-7.4698987824510832" p2="8.4240976028357508" q2="6.7395857578573901">
         <iidm:alias>_04492688-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047cb9a5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10483,7 +10612,7 @@
             <iidm:temporaryLimit name="_f0e21213-6535-44a7-89b6-3063f8738d6b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044a10e4-c766-11e1-8775-005056c00008" name="65-68" r="0.66791999999999996" x="7.7439999999999998" g1="0" b1="0.00065909092999999995" g2="0" b2="0.00065909092999999995" node1="41" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0449e9d2-c766-11e1-8775-005056c00008" p1="-186.5745489893539" q1="27.164480512124477" p2="187.09834240064055" q2="-85.12041283042791">
+    <iidm:line id="_044a10e4-c766-11e1-8775-005056c00008" name="65-68" r="0.66791999999999996" x="7.7439999999999998" g1="0" b1="0.00065909092999999995" g2="0" b2="0.00065909092999999995" node1="41" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0449e9d2-c766-11e1-8775-005056c00008" p1="-185.04046352318301" q1="26.95620966255478" p2="185.55613016101438" q2="-85.006691255695316">
         <iidm:alias>_0461dea7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047629f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10491,7 +10620,7 @@
             <iidm:temporaryLimit name="_ab31cd46-6d0c-4d9c-95f1-396a45a237e1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046b7b92-c766-11e1-8775-005056c00008" name="49-54" r="12.719519999999999" x="50.355361899999998" g1="0" b1="0.00021177684999999999" g2="0" b2="0.00021177684999999999" node1="120" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="55.571494557883248" q1="14.531494004005799" p2="-53.19029230821787" q2="-12.2730989337011">
+    <iidm:line id="_046b7b92-c766-11e1-8775-005056c00008" name="49-54" r="12.719519999999999" x="50.355361899999998" g1="0" b1="0.00021177684999999999" g2="0" b2="0.00021177684999999999" node1="120" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="55.58839917426144" q1="14.530692984650409" p2="-53.205916122622654" q2="-12.26722553391712">
         <iidm:alias>_0462f017-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047120e1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10499,7 +10628,7 @@
             <iidm:temporaryLimit name="_1bf78539-b6fa-4d8b-ba8e-9b5970019be6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04607f15-c766-11e1-8775-005056c00008" name="70-71" r="1.536797" x="6.1855200000000004" g1="0" b1="2.5195149999999999e-05" g2="0" b2="2.5195149999999999e-05" node1="52" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04664b78-c766-11e1-8775-005056c00008" p1="-8.0218689302454003" q1="-3.3778457760090821" p2="8.0285252334328661" q2="2.5529989937205992">
+    <iidm:line id="_04607f15-c766-11e1-8775-005056c00008" name="70-71" r="1.536797" x="6.1855200000000004" g1="0" b1="2.5195149999999999e-05" g2="0" b2="2.5195149999999999e-05" node1="52" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04664b78-c766-11e1-8775-005056c00008" p1="-7.3761386607727015" q1="-3.8164466964910173" p2="7.3821408093480398" q2="2.9886263720045916">
         <iidm:alias>_04486336-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f51b4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10507,7 +10636,7 @@
             <iidm:temporaryLimit name="_08ff3ae4-d1dd-49f7-9eda-32ffc8eb0010" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c5ad7-c766-11e1-8775-005056c00008" name="55-56" r="0.85029100000000002" x="2.631024" g1="0" b1="1.0732300000000001e-05" g2="0" b2="1.0732300000000001e-05" node1="31" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="-26.879547985053957" q1="-5.4944060305023346" p2="26.920829517508892" q2="5.2893619072866906">
+    <iidm:line id="_044c5ad7-c766-11e1-8775-005056c00008" name="55-56" r="0.85029100000000002" x="2.631024" g1="0" b1="1.0732300000000001e-05" g2="0" b2="1.0732300000000001e-05" node1="31" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="-26.89127227317994" q1="-5.4898781893750197" p2="26.932585902933038" q2="5.2849341495491853">
         <iidm:alias>_04558294-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045868c2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10515,7 +10644,7 @@
             <iidm:temporaryLimit name="_94316214-afd8-4c0d-bca4-916acb92af85" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048a2725-c766-11e1-8775-005056c00008" name="35-37" r="1.9166399999999999" x="8.6597279999999994" g1="0" b1="3.7821399999999997e-05" g2="0" b2="3.7821399999999997e-05" node1="21" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-29.3509568948169" q1="-14.506599712806583" p2="29.483480942286853" q2="13.937072651984375">
+    <iidm:line id="_048a2725-c766-11e1-8775-005056c00008" name="35-37" r="1.9166399999999999" x="8.6597279999999994" g1="0" b1="3.7821399999999997e-05" g2="0" b2="3.7821399999999997e-05" node1="21" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-29.269424717648203" q1="-14.542398596034605" p2="29.401624765641245" q2="13.972692609877384">
         <iidm:alias>_0471bd29-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04808a30-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10523,7 +10652,7 @@
             <iidm:temporaryLimit name="_4ea6b532-d914-4b0c-97ee-9f02a14a40b3" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04614263-c766-11e1-8775-005056c00008" name="4-5" r="0.30666199999999999" x="1.3904350000000001" g1="0" b1="6.0261499999999999e-06" g2="0" b2="6.0261499999999999e-06" node1="22" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-113.89921313067866" q1="-17.521655950471942" p2="114.13053880241134" q2="18.357665484857481">
+    <iidm:line id="_04614263-c766-11e1-8775-005056c00008" name="4-5" r="0.30666199999999999" x="1.3904350000000001" g1="0" b1="6.0261499999999999e-06" g2="0" b2="6.0261499999999999e-06" node1="22" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-109.33752614140144" q1="-19.36939372180117" p2="109.55189706171741" q2="20.12812737824768">
         <iidm:alias>_04529c66-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04753f92-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10531,7 +10660,7 @@
             <iidm:temporaryLimit name="_2a95fb2b-6661-46e7-a9f6-fe63c1b7433c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0451b208-c766-11e1-8775-005056c00008" name="20-21" r="3.1885919999999999" x="14.7929754" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_046b2d70-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0460f448-c766-11e1-8775-005056c00008" p1="-33.321338743964738" q1="1.5281812230791718" p2="33.553504579738394" q2="-2.3615940734307865">
+    <iidm:line id="_0451b208-c766-11e1-8775-005056c00008" name="20-21" r="3.1885919999999999" x="14.7929754" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_046b2d70-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0460f448-c766-11e1-8775-005056c00008" p1="-31.30569056609172" q1="0.53080815984225815" p2="31.509775451681882" q2="-1.4970022693512559">
         <iidm:alias>_046c65f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048c22f6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10539,7 +10668,7 @@
             <iidm:temporaryLimit name="_4b67f5f5-f0e1-4bfb-9d57-4d3474720a45" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047d55e4-c766-11e1-8775-005056c00008" name="104-105" r="1.731946" x="6.5862720000000001" g1="0" b1="2.8294300000000001e-05" g2="0" b2="2.8294300000000001e-05" node1="32" voltageLevelId1="_0483977a-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="47.886170435885042" q1="0.90397634179252151" p2="-47.644019000214563" q2="-0.90696069315246564">
+    <iidm:line id="_047d55e4-c766-11e1-8775-005056c00008" name="104-105" r="1.731946" x="6.5862720000000001" g1="0" b1="2.8294300000000001e-05" g2="0" b2="2.8294300000000001e-05" node1="32" voltageLevelId1="_0483977a-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="47.8878759776821" q1="0.90351042948831994" p2="-47.6457069299124" q2="-0.90642586373830214">
         <iidm:alias>_0451d910-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046c65f2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10547,7 +10676,7 @@
             <iidm:temporaryLimit name="_1ca40dc7-6736-4fa8-b4cb-ca696949e421" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046dc589-c766-11e1-8775-005056c00008" name="44-45" r="3.9029759999999998" x="15.699023199999999" g1="0" b1="6.4279149999999996e-05" g2="0" b2="6.4279149999999996e-05" node1="23" voltageLevelId1="_04544a15-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_045d23b4-c766-11e1-8775-005056c00008" p1="-19.272694016781191" q1="-5.3913122200497687" p2="19.364769025583445" q2="3.6166451092440246">
+    <iidm:line id="_046dc589-c766-11e1-8775-005056c00008" name="44-45" r="3.9029759999999998" x="15.699023199999999" g1="0" b1="6.4279149999999996e-05" g2="0" b2="6.4279149999999996e-05" node1="23" voltageLevelId1="_04544a15-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_045d23b4-c766-11e1-8775-005056c00008" p1="-19.014316000021651" q1="-5.5555580510145939" p2="19.104423623115753" q2="3.7733643926859761">
         <iidm:alias>_04518afa-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04667287-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10555,7 +10684,7 @@
             <iidm:temporaryLimit name="_ba738481-ddba-4ebe-a218-8aad0b537f5b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04642896-c766-11e1-8775-005056c00008" name="4-11" r="3.641616" x="11.9877129" g1="0" b1="5.0160700000000002e-05" g2="0" b2="5.0160700000000002e-05" node1="23" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="74.908415604396708" q1="5.5263570929482029" p2="-73.738892564952536" q2="-3.4095612279167784">
+    <iidm:line id="_04642896-c766-11e1-8775-005056c00008" name="4-11" r="3.641616" x="11.9877129" g1="0" b1="5.0160700000000002e-05" g2="0" b2="5.0160700000000002e-05" node1="23" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="70.346417501674338" q1="7.3739512079499807" p2="-69.310286371053806" q2="-5.6986474754325878">
         <iidm:alias>_0455f7c5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04803c17-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10563,7 +10692,7 @@
             <iidm:temporaryLimit name="_b1d87c24-e527-4174-aa04-cd0b9de271ea" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047d07c0-c766-11e1-8775-005056c00008" name="92-93" r="4.4953919999999998" x="14.775551800000001" g1="0" b1="6.2557400000000005e-05" g2="0" b2="6.2557400000000005e-05" node1="72" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04789af0-c766-11e1-8775-005056c00008" p1="72.530462336813869" q1="-13.060000744329569" p2="-71.105251451495761" q2="15.625488311880106">
+    <iidm:line id="_047d07c0-c766-11e1-8775-005056c00008" name="92-93" r="4.4953919999999998" x="14.775551800000001" g1="0" b1="6.2557400000000005e-05" g2="0" b2="6.2557400000000005e-05" node1="72" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04789af0-c766-11e1-8775-005056c00008" p1="72.588212076889732" q1="-12.9968817750957" p2="-71.161037423127965" q2="15.569192376246576">
         <iidm:alias>_044a5f07-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047602e5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10571,7 +10700,7 @@
             <iidm:temporaryLimit name="_4e1daf8e-7708-4b96-8d3f-67f58f2505f9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044f4109-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="43" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="121" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-51.812088469133698" q1="-19.858392085749081" p2="54.344939826568471" q2="23.202601033047795">
+    <iidm:line id="_044f4109-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="43" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="121" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-51.61973632152224" q1="-20.004248881804351" p2="54.141188343284178" q2="23.299123105994042">
         <iidm:alias>_046958b0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04758db0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10579,7 +10708,7 @@
             <iidm:temporaryLimit name="_c58940cb-bd36-4dfc-9615-11716dd652a7" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046e61c8-c766-11e1-8775-005056c00008" name="69-75" r="7.0567200000000003" x="21.257280000000002" g1="0" b1="0.00035583104999999999" g2="0" b2="0.00035583104999999999" node1="61" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="87.048346606433967" q1="25.118719748811102" p2="-83.802172828181014" q2="-27.787806455199711">
+    <iidm:line id="_046e61c8-c766-11e1-8775-005056c00008" name="69-75" r="7.0567200000000003" x="21.257280000000002" g1="0" b1="0.00035583104999999999" g2="0" b2="0.00035583104999999999" node1="61" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="87.415467567230522" q1="25.035868841568693" p2="-84.147065131127761" q2="-27.637964936394216">
         <iidm:alias>_046d294a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048ac362-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10587,7 +10716,7 @@
             <iidm:temporaryLimit name="_3c9a454c-10ee-4c72-a059-77f723f5b7c7" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0463da71-c766-11e1-8775-005056c00008" name="79-80" r="2.7181440000000001" x="12.2664957" g1="0" b1="5.3661600000000001e-05" g2="0" b2="5.3661600000000001e-05" node1="23" voltageLevelId1="_04481510-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-66.902960191943222" q1="-32.280058364581244" p2="67.742763099697896" q2="34.110727127057871">
+    <iidm:line id="_0463da71-c766-11e1-8775-005056c00008" name="79-80" r="2.7181440000000001" x="12.2664957" g1="0" b1="5.3661600000000001e-05" g2="0" b2="5.3661600000000001e-05" node1="23" voltageLevelId1="_04481510-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-66.990166216089037" q1="-32.388877041433034" p2="67.832977953635364" q2="34.233304160240266">
         <iidm:alias>_0464ebe9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04662468-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10595,7 +10724,7 @@
             <iidm:temporaryLimit name="_270a7d04-9ff9-4178-8b72-b610735a72ac" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044fdd41-c766-11e1-8775-005056c00008" name="51-52" r="3.5370720000000002" x="10.2453117" g1="0" b1="4.0059699999999999e-05" g2="0" b2="4.0059699999999999e-05" node1="32" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04806326-c766-11e1-8775-005056c00008" p1="34.946794685755044" q1="5.7806628112791696" p2="-34.668167397500575" q2="-6.2429016955748615">
+    <iidm:line id="_044fdd41-c766-11e1-8775-005056c00008" name="51-52" r="3.5370720000000002" x="10.2453117" g1="0" b1="4.0059699999999999e-05" g2="0" b2="4.0059699999999999e-05" node1="32" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04806326-c766-11e1-8775-005056c00008" p1="34.95263091955637" q1="5.7791420778730469" p2="-34.673916354211002" q2="-6.2411206505125909">
         <iidm:alias>_045115c2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0464ebe5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10603,7 +10732,7 @@
             <iidm:temporaryLimit name="_9d1eb182-ceb5-426e-9440-5f4d426a31cb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c3958-c766-11e1-8775-005056c00008" name="53-54" r="4.5825120000000004" x="21.257280000000002" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="22" voltageLevelId1="_04876804-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="-6.3130657204009513" q1="-6.5822490504894526" p2="6.3332291606277185" q2="3.9354482808306992">
+    <iidm:line id="_045c3958-c766-11e1-8775-005056c00008" name="53-54" r="4.5825120000000004" x="21.257280000000002" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="22" voltageLevelId1="_04876804-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="-6.3076985177731721" q1="-6.5840912255083834" p2="6.3278475136203296" q2="3.9372336759566111">
         <iidm:alias>_044f6817-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0455f7c6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10611,7 +10740,7 @@
             <iidm:temporaryLimit name="_735ac8df-6a6a-43f0-86f2-49d3280c9a3b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044ef2e1-c766-11e1-8775-005056c00008" name="54-55" r="2.9446560000000002" x="12.3187675" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="63" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04767817-c766-11e1-8775-005056c00008" p1="6.5749357692248465" q1="0.66664921964196922" p2="-6.5662804795361209" q2="-2.4279712662377042">
+    <iidm:line id="_044ef2e1-c766-11e1-8775-005056c00008" name="54-55" r="2.9446560000000002" x="12.3187675" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="63" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04767817-c766-11e1-8775-005056c00008" p1="6.5795480030733158" q1="0.66518190947136535" p2="-6.5708820677437041" q2="-2.4264549343245401">
         <iidm:alias>_04640181-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047dcb17-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10619,7 +10748,7 @@
             <iidm:temporaryLimit name="_52aadf8d-53f2-4827-8c70-421bdf1ba822" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0456e226-c766-11e1-8775-005056c00008" name="80-97" r="3.1885919999999999" x="16.2740154" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="82" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="10.025899818321633" q1="31.530299221387171" p2="-9.8257120319976163" q2="-33.174379676999536">
+    <iidm:line id="_0456e226-c766-11e1-8775-005056c00008" name="80-97" r="3.1885919999999999" x="16.2740154" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="82" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="10.071056280413167" q1="31.730606278706176" p2="-9.8684777269140014" q2="-33.3620011587752">
         <iidm:alias>_04479fe9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047df222-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10627,7 +10756,7 @@
             <iidm:temporaryLimit name="_fece5807-6af8-4161-8de8-8f8473d92f11" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0487b624-c766-11e1-8775-005056c00008" name="103-110" r="6.8058139999999998" x="31.5897121" g1="0" b1="0.00013228879999999999" g2="0" b2="0.00013228879999999999" node1="43" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="57.413326670972651" q1="18.52543682604972" p2="-55.98428358772005" q2="-16.346230277621654">
+    <iidm:line id="_0487b624-c766-11e1-8775-005056c00008" name="103-110" r="6.8058139999999998" x="31.5897121" g1="0" b1="0.00013228879999999999" g2="0" b2="0.00013228879999999999" node1="43" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="57.417007961646085" q1="18.525078074669985" p2="-55.987806136386553" q2="-16.345125503492234">
         <iidm:alias>_046a9139-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b3895-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10635,7 +10764,7 @@
             <iidm:temporaryLimit name="_3eacc034-737e-41de-a7b6-b610d3bd0921" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045338a8-c766-11e1-8775-005056c00008" name="56-58" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="61" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="-18.386429055310014" q1="-0.096371108499766073" p2="18.516807135871051" q2="-1.7083238609875933">
+    <iidm:line id="_045338a8-c766-11e1-8775-005056c00008" name="56-58" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="61" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="-18.397873837022853" q1="-0.090917673173185332" p2="18.528418262034123" q2="-1.7133009842895834">
         <iidm:alias>_0451d915-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04817494-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10643,7 +10772,7 @@
             <iidm:temporaryLimit name="_0d0c3ec5-798a-48a4-9bc8-d19c57128a13" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04854529-c766-11e1-8775-005056c00008" name="15-33" r="6.6211200000000003" x="21.675455100000001" g1="0" b1="9.1655200000000003e-05" g2="0" b2="9.1655200000000003e-05" node1="52" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456bb11-c766-11e1-8775-005056c00008" p1="68.948734569636756" q1="-8.5215174872167996" p2="-66.913513862729531" q2="12.360220509394546">
+    <iidm:line id="_04854529-c766-11e1-8775-005056c00008" name="15-33" r="6.6211200000000003" x="21.675455100000001" g1="0" b1="9.1655200000000003e-05" g2="0" b2="9.1655200000000003e-05" node1="52" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456bb11-c766-11e1-8775-005056c00008" p1="70.023396521607822" q1="-8.5734152993610628" p2="-67.92279406393223" q2="12.629230546664511">
         <iidm:alias>_0448d862-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047d2ed5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10651,7 +10780,7 @@
             <iidm:temporaryLimit name="_5b0395f4-534d-4975-a1af-e0b6ef439193" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04649dc2-c766-11e1-8775-005056c00008" name="35-36" r="0.39029799999999998" x="1.7772479999999999" g1="0" b1="7.6905500000000004e-06" g2="0" b2="7.6905500000000004e-06" node1="22" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="-3.6032565583004219" q1="5.527438516138572" p2="3.6044032081258859" q2="-5.7568815623799043">
+    <iidm:line id="_04649dc2-c766-11e1-8775-005056c00008" name="35-36" r="0.39029799999999998" x="1.7772479999999999" g1="0" b1="7.6905500000000004e-06" g2="0" b2="7.6905500000000004e-06" node1="22" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="-3.6844714461831325" q1="5.5635070351163911" p2="3.6856449525905277" q2="-5.7925636636698741">
         <iidm:alias>_044c0cb5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0456e225-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10659,7 +10788,7 @@
             <iidm:temporaryLimit name="_74c4b341-7b99-4a81-b88a-2ed3b0c4b1de" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0470d2c9-c766-11e1-8775-005056c00008" name="37-40" r="10.3324327" x="29.272320000000001" g1="0" b1="0.0001205234" g2="0" b2="0.0001205234" node1="61" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="58.095722667846225" q1="9.6518248721872126" p2="-55.7757807040242" q2="-6.6455347265690339">
+    <iidm:line id="_0470d2c9-c766-11e1-8775-005056c00008" name="37-40" r="10.3324327" x="29.272320000000001" g1="0" b1="0.0001205234" g2="0" b2="0.0001205234" node1="61" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="58.301722623935824" q1="9.5629416970644563" p2="-55.964787733281938" q2="-6.5047712095770427">
         <iidm:alias>_045b9d10-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046a4317-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10667,7 +10796,7 @@
             <iidm:temporaryLimit name="_e98d56fe-a54b-45e4-acff-0ac310beb3dd" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044e56a2-c766-11e1-8775-005056c00008" name="48-49" r="3.1188959999999999" x="8.7991200000000003" g1="0" b1="3.6099649999999999e-05" g2="0" b2="3.6099649999999999e-05" node1="23" voltageLevelId1="_044778d3-c766-11e1-8775-005056c00008" node2="122" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-27.785556404014589" q1="0.98092795061853932" p2="27.918625848541577" q2="-1.9218443666893599">
+    <iidm:line id="_044e56a2-c766-11e1-8775-005056c00008" name="48-49" r="3.1188959999999999" x="8.7991200000000003" g1="0" b1="3.6099649999999999e-05" g2="0" b2="3.6099649999999999e-05" node1="23" voltageLevelId1="_044778d3-c766-11e1-8775-005056c00008" node2="122" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-27.75483643101964" q1="0.97107013995126201" p2="27.887606835509278" q2="-1.9128336998144577">
         <iidm:alias>_0454bf49-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0460a623-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10675,7 +10804,7 @@
             <iidm:temporaryLimit name="_f2e58700-2366-46e0-8408-9472d85acd23" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047eb573-c766-11e1-8775-005056c00008" name="56-59" r="14.3748007" x="43.734237700000001" g1="0" b1="0.0001632805" g2="0" b2="0.0001632805" node1="62" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-23.767485059673248" q1="-9.3716966178008327" p2="24.333200012923857" q2="5.7950512010466078">
+    <iidm:line id="_047eb573-c766-11e1-8775-005056c00008" name="56-59" r="14.3748007" x="43.734237700000001" g1="0" b1="0.0001632805" g2="0" b2="0.0001632805" node1="62" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-23.753963218310997" q1="-9.3779665280044195" p2="24.319164549867029" q2="5.7997569017458988">
         <iidm:alias>_0468bc78-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048915b0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10683,7 +10812,7 @@
             <iidm:temporaryLimit name="_89654167-95a6-4c76-aad7-63a881116e17" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046f9a4b-c766-11e1-8775-005056c00008" name="94-100" r="3.1014719999999998" x="10.105919999999999" g1="0" b1="0.00017332415000000001" g2="0" b2="0.00017332415000000001" node1="52" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-7.6212657578629743" q1="-52.23953799092628" p2="8.0763088055879422" q2="47.658887816241055">
+    <iidm:line id="_046f9a4b-c766-11e1-8775-005056c00008" name="94-100" r="3.1014719999999998" x="10.105919999999999" g1="0" b1="0.00017332415000000001" g2="0" b2="0.00017332415000000001" node1="52" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-7.6360025944562064" q1="-52.514737384098979" p2="8.0962407389356041" q2="47.952042288310373">
         <iidm:alias>_04812676-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048a2722-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10691,7 +10820,7 @@
             <iidm:temporaryLimit name="_216c0f3b-03e8-4b7d-96fc-a5f891331f7f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046735d0-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="123" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-99.828422657255516" q1="-0.48107172279121085" p2="101.53592968122378" q2="6.5402867078455635">
+    <iidm:line id="_046735d0-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="123" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-99.733941774635483" q1="-0.50781674624899575" p2="101.43820780268287" q2="6.5504804756321393">
         <iidm:alias>_04570934-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b3894-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10699,7 +10828,7 @@
             <iidm:temporaryLimit name="_32655e4f-e7da-46b0-a908-b601224ddb73" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046d294b-c766-11e1-8775-005056c00008" name="21-22" r="3.641616" x="16.901281399999998" g1="0" b1="7.0592299999999998e-05" g2="0" b2="7.0592299999999998e-05" node1="22" voltageLevelId1="_0460f448-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04773b6a-c766-11e1-8775-005056c00008" p1="-47.541536647899015" q1="-5.6270388770493369" p2="48.077751232167124" q2="5.8904633004069087">
+    <iidm:line id="_046d294b-c766-11e1-8775-005056c00008" name="21-22" r="3.641616" x="16.901281399999998" g1="0" b1="7.0592299999999998e-05" g2="0" b2="7.0592299999999998e-05" node1="22" voltageLevelId1="_0460f448-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04773b6a-c766-11e1-8775-005056c00008" p1="-45.498328205235097" q1="-6.4920847864110423" p2="45.990989666522083" q2="6.5487325394443019">
         <iidm:alias>_044a37f0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_044be5a2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10707,7 +10836,7 @@
             <iidm:temporaryLimit name="_bafaeace-e459-4dc2-87a0-467a9ea25f8d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_6a131803-f462-47e2-bc21-bda919364fe9" name="reactor1" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="36" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="37" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="-4.163336342344337e-15" q1="-83.151460239066751" p2="2.7755575615628914e-15" q2="92.151107878820213">
+    <iidm:line id="_6a131803-f462-47e2-bc21-bda919364fe9" name="reactor1" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="36" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="37" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="0" q1="-83.151691425554901" p2="0" q2="92.151364087080978">
         <iidm:alias>_04531196-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_ca0adad2-ffe3-4efa-b56b-7d333b8ae18f</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10715,7 +10844,7 @@
             <iidm:temporaryLimit name="_ae4eadea-f3fc-4ac6-8899-c1698ece7a89" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_9803b364-2a93-4f21-94b7-8bdbe27a16f2" name="reactor2" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="38" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="2.883715499030215e-07" q1="27.765627025768868" p2="-2.8837154920913211e-07" q2="-26.861558230489834">
+    <iidm:line id="_9803b364-2a93-4f21-94b7-8bdbe27a16f2" name="reactor2" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="38" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="1.355792186574778e-05" q1="27.765054131442767" p2="-1.3557921866094724e-05" q2="-26.861023508233867">
         <iidm:alias>_0461b792-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_afe0e60b-3870-44fb-ba93-a056228f9636</iidm:alias>
     </iidm:line>

--- a/tests/main_sa/reference/launch/hvdcline_contingency/outputIIDM.xml
+++ b/tests/main_sa/reference/launch/hvdcline_contingency/outputIIDM.xml
@@ -31,8 +31,8 @@
                     <iidm:alias>_bea273f1-1e21-476d-b0d0-92dd6cb9a2d4</iidm:alias>
                     <iidm:alias>_c94e6b68-da6c-43d1-94fd-09ad60c74134</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_047abdd7-c766-11e1-8775-005056c00008-BREAKER" name="BREAKER-Jay LD" kind="BREAKER" retained="true" open="false" node1="0" node2="8"/>
                 <iidm:internalConnection node1="7" node2="0"/>
-                <iidm:internalConnection node1="8" node2="0"/>
                 <iidm:internalConnection node1="9" node2="1"/>
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="4"/>
@@ -47,9 +47,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="124.73850447267388" angle="8.3835458500151603" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.89616556416222" angle="-4.0606525456934008" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047abdd7-c766-11e1-8775-005056c00008" name="Jay LD" loadType="UNDEFINED" p0="14" q0="8" node="8" p="14.001084048597773" q="8.0010324538833917">
+            <iidm:load id="_047abdd7-c766-11e1-8775-005056c00008" name="Jay LD" loadType="UNDEFINED" p0="14" q0="8" node="8" p="14.003638766453678" q="8.0034657920928201">
                 <iidm:alias>_04590500-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -139,12 +139,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="127.72957958909267" angle="11.887188840050376" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="127.94055525360032" angle="-0.75782002563311934" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045b00d5-c766-11e1-8775-005056c00008" name="Madison LD" loadType="UNDEFINED" p0="62" q0="13" node="14" p="62.001265458390812" q="13.000442233091533">
+            <iidm:load id="_045b00d5-c766-11e1-8775-005056c00008" name="Madison LD" loadType="UNDEFINED" p0="62" q0="13" node="14" p="62.005034279836266" q="13.001759338957219">
                 <iidm:alias>_045b27e3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_04689566-c766-11e1-8775-005056c00008" name="Madison NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="15" p="9.0001836955728578" q="0">
+            <iidm:load id="_04689566-c766-11e1-8775-005056c00008" name="Madison NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="15" p="9.000730782556877" q="0">
                 <iidm:alias>_04765100-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -272,16 +272,16 @@
                 <iidm:internalConnection node1="61" node2="12"/>
                 <iidm:internalConnection node1="62" node2="15"/>
                 <iidm:internalConnection node1="63" node2="18"/>
-                <iidm:bus v="126.06000145419115" angle="-7.0509338265492296" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63"/>
+                <iidm:bus v="126.06000593162055" angle="-19.514016872535322" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_046c3ee7-c766-11e1-8775-005056c00008" name="Torrey SM" energySource="THERMAL" minP="20" maxP="80" ratedS="100" voltageRegulatorOn="true" targetP="48" targetV="126.06" targetQ="0" node="21" p="-53.170800162427071" q="-7.2684477193126096">
+            <iidm:generator id="_046c3ee7-c766-11e1-8775-005056c00008" name="Torrey SM" energySource="THERMAL" minP="20" maxP="80" ratedS="100" voltageRegulatorOn="true" targetP="48" targetV="126.06" targetQ="0" node="21" p="-53.162052546223528" q="-7.2798658132484064">
                 <iidm:alias>_047147f3-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_b97aee41-3115-4cfd-9071-b52fb44d0b66"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_5005c073-28d1-4a7d-b257-649dec43ec73"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-30" maxQ="85"/>
             </iidm:generator>
-            <iidm:load id="_044afb44-c766-11e1-8775-005056c00008" name="Torrey LD" loadType="UNDEFINED" p0="113" q0="32" node="20" p="113.00000195530224" q="32.000000922856522">
+            <iidm:load id="_044afb44-c766-11e1-8775-005056c00008" name="Torrey LD" loadType="UNDEFINED" p0="113" q0="32" node="20" p="113.0000079756441" q="32.000003764315892">
                 <iidm:alias>_04522737-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -332,9 +332,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="123.84846003363434" angle="8.809091585719182" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="123.83933066156348" angle="-3.7127462273562237" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04481515-c766-11e1-8775-005056c00008" name="Darrah LD" loadType="UNDEFINED" p0="68" q0="36" node="8" p="68.002323556080697" q="36.002050219893398">
+            <iidm:load id="_04481515-c766-11e1-8775-005056c00008" name="Darrah LD" loadType="UNDEFINED" p0="68" q0="36" node="8" p="68.002614759035907" q="36.002307169897321">
                 <iidm:alias>_044e7db8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -385,9 +385,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.46338107783041" angle="23.202490653892308" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.45755437616722" angle="10.704897031815591" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044c0cb3-c766-11e1-8775-005056c00008" name="Smythe LD" loadType="UNDEFINED" p0="5" q0="3" node="8" p="4.9999615826569341" q="2.9999615827553261">
+            <iidm:load id="_044c0cb3-c766-11e1-8775-005056c00008" name="Smythe LD" loadType="UNDEFINED" p0="5" q0="3" node="8" p="4.9999627216991138" q="2.9999627217917584">
                 <iidm:alias>_045163e8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -514,9 +514,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="125.908204527319" angle="-7.2234348592373792" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="125.90817441841936" angle="-19.686592136632932" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0450a093-c766-11e1-8775-005056c00008" name="Sunnysde LD" loadType="UNDEFINED" p0="84" q0="18" node="20" p="83.999995827299543" q="17.999998509749865">
+            <iidm:load id="_0450a093-c766-11e1-8775-005056c00008" name="Sunnysde LD" loadType="UNDEFINED" p0="84" q0="18" node="20" p="83.9999991232512" q="17.99999968687543">
                 <iidm:alias>_045f4695-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -568,12 +568,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="126.74482342019236" angle="8.7005212837831998" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="126.75002470619521" angle="-3.8401411772201475" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044b2251-c766-11e1-8775-005056c00008" name="Bellefnt LD" loadType="UNDEFINED" p0="68" q0="27" node="8" p="68.002734415315444" q="27.001809563801938">
+            <iidm:load id="_044b2251-c766-11e1-8775-005056c00008" name="Bellefnt LD" loadType="UNDEFINED" p0="68" q0="27" node="8" p="68.003367574793245" q="27.002228578930527">
                 <iidm:alias>_04622cc1-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0449e9d5-c766-11e1-8775-005056c00008" name="Bellefnt SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.40300000000001" targetDeadband="1" node="9" q="-11.068268431769043">
+            <iidm:shunt id="_0449e9d5-c766-11e1-8775-005056c00008" name="Bellefnt SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.40300000000001" targetDeadband="1" node="9" q="-11.069176877721533">
                 <iidm:alias>_047bcf48-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_6cc38790-c6a6-4309-99f4-a3258e24e785"/>
                 <iidm:shuntLinearModel bPerSection="0.00013779999999999999" gPerSection="0" maximumSectionCount="10"/>
@@ -665,12 +665,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="126.0659734684882" angle="8.8610206126329931" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="126.06596724884074" angle="-3.6431634690203452" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04682035-c766-11e1-8775-005056c00008" name="Fieldale LD" loadType="UNDEFINED" p0="39" q0="30" node="14" p="39.000010678628875" q="30.000013690551086">
+            <iidm:load id="_04682035-c766-11e1-8775-005056c00008" name="Fieldale LD" loadType="UNDEFINED" p0="39" q0="30" node="14" p="39.000016254440048" q="30.000020839028597">
                 <iidm:alias>_0478c20a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_045c6067-c766-11e1-8775-005056c00008" name="Fieldale SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.066" targetDeadband="1" node="15" q="-5.4670646052958052">
+            <iidm:shunt id="_045c6067-c766-11e1-8775-005056c00008" name="Fieldale SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.066" targetDeadband="1" node="15" q="-5.4670640658447116">
                 <iidm:alias>_0451b209-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_2d222dd9-7306-4afd-baa5-fd303b0eeb40"/>
                 <iidm:shuntLinearModel bPerSection="6.8800000000000005e-05" gPerSection="0" maximumSectionCount="10"/>
@@ -780,7 +780,7 @@
                 <iidm:internalConnection node1="51" node2="9"/>
                 <iidm:internalConnection node1="52" node2="12"/>
                 <iidm:internalConnection node1="53" node2="15"/>
-                <iidm:bus v="138.01466846794096" angle="4.7351137892495938" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
+                <iidm:bus v="138.01461711414626" angle="-7.7300804273728669" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="_047f0391-c766-11e1-8775-005056c00008" name="Muskngum SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="392" targetV="138.59999099999999" targetQ="0" node="18" p="-0" q="-0">
                 <iidm:alias>_047eb572-c766-11e1-8775-005056c00008</iidm:alias>
@@ -789,7 +789,7 @@
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
-            <iidm:load id="_047e1936-c766-11e1-8775-005056c00008" name="Muskngum LD" loadType="UNDEFINED" p0="39" q0="18" node="17" p="38.999727554872976" q="17.999790427313378">
+            <iidm:load id="_047e1936-c766-11e1-8775-005056c00008" name="Muskngum LD" loadType="UNDEFINED" p0="39" q0="18" node="17" p="38.999728298468099" q="17.999790999306963">
                 <iidm:alias>_046e88d5-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -876,9 +876,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="221.1000034364005" angle="9.8901253771388724" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="221.10001228704692" angle="-2.578690745468927" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0458ddf1-c766-11e1-8775-005056c00008" name="Muskngum SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="391" targetV="221.09999999999999" targetQ="0" node="14" p="-433.12047632310379" q="-156.20819984713188">
+            <iidm:generator id="_0458ddf1-c766-11e1-8775-005056c00008" name="Muskngum SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="391" targetV="221.09999999999999" targetQ="0" node="14" p="-433.04921969944587" q="-155.92240397317818">
                 <iidm:alias>_04522732-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_5036c3a5-56f9-489c-9ecb-8c15aa7c70c5"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_12b01822-ca11-4cf8-a6b4-2f8ff805ca20"/>
@@ -886,7 +886,7 @@
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045cae83-c766-11e1-8775-005056c00008" name="65-66" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="42" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="272.91347060159342" q1="97.4052644028136" p2="-272.91347060159347" q2="-70.513789396893173">
+        <iidm:twoWindingsTransformer id="_045cae83-c766-11e1-8775-005056c00008" name="65-66" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="42" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="272.72214844306626" q1="97.389272963070724" p2="-272.72214844306615" q2="-70.532229588554259">
             <iidm:alias>_044b2254-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_044b4964-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_045645e1-c766-11e1-8775-005056c00008</iidm:alias>
@@ -961,9 +961,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="124.15522281032541" angle="6.5505843952460658" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.26431829098219" angle="-5.7648254432856456" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0453d4e2-c766-11e1-8775-005056c00008" name="Adams LD" loadType="UNDEFINED" p0="18" q0="3" node="8" p="18.002584209881871" q="3.0007178704303255">
+            <iidm:load id="_0453d4e2-c766-11e1-8775-005056c00008" name="Adams LD" loadType="UNDEFINED" p0="18" q0="3" node="8" p="18.0063677912534" q="3.0017690394797087">
                 <iidm:alias>_0448ff77-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1053,16 +1053,16 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="133.31999979028254" angle="14.601503391583494" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="133.32001259845819" angle="2.0977008348829957" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_046bf0c4-c766-11e1-8775-005056c00008" name="Claytor SM" energySource="THERMAL" minP="0" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="40" targetV="133.31999200000001" targetQ="0" node="15" p="-44.309000135355888" q="-83.061952155351349">
+            <iidm:generator id="_046bf0c4-c766-11e1-8775-005056c00008" name="Claytor SM" energySource="THERMAL" minP="0" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="40" targetV="133.31999200000001" targetQ="0" node="15" p="-44.301710455186274" q="-83.065700197255282">
                 <iidm:alias>_0460a627-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e56da2eb-bb6a-4133-953c-40073c5bc5f4"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_d41be6b4-155e-4c8f-b46b-16b50c49f0f4"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-60" maxQ="170"/>
             </iidm:generator>
-            <iidm:load id="_048433b6-c766-11e1-8775-005056c00008" name="Claytor LD" loadType="UNDEFINED" p0="23" q0="16" node="14" p="23.000002015937348" q="16.000002337318733">
+            <iidm:load id="_048433b6-c766-11e1-8775-005056c00008" name="Claytor LD" loadType="UNDEFINED" p0="23" q0="16" node="14" p="23.000005330384624" q="16.000006180156561">
                 <iidm:alias>_0480ff6b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1133,12 +1133,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="129.78368371969884" angle="-3.8938908522755544" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="129.78365763382277" angle="-16.336435920651205" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0449e9d7-c766-11e1-8775-005056c00008" name="N.Newark LD" loadType="UNDEFINED" p0="53" q0="22" node="11" p="53.005319573340834" q="22.003680331096916">
+            <iidm:load id="_0449e9d7-c766-11e1-8775-005056c00008" name="N.Newark LD" loadType="UNDEFINED" p0="53" q0="22" node="11" p="53.006173609839557" q="22.004271216665476">
                 <iidm:alias>_04531191-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_04684741-c766-11e1-8775-005056c00008" name="N.Newark SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.32300000000001" targetDeadband="1" node="12" q="-9.6683438173566678">
+            <iidm:shunt id="_04684741-c766-11e1-8775-005056c00008" name="N.Newark SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.32300000000001" targetDeadband="1" node="12" q="-9.6683399307788456">
                 <iidm:alias>_04607f19-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_eae61817-d3cb-488f-a1f3-13bc8e31431b"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -1191,9 +1191,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.91379914745977" angle="11.849178368381324" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="131.0149209042421" angle="-0.82366938358371355" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0448d86a-c766-11e1-8775-005056c00008" name="Hillsbro NegG LD" loadType="UNDEFINED" p0="12" q0="0" node="8" p="11.99859492914015" q="0">
+            <iidm:load id="_0448d86a-c766-11e1-8775-005056c00008" name="Hillsbro NegG LD" loadType="UNDEFINED" p0="12" q0="0" node="8" p="11.99913600039895" q="0">
                 <iidm:alias>_044ef2e8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1244,9 +1244,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="125.55222575006661" angle="-5.5506601335100596" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="125.52867743773461" angle="-17.930197446967352" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047dcb12-c766-11e1-8775-005056c00008" name="S.Kenton LD" loadType="UNDEFINED" p0="18" q0="7" node="8" p="18.009864546249226" q="7.006394855290889">
+            <iidm:load id="_047dcb12-c766-11e1-8775-005056c00008" name="S.Kenton LD" loadType="UNDEFINED" p0="18" q0="7" node="8" p="18.011251025191715" q="7.0072938504113811">
                 <iidm:alias>_0451b205-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1281,6 +1281,9 @@
                     <iidm:alias>_8ef85f09-3622-4a12-87bf-fefcecc01e4a</iidm:alias>
                     <iidm:alias>_a0244ab3-80e5-4c20-b201-a142d50e6ec1</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_dffdb415-95a8-496a-ad1a-93cdeb444fae-1" name="DISCONNECTOR723-1" kind="DISCONNECTOR" retained="false" open="false" node1="24" node2="25"/>
+                <iidm:switch id="_aa063f2e-1205-4d1a-a549-3ccc5b31e65d-1" name="BREAKER362-1" kind="BREAKER" retained="false" open="false" node1="23" node2="24"/>
+                <iidm:switch id="_28b3e895-483c-478d-a5a3-7b9d7c9e11f3-1" name="DISCONNECTOR724-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="23"/>
                 <iidm:internalConnection node1="7" node2="0"/>
                 <iidm:internalConnection node1="8" node2="0"/>
                 <iidm:internalConnection node1="9" node2="1"/>
@@ -1297,9 +1300,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="125.20808932325535" angle="21.708891783415869" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.17821821262837" angle="9.3075709179617885" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044afb49-c766-11e1-8775-005056c00008" name="Hazard LD" loadType="UNDEFINED" p0="21" q0="10" node="8" p="20.99826007470838" q="9.9986191450490818">
+            <iidm:load id="_044afb49-c766-11e1-8775-005056c00008" name="Hazard LD" loadType="UNDEFINED" p0="21" q0="10" node="8" p="20.997891144720413" q="9.9983263613593625">
                 <iidm:alias>_045e5c31-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1320,6 +1323,9 @@
                     <iidm:alias>_2a61ce12-8d9c-4aae-8bc7-c8f820ecae6c</iidm:alias>
                     <iidm:alias>_a3d5e8cc-be34-4d4a-a586-ce582737826b</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_83a05cd7-017e-4e7a-bc5e-a01ee9681f9f-1" name="DISCONNECTOR725-1" kind="DISCONNECTOR" retained="false" open="false" node1="14" node2="15"/>
+                <iidm:switch id="_cf4393c0-21c2-4e35-b330-c1acda2647ba-1" name="BREAKER363-1" kind="BREAKER" retained="false" open="true" node1="13" node2="14"/>
+                <iidm:switch id="_b9ab29b9-3d90-4536-8d1a-7757d8c22ae4-1" name="DISCONNECTOR726-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="13"/>
                 <iidm:internalConnection node1="4" node2="0"/>
                 <iidm:internalConnection node1="5" node2="0"/>
                 <iidm:internalConnection node1="6" node2="1"/>
@@ -1329,14 +1335,14 @@
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="3"/>
-                <iidm:bus v="31.302022330813838" angle="21.708891783415869" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="31.044554553157088" angle="9.3075709179617903" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13"/>
             </iidm:nodeBreakerTopology>
             <iidm:staticVarCompensator id="_047fc6e6-c766-11e1-8775-005056c00008" name="Pinevlle SVC" bMin="-10" bMax="10" voltageSetpoint="33.494999999999997" regulationMode="VOLTAGE" node="5" p="0" q="0">
                 <iidm:alias>_046ab846-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_98f667da-02d1-4a31-b826-44314a1fbbfe"/>
             </iidm:staticVarCompensator>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045e3525-c766-11e1-8775-005056c00008" name="86-87" r="0.30796918750000002" x="2.2585859312499998" g="0" b="-0.0040863184000000004" ratedU1="132" ratedU2="33" node1="22" voltageLevelId1="_0484f70a-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_04555b88-c766-11e1-8775-005056c00008" p1="1.214306433183765e-14" q1="4.0038426093730521" p2="5.8429698672625789e-15" q2="-1.4676104776164648e-14">
+        <iidm:twoWindingsTransformer id="_045e3525-c766-11e1-8775-005056c00008" name="86-87" r="0.30796918750000002" x="2.2585859312499998" g="0" b="-0.0040863184000000004" ratedU1="132" ratedU2="33" node1="22" voltageLevelId1="_0484f70a-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_04555b88-c766-11e1-8775-005056c00008" p1="-2.8189256484623115e-14" q1="3.9382480677871605" p2="2.005936865913264e-14" q2="-1.2239385131289004e-13">
             <iidm:alias>_0452755a-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04682034-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_048c7110-c766-11e1-8775-005056c00008</iidm:alias>
@@ -1412,6 +1418,82 @@
                 <iidm:temporaryLimit name="_257d56c1-d70a-4a96-b85c-d928ade03ad4" acceptableDuration="60" value="12246"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
+        <iidm:twoWindingsTransformer id="_045e3525-c766-11e1-8775-005056c00008-1" name="86-87-open-ended" r="0.30796918750000002" x="2.2585859312499998" g="0" b="-0.0040863184000000004" ratedU1="132" ratedU2="33" node1="25" voltageLevelId1="_0484f70a-c766-11e1-8775-005056c00008" node2="15" voltageLevelId2="_04555b88-c766-11e1-8775-005056c00008" p1="-8.6736173798840355e-17" q1="3.9382480677871081" p2="0" q2="0">
+            <iidm:alias>_0452755a-c766-11e1-8775-005056c00008-1</iidm:alias>
+            <iidm:alias>_04682034-c766-11e1-8775-005056c00008-1</iidm:alias>
+            <iidm:alias>_048c7110-c766-11e1-8775-005056c00008-1</iidm:alias>
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="31" loadTapChangingCapabilities="false">
+                <iidm:step r="-78.460970487743992" x="-78.460970487743992" g="364.27347129590328" b="364.27347129590328" rho="0.4641016"/>
+                <iidm:step r="-76.770985444658564" x="-76.770985444658564" g="330.49609255595948" b="330.49609255595948" rho="0.48196488000000004"/>
+                <iidm:step r="-75.017181047101431" x="-75.017181047101431" g="300.27508580410921" b="300.27508580410921" rho="0.49982816000000002"/>
+                <iidm:step r="-73.199557295072623" x="-73.199557295072623" g="273.1281647135425" b="273.1281647135425" rho="0.51769144000000011"/>
+                <iidm:step r="-71.318114188572153" x="-71.318114188572153" g="248.65210975826625" b="248.65210975826625" rho="0.53555472000000004"/>
+                <iidm:step r="-69.372851727600008" x="-69.372851727600008" g="226.50770848984379" b="226.50770848984379" rho="0.55341799999999997"/>
+                <iidm:step r="-67.363769912156158" x="-67.363769912156158" g="206.40793906293555" b="206.40793906293555" rho="0.57128128"/>
+                <iidm:step r="-65.290868742240633" x="-65.290868742240633" g="188.10862264852744" b="188.10862264852744" rho="0.58914456000000004"/>
+                <iidm:step r="-63.154148217853432" x="-63.154148217853432" g="171.40097232995538" b="171.40097232995538" rho="0.60700784000000008"/>
+                <iidm:step r="-60.953608338994556" x="-60.953608338994556" g="156.10561116167679" b="156.10561116167679" rho="0.62487112"/>
+                <iidm:step r="-58.689249105663997" x="-58.689249105663997" g="142.06773741726079" b="142.06773741726079" rho="0.64273440000000004"/>
+                <iidm:step r="-56.361070517861769" x="-56.361070517861769" g="129.15319231405709" b="129.15319231405709" rho="0.66059767999999996"/>
+                <iidm:step r="-53.969072575587838" x="-53.969072575587838" g="117.24524269951107" b="117.24524269951107" rho="0.67846096"/>
+                <iidm:step r="-51.51325527884223" x="-51.51325527884223" g="106.24193390397649" b="106.24193390397649" rho="0.69632424000000004"/>
+                <iidm:step r="-48.993618627624947" x="-48.993618627624947" g="96.053900138385018" b="96.053900138385018" rho="0.71418752000000008"/>
+                <iidm:step r="-46.410162621936003" x="-46.410162621936003" g="86.602544237115268" b="86.602544237115268" rho="0.7320508"/>
+                <iidm:step r="-43.762887261775354" x="-43.762887261775354" g="77.81851722275475" b="77.81851722275475" rho="0.74991407999999993"/>
+                <iidm:step r="-41.051792547143037" x="-41.051792547143037" g="69.640442552852292" b="69.640442552852292" rho="0.76777735999999996"/>
+                <iidm:step r="-38.276878478039045" x="-38.276878478039045" g="62.013841060226049" b="62.013841060226049" rho="0.78564064"/>
+                <iidm:step r="-35.438145054463355" x="-35.438145054463355" g="54.890221299184191" b="54.890221299184191" rho="0.80350392000000004"/>
+                <iidm:step r="-32.53559227641599" x="-32.53559227641599" g="48.2263068397802" b="48.2263068397802" rho="0.82136720000000008"/>
+                <iidm:step r="-29.569220143896956" x="-29.569220143896956" g="41.983377444222199" b="41.983377444222199" rho="0.83923048"/>
+                <iidm:step r="-26.53902865690624" x="-26.53902865690624" g="36.126705339843348" b="36.126705339843348" rho="0.85709376000000004"/>
+                <iidm:step r="-23.445017815443848" x="-23.445017815443848" g="30.625071218648301" b="30.625071218648301" rho="0.87495704000000007"/>
+                <iidm:step r="-20.287187619509762" x="-20.287187619509762" g="25.450347332714429" b="25.450347332714429" rho="0.89282032000000011"/>
+                <iidm:step r="-17.06553806910399" x="-17.06553806910399" g="20.577137262099331" b="20.577137262099331" rho="0.91068360000000004"/>
+                <iidm:step r="-13.780069164226571" x="-13.780069164226571" g="15.982463718828566" b="15.982463718828566" rho="0.92854687999999996"/>
+                <iidm:step r="-10.430780904877434" x="-10.430780904877434" g="11.645497203453271" b="11.645497203453271" rho="0.94641016"/>
+                <iidm:step r="-7.0176732910566368" x="-7.0176732910566368" g="7.5473195169912355" b="7.5473195169912355" rho="0.96427344000000004"/>
+                <iidm:step r="-3.5407463227641656" x="-3.5407463227641656" g="3.6707171036300279" b="3.6707171036300279" rho="0.98213671999999985"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1"/>
+                <iidm:step r="3.6045656772358381" x="3.6045656772358381" g="-3.4791571719583358" b="-3.4791571719583358" rho="1.01786328"/>
+                <iidm:step r="7.272950708943382" x="7.272950708943382" g="-6.7798551833225922" b="-6.7798551833225922" rho="1.0357265600000001"/>
+                <iidm:step r="11.005155095122543" x="11.005155095122543" g="-9.9140937064517427" b="-9.9140937064517427" rho="1.0535898399999999"/>
+                <iidm:step r="14.801178835773431" x="14.801178835773431" g="-12.892880531259154" b="-12.892880531259154" rho="1.0714531199999999"/>
+                <iidm:step r="18.661021930895984" x="18.661021930895984" g="-15.726328348801433" b="-15.726328348801433" rho="1.0893164"/>
+                <iidm:step r="22.584684380490238" x="22.584684380490238" g="-18.423740693731116" b="-18.423740693731116" rho="1.10717968"/>
+                <iidm:step r="26.572166184556178" x="26.572166184556178" g="-20.993688411566747" b="-20.993688411566747" rho="1.12504296"/>
+                <iidm:step r="30.623467343093779" x="30.623467343093779" g="-23.444077826121855" b="-23.444077826121855" rho="1.1429062400000001"/>
+                <iidm:step r="34.738587856103067" x="34.738587856103067" g="-25.782211620922489" b="-25.782211620922489" rho="1.1607695200000001"/>
+                <iidm:step r="38.917527723583987" x="38.917527723583987" g="-28.014843311220961" b="-28.014843311220961" rho="1.1786327999999999"/>
+                <iidm:step r="43.16028694553664" x="43.16028694553664" g="-30.148226066322692" b="-30.148226066322692" rho="1.19649608"/>
+                <iidm:step r="47.466865521960955" x="47.466865521960955" g="-32.188156542116317" b="-32.188156542116317" rho="1.21435936"/>
+                <iidm:step r="51.837263452856973" x="51.837263452856973" g="-34.140014298236885" b="-34.140014298236885" rho="1.23222264"/>
+                <iidm:step r="56.271480738224653" x="56.271480738224653" g="-36.0087973009527" b="-36.0087973009527" rho="1.2500859200000001"/>
+                <iidm:step r="60.769517378063973" x="60.769517378063973" g="-37.799153949786998" b="-37.799153949786998" rho="1.2679491999999999"/>
+                <iidm:step r="65.331373372375026" x="65.331373372375026" g="-39.515412011505823" b="-39.515412011505823" rho="1.2858124799999999"/>
+                <iidm:step r="69.957048721157761" x="69.957048721157761" g="-41.161604798123854" b="-41.161604798123854" rho="1.30367576"/>
+                <iidm:step r="74.646543424412172" x="74.646543424412172" g="-42.741494884907091" b="-42.741494884907091" rho="1.32153904"/>
+                <iidm:step r="79.399857482138245" x="79.399857482138245" g="-44.258595629064871" b="-44.258595629064871" rho="1.33940232"/>
+                <iidm:step r="84.216990894335964" x="84.216990894335964" g="-45.716190719151165" b="-45.716190719151165" rho="1.3572655999999998"/>
+                <iidm:step r="89.097943661005473" x="89.097943661005473" g="-47.11735195848069" b="-47.11735195848069" rho="1.3751288800000001"/>
+                <iidm:step r="94.04271578214653" x="94.04271578214653" g="-48.464955462553469" b="-48.464955462553469" rho="1.3929921599999999"/>
+                <iidm:step r="99.051307257759348" x="99.051307257759348" g="-49.761696430103783" b="-49.761696430103783" rho="1.41085544"/>
+                <iidm:step r="104.12371808784383" x="104.12371808784383" g="-51.010102629540867" b="-51.010102629540867" rho="1.42871872"/>
+                <iidm:step r="109.25994827240002" x="109.25994827240002" g="-52.212546726893493" b="-52.212546726893493" rho="1.446582"/>
+                <iidm:step r="114.45999781142788" x="114.45999781142788" g="-53.371257567609966" b="-53.371257567609966" rho="1.4644452800000001"/>
+                <iidm:step r="119.72386670492732" x="119.72386670492732" g="-54.488330512455207" b="-54.488330512455207" rho="1.4823085599999999"/>
+                <iidm:step r="125.05155495289854" x="125.05155495289854" g="-55.565736917068101" b="-55.565736917068101" rho="1.5001718399999999"/>
+                <iidm:step r="130.44306255534144" x="130.44306255534144" g="-56.605332835313817" b="-56.605332835313817" rho="1.51803512"/>
+                <iidm:step r="135.89838951225599" x="135.89838951225599" g="-57.608867018227542" b="-57.608867018227542" rho="1.5358984"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="2186">
+                <iidm:temporaryLimit name="_580d3b53-5508-4d8d-97cc-4ea463e0cdb9-1" acceptableDuration="900" value="2514"/>
+                <iidm:temporaryLimit name="_a867e68a-58d1-49cb-955f-bb8e59cf2a11-1" acceptableDuration="60" value="3061"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="8747">
+                <iidm:temporaryLimit name="_1a7f23f9-e2c0-46a6-a93c-687f2209e33d-1" acceptableDuration="900" value="10059"/>
+                <iidm:temporaryLimit name="_257d56c1-d70a-4a96-b85c-d928ade03ad4-1" acceptableDuration="60" value="12246"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
     </iidm:substation>
     <iidm:substation id="_045beb3a-c766-11e1-8775-005056c00008" name="Minas Tirith" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
         <iidm:voltageLevel id="_048a9c58-c766-11e1-8775-005056c00008" name="MNT132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -1460,12 +1542,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="132.78996476823656" angle="13.3697727443012" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="132.90604293117997" angle="0.045551289907840374" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0447ee05-c766-11e1-8775-005056c00008" name="NwCarlsl NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="8" p="9.0011842009840297" q="0">
+            <iidm:load id="_0447ee05-c766-11e1-8775-005056c00008" name="NwCarlsl NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="8" p="9.0011367608959869" q="0">
                 <iidm:alias>_04731cb7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_047a48a8-c766-11e1-8775-005056c00008" name="NwCarlsl LD" loadType="UNDEFINED" p0="30" q0="12" node="9" p="30.003947336613436" q="12.002631673158874">
+            <iidm:load id="_047a48a8-c766-11e1-8775-005056c00008" name="NwCarlsl LD" loadType="UNDEFINED" p0="30" q0="12" node="9" p="30.003789202986621" q="12.002526241678918">
                 <iidm:alias>_044c0cb9-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1516,9 +1598,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.62197378316066" angle="9.879139246008279" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.62196191019387" angle="-2.6248070135053823" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044ecbd1-c766-11e1-8775-005056c00008" name="Blaine LD" loadType="UNDEFINED" p0="2" q0="1" node="8" p="2.0000007859440188" q="1.0000006549534348">
+            <iidm:load id="_044ecbd1-c766-11e1-8775-005056c00008" name="Blaine LD" loadType="UNDEFINED" p0="2" q0="1" node="8" p="2.0000010650965341" q="1.0000008875806028">
                 <iidm:alias>_04700f74-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1569,9 +1651,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="133.18443043729559" angle="15.885531750048143" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="133.15966293274255" angle="3.3829165335717626" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046b7b95-c766-11e1-8775-005056c00008" name="Sundial LD" loadType="UNDEFINED" p0="15" q0="9" node="8" p="14.999881505313727" q="8.9998815056257495">
+            <iidm:load id="_046b7b95-c766-11e1-8775-005056c00008" name="Sundial LD" loadType="UNDEFINED" p0="15" q0="9" node="8" p="14.999878002093029" q="8.9998780024237721">
                 <iidm:alias>_046efe07-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1622,9 +1704,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.71981875009183" angle="8.5540971327480513" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.76700221331959" angle="-4.5939597831067065" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045645e2-c766-11e1-8775-005056c00008" name="Riversde LD" loadType="UNDEFINED" p0="51" q0="27" node="8" p="51.002785545981531" q="27.002457879437102">
+            <iidm:load id="_045645e2-c766-11e1-8775-005056c00008" name="Riversde LD" loadType="UNDEFINED" p0="51" q0="27" node="8" p="51.002662770499505" q="27.002349544271809">
                 <iidm:alias>_0476ed4b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1675,9 +1757,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.84506311399427" angle="11.212717710760469" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.03115629050905" angle="-1.3786505596576646" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04887973-c766-11e1-8775-005056c00008" name="Randolph LD" loadType="UNDEFINED" p0="10" q0="5" node="8" p="10.000095628365733" q="5.0000796905587999">
+            <iidm:load id="_04887973-c766-11e1-8775-005056c00008" name="Randolph LD" loadType="UNDEFINED" p0="10" q0="5" node="8" p="10.001523906995526" q="5.0012699870033055">
                 <iidm:alias>_0462f018-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1728,9 +1810,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.48456264392395" angle="-6.4234700798331854" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.4843165284603" angle="-18.885675494619402" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0477627b-c766-11e1-8775-005056c00008" name="WNwPhil2 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="11.999983023135272" q="2.9999929263096989">
+            <iidm:load id="_0477627b-c766-11e1-8775-005056c00008" name="WNwPhil2 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="11.999982359639572" q="2.9999926498534233">
                 <iidm:alias>_045841b6-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1800,9 +1882,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="126.73063875752312" angle="10.60883561677139" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="126.73062552597574" angle="-1.8948968556367827" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0476781a-c766-11e1-8775-005056c00008" name="Cloverdl LD" loadType="UNDEFINED" p0="43" q0="16" node="11" p="43.000018458662773" q="16.000011447234368">
+            <iidm:load id="_0476781a-c766-11e1-8775-005056c00008" name="Cloverdl LD" loadType="UNDEFINED" p0="43" q0="16" node="11" p="43.000024371214387" q="16.000015113934257">
                 <iidm:alias>_0481749a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1872,9 +1954,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="128.11694474231962" angle="11.978141350504627" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="128.11694248795953" angle="-0.5256065665693862" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046b0665-c766-11e1-8775-005056c00008" name="Hancock LD" loadType="UNDEFINED" p0="38" q0="25" node="11" p="38.00001050378858" q="25.000011517313098">
+            <iidm:load id="_046b0665-c766-11e1-8775-005056c00008" name="Hancock LD" loadType="UNDEFINED" p0="38" q0="25" node="11" p="38.000015835905018" q="25.00001736393336">
                 <iidm:alias>_0464c4d5-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1926,12 +2008,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="128.75981628904023" angle="-5.01750369740635" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="128.75411957937132" angle="-17.443540373234033" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044bbe92-c766-11e1-8775-005056c00008" name="WMVernon LD" loadType="UNDEFINED" p0="16" q0="8" node="8" p="16.003496294391013" q="8.0029137908775407">
+            <iidm:load id="_044bbe92-c766-11e1-8775-005056c00008" name="WMVernon LD" loadType="UNDEFINED" p0="16" q0="8" node="8" p="16.004019818368793" q="8.0033501291699789">
                 <iidm:alias>_04500452-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_047825c8-c766-11e1-8775-005056c00008" name="WMVernon SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.21199999999999" targetDeadband="1" node="9" q="-9.5163978269119642">
+            <iidm:shunt id="_047825c8-c766-11e1-8775-005056c00008" name="WMVernon SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.21199999999999" targetDeadband="1" node="9" q="-9.5155557791702918">
                 <iidm:alias>_047084aa-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_2a6c1dcd-201b-4911-83b2-c16acc50a0f4"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -1965,9 +2047,9 @@
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="3"/>
-                <iidm:bus v="230.99998539629303" angle="35.993765079400617" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="230.99998575148425" angle="22.347280458544382" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_045868c0-c766-11e1-8775-005056c00008" name="Breed SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="450" targetV="230.99998500000001" targetQ="0" node="5" p="-498.47625152275373" q="24.721530647815882">
+            <iidm:generator id="_045868c0-c766-11e1-8775-005056c00008" name="Breed SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="450" targetV="230.99998500000001" targetQ="0" node="5" p="-498.39424262084549" q="28.298436872833349">
                 <iidm:alias>_045b7606-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_f26d4eb3-ebdb-4025-8080-f856ce656b42"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_7566f2a7-61eb-42fe-a59a-8276257fdbc6"/>
@@ -2041,9 +2123,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="127.47320303484197" angle="-5.3179566759411427" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="127.47284920284385" angle="-17.77945856023506" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044d1e22-c766-11e1-8775-005056c00008" name="Newcmrst LD" loadType="UNDEFINED" p0="17" q0="8" node="11" p="16.999964105848768" q="7.9999718477443356">
+            <iidm:load id="_044d1e22-c766-11e1-8775-005056c00008" name="Newcmrst LD" loadType="UNDEFINED" p0="17" q0="8" node="11" p="16.999962373097855" q="7.9999704887259711">
                 <iidm:alias>_048a754b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2113,9 +2195,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="138.59999136917816" angle="25.509887985857976" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="138.5999916395545" angle="12.328325354794782" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_045ab2b0-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="220" targetV="138.59999099999999" targetQ="0" node="11" p="-243.6995007444574" q="-48.617059613245814">
+            <iidm:generator id="_045ab2b0-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="220" targetV="138.59999099999999" targetQ="0" node="11" p="-243.65940750352451" q="-45.593261245182696">
                 <iidm:alias>_046ba2a5-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_56975783-9739-40fc-8ec1-e1de8cb06c9a"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b8449cd9-5a17-497e-bf04-70f728b0f9f2"/>
@@ -2168,9 +2250,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="223.30000054904974" angle="27.959239626835608" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="223.30000093016847" angle="14.505458933167088" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0483224a-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="314" targetV="223.30000000000001" targetQ="0" node="8" p="-347.82565106254373" q="-20.830547850771115">
+            <iidm:generator id="_0483224a-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="314" targetV="223.30000000000001" targetQ="0" node="8" p="-347.76842707321225" q="-16.487702503014447">
                 <iidm:alias>_045cd594-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_05df66ba-3f64-40cb-8b18-c66d26c4e2c1"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_c1d29442-5f57-41d1-bb60-4b74b4994c20"/>
@@ -2178,7 +2260,7 @@
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045b7604-c766-11e1-8775-005056c00008" name="26-25" r="0" x="6.6559680000000006" g="0" b="0" ratedU1="220" ratedU2="132" node1="22" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="124.19867089220247" q1="22.83707758970931" p2="-124.19867089220249" q2="-17.387681013050731">
+        <iidm:twoWindingsTransformer id="_045b7604-c766-11e1-8775-005056c00008" name="26-25" r="0" x="6.6559680000000006" g="0" b="0" ratedU1="220" ratedU2="132" node1="22" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="110.40243664547489" q1="22.279769075624063" p2="-110.40243664547478" q2="-17.944988255951742">
             <iidm:alias>_0447c6f3-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0463b364-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04803c1c-c766-11e1-8775-005056c00008</iidm:alias>
@@ -2321,9 +2403,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="136.62000307865515" angle="15.284499265982006" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="136.62000972925412" angle="2.7820123027032642" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_048aea70-c766-11e1-8775-005056c00008" name="Sporn SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="513.43743900000004" targetV="136.62" targetQ="-62.132553100000003" node="20" p="-568.74748885369456" q="50.09708239181564">
+            <iidm:generator id="_048aea70-c766-11e1-8775-005056c00008" name="Sporn SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="513.43743900000004" targetV="136.62" targetQ="-62.132553100000003" node="20" p="-568.65391898575911" q="50.394758437171184">
                 <iidm:alias>_04555b84-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_27799004-aa1e-4889-ba95-ee6fdae64895"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_827a9c80-183d-4e33-9e73-ef0aab3dfb13"/>
@@ -2413,9 +2495,9 @@
                 <iidm:internalConnection node1="39" node2="9"/>
                 <iidm:internalConnection node1="40" node2="12"/>
                 <iidm:internalConnection node1="41" node2="3"/>
-                <iidm:bus v="219.70511107001474" angle="11.457100442284068" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41"/>
+                <iidm:bus v="219.70596025086306" angle="-1.0263839471715364" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41"/>
             </iidm:nodeBreakerTopology>
-            <iidm:danglingLine id="_0482fb33-c766-11e1-8775-005056c00008" name="68-116" p0="184" q0="0" r="0.16456000000000001" x="1.9601999999999999" g="0" b="0.00033884300000000002" ucteXnodeCode="XWE_BR21" node="41" p="184.11557855198652" q="-14.979409400540783">
+            <iidm:danglingLine id="_0482fb33-c766-11e1-8775-005056c00008" name="68-116" p0="184" q0="0" r="0.16456000000000001" x="1.9601999999999999" g="0" b="0.00033884300000000002" ucteXnodeCode="XWE_BR21" node="41" p="184.11559476883343" q="-14.979546174914619">
                 <iidm:alias>_0459c855-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_04684742-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_5631ccc0-d9d2-11e2-bb49-005056c00008</iidm:alias>
@@ -2428,7 +2510,7 @@
                 </iidm:currentLimits>
             </iidm:danglingLine>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_044f6815-c766-11e1-8775-005056c00008" name="68-69" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-199.43553750795192" q1="102.17101914268181" p2="199.43553750795186" q2="-85.88518321554443">
+        <iidm:twoWindingsTransformer id="_044f6815-c766-11e1-8775-005056c00008" name="68-69" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-198.44760309548971" q1="102.11720546610499" p2="198.44760309548974" q2="-85.962549234250673">
             <iidm:alias>_047e8e67-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04840ca7-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0487dd39-c766-11e1-8775-005056c00008</iidm:alias>
@@ -2535,9 +2617,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="131.60566412751578" angle="3.3995856381771894" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="131.60567209755052" angle="-9.0674426303586575" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04547126-c766-11e1-8775-005056c00008" name="Natrium LD" loadType="UNDEFINED" p0="77" q0="14" node="14" p="76.999910767421795" q="13.999972959835233">
+            <iidm:load id="_04547126-c766-11e1-8775-005056c00008" name="Natrium LD" loadType="UNDEFINED" p0="77" q0="14" node="14" p="76.999915479475519" q="13.999974387729228">
                 <iidm:alias>_047b3307-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2588,9 +2670,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="124.14486768965183" angle="-4.6013870102381356" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.11089052797793" angle="-16.949226031614856" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045d4ac9-c766-11e1-8775-005056c00008" name="Sterling LD" loadType="UNDEFINED" p0="31" q0="17" node="8" p="31.024447507925963" q="17.022350369818358">
+            <iidm:load id="_045d4ac9-c766-11e1-8775-005056c00008" name="Sterling LD" loadType="UNDEFINED" p0="31" q0="17" node="8" p="31.027730476274961" q="17.025352615527876">
                 <iidm:alias>_0477b094-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2698,9 +2780,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="130.29382126477049" angle="18.436339291949139" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="130.27133299280101" angle="5.9351404198474444" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0466246a-c766-11e1-8775-005056c00008" name="Switchbk LD" loadType="UNDEFINED" p0="30" q0="16" node="17" p="29.99964289381894" q="15.999682573543009">
+            <iidm:load id="_0466246a-c766-11e1-8775-005056c00008" name="Switchbk LD" loadType="UNDEFINED" p0="30" q0="16" node="17" p="29.999639757556995" q="15.999679785776832">
                 <iidm:alias>_04882b59-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2751,9 +2833,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="135.08635457002256" angle="15.696759615709153" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="135.08638749978979" angle="3.1939987279477982" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046adf5a-c766-11e1-8775-005056c00008" name="Bradley LD" loadType="UNDEFINED" p0="34" q0="8" node="8" p="33.999965845300125" q="7.9999866060045308">
+            <iidm:load id="_046adf5a-c766-11e1-8775-005056c00008" name="Bradley LD" loadType="UNDEFINED" p0="34" q0="8" node="8" p="33.999971077301083" q="7.9999886577683466">
                 <iidm:alias>_04555b85-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2788,6 +2870,9 @@
                     <iidm:alias>_7f359893-b7c5-41b0-ada8-8df06cf7a8e6</iidm:alias>
                     <iidm:alias>_a4edf081-2fb2-4da4-94db-98a2a596247f</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_312f25f3-55bc-4417-848c-236d31d823f4-1" name="DISCONNECTOR524-1" kind="DISCONNECTOR" retained="false" open="false" node1="24" node2="25"/>
+                <iidm:switch id="_686e884a-a0b1-454e-b7d1-33c7ad46f89f-1" name="BREAKER262-1" kind="BREAKER" retained="false" open="false" node1="23" node2="24"/>
+                <iidm:switch id="_346a5319-3ec2-40a2-aefd-38dfacbbe97c-1" name="DISCONNECTOR523-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="23"/>
                 <iidm:internalConnection node1="7" node2="0"/>
                 <iidm:internalConnection node1="8" node2="0"/>
                 <iidm:internalConnection node1="9" node2="1"/>
@@ -2804,9 +2889,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.8977819021235" angle="10.074173343078577" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.18283809412928" angle="-2.4629167401730823" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047a48a2-c766-11e1-8775-005056c00008" name="Mullin LD" loadType="UNDEFINED" p0="17" q0="7" node="8" p="17.000210983873608" q="7.0001447934534315">
+            <iidm:load id="_047a48a2-c766-11e1-8775-005056c00008" name="Mullin LD" loadType="UNDEFINED" p0="17" q0="7" node="8" p="17.00087670662765" q="7.00060167175383">
                 <iidm:alias>_0474553a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2972,16 +3057,16 @@
                 <iidm:internalConnection node1="81" node2="18"/>
                 <iidm:internalConnection node1="82" node2="21"/>
                 <iidm:internalConnection node1="83" node2="24"/>
-                <iidm:bus v="134.24399564649741" angle="18.141290928571561" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
+                <iidm:bus v="134.24400829132429" angle="5.63781797371362" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_044cd00a-c766-11e1-8775-005056c00008" name="Glen Lyn SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="252" targetV="134.243988" targetQ="0" node="27" p="-279.14670085274207" q="-83.982292846087219">
+            <iidm:generator id="_044cd00a-c766-11e1-8775-005056c00008" name="Glen Lyn SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="252" targetV="134.243988" targetQ="0" node="27" p="-279.10077586767352" q="-84.334276644167687">
                 <iidm:alias>_045e5c30-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e54b499b-436c-4b89-9803-b1d75e2fa364"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_32c8ab65-80f7-4c17-b3f5-ff075cce0ba5"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
-            <iidm:load id="_04566cf5-c766-11e1-8775-005056c00008" name="Glen Lyn LD" loadType="UNDEFINED" p0="37" q0="18" node="26" p="37.000003161263443" q="18.000002563186651">
+            <iidm:load id="_04566cf5-c766-11e1-8775-005056c00008" name="Glen Lyn LD" loadType="UNDEFINED" p0="37" q0="18" node="26" p="37.000008388968155" q="18.000006801866579">
                 <iidm:alias>_04577e64-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3032,9 +3117,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.59012933189658" angle="11.008295413596677" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.66195556917779" angle="-2.1847739980233905" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044ea4c0-c766-11e1-8775-005056c00008" name="Kankakee LD" loadType="UNDEFINED" p0="52" q0="22" node="8" p="52.003673209824285" q="22.002590144836649">
+            <iidm:load id="_044ea4c0-c766-11e1-8775-005056c00008" name="Kankakee LD" loadType="UNDEFINED" p0="52" q0="22" node="8" p="52.003577863301153" q="22.002522910188958">
                 <iidm:alias>_047e6758-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3143,12 +3228,12 @@
                 <iidm:internalConnection node1="51" node2="9"/>
                 <iidm:internalConnection node1="52" node2="12"/>
                 <iidm:internalConnection node1="53" node2="15"/>
-                <iidm:bus v="127.42284447553007" angle="10.876014224238157" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
+                <iidm:bus v="127.42284393368129" angle="-1.627774301713536" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0484cffb-c766-11e1-8775-005056c00008" name="Roanoke LD" loadType="UNDEFINED" p0="31" q0="26" node="17" p="31.000006956253568" q="26.000009723796037">
+            <iidm:load id="_0484cffb-c766-11e1-8775-005056c00008" name="Roanoke LD" loadType="UNDEFINED" p0="31" q0="26" node="17" p="31.000011333024535" q="26.000015841864194">
                 <iidm:alias>_0454983a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0489d903-c766-11e1-8775-005056c00008" name="Roanoke SC" sectionCount="5" voltageRegulatorOn="true" targetV="127.423" targetDeadband="1" node="18" q="-18.639595325781926">
+            <iidm:shunt id="_0489d903-c766-11e1-8775-005056c00008" name="Roanoke SC" sectionCount="5" voltageRegulatorOn="true" targetV="127.423" targetDeadband="1" node="18" q="-18.639595167257099">
                 <iidm:alias>_0476c638-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_5be38d1a-9d01-42d8-b8bb-e9a26cfbcf1a"/>
                 <iidm:shuntLinearModel bPerSection="0.0002296" gPerSection="0" maximumSectionCount="10"/>
@@ -3240,12 +3325,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="120.7751694273442" angle="-9.8118402608572683" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="120.75794193493235" angle="-22.225977075242731" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047a219a-c766-11e1-8775-005056c00008" name="Howard LD" loadType="UNDEFINED" p0="37" q0="23" node="14" p="37.014187335253226" q="23.014700469180813">
+            <iidm:load id="_047a219a-c766-11e1-8775-005056c00008" name="Howard LD" loadType="UNDEFINED" p0="37" q0="23" node="14" p="37.016314870860647" q="23.016905278399726">
                 <iidm:alias>_04882b51-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_04488a49-c766-11e1-8775-005056c00008" name="Howard NegG LD" loadType="UNDEFINED" p0="59" q0="0" node="15" p="59.022623048106496" q="0">
+            <iidm:load id="_04488a49-c766-11e1-8775-005056c00008" name="Howard NegG LD" loadType="UNDEFINED" p0="59" q0="0" node="15" p="59.026015604885899" q="0">
                 <iidm:alias>_046d9e74-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3295,7 +3380,7 @@
                 <iidm:internalConnection node1="19" node2="6"/>
                 <iidm:internalConnection node1="20" node2="3"/>
                 <iidm:internalConnection node1="21" node2="6"/>
-                <iidm:bus v="218.77218262496621" angle="13.262962118018342" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
+                <iidm:bus v="218.77264320005116" angle="0.77233079679219951" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_046efe09-c766-11e1-8775-005056c00008" name="CRI132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -3458,20 +3543,20 @@
                 <iidm:internalConnection node1="81" node2="18"/>
                 <iidm:internalConnection node1="82" node2="21"/>
                 <iidm:internalConnection node1="83" node2="24"/>
-                <iidm:bus v="137.28000486666642" angle="16.181054662790395" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
+                <iidm:bus v="137.28001404260351" angle="3.6787131358767313" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_045868c1-c766-11e1-8775-005056c00008" name="CabinCrk SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="477" targetV="137.28" targetQ="0" node="27" p="-528.38482661411888" q="-140.1900140500627">
+            <iidm:generator id="_045868c1-c766-11e1-8775-005056c00008" name="CabinCrk SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="477" targetV="137.28" targetQ="0" node="27" p="-528.29789717809626" q="-141.01556339763715">
                 <iidm:alias>_0487dd36-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_a6ec9760-88da-48df-a23f-7877e7c85ccd"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_e6131af8-c298-413b-84e3-4e21c3b6b06f"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-225" maxQ="640"/>
             </iidm:generator>
-            <iidm:load id="_04747c44-c766-11e1-8775-005056c00008" name="CabinCrk LD" loadType="UNDEFINED" p0="130" q0="26" node="26" p="130.00000691287852" q="26.000002304292874">
+            <iidm:load id="_04747c44-c766-11e1-8775-005056c00008" name="CabinCrk LD" loadType="UNDEFINED" p0="130" q0="26" node="26" p="130.00001994688049" q="26.000006648960504">
                 <iidm:alias>_046a9138-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_0488c79b-c766-11e1-8775-005056c00008" name="81-80" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="21" voltageLevelId1="_048a272b-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-152.18719005352955" q1="71.568975484716574" p2="152.18719005352943" q2="-62.317468337177196">
+        <iidm:twoWindingsTransformer id="_0488c79b-c766-11e1-8775-005056c00008" name="81-80" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="21" voltageLevelId1="_048a272b-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-151.57732226884806" q1="71.544320724626644" p2="151.57732226884804" q2="-62.354604509284172">
             <iidm:alias>_044974a0-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_045a3d83-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_046adf57-c766-11e1-8775-005056c00008</iidm:alias>
@@ -3551,12 +3636,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="134.74744282064026" angle="-0.60915971937760727" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="134.74756199432323" angle="-13.067782504417575" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04524e4a-c766-11e1-8775-005056c00008" name="Zanesvll LD" loadType="UNDEFINED" p0="20" q0="11" node="8" p="20.000008802730576" q="11.00000806917088">
+            <iidm:load id="_04524e4a-c766-11e1-8775-005056c00008" name="Zanesvll LD" loadType="UNDEFINED" p0="20" q0="11" node="8" p="20.000010371536504" q="11.000009507243442">
                 <iidm:alias>_045c1240-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_048b5fa9-c766-11e1-8775-005056c00008" name="Zanesvll SC" sectionCount="5" voltageRegulatorOn="true" targetV="134.72300000000001" targetDeadband="1" node="9" q="-15.63306795151018">
+            <iidm:shunt id="_048b5fa9-c766-11e1-8775-005056c00008" name="Zanesvll SC" sectionCount="5" voltageRegulatorOn="true" targetV="134.72300000000001" targetDeadband="1" node="9" q="-15.633095603999445">
                 <iidm:alias>_04736ad5-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_99c6c4ad-5247-4058-96d4-ee8495103e85"/>
                 <iidm:shuntLinearModel bPerSection="0.00017220000000000001" gPerSection="0" maximumSectionCount="10"/>
@@ -3609,9 +3694,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.77349995566973" angle="21.191388098110281" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.75792997874507" angle="8.6926961969307062" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044ca8f2-c766-11e1-8775-005056c00008" name="Tazewell LD" loadType="UNDEFINED" p0="12" q0="7" node="8" p="11.999851891990716" q="6.9998560066944924">
+            <iidm:load id="_044ca8f2-c766-11e1-8775-005056c00008" name="Tazewell LD" loadType="UNDEFINED" p0="12" q0="7" node="8" p="11.999852857210596" q="6.999856945095015">
                 <iidm:alias>_04542305-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3662,9 +3747,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="120.12724654150469" angle="-8.0712618636262441" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="120.09331492942916" angle="-20.442179244131388" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04778989-c766-11e1-8775-005056c00008" name="NwLibrty LD" loadType="UNDEFINED" p0="27" q0="11" node="8" p="27.019228334524382" q="11.013059375672009">
+            <iidm:load id="_04778989-c766-11e1-8775-005056c00008" name="NwLibrty LD" loadType="UNDEFINED" p0="27" q0="11" node="8" p="27.021763999320726" q="11.01478199460186">
                 <iidm:alias>_0483e592-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3697,12 +3782,12 @@
                 <iidm:internalConnection node1="11" node2="2"/>
                 <iidm:internalConnection node1="12" node2="3"/>
                 <iidm:internalConnection node1="13" node2="3"/>
-                <iidm:bus v="122.60534733632588" angle="6.2138648795279758" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13"/>
+                <iidm:bus v="122.60534013823087" angle="-6.290319984026314" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0463da70-c766-11e1-8775-005056c00008" name="Danville LD" loadType="UNDEFINED" p0="25" q0="13" node="5" p="25.000007271993912" q="13.000006302395335">
+            <iidm:load id="_0463da70-c766-11e1-8775-005056c00008" name="Danville LD" loadType="UNDEFINED" p0="25" q0="13" node="5" p="25.000010842179389" q="13.00000939655683">
                 <iidm:alias>_0488eeab-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_0448b150-c766-11e1-8775-005056c00008" name="Danville NegG LD" loadType="UNDEFINED" p0="43" q0="0" node="6" p="43.000012507829524" q="0">
+            <iidm:load id="_0448b150-c766-11e1-8775-005056c00008" name="Danville NegG LD" loadType="UNDEFINED" p0="43" q0="0" node="6" p="43.000018648548547" q="0">
                 <iidm:alias>_0457cc88-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3753,9 +3838,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.59245445863911" angle="26.975869031940235" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.45550422292891" angle="14.494459518001726" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045cae82-c766-11e1-8775-005056c00008" name="Fremont LD" loadType="UNDEFINED" p0="48" q0="10" node="8" p="47.999147313180011" q="9.9997039299406794">
+            <iidm:load id="_045cae82-c766-11e1-8775-005056c00008" name="Fremont LD" loadType="UNDEFINED" p0="48" q0="10" node="8" p="47.999034445232432" q="9.9996647401759464">
                 <iidm:alias>_045f4693-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3901,9 +3986,9 @@
                 <iidm:internalConnection node1="70" node2="15"/>
                 <iidm:internalConnection node1="71" node2="18"/>
                 <iidm:internalConnection node1="72" node2="21"/>
-                <iidm:bus v="132.354869384305" angle="13.880507726459779" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
+                <iidm:bus v="132.33621818520757" angle="1.3739155045717399" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0448d863-c766-11e1-8775-005056c00008" name="Turner LD" loadType="UNDEFINED" p0="61" q0="28" node="23" p="61.000379429806848" q="28.000290274771029">
+            <iidm:load id="_0448d863-c766-11e1-8775-005056c00008" name="Turner LD" loadType="UNDEFINED" p0="61" q0="28" node="23" p="61.00041010427956" q="28.000313741682">
                 <iidm:alias>_046e3ab3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3938,6 +4023,9 @@
                     <iidm:alias>_0b877750-4384-4ec3-bb38-08ee5ccf16d3</iidm:alias>
                     <iidm:alias>_1ed822d3-f3ab-4432-80f0-4c55ae3b4b78</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_3be2355e-0065-43df-a264-57a295042faa-1" name="DISCONNECTOR526-1" kind="DISCONNECTOR" retained="false" open="false" node1="24" node2="25"/>
+                <iidm:switch id="_2463ff2c-7690-4dd6-bf44-039f9f475bb1-1" name="BREAKER263-1" kind="BREAKER" retained="false" open="true" node1="23" node2="24"/>
+                <iidm:switch id="_ddcf7aac-e7c3-45e9-bd81-6146e951addd-1" name="DISCONNECTOR525-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="23"/>
                 <iidm:internalConnection node1="7" node2="0"/>
                 <iidm:internalConnection node1="8" node2="0"/>
                 <iidm:internalConnection node1="9" node2="1"/>
@@ -3954,9 +4042,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.13982533166526" angle="8.9838531859487833" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.21058208084655" angle="-3.4060014883844656" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047d7cf6-c766-11e1-8775-005056c00008" name="Grant LD" loadType="UNDEFINED" p0="24" q0="4" node="8" p="24.000066659235696" q="4.0000185164715019">
+            <iidm:load id="_047d7cf6-c766-11e1-8775-005056c00008" name="Grant LD" loadType="UNDEFINED" p0="24" q0="4" node="8" p="24.000294680077726" q="4.0000818559121631">
                 <iidm:alias>_0481e9c0-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4026,9 +4114,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="221.1811262839764" angle="19.402555892912559" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="221.63122614282446" angle="5.7838218492023206" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04867dab-c766-11e1-8775-005056c00008" name="Olive NegG LD" loadType="UNDEFINED" p0="28" q0="0" node="11" p="28.006608261972062" q="0">
+            <iidm:load id="_04867dab-c766-11e1-8775-005056c00008" name="Olive NegG LD" loadType="UNDEFINED" p0="28" q0="0" node="11" p="28.006305765397006" q="0">
                 <iidm:alias>_048433b8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4134,15 +4222,15 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="133.24799641897067" angle="13.862683928787868" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="133.37140675075719" angle="0.51439015253706799" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:shunt id="_0447c6f6-c766-11e1-8775-005056c00008" name="Olive SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.67599999999999" targetDeadband="1" node="17" q="-40.76554555004239">
+            <iidm:shunt id="_0447c6f6-c766-11e1-8775-005056c00008" name="Olive SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.67599999999999" targetDeadband="1" node="17" q="-40.841092190399927">
                 <iidm:alias>_045e8340-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_c701959a-91c1-4a35-9a37-71fb790426ca"/>
                 <iidm:shuntLinearModel bPerSection="0.00045919999999999999" gPerSection="0" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_04575750-c766-11e1-8775-005056c00008" name="8-5" r="0" x="4.6522079999999999" g="0" b="0" ratedU1="220" ratedU2="132" node1="32" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="372.53307949349448" q1="60.932285392754927" p2="-372.53307949349414" q2="-24.412481298535983">
+        <iidm:twoWindingsTransformer id="_04575750-c766-11e1-8775-005056c00008" name="8-5" r="0" x="4.6522079999999999" g="0" b="0" ratedU1="220" ratedU2="132" node1="32" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="355.44983430306002" q1="63.727345914128023" p2="-355.44983430305996" q2="-30.441165188486085">
             <iidm:alias>_045eaa55-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_046b2d74-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04745533-c766-11e1-8775-005056c00008</iidm:alias>
@@ -4213,9 +4301,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.77658902859451" angle="20.122293871543587" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.77316260841641" angle="7.62180410341551" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047b0bf0-c766-11e1-8775-005056c00008" name="Wythe LD" loadType="UNDEFINED" p0="22" q0="15" node="8" p="21.999881744073416" q="14.999865618506023">
+            <iidm:load id="_047b0bf0-c766-11e1-8775-005056c00008" name="Wythe LD" loadType="UNDEFINED" p0="22" q0="15" node="8" p="21.999886421434688" q="14.99987093367062">
                 <iidm:alias>_0479d376-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4266,9 +4354,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="124.21587933832512" angle="-4.6339603672507215" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.1820840509854" angle="-16.98241722597059" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0458ddf5-c766-11e1-8775-005056c00008" name="WestLima LD" loadType="UNDEFINED" p0="33" q0="9" node="8" p="33.026249212029207" q="9.0119346232834836">
+            <iidm:load id="_0458ddf5-c766-11e1-8775-005056c00008" name="WestLima LD" loadType="UNDEFINED" p0="33" q0="9" node="8" p="33.029730422829964" q="9.0135178864543377">
                 <iidm:alias>_04492686-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4376,9 +4464,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="128.44946966266613" angle="23.034996540345144" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="128.11433834743775" angle="10.562627646197514" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044b2257-c766-11e1-8775-005056c00008" name="BeaverCk LD" loadType="UNDEFINED" p0="24" q0="15" node="17" p="23.999162167909059" q="14.999127268394352">
+            <iidm:load id="_044b2257-c766-11e1-8775-005056c00008" name="BeaverCk LD" loadType="UNDEFINED" p0="24" q0="15" node="17" p="23.999023557616699" q="14.998982886311435">
                 <iidm:alias>_045868c4-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4437,6 +4525,9 @@
                     <iidm:alias>_2b636cdd-aa2f-4a65-92fc-12b4fc392e5f</iidm:alias>
                     <iidm:alias>_c96e50b9-ea15-4421-b6c8-bd9c9158a69a</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_e5318967-afcc-4fcc-b0de-d5f2522a95a6-1" name="DISCONNECTOR699-1" kind="DISCONNECTOR" retained="false" open="false" node1="43" node2="44"/>
+                <iidm:switch id="_e9f91b69-a29b-44ea-aa0f-cff86ee80320-1" name="BREAKER350-1" kind="BREAKER" retained="true" open="true" node1="42" node2="43"/>
+                <iidm:switch id="_ad86e83d-6334-4dd8-b642-b4c16d65329a-1" name="DISCONNECTOR700-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="42"/>
                 <iidm:internalConnection node1="13" node2="0"/>
                 <iidm:internalConnection node1="14" node2="1"/>
                 <iidm:internalConnection node1="15" node2="2"/>
@@ -4466,7 +4557,7 @@
                 <iidm:internalConnection node1="39" node2="9"/>
                 <iidm:internalConnection node1="40" node2="12"/>
                 <iidm:internalConnection node1="41" node2="3"/>
-                <iidm:bus v="215.01046306925252" angle="16.990794007496984" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41"/>
+                <iidm:bus v="215.98372367235544" angle="2.8765639278520583" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_047bcf46-c766-11e1-8775-005056c00008" name="STN132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -4546,6 +4637,9 @@
                     <iidm:alias>_4aab41d6-d1b6-4dbe-a6aa-cb7ccd941912</iidm:alias>
                     <iidm:alias>_e9315b98-af75-40bb-bf8e-05bd03d43db5</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_b8b0b9a9-af8b-41d2-a4f8-940637e63f70-1" name="DISCONNECTOR701-1" kind="DISCONNECTOR" retained="false" open="false" node1="64" node2="65"/>
+                <iidm:switch id="_0b78ffaa-9859-4658-af17-c8d355633556-1" name="BREAKER351-1" kind="BREAKER" retained="true" open="false" node1="63" node2="64"/>
+                <iidm:switch id="_9dfeeaef-5c49-4c2c-97b1-03876970bee4-1" name="DISCONNECTOR702-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="63"/>
                 <iidm:internalConnection node1="19" node2="0"/>
                 <iidm:internalConnection node1="20" node2="0"/>
                 <iidm:internalConnection node1="21" node2="1"/>
@@ -4590,9 +4684,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="129.5325662356303" angle="10.176384620256766" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="129.57332756505744" angle="-1.6977544327893319" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045dbff4-c766-11e1-8775-005056c00008" name="Sorenson LD" loadType="UNDEFINED" p0="11" q0="3" node="20" p="11.004227550316934" q="3.0019218599432147">
+            <iidm:load id="_045dbff4-c766-11e1-8775-005056c00008" name="Sorenson LD" loadType="UNDEFINED" p0="11" q0="3" node="20" p="11.007637019254522" q="3.0034721756882115">
                 <iidm:alias>_044d4536-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4613,6 +4707,9 @@
                     <iidm:alias>_340082f1-db9c-446d-97df-80e45aa0058b</iidm:alias>
                     <iidm:alias>_90c04b95-703a-4bae-82b8-7edf3075aa24</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_4d08a684-cdcb-484a-a767-03b10f4ada7f-1" name="DISCONNECTOR735-1" kind="DISCONNECTOR" retained="false" open="false" node1="14" node2="15"/>
+                <iidm:switch id="_f468d841-1bf6-470e-85d4-55d34fab8bff-1" name="BREAKER368-1" kind="BREAKER" retained="true" open="true" node1="13" node2="14"/>
+                <iidm:switch id="_f193bd8f-badf-4600-82ac-f212d1f33534-1" name="DISCONNECTOR736-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="13"/>
                 <iidm:internalConnection node1="4" node2="0"/>
                 <iidm:internalConnection node1="5" node2="1"/>
                 <iidm:internalConnection node1="6" node2="2"/>
@@ -4622,13 +4719,13 @@
                 <iidm:internalConnection node1="10" node2="3"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="0"/>
-                <iidm:bus v="386.04151323797618" angle="16.990794007496984" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="390.27052742099926" angle="0" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13"/>
             </iidm:nodeBreakerTopology>
             <iidm:lccConverterStation id="_7393a68e-c4e6-48dd-9347-543858363fdb" name="Conv1" lossFactor="0" powerFactor="0.80000000000000004" node="12" p="-0" q="-0">
                 <iidm:alias>_739658a7-e08b-4395-8d79-93e87b7855e3</iidm:alias>
             </iidm:lccConverterStation>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_047120e9-c766-11e1-8775-005056c00008" name="30-17" r="0" x="6.7605125399999997" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_047b8123-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="305.50632402212091" q1="114.5741006280157" p2="-305.50632402212091" q2="-74.718229753910492">
+        <iidm:twoWindingsTransformer id="_047120e9-c766-11e1-8775-005056c00008" name="30-17" r="0" x="6.7605125399999997" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_047b8123-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="206.33805669322084" q1="116.39452534326402" p2="-206.33805669322086" q2="-95.572689818919017">
             <iidm:alias>_044f6811-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0463b36a-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_047d2ed8-c766-11e1-8775-005056c00008</iidm:alias>
@@ -4647,7 +4744,7 @@
                 <iidm:temporaryLimit name="_f62f2fc6-4b6c-4571-a8c5-40d6a89ac703" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_b08e9e50-4e0c-4ac0-9f21-4a27429caeb2" name="PowTrans1" r="0.4840000000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_3bbfa58a-a1ad-4b23-a526-3d76b096c1f4" node2="41" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="5.066638089243031e-14" q1="1.27519690062597e-13" p2="1.2524236867718855e-13" q2="-4.0988486530863719e-13">
+        <iidm:twoWindingsTransformer id="_b08e9e50-4e0c-4ac0-9f21-4a27429caeb2" name="PowTrans1" r="0.4840000000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_3bbfa58a-a1ad-4b23-a526-3d76b096c1f4" node2="41" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="-129.18877628835401" q1="23.256897801889323" p2="129.36528399260496" q2="-16.637858892478839">
             <iidm:alias>_046ba2aa-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_a5bf9702-545a-437d-9663-773550202828</iidm:alias>
             <iidm:alias>_ee9505e1-96d7-49b3-9d1a-924397ffb27e</iidm:alias>
@@ -4667,6 +4764,32 @@
                 <iidm:temporaryLimit name="_611bb05e-9b9a-469c-b1d1-80a944c3ce2f" acceptableDuration="60" value="1400"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
+        <iidm:threeWindingsTransformer id="_86d83c7d-7826-4c16-b161-4ce17174e77f-1" name="T422" r1="-1.5199999809265099" x1="23.199999999999999" g1="0" b1="0" ratedU1="400" r2="2.0000000630528461" x2="19.999999999999996" g2="0" b2="0" ratedU2="220" r3="1.2000000564689806" x3="12" g3="0" b3="0" ratedU3="132" ratedU0="400" node1="15" voltageLevelId1="_3bbfa58a-a1ad-4b23-a526-3d76b096c1f4" node2="44" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" node3="65" voltageLevelId3="_047bcf46-c766-11e1-8775-005056c00008" p1="129.18877628835398" q1="-23.256897801890229" p2="0" q2="0" p3="-129.22497718694487" q3="27.238997586941888">
+            <iidm:alias>_1b2d419c-ac88-4dae-8dfe-2eb92d18c40a-1</iidm:alias>
+            <iidm:alias>_206474da-93c8-46b1-863f-9a308bfc2117-1</iidm:alias>
+            <iidm:alias>_9ac069ea-557b-4b8c-b12e-f9f2aecc3bf5-1</iidm:alias>
+            <iidm:alias>_ae46e10e-1fbe-4139-b493-ed8e2844ee8d-1</iidm:alias>
+            <iidm:ratioTapChanger1 lowTapPosition="1" tapPosition="11" targetDeadband="0" loadTapChangingCapabilities="true" regulating="false" targetV="220">
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.95238095238095233"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.96385542168674687"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.97560975609756106"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.98765432098765438"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0126582278481011"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0256410256410258"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0389610389610389"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0526315789473684"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0666666666666667"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0810810810810809"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.095890410958904"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.1111111111111112"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.1267605633802817"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.1428571428571428"/>
+            </iidm:ratioTapChanger1>
+            <iidm:currentLimits1 permanentLimit="500">
+                <iidm:temporaryLimit name="_3fd18f6e-749a-4fa7-af1b-b0c2d3952638-1" acceptableDuration="1800" value="533"/>
+            </iidm:currentLimits1>
+        </iidm:threeWindingsTransformer>
     </iidm:substation>
     <iidm:substation id="_04642898-c766-11e1-8775-005056c00008" name="Rómenna" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
         <iidm:voltageLevel id="_0457f394-c766-11e1-8775-005056c00008" name="RÓM132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -4905,16 +5028,16 @@
                 <iidm:internalConnection node1="121" node2="30"/>
                 <iidm:internalConnection node1="122" node2="33"/>
                 <iidm:internalConnection node1="123" node2="36"/>
-                <iidm:bus v="135.30000103373729" angle="0.20815741004551239" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123"/>
+                <iidm:bus v="135.30000492949341" angle="-12.251487286357188" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04859346-c766-11e1-8775-005056c00008" name="Philo SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="204" targetV="135.30000000000001" targetQ="0" node="39" p="-225.97590069031503" q="-174.30009803714162">
+            <iidm:generator id="_04859346-c766-11e1-8775-005056c00008" name="Philo SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="204" targetV="135.30000000000001" targetQ="0" node="39" p="-225.93872332145" q="-174.1840398235459">
                 <iidm:alias>_048719e2-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e3753d6d-b894-4cce-b6fa-307c50dc107f"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_dff93c01-9c84-4c1f-8529-66c054ed9e37"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
-            <iidm:load id="_045163e2-c766-11e1-8775-005056c00008" name="Philo LD" loadType="UNDEFINED" p0="87" q0="30" node="38" p="87.000000997063665" q="30.000000573025094">
+            <iidm:load id="_045163e2-c766-11e1-8775-005056c00008" name="Philo LD" loadType="UNDEFINED" p0="87" q0="30" node="38" p="87.000004754611211" q="30.000002732535226">
                 <iidm:alias>_04513cd3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4965,9 +5088,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.79803693071624" angle="21.031947132673633" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.5119368008049" angle="8.5487040122306119" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04524e46-c766-11e1-8775-005056c00008" name="BetsyLne LD" loadType="UNDEFINED" p0="11" q0="7" node="8" p="10.999611977292927" q="6.9995884656042309">
+            <iidm:load id="_04524e46-c766-11e1-8775-005056c00008" name="BetsyLne LD" loadType="UNDEFINED" p0="11" q0="7" node="8" p="10.999556650892826" q="6.9995297875673019">
                 <iidm:alias>_04549830-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5020,15 +5143,15 @@
                 <iidm:internalConnection node1="22" node2="6"/>
                 <iidm:internalConnection node1="23" node2="3"/>
                 <iidm:internalConnection node1="24" node2="6"/>
-                <iidm:bus v="124.75920341513931" angle="7.9012884233329084" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24"/>
+                <iidm:bus v="124.75919567794496" angle="-4.6024729556220096" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04566cf3-c766-11e1-8775-005056c00008" name="Reusens NegG LD" loadType="UNDEFINED" p0="22" q0="0" node="8" p="22.00000545280875" q="0">
+            <iidm:load id="_04566cf3-c766-11e1-8775-005056c00008" name="Reusens NegG LD" loadType="UNDEFINED" p0="22" q0="0" node="8" p="22.000008515992846" q="0">
                 <iidm:alias>_0483be81-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_0482fb36-c766-11e1-8775-005056c00008" name="Reusens LD" loadType="UNDEFINED" p0="28" q0="12" node="9" p="28.000006939938416" q="12.000004957099272">
+            <iidm:load id="_0482fb36-c766-11e1-8775-005056c00008" name="Reusens LD" loadType="UNDEFINED" p0="28" q0="12" node="9" p="28.000010838536348" q="12.000007741812675">
                 <iidm:alias>_0486cbc1-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_04558293-c766-11e1-8775-005056c00008" name="Reusens SC" sectionCount="5" voltageRegulatorOn="true" targetV="124.76300000000001" targetDeadband="1" node="10" q="-5.3543114398523581">
+            <iidm:shunt id="_04558293-c766-11e1-8775-005056c00008" name="Reusens SC" sectionCount="5" voltageRegulatorOn="true" targetV="124.76300000000001" targetDeadband="1" node="10" q="-5.3543107757354695">
                 <iidm:alias>_04893ccc-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_99303cd3-6b53-4ee2-a5ce-fe8d5feeb304"/>
                 <iidm:shuntLinearModel bPerSection="6.8800000000000005e-05" gPerSection="0" maximumSectionCount="10"/>
@@ -5101,12 +5224,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="126.42399146834137" angle="25.237015488452872" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="126.42220513901106" angle="12.743647684804333" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045c8777-c766-11e1-8775-005056c00008" name="Holston NegG LD" loadType="UNDEFINED" p0="85" q0="0" node="11" p="84.999731482421097" q="0">
+            <iidm:load id="_045c8777-c766-11e1-8775-005056c00008" name="Holston NegG LD" loadType="UNDEFINED" p0="85" q0="0" node="11" p="84.999746741074233" q="0">
                 <iidm:alias>_0487dd31-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_0451d918-c766-11e1-8775-005056c00008" name="Holston LD" loadType="UNDEFINED" p0="78" q0="42" node="12" p="77.999753595633493" q="41.999778868109054">
+            <iidm:load id="_0451d918-c766-11e1-8775-005056c00008" name="Holston LD" loadType="UNDEFINED" p0="78" q0="42" node="12" p="77.999767597691644" q="41.999791434032979">
                 <iidm:alias>_0485ba54-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5214,9 +5337,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="127.74288828249468" angle="9.7833812167494791" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="127.74298231596904" angle="-2.7486038037571419" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04742e27-c766-11e1-8775-005056c00008" name="SthPoint LD" loadType="UNDEFINED" p0="47" q0="11" node="17" p="47.001836383268738" q="11.00071632904406">
+            <iidm:load id="_04742e27-c766-11e1-8775-005056c00008" name="SthPoint LD" loadType="UNDEFINED" p0="47" q0="11" node="17" p="47.002157307071293" q="11.000841515633276">
                 <iidm:alias>_047b3303-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5268,12 +5391,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="132.92450700713667" angle="13.894131946518858" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="132.91198975344986" angle="1.3889262328321048" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04716f06-c766-11e1-8775-005056c00008" name="CapitlHl LD" loadType="UNDEFINED" p0="39" q0="32" node="8" p="39.000163441757202" q="32.000223510407544">
+            <iidm:load id="_04716f06-c766-11e1-8775-005056c00008" name="CapitlHl LD" loadType="UNDEFINED" p0="39" q0="32" node="8" p="39.000176363892983" q="32.000241181755655">
                 <iidm:alias>_04700f70-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0466c0a0-c766-11e1-8775-005056c00008" name="CapitlHl SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.00200000000001" targetDeadband="1" node="9" q="-20.283925398427694">
+            <iidm:shunt id="_0466c0a0-c766-11e1-8775-005056c00008" name="CapitlHl SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.00200000000001" targetDeadband="1" node="9" q="-20.280105379213893">
                 <iidm:alias>_045e8346-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_99931a87-ee15-4fd0-b251-9556df7fe598"/>
                 <iidm:shuntLinearModel bPerSection="0.0002296" gPerSection="0" maximumSectionCount="10"/>
@@ -5326,9 +5449,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="132.06321558960866" angle="13.580120816987355" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="132.04664592632176" angle="1.0738832139658601" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046efe03-c766-11e1-8775-005056c00008" name="Chemical LD" loadType="UNDEFINED" p0="71" q0="26" node="8" p="71.000370506641985" q="26.000226131207711">
+            <iidm:load id="_046efe03-c766-11e1-8775-005056c00008" name="Chemical LD" loadType="UNDEFINED" p0="71" q0="26" node="8" p="71.000402490149355" q="26.000245651729053">
                 <iidm:alias>_045d71d5-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5379,9 +5502,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.53740993721794" angle="10.463423279018283" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.58096948391318" angle="-2.6698125091112912" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046a4319-c766-11e1-8775-005056c00008" name="JacksnRd LD" loadType="UNDEFINED" p0="19" q0="2" node="8" p="19.000840168293252" q="2.0001474001187889">
+            <iidm:load id="_046a4319-c766-11e1-8775-005056c00008" name="JacksnRd LD" loadType="UNDEFINED" p0="19" q0="2" node="8" p="19.000815190678015" q="2.0001430179537696">
                 <iidm:alias>_046c8d06-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5527,9 +5650,9 @@
                 <iidm:internalConnection node1="70" node2="15"/>
                 <iidm:internalConnection node1="71" node2="18"/>
                 <iidm:internalConnection node1="72" node2="21"/>
-                <iidm:bus v="130.60543620622042" angle="24.899135734541492" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
+                <iidm:bus v="130.59870671572526" angle="12.403041172091626" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0458ddf4-c766-11e1-8775-005056c00008" name="Saltvlle LD" loadType="UNDEFINED" p0="65" q0="10" node="23" p="64.99949391881195" q="9.9998702359295866">
+            <iidm:load id="_0458ddf4-c766-11e1-8775-005056c00008" name="Saltvlle LD" loadType="UNDEFINED" p0="65" q0="10" node="23" p="64.999507477800194" q="9.9998737125754324">
                 <iidm:alias>_045645e4-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5599,9 +5722,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="131.55408991081572" angle="14.822605898562916" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="131.70932119296731" angle="2.0520775796575919" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0476ed42-c766-11e1-8775-005056c00008" name="Trenton NegG LD" loadType="UNDEFINED" p0="13" q0="0" node="11" p="12.997751831768193" q="0">
+            <iidm:load id="_0476ed42-c766-11e1-8775-005056c00008" name="Trenton NegG LD" loadType="UNDEFINED" p0="13" q0="0" node="11" p="12.998579589723732" q="0">
                 <iidm:alias>_0471e432-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5671,9 +5794,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="128.37294799054942" angle="9.4864684025449009" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="128.43157140294906" angle="-3.6925719893459608" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044a5f08-c766-11e1-8775-005056c00008" name="HickryCk LD" loadType="UNDEFINED" p0="39" q0="10" node="11" p="39.002634298923709" q="10.001125794117732">
+            <iidm:load id="_044a5f08-c766-11e1-8775-005056c00008" name="HickryCk LD" loadType="UNDEFINED" p0="39" q0="10" node="11" p="39.00251560231375" q="10.001075066838037">
                 <iidm:alias>_047d7cf3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5802,9 +5925,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="125.66376537675968" angle="-3.7997237931694405" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="125.63125765010848" angle="-16.150531728120903" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:shunt id="_0450eeb7-c766-11e1-8775-005056c00008" name="EastLima SC" sectionCount="5" voltageRegulatorOn="true" targetV="131.565" targetDeadband="1" node="20" q="-22.660633067634713">
+            <iidm:shunt id="_0450eeb7-c766-11e1-8775-005056c00008" name="EastLima SC" sectionCount="5" voltageRegulatorOn="true" targetV="131.565" targetDeadband="1" node="20" q="-22.648910509703295">
                 <iidm:alias>_044aad27-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_6c36f421-303e-4932-93a9-5b0ff86cb7d4"/>
                 <iidm:shuntLinearModel bPerSection="0.00028699999999999998" gPerSection="0" maximumSectionCount="10"/>
@@ -5892,16 +6015,16 @@
                 <iidm:internalConnection node1="41" node2="7"/>
                 <iidm:internalConnection node1="42" node2="12"/>
                 <iidm:internalConnection node1="43" node2="11"/>
-                <iidm:bus v="218.9079875955083" angle="7.1919842575042159" nodes="0,1,2,3,8,9,10,13,17,18,21,22,23,24,25,26,31,32,33,34,35,39,40"/>
-                <iidm:bus v="237.93768647798791" angle="-4.5449982618400959" nodes="11,15,37,43"/>
-                <iidm:bus v="226.19467552670861" angle="7.1919842577146413" nodes="12,16,38,42"/>
-                <iidm:bus v="214.70025192282307" angle="-4.5449982618400959" nodes="4,5,6,7,14,19,20,27,28,29,30,36,41"/>
+                <iidm:bus v="218.90819460082702" angle="-5.2761367886685893" nodes="0,1,2,3,8,9,10,13,17,18,21,22,23,24,25,26,31,32,33,34,35,39,40"/>
+                <iidm:bus v="237.93769604999289" angle="-17.010644836353688" nodes="11,15,37,43"/>
+                <iidm:bus v="226.1946846998672" angle="-5.2761367862114943" nodes="12,16,38,42"/>
+                <iidm:bus v="214.70026056000836" angle="-17.010644836353691" nodes="4,5,6,7,14,19,20,27,28,29,30,36,41"/>
             </iidm:nodeBreakerTopology>
-            <iidm:vscConverterStation id="_b46bfb8e-7af6-459e-acf3-53a42c943a7c" name="VSC2" voltageRegulatorOn="true" lossFactor="0.32362458" voltageSetpoint="218.47" reactivePowerSetpoint="0" node="42" p="-0" q="-27.470166014436124">
+            <iidm:vscConverterStation id="_b46bfb8e-7af6-459e-acf3-53a42c943a7c" name="VSC2" voltageRegulatorOn="true" lossFactor="0.32362458" voltageSetpoint="218.47" reactivePowerSetpoint="0" node="42" p="-0" q="-27.46941909078069">
                 <iidm:alias>_a168e701-bd48-4f66-8f0b-0f69b2545530</iidm:alias>
                 <iidm:minMaxReactiveLimits minQ="-1.7976931348623157e+308" maxQ="1.7976931348623157e+308"/>
             </iidm:vscConverterStation>
-            <iidm:vscConverterStation id="_b48ce7cf-abf5-413f-bc51-9e1d3103c9bd" name="VSC1" voltageRegulatorOn="true" lossFactor="0.32467531999999999" voltageSetpoint="213.53999999999999" reactivePowerSetpoint="0" node="43" p="-0" q="-92.151020935009001">
+            <iidm:vscConverterStation id="_b48ce7cf-abf5-413f-bc51-9e1d3103c9bd" name="VSC1" voltageRegulatorOn="true" lossFactor="0.32467531999999999" voltageSetpoint="213.53999999999999" reactivePowerSetpoint="0" node="43" p="-0" q="-92.151020935009186">
                 <iidm:alias>_071bb138-ff00-4874-8acc-a884aa5cf4a9</iidm:alias>
                 <iidm:minMaxReactiveLimits minQ="-1.7976931348623157e+308" maxQ="1.7976931348623157e+308"/>
             </iidm:vscConverterStation>
@@ -5969,7 +6092,7 @@
                 <iidm:internalConnection node1="29" node2="6"/>
                 <iidm:internalConnection node1="30" node2="9"/>
                 <iidm:internalConnection node1="31" node2="3"/>
-                <iidm:bus v="202.70796491525206" angle="-2.5567370038554723e-16" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
+                <iidm:bus v="202.69683776309563" angle="-12.381369407433525" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_0448d867-c766-11e1-8775-005056c00008" name="EDO132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -6055,9 +6178,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="131.34000205346314" angle="4.7893765045364818" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="131.34000744060853" angle="-7.67813437654043" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0472a789-c766-11e1-8775-005056c00008" name="W.Kammer SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="160" targetV="131.34" targetQ="0" node="14" p="-177.23600054142358" q="94.114276410844141">
+            <iidm:generator id="_0472a789-c766-11e1-8775-005056c00008" name="W.Kammer SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="160" targetV="131.34" targetQ="0" node="14" p="-177.2068418207451" q="94.11165056977751">
                 <iidm:alias>_04697fc0-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_17852426-f663-4add-9a2b-0a635d51f101"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b512ea0a-96d0-4a48-9de1-a5cf499bf0dd"/>
@@ -6206,16 +6329,16 @@
                 <iidm:internalConnection node1="71" node2="15"/>
                 <iidm:internalConnection node1="72" node2="18"/>
                 <iidm:internalConnection node1="73" node2="21"/>
-                <iidm:bus v="130.02000190053121" angle="-4.5449982618400959" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
+                <iidm:bus v="130.02000713111124" angle="-17.010644836353695" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04839777-c766-11e1-8775-005056c00008" name="Tidd SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="155" targetV="130.02000000000001" targetQ="0" node="24" p="-171.69737552450405" q="-94.828921843279545">
+            <iidm:generator id="_04839777-c766-11e1-8775-005056c00008" name="Tidd SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="155" targetV="130.02000000000001" targetQ="0" node="24" p="-171.6691280138468" q="-94.829314826791844">
                 <iidm:alias>_045fe2d8-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_d2a96d8d-65be-4fd6-a012-ceeeabd2bee6"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_29df1e0b-36ca-4536-97b4-6f98b84d49d8"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-90" maxQ="255"/>
             </iidm:generator>
-            <iidm:load id="_04798556-c766-11e1-8775-005056c00008" name="Tidd LD" loadType="UNDEFINED" p0="277" q0="113" node="23" p="277.00000607345578" q="113.00000412936528">
+            <iidm:load id="_04798556-c766-11e1-8775-005056c00008" name="Tidd LD" loadType="UNDEFINED" p0="277" q0="113" node="23" p="277.00002278862297" q="113.00001549407015">
                 <iidm:alias>_04502b62-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6245,13 +6368,13 @@
                 <iidm:internalConnection node1="10" node2="3"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="0"/>
-                <iidm:bus v="363.95293700692986" angle="0" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="363.93295871101265" angle="-12.381369407433525" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
             </iidm:nodeBreakerTopology>
             <iidm:lccConverterStation id="_9793118d-5ba1-4a9c-b2e0-db1d15be5913" name="Conv2" lossFactor="0" powerFactor="-0.75741000000000003" node="12" p="-0" q="-0">
                 <iidm:alias>_453bdc57-5855-4eb5-8712-d6a0255e0da8</iidm:alias>
             </iidm:lccConverterStation>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045c1248-c766-11e1-8775-005056c00008" name="38-37" r="0" x="6.5340005399999992" g="0" b="0" ratedU1="220" ratedU2="132" node1="30" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="165.78772214431132" q1="93.418035703829673" p2="-165.78772214431132" q2="-79.434508018328685">
+        <iidm:twoWindingsTransformer id="_045c1248-c766-11e1-8775-005056c00008" name="38-37" r="0" x="6.5340005399999992" g="0" b="0" ratedU1="220" ratedU2="132" node1="30" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="164.40464260924455" q1="93.828425950094839" p2="-164.40464260924458" q2="-79.99005432347353">
             <iidm:alias>_0453d4e8-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0477d7aa-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_047df228-c766-11e1-8775-005056c00008</iidm:alias>
@@ -6275,7 +6398,7 @@
                 <iidm:temporaryLimit name="_c97df399-5a91-4c8b-b72c-496cade334b5" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_0485ba57-c766-11e1-8775-005056c00008" name="64-61" r="0" x="4.669632" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="157.22584683645374" q1="60.550284736226409" p2="-157.22584683645366" q2="-53.095445947356538">
+        <iidm:twoWindingsTransformer id="_0485ba57-c766-11e1-8775-005056c00008" name="64-61" r="0" x="4.669632" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="157.18609632114152" q1="60.552114879497765" p2="-157.18609632114152" q2="-53.100514224165096">
             <iidm:alias>_04549831-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0472ce92-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0489d905-c766-11e1-8775-005056c00008</iidm:alias>
@@ -6301,7 +6424,7 @@
                 <iidm:temporaryLimit name="_f6b1a81c-eda7-4a08-b290-bd29a5ed9fa4" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_044cd007-c766-11e1-8775-005056c00008" name="63-59" r="0" x="6.7256646120000001" g="0" b="0" ratedU1="220" ratedU2="132" node1="41" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="73" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-2.7755575615628914e-14" q1="83.151384217233485" p2="-1.5265566588595902e-14" q2="-80.568832588842511">
+        <iidm:twoWindingsTransformer id="_044cd007-c766-11e1-8775-005056c00008" name="63-59" r="0" x="6.7256646120000001" g="0" b="0" ratedU1="220" ratedU2="132" node1="41" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="73" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="9.4368957093138306e-14" q1="83.151390907434632" p2="-2.8033131371785203e-13" q2="-80.568839071256832">
             <iidm:alias>_044e7db4-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_046eafe5-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0488797a-c766-11e1-8775-005056c00008</iidm:alias>
@@ -6347,7 +6470,7 @@
                 <iidm:temporaryLimit name="_f2daef4d-6f1a-44d1-9c9b-228acff12575" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_ffd940c8-03c8-4dcf-ad46-62018a0d813d" name="PowTrans2" r="0.3932500000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_04f97116-552a-4a34-afd9-4862f62ac7aa" node2="31" voltageLevelId2="_04742e21-c766-11e1-8775-005056c00008" p1="-3.9737542309886409e-18" q1="-2.1878457270356008e-16" p2="-2.0327342687750589e-14" q2="2.1878457270356013e-16">
+        <iidm:twoWindingsTransformer id="_ffd940c8-03c8-4dcf-ad46-62018a0d813d" name="PowTrans2" r="0.3932500000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_04f97116-552a-4a34-afd9-4862f62ac7aa" node2="31" voltageLevelId2="_04742e21-c766-11e1-8775-005056c00008" p1="8.6093321978686541e-14" q1="3.9218289246081352e-13" p2="-1.4106684473764562e-13" q2="-2.6095633281466598e-13">
             <iidm:alias>_04479fea-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_c089eb25-9f67-4d82-88a8-635dd4808bae</iidm:alias>
             <iidm:alias>_ea8cd467-31f0-40dc-95d7-4064463724c4</iidm:alias>
@@ -6414,9 +6537,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="124.78804992352995" angle="-7.7128299842566035" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.787863100764" angle="-20.175362351885408" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0481c2b3-c766-11e1-8775-005056c00008" name="Wooster LD" loadType="UNDEFINED" p0="23" q0="11" node="8" p="22.999971585977129" q="10.999977351150516">
+            <iidm:load id="_0481c2b3-c766-11e1-8775-005056c00008" name="Wooster LD" loadType="UNDEFINED" p0="23" q0="11" node="8" p="22.999970903826334" q="10.999976807407581">
                 <iidm:alias>_04614268-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6486,9 +6609,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="125.56950871492876" angle="-7.4758976869589953" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="125.56947708333973" angle="-19.939185652128344" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044974a8-c766-11e1-8775-005056c00008" name="Wagenhls LD" loadType="UNDEFINED" p0="63" q0="22" node="11" p="62.999995112080555" q="21.999997155179233">
+            <iidm:load id="_044974a8-c766-11e1-8775-005056c00008" name="Wagenhls LD" loadType="UNDEFINED" p0="63" q0="22" node="11" p="62.999997546218047" q="21.999998571872954">
                 <iidm:alias>_048481d4-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6539,9 +6662,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.30985286702349" angle="8.4920416751928673" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.38581538991139" angle="-4.4038214706733632" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047fedf2-c766-11e1-8775-005056c00008" name="Concord LD" loadType="UNDEFINED" p0="34" q0="16" node="8" p="34.002655564293995" q="16.002082849749694">
+            <iidm:load id="_047fedf2-c766-11e1-8775-005056c00008" name="Concord LD" loadType="UNDEFINED" p0="34" q0="16" node="8" p="34.005014706674771" q="16.003933296637435">
                 <iidm:alias>_046d9e75-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6649,9 +6772,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="127.45696980000979" angle="11.012660875174765" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="127.60538662260018" angle="-1.5178210603834437" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045f94ba-c766-11e1-8775-005056c00008" name="Delaware LD" loadType="UNDEFINED" p0="59" q0="23" node="17" p="59.002331474577176" q="23.001514819819644">
+            <iidm:load id="_045f94ba-c766-11e1-8775-005056c00008" name="Delaware LD" loadType="UNDEFINED" p0="59" q0="23" node="17" p="59.006803405820207" q="23.004420461819088">
                 <iidm:alias>_0463654a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6759,9 +6882,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="125.37091534549015" angle="6.1552528493252368" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="125.38660525580833" angle="-6.0033592504734736" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04697fc9-c766-11e1-8775-005056c00008" name="FtWayne LD" loadType="UNDEFINED" p0="90" q0="30" node="17" p="90.020604877470888" q="30.011448027710529">
+            <iidm:load id="_04697fc9-c766-11e1-8775-005056c00008" name="FtWayne LD" loadType="UNDEFINED" p0="90" q0="30" node="17" p="90.041945943033156" q="30.023306921790095">
                 <iidm:alias>_044d1e25-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6812,9 +6935,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.01461660717089" angle="-5.472997958716614" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.01438355068822" angle="-17.934996691584693" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0474f170-c766-11e1-8775-005056c00008" name="WNwPhil1 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="11.999985641034659" q="2.9999940171001613">
+            <iidm:load id="_0474f170-c766-11e1-8775-005056c00008" name="WNwPhil1 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="11.999985038562349" q="2.9999937660702356">
                 <iidm:alias>_0466c0a7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6885,12 +7008,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="129.61364802375846" angle="15.861582575363059" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="129.50943296686148" angle="3.3590041510552124" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044a5f05-c766-11e1-8775-005056c00008" name="Logan LD" loadType="UNDEFINED" p0="54" q0="27" node="11" p="53.999034467492322" q="26.999195394372489">
+            <iidm:load id="_044a5f05-c766-11e1-8775-005056c00008" name="Logan LD" loadType="UNDEFINED" p0="54" q0="27" node="11" p="53.998953480464621" q="26.999127906020952">
                 <iidm:alias>_04767811-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0475dbd6-c766-11e1-8775-005056c00008" name="Logan SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.41900000000001" targetDeadband="1" node="12" q="-19.286053021622703">
+            <iidm:shunt id="_0475dbd6-c766-11e1-8775-005056c00008" name="Logan SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.41900000000001" targetDeadband="1" node="12" q="-19.255051825052892">
                 <iidm:alias>_04577e67-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_a7768441-642e-48a2-b4a8-0ae06bebf676"/>
                 <iidm:shuntLinearModel bPerSection="0.0002296" gPerSection="0" maximumSectionCount="10"/>
@@ -6964,19 +7087,19 @@
                 <iidm:internalConnection node1="32" node2="3"/>
                 <iidm:internalConnection node1="33" node2="6"/>
                 <iidm:internalConnection node1="34" node2="9"/>
-                <iidm:bus v="132.66000072246669" angle="-1.3500895252164939" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34"/>
+                <iidm:bus v="132.66000397346812" angle="-13.804853150012887" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04633e31-c766-11e1-8775-005056c00008" name="W.Lancst SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="19" targetV="132.66" targetQ="0" node="13" p="-21.046775064294046" q="1.7135549596063246">
+            <iidm:generator id="_04633e31-c766-11e1-8775-005056c00008" name="W.Lancst SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="19" targetV="132.66" targetQ="0" node="13" p="-21.043312466213479" q="1.7466417055805052">
                 <iidm:alias>_047bcf42-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_83fae784-1da1-4055-8108-ba978276d1b6"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_5f711f63-f631-45d3-b26c-33821ab2ee56"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-15" maxQ="45"/>
             </iidm:generator>
-            <iidm:load id="_048a9c51-c766-11e1-8775-005056c00008" name="W.Lancst LD" loadType="UNDEFINED" p0="28" q0="10" node="11" p="28.000000228732112" q="10.000000136150065">
+            <iidm:load id="_048a9c51-c766-11e1-8775-005056c00008" name="W.Lancst LD" loadType="UNDEFINED" p0="28" q0="10" node="11" p="28.000001257995354" q="10.000000748806768">
                 <iidm:alias>_044e7db6-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_045b00d9-c766-11e1-8775-005056c00008" name="W.Lancst SC" sectionCount="5" voltageRegulatorOn="true" targetV="132.66" targetDeadband="1" node="12" q="-10.101639904427111">
+            <iidm:shunt id="_045b00d9-c766-11e1-8775-005056c00008" name="W.Lancst SC" sectionCount="5" voltageRegulatorOn="true" targetV="132.66" targetDeadband="1" node="12" q="-10.101640399534091">
                 <iidm:alias>_04758db6-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_be267a3c-f7a7-4bdf-bb17-71b773247fbf"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -7086,9 +7209,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="129.8970363924405" angle="10.348204466948502" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="129.91791144904479" angle="-2.2206801912073617" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045dbff2-c766-11e1-8775-005056c00008" name="Portsmth LD" loadType="UNDEFINED" p0="66" q0="20" node="17" p="66.00262285152597" q="20.001324690035361">
+            <iidm:load id="_045dbff2-c766-11e1-8775-005056c00008" name="Portsmth LD" loadType="UNDEFINED" p0="66" q0="20" node="17" p="66.003665238761357" q="20.001851164954193">
                 <iidm:alias>_0454bf45-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7159,16 +7282,16 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="127.64400000635054" angle="9.0657198702285395" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="127.64400000127533" angle="-3.2704091706277132" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04856c34-c766-11e1-8775-005056c00008" name="DeerCrk SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="7" targetV="127.64400000000001" targetQ="0" node="12" p="-7.7540750236872817" q="-38.443240980085079">
+            <iidm:generator id="_04856c34-c766-11e1-8775-005056c00008" name="DeerCrk SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="7" targetV="127.64400000000001" targetQ="0" node="12" p="-7.7527993296575977" q="-35.556673748163661">
                 <iidm:alias>_0477d7a5-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e5a479a8-ab8d-4a54-bb52-376874ae2784"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b55d80d5-720f-46f9-897f-ff8c5eaf8b44"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-15" maxQ="45"/>
             </iidm:generator>
-            <iidm:load id="_04791028-c766-11e1-8775-005056c00008" name="DeerCrk LD" loadType="UNDEFINED" p0="43" q0="27" node="11" p="43.000000003209003" q="27.000000003358267">
+            <iidm:load id="_04791028-c766-11e1-8775-005056c00008" name="DeerCrk LD" loadType="UNDEFINED" p0="43" q0="27" node="11" p="43.000000000644427" q="27.000000000674401">
                 <iidm:alias>_04486337-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7219,9 +7342,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.87219082421005" angle="10.833848038988943" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.05354558372312" angle="-1.7512290728928361" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0462c904-c766-11e1-8775-005056c00008" name="Medford LD" loadType="UNDEFINED" p0="22" q0="7" node="8" p="22.000655788119328" q="7.0003477698823762">
+            <iidm:load id="_0462c904-c766-11e1-8775-005056c00008" name="Medford LD" loadType="UNDEFINED" p0="22" q0="7" node="8" p="22.002185872570017" q="7.0011592132383518">
                 <iidm:alias>_0489b1f7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7310,9 +7433,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="132.01319723837989" angle="16.507842273106395" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="132.17086710136036" angle="3.6860417238917673" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046205b5-c766-11e1-8775-005056c00008" name="CollCrnr LD" loadType="UNDEFINED" p0="7" q0="3" node="14" p="6.9994368499502748" q="2.999597760751584">
+            <iidm:load id="_046205b5-c766-11e1-8775-005056c00008" name="CollCrnr LD" loadType="UNDEFINED" p0="7" q0="3" node="14" p="6.9998978887501808" q="2.999927063747637">
                 <iidm:alias>_04486334-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7363,9 +7486,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.92644846794974" angle="17.014989763852963" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.89230580075679" angle="4.5129986327706693" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0483be82-c766-11e1-8775-005056c00008" name="Caldwell LD" loadType="UNDEFINED" p0="42" q0="31" node="8" p="41.999374474830859" q="30.999230508572399">
+            <iidm:load id="_0483be82-c766-11e1-8775-005056c00008" name="Caldwell LD" loadType="UNDEFINED" p0="42" q0="31" node="8" p="41.999359777669312" q="30.999212428912447">
                 <iidm:alias>_045841b9-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7416,9 +7539,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.33155998219995" angle="9.5045279400100071" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.33154777746272" angle="-2.9994833788703126" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045f94b4-c766-11e1-8775-005056c00008" name="Franklin LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="8.0000031373798617" q="3.00000196086267">
+            <iidm:load id="_045f94b4-c766-11e1-8775-005056c00008" name="Franklin LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="8.0000042575960375" q="3.0000026609979953">
                 <iidm:alias>_047da403-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7469,9 +7592,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="125.03914919653415" angle="6.9756625554138489" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="125.05484265550483" angle="-5.0307113591789614" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045f6da2-c766-11e1-8775-005056c00008" name="McKinley LD" loadType="UNDEFINED" p0="60" q0="34" node="8" p="60.017533471521531" q="34.016561002737909">
+            <iidm:load id="_045f6da2-c766-11e1-8775-005056c00008" name="McKinley LD" loadType="UNDEFINED" p0="60" q0="34" node="8" p="60.034404094624314" q="34.032498966104328">
                 <iidm:alias>_0465d641-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7618,19 +7741,19 @@
                 <iidm:internalConnection node1="71" node2="18"/>
                 <iidm:internalConnection node1="72" node2="21"/>
                 <iidm:internalConnection node1="73" node2="12"/>
-                <iidm:bus v="130.68000802752647" angle="9.939780926242257" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
+                <iidm:bus v="130.68000805180512" angle="-3.0949406910947763" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_044ca8f0-c766-11e1-8775-005056c00008" name="TwinBrch SM" energySource="THERMAL" minP="50" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="85" targetV="130.68000799999999" targetQ="0" node="24" p="-94.156625287631243" q="-88.694547578235387">
+            <iidm:generator id="_044ca8f0-c766-11e1-8775-005056c00008" name="TwinBrch SM" energySource="THERMAL" minP="50" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="85" targetV="130.68000799999999" targetQ="0" node="24" p="-94.14113471727083" q="-84.26360181541736">
                 <iidm:alias>_04633e38-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_0f6ab5a4-6b72-42f4-92bc-1993e1ae58a3"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_668eb671-5c36-4351-a95d-53ca850581db"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-60" maxQ="170"/>
             </iidm:generator>
-            <iidm:load id="_048740f1-c766-11e1-8775-005056c00008" name="TwinBrch LD" loadType="UNDEFINED" p0="47" q0="10" node="23" p="47.000000014850144" q="10.00000000526601">
+            <iidm:load id="_048740f1-c766-11e1-8775-005056c00008" name="TwinBrch LD" loadType="UNDEFINED" p0="47" q0="10" node="23" p="47.000000027948126" q="10.000000009910684">
                 <iidm:alias>_044ecbda-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:danglingLine id="_045338a1-c766-11e1-8775-005056c00008" name="12-117" p0="20" q0="8" r="5.7324960000000003" x="24.393599999999999" g="0" b="0.00020546369999999999" ucteXnodeCode="XMO_TE32" node="73" p="20.161793624429688" q="5.1797255260860684">
+            <iidm:danglingLine id="_045338a1-c766-11e1-8775-005056c00008" name="12-117" p0="20" q0="8" r="5.7324960000000003" x="24.393599999999999" g="0" b="0.00020546369999999999" ucteXnodeCode="XMO_TE32" node="73" p="20.161793631922841" q="5.1797255280070384">
                 <iidm:alias>_044afb42-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_0457f391-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_5631f3d0-d9d2-11e2-bb49-005056c00008</iidm:alias>
@@ -7728,9 +7851,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="124.22285868138857" angle="5.3660354649584212" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="124.24488487929216" angle="-6.7748734198169238" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0479fa87-c766-11e1-8775-005056c00008" name="Lincoln LD" loadType="UNDEFINED" p0="45" q0="25" node="14" p="45.010725416701177" q="25.009931730357867">
+            <iidm:load id="_0479fa87-c766-11e1-8775-005056c00008" name="Lincoln LD" loadType="UNDEFINED" p0="45" q0="25" node="14" p="45.021601202667675" q="25.020004313766876">
                 <iidm:alias>_047fc6e2-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7781,9 +7904,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="134.64590280589749" angle="16.205357736198845" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="134.64593378697086" angle="3.7022104508051075" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044c81e4-c766-11e1-8775-005056c00008" name="Hinton NegG LD" loadType="UNDEFINED" p0="42" q0="0" node="8" p="41.999965199907791" q="0">
+            <iidm:load id="_044c81e4-c766-11e1-8775-005056c00008" name="Hinton NegG LD" loadType="UNDEFINED" p0="42" q0="0" node="8" p="41.999972037582722" q="0">
                 <iidm:alias>_04494d96-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7834,9 +7957,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.29976647665791" angle="9.227709736234802" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.30557772996355" angle="-3.4416846451700436" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_048bfbe0-c766-11e1-8775-005056c00008" name="N. E. LD" loadType="UNDEFINED" p0="25" q0="10" node="8" p="25.003074050816725" q="10.002049451208125">
+            <iidm:load id="_048bfbe0-c766-11e1-8775-005056c00008" name="N. E. LD" loadType="UNDEFINED" p0="25" q0="10" node="8" p="25.005549370365561" q="10.003699853974835">
                 <iidm:alias>_0480b140-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7887,9 +8010,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.13847781401726" angle="-6.3967959782113901" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.13810851324355" angle="-18.858575099122636" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04854525-c766-11e1-8775-005056c00008" name="SCoshoct LD" loadType="UNDEFINED" p0="18" q0="5" node="8" p="17.999958867442" q="4.9999809571635803">
+            <iidm:load id="_04854525-c766-11e1-8775-005056c00008" name="SCoshoct LD" loadType="UNDEFINED" p0="18" q0="5" node="8" p="17.999956908780977" q="4.9999800503774843">
                 <iidm:alias>_04747c42-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7940,9 +8063,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="125.06005398778061" angle="8.8671522992825444" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="125.05587500538499" angle="-3.6601642664577749" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044aad24-c766-11e1-8775-005056c00008" name="WHuntngd LD" loadType="UNDEFINED" p0="33" q0="15" node="8" p="33.001220522576155" q="15.000924649714628">
+            <iidm:load id="_044aad24-c766-11e1-8775-005056c00008" name="WHuntngd LD" loadType="UNDEFINED" p0="33" q0="15" node="8" p="33.001410035785923" q="15.001068224142927">
                 <iidm:alias>_04784cd2-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7974,9 +8097,9 @@
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="3"/>
-                <iidm:bus v="129.36000797855695" angle="10.41842040600571" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="129.36002093824055" angle="-2.0860924007177681" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0452ea80-c766-11e1-8775-005056c00008" name="DanRiver SM" energySource="THERMAL" minP="20" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="36" targetV="129.36000000000001" targetQ="0" node="5" p="-39.878100121820296" q="-20.269091450664668">
+            <iidm:generator id="_0452ea80-c766-11e1-8775-005056c00008" name="DanRiver SM" energySource="THERMAL" minP="20" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="36" targetV="129.36000000000001" targetQ="0" node="5" p="-39.871539409667641" q="-20.270992789425936">
                 <iidm:alias>_046a4316-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_fec62959-21c5-4921-90b2-7c85e9f3bfab"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_9db08c95-4586-4a2b-87e3-5a17c944b43a"/>
@@ -8049,9 +8172,9 @@
                 <iidm:internalConnection node1="29" node2="3"/>
                 <iidm:internalConnection node1="30" node2="9"/>
                 <iidm:internalConnection node1="31" node2="6"/>
-                <iidm:bus v="130.14668731996386" angle="10.475935889648714" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
+                <iidm:bus v="130.1816412983834" angle="-2.1100147092431438" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
             </iidm:nodeBreakerTopology>
-            <iidm:danglingLine id="_044ef2e7-c766-11e1-8775-005056c00008" name="71-73" p0="6" q0="0" r="1.508918" x="7.9104960000000002" g="0" b="6.76079e-05" ucteXnodeCode="XMO_TE31" node="31" p="6.003210675325132" q="-1.1283224923329747">
+            <iidm:danglingLine id="_044ef2e7-c766-11e1-8775-005056c00008" name="71-73" p0="6" q0="0" r="1.508918" x="7.9104960000000002" g="0" b="6.76079e-05" ucteXnodeCode="XMO_TE31" node="31" p="6.0032093315519344" q="-1.1289467000008286">
                 <iidm:alias>_04670ec2-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_046b2d7a-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_26a070b9-db0c-47cd-9991-0a461576aec2</iidm:alias>
@@ -8111,9 +8234,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="134.29650754499522" angle="3.3192210582916855" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="134.2964581223271" angle="-9.146804246658867" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0453add4-c766-11e1-8775-005056c00008" name="Summerfl LD" loadType="UNDEFINED" p0="28" q0="7" node="8" p="27.999895285001049" q="6.9999563688048259">
+            <iidm:load id="_0453add4-c766-11e1-8775-005056c00008" name="Summerfl LD" loadType="UNDEFINED" p0="28" q0="7" node="8" p="27.999896073675544" q="6.9999566974183853">
                 <iidm:alias>_04851e16-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8240,9 +8363,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="132.66000968300884" angle="31.564279073386942" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="132.66002474269686" angle="19.071851020749076" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0489b1fa-c766-11e1-8775-005056c00008" name="ClinchRv SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="607" targetV="132.66" targetQ="0" node="20" p="-672.38907705402562" q="-45.993679727896705">
+            <iidm:generator id="_0489b1fa-c766-11e1-8775-005056c00008" name="ClinchRv SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="607" targetV="132.66" targetQ="0" node="20" p="-672.27845615745173" q="-49.043442663979462">
                 <iidm:alias>_04840caa-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_2621b09a-22e3-4630-b3bd-32c102e36741"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b0d662e5-64c9-4d59-b8e0-9b1ed175769b"/>
@@ -8297,9 +8420,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.47900777961502" angle="9.0119338217204543" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.49559822877976" angle="-4.0652265423955436" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0485e168-c766-11e1-8775-005056c00008" name="Pokagon LD" loadType="UNDEFINED" p0="20" q0="9" node="8" p="20.000418815839456" q="9.0003141140721699">
+            <iidm:load id="_0485e168-c766-11e1-8775-005056c00008" name="Pokagon LD" loadType="UNDEFINED" p0="20" q0="9" node="8" p="20.000395586339131" q="9.0002966917104494">
                 <iidm:alias>_0462c902-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8350,9 +8473,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.07143460102048" angle="8.5068380814401507" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.09744129196406" angle="-4.301895301790835" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04812679-c766-11e1-8775-005056c00008" name="GoshenJt LD" loadType="UNDEFINED" p0="14" q0="1" node="8" p="14.00065535167642" q="1.0000780192740737">
+            <iidm:load id="_04812679-c766-11e1-8775-005056c00008" name="GoshenJt LD" loadType="UNDEFINED" p0="14" q0="1" node="8" p="14.001598112120181" q="1.0001902586819091">
                 <iidm:alias>_045b9d17-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8403,9 +8526,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="118.24843154500761" angle="-10.549163231295026" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="118.22026673319967" angle="-22.940558260296953" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0489b1f2-c766-11e1-8775-005056c00008" name="S.Tiffin LD" loadType="UNDEFINED" p0="37" q0="10" node="8" p="37.021079257174833" q="10.009496963937051">
+            <iidm:load id="_0489b1f2-c766-11e1-8775-005056c00008" name="S.Tiffin LD" loadType="UNDEFINED" p0="37" q0="10" node="8" p="37.024044031803442" q="10.01083299084455">
                 <iidm:alias>_046476b8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8456,9 +8579,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="123.75269811144086" angle="0.58430599182832876" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="123.72549144550221" angle="-11.663760214425405" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045cfca7-c766-11e1-8775-005056c00008" name="Haviland LD" loadType="UNDEFINED" p0="23" q0="9" node="8" p="23.007030175886037" q="9.0045853644407448">
+            <iidm:load id="_045cfca7-c766-11e1-8775-005056c00008" name="Haviland LD" loadType="UNDEFINED" p0="23" q0="9" node="8" p="23.011034954790578" q="9.007197860532008">
                 <iidm:alias>_0482ad17-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8528,9 +8651,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="131.00736030822927" angle="3.4381355464464995" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="131.00740294049152" angle="-9.0291606404821749" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04555b82-c766-11e1-8775-005056c00008" name="SWKammer LD" loadType="UNDEFINED" p0="78" q0="3" node="11" p="77.99995401488485" q="2.9999970522367869">
+            <iidm:load id="_04555b82-c766-11e1-8775-005056c00008" name="SWKammer LD" loadType="UNDEFINED" p0="78" q0="3" node="11" p="77.999960471835649" q="2.9999974661437383">
                 <iidm:alias>_0474ca6b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8638,9 +8761,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="130.39967179104795" angle="16.288615600576726" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="130.35174218328862" angle="3.7859915743066233" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04817492-c766-11e1-8775-005056c00008" name="Baileysv LD" loadType="UNDEFINED" p0="38" q0="15" node="17" p="37.999412137501452" q="14.999613250350574">
+            <iidm:load id="_04817492-c766-11e1-8775-005056c00008" name="Baileysv LD" loadType="UNDEFINED" p0="38" q0="15" node="17" p="37.999392066924756" q="14.999600046162312">
                 <iidm:alias>_0474f17b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8691,9 +8814,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.04555545447363" angle="24.76973358891869" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.04178927167968" angle="12.275247933221126" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0461b790-c766-11e1-8775-005056c00008" name="HolstonT NegG LD" loadType="UNDEFINED" p0="10" q0="0" node="8" p="9.9999490315928075" q="0">
+            <iidm:load id="_0461b790-c766-11e1-8775-005056c00008" name="HolstonT NegG LD" loadType="UNDEFINED" p0="10" q0="0" node="8" p="9.9999509481878412" q="0">
                 <iidm:alias>_0464ebe7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8744,9 +8867,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.90959438942956" angle="10.818424638441478" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.08620832627176" angle="-1.7585875908703494" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044c81e5-c766-11e1-8775-005056c00008" name="WMedford LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="8.0002498554144399" q="3.000156161259742">
+            <iidm:load id="_044c81e5-c766-11e1-8775-005056c00008" name="WMedford LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="8.0008140619352144" q="3.0005088059670433">
                 <iidm:alias>_04570939-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8836,12 +8959,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="124.98400861316007" angle="-4.0642023280655781" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="124.95036737979135" angle="-16.410090025710847" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04854520-c766-11e1-8775-005056c00008" name="Rockhill LD" loadType="UNDEFINED" p0="59" q0="26" node="14" p="59.045484154471836" q="26.033415024943206">
+            <iidm:load id="_04854520-c766-11e1-8775-005056c00008" name="Rockhill LD" loadType="UNDEFINED" p0="59" q0="26" node="14" p="59.051708366806032" q="26.037988990218157">
                 <iidm:alias>_0461b799-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0460cd38-c766-11e1-8775-005056c00008" name="Rockhill SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.81399999999999" targetDeadband="1" node="15" q="-12.543664934438622">
+            <iidm:shunt id="_0460cd38-c766-11e1-8775-005056c00008" name="Rockhill SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.81399999999999" targetDeadband="1" node="15" q="-12.536913229600897">
                 <iidm:alias>_048b86b4-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_069d84c6-bd26-4c26-ac6c-e801a0202a00"/>
                 <iidm:shuntLinearModel bPerSection="0.0001606" gPerSection="0" maximumSectionCount="10"/>
@@ -8914,12 +9037,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="128.70618162528876" angle="17.594927307272048" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="128.52978742114252" angle="5.0965199334911775" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047a48a5-c766-11e1-8775-005056c00008" name="Sprigg LD" loadType="UNDEFINED" p0="20" q0="10" node="11" p="19.999451066917239" q="9.9995425599494823">
+            <iidm:load id="_047a48a5-c766-11e1-8775-005056c00008" name="Sprigg LD" loadType="UNDEFINED" p0="20" q0="10" node="11" p="19.999394685696899" q="9.9994955765030635">
                 <iidm:alias>_0472ce97-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_04553478-c766-11e1-8775-005056c00008" name="Sprigg SC" sectionCount="5" voltageRegulatorOn="true" targetV="129.935" targetDeadband="1" node="12" q="-9.5084714022344841">
+            <iidm:shunt id="_04553478-c766-11e1-8775-005056c00008" name="Sprigg SC" sectionCount="5" voltageRegulatorOn="true" targetV="129.935" targetDeadband="1" node="12" q="-9.4824261900968274">
                 <iidm:alias>_045bc428-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_f4cdc674-4a66-4ab8-8d4f-552cb066e259"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -9011,12 +9134,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="118.73563002753598" angle="-9.6235701444530015" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="118.70406014177058" angle="-22.005994079625747" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04819ba4-c766-11e1-8775-005056c00008" name="West End NegG LD" loadType="UNDEFINED" p0="46" q0="0" node="14" p="46.029217362641859" q="0">
+            <iidm:load id="_04819ba4-c766-11e1-8775-005056c00008" name="West End NegG LD" loadType="UNDEFINED" p0="46" q0="0" node="14" p="46.033203247812693" q="0">
                 <iidm:alias>_04627ae0-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_04555b89-c766-11e1-8775-005056c00008" name="West End LD" loadType="UNDEFINED" p0="20" q0="23" node="15" p="20.012703201148636" q="23.024352956754978">
+            <iidm:load id="_04555b89-c766-11e1-8775-005056c00008" name="West End LD" loadType="UNDEFINED" p0="20" q0="23" node="15" p="20.014436194701172" q="23.027676029984423">
                 <iidm:alias>_04592c18-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9067,9 +9190,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.29933508881822" angle="10.175377453446037" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.35545684715302" angle="-1.7822641107772947" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046d0232-c766-11e1-8775-005056c00008" name="Deer Crk NegG LD" loadType="UNDEFINED" p0="6" q0="0" node="8" p="6.0020467190261435" q="0">
+            <iidm:load id="_046d0232-c766-11e1-8775-005056c00008" name="Deer Crk NegG LD" loadType="UNDEFINED" p0="6" q0="0" node="8" p="6.0037271906374219" q="0">
                 <iidm:alias>_0480150a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9139,9 +9262,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="133.91836713270447" angle="1.0308973661667937" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="133.92170899105821" angle="-11.432889437295199" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046c3ee3-c766-11e1-8775-005056c00008" name="Crooksvl LD" loadType="UNDEFINED" p0="34" q0="0" node="11" p="33.999515346476613" q="0">
+            <iidm:load id="_046c3ee3-c766-11e1-8775-005056c00008" name="Crooksvl LD" loadType="UNDEFINED" p0="34" q0="0" node="11" p="33.999546659552323" q="0">
                 <iidm:alias>_047e4047-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9192,9 +9315,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="132.05293577030216" angle="-2.2146739552294505" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="132.0527295339478" angle="-14.675133392466629" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046dc585-c766-11e1-8775-005056c00008" name="WCambrdg LD" loadType="UNDEFINED" p0="17" q0="4" node="8" p="16.999981480782665" q="3.9999927375644666">
+            <iidm:load id="_046dc585-c766-11e1-8775-005056c00008" name="WCambrdg LD" loadType="UNDEFINED" p0="17" q0="4" node="8" p="16.999980787848056" q="3.9999924658256054">
                 <iidm:alias>_045dbff8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9283,9 +9406,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="130.25815923360383" angle="10.497721394205014" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="130.31799149999088" angle="-2.6117888649110927" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_048b5fa5-c766-11e1-8775-005056c00008" name="SouthBnd LD" loadType="UNDEFINED" p0="70" q0="23" node="14" p="70.003577599217266" q="23.001959194852578">
+            <iidm:load id="_048b5fa5-c766-11e1-8775-005056c00008" name="SouthBnd LD" loadType="UNDEFINED" p0="70" q0="23" node="14" p="70.004287373197982" q="23.002347895160945">
                 <iidm:alias>_04522734-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9335,11 +9458,11 @@
                 <iidm:internalConnection node1="19" node2="6"/>
                 <iidm:internalConnection node1="20" node2="3"/>
                 <iidm:internalConnection node1="21" node2="6"/>
-                <iidm:bus v="227.85960546336503" angle="27.565493456149653" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
+                <iidm:bus v="228.10078396346381" angle="13.924480233319768" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:line id="_044cd006-c766-11e1-8775-005056c00008" name="31-32" r="5.1923519999999996" x="17.16264" g1="0" b1="7.20271e-05" g2="0" b2="7.20271e-05" node1="31" voltageLevelId1="_04636548-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="-28.967474596179187" q1="9.5284581680270666" p2="29.271388865419425" q2="-10.867546544134527">
+    <iidm:line id="_044cd006-c766-11e1-8775-005056c00008" name="31-32" r="5.1923519999999996" x="17.16264" g1="0" b1="7.20271e-05" g2="0" b2="7.20271e-05" node1="31" voltageLevelId1="_04636548-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="-26.388644370838403" q1="7.54116454364127" p2="26.634767850640102" q2="-9.0739994360098297">
         <iidm:alias>_04682030-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0471bd25-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9347,7 +9470,7 @@
             <iidm:temporaryLimit name="_de6da3cb-8cb5-4900-9c33-8ad45632b535" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045a3d89-c766-11e1-8775-005056c00008" name="2-12" r="3.2582879999999999" x="10.7331839" g1="0" b1="4.5110200000000001e-05" g2="0" b2="4.5110200000000001e-05" node1="21" voltageLevelId1="_045d4ac5-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-30.459501469127677" q1="-17.639432352668237" p2="30.698978093714647" q2="16.913310153196225">
+    <iidm:line id="_045a3d89-c766-11e1-8775-005056c00008" name="2-12" r="3.2582879999999999" x="10.7331839" g1="0" b1="4.5110200000000001e-05" g2="0" b2="4.5110200000000001e-05" node1="21" voltageLevelId1="_045d4ac5-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-31.463768739675285" q1="-17.120322216807136" p2="31.712046056417474" q2="16.422998212709199">
         <iidm:alias>_046adf51-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046fe868-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9355,7 +9478,7 @@
             <iidm:temporaryLimit name="_6bd63dd1-1344-4183-b7bd-af326919f4eb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04513cd7-c766-11e1-8775-005056c00008" name="32-114" r="2.3522400000000001" x="10.6634884" g1="0" b1="4.6717149999999997e-05" g2="0" b2="4.6717149999999997e-05" node1="49" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04791027-c766-11e1-8775-005056c00008" p1="6.2818664801046937" q1="4.4066655904751384" p2="-6.2722889580879722" q2="-5.8746091589981191">
+    <iidm:line id="_04513cd7-c766-11e1-8775-005056c00008" name="32-114" r="2.3522400000000001" x="10.6634884" g1="0" b1="4.6717149999999997e-05" g2="0" b2="4.6717149999999997e-05" node1="49" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04791027-c766-11e1-8775-005056c00008" p1="7.403749397836477" q1="3.8323292994209694" p2="-7.3927833323194356" q2="-5.2978423342364573">
         <iidm:alias>_046d0237-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0470d2c7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9363,7 +9486,7 @@
             <iidm:temporaryLimit name="_5f05650a-c63d-46e5-a426-2db4f036929f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045d71d4-c766-11e1-8775-005056c00008" name="24-72" r="8.5029120000000002" x="34.151040000000002" g1="0" b1="0.00014003675" g2="0" b2="0.00014003675" node1="30" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="25.369723346234863" q1="-5.594671614176689" p2="-25.048561863060424" q2="2.0610304459678659">
+    <iidm:line id="_045d71d4-c766-11e1-8775-005056c00008" name="24-72" r="8.5029120000000002" x="34.151040000000002" g1="0" b1="0.00014003675" g2="0" b2="0.00014003675" node1="30" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="24.647364301226222" q1="-5.25157393377705" p2="-24.345693639780009" q2="1.6302180044657777">
         <iidm:alias>_04667281-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d0234-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9371,7 +9494,7 @@
             <iidm:temporaryLimit name="_d2074163-ab09-4251-a1d7-6983091dc4f1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045f94b8-c766-11e1-8775-005056c00008" name="17-18" r="2.1431520000000002" x="8.7991200000000003" g1="0" b1="3.7247499999999999e-05" g2="0" b2="3.7247499999999999e-05" node1="57" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04689563-c766-11e1-8775-005056c00008" p1="112.8881738909333" q1="40.898859208841934" p2="-111.04017134465043" q2="-34.518852574624049">
+    <iidm:line id="_045f94b8-c766-11e1-8775-005056c00008" name="17-18" r="2.1431520000000002" x="8.7991200000000003" g1="0" b1="3.7247499999999999e-05" g2="0" b2="3.7247499999999999e-05" node1="57" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04689563-c766-11e1-8775-005056c00008" p1="117.0821006253517" q1="40.51039423772508" p2="-115.11623939171751" q2="-33.647035824837175">
         <iidm:alias>_045e0e17-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0485ba59-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9379,7 +9502,7 @@
             <iidm:temporaryLimit name="_2b6693c7-4e29-4c2c-91d0-3485bbe8fe87" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048963d8-c766-11e1-8775-005056c00008" name="17-113" r="1.590811" x="5.244624" g1="0" b1="2.2038549999999999e-05" g2="0" b2="2.2038549999999999e-05" node1="58" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="1.6514469417473421" q1="4.8896823736151376" p2="-1.648565698631655" q2="-5.6184088143866076">
+    <iidm:line id="_048963d8-c766-11e1-8775-005056c00008" name="17-113" r="1.590811" x="5.244624" g1="0" b1="2.2038549999999999e-05" g2="0" b2="2.2038549999999999e-05" node1="58" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="5.8127337175204836" q1="3.2530336782067626" p2="-5.8082885020176978" q2="-3.9771566524807165">
         <iidm:alias>_045841b5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046958b4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9387,7 +9510,7 @@
             <iidm:temporaryLimit name="_786432da-fa4d-4751-a275-87d0e20529f1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0458ddf0-c766-11e1-8775-005056c00008" name="49-50" r="4.6522079999999999" x="13.102848099999999" g1="0" b1="5.3776400000000002e-05" g2="0" b2="5.3776400000000002e-05" node1="112" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044d1e26-c766-11e1-8775-005056c00008" p1="62.146680746603344" q1="11.698332867519758" p2="-61.12428200013148" q2="-10.740955141886028">
+    <iidm:line id="_0458ddf0-c766-11e1-8775-005056c00008" name="49-50" r="4.6522079999999999" x="13.102848099999999" g1="0" b1="5.3776400000000002e-05" g2="0" b2="5.3776400000000002e-05" node1="112" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044d1e26-c766-11e1-8775-005056c00008" p1="62.16474847136876" q1="11.694906552058066" p2="-61.141801075138837" q2="-10.735980693258201">
         <iidm:alias>_0464ebe8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f9fd8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9395,7 +9518,7 @@
             <iidm:temporaryLimit name="_1f0844a5-ea5c-42b2-abcb-6fac2c426092" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04535fb7-c766-11e1-8775-005056c00008" name="1-3" r="2.2476959999999999" x="7.3877759999999997" g1="0" b1="3.1049149999999997e-05" g2="0" b2="3.1049149999999997e-05" node1="21" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_047eb579-c766-11e1-8775-005056c00008" p1="-40.609672477676526" q1="-16.207264862225767" p2="40.87505100332077" q2="16.069254227617762">
+    <iidm:line id="_04535fb7-c766-11e1-8775-005056c00008" name="1-3" r="2.2476959999999999" x="7.3877759999999997" g1="0" b1="3.1049149999999997e-05" g2="0" b2="3.1049149999999997e-05" node1="21" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_047eb579-c766-11e1-8775-005056c00008" p1="-39.609102845949565" q1="-16.737739088812603" p2="39.865426014716441" q2="16.569126313432022">
         <iidm:alias>_044ef2e9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047c4474-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9403,7 +9526,7 @@
             <iidm:temporaryLimit name="_4ea43e34-67a3-42b8-9601-2189db7790d4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0478e912-c766-11e1-8775-005056c00008" name="92-102" r="2.1431520000000002" x="9.7400160000000007" g1="0" b1="4.2011000000000001e-05" g2="0" b2="4.2011000000000001e-05" node1="66" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="49.96467905303895" q1="-9.0388446695919313" p2="-49.642319019052401" q2="9.0722085340921019">
+    <iidm:line id="_0478e912-c766-11e1-8775-005056c00008" name="92-102" r="2.1431520000000002" x="9.7400160000000007" g1="0" b1="4.2011000000000001e-05" g2="0" b2="4.2011000000000001e-05" node1="66" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="50.001268602513015" q1="-9.0577431357323999" p2="-49.678376017290631" q2="9.0936650094476406">
         <iidm:alias>_045a1673-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0468bc79-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9411,7 +9534,7 @@
             <iidm:temporaryLimit name="_23cc194e-9273-46e9-a793-84a9c2911737" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04547127-c766-11e1-8775-005056c00008" name="93-94" r="3.8855520000000001" x="12.7543688" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="21" voltageLevelId1="_04789af0-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="57.26171168530049" q1="-22.112961576396732" p2="-56.401455252710662" q2="23.116231007453564">
+    <iidm:line id="_04547127-c766-11e1-8775-005056c00008" name="93-94" r="3.8855520000000001" x="12.7543688" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="21" voltageLevelId1="_04789af0-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="57.318106741657715" q1="-22.056564983692461" p2="-56.456701789635432" q2="23.064137427580871">
         <iidm:alias>_04500450-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047b0bfb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9419,7 +9542,7 @@
             <iidm:temporaryLimit name="_1a9fe09e-3f63-4904-8e36-aa38c5e16c59" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04791021-c766-11e1-8775-005056c00008" name="46-48" r="10.4718237" x="32.931359999999998" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044778d3-c766-11e1-8775-005056c00008" p1="-8.7900113326359328" q1="-7.952150126398057" p2="8.8544371703484792" q2="3.3118309806459085">
+    <iidm:line id="_04791021-c766-11e1-8775-005056c00008" name="46-48" r="10.4718237" x="32.931359999999998" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044778d3-c766-11e1-8775-005056c00008" p1="-8.7570871679793143" q1="-7.963558478108669" p2="8.8212449155311603" q2="3.3223917865691295">
         <iidm:alias>_0459ef69-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04640186-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9427,7 +9550,7 @@
             <iidm:temporaryLimit name="_467ba04d-dbad-4fe1-81c8-3bc87b41fcd1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046958b6-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="113" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-92.283009380530672" q1="-2.5274493311252875" p2="93.742309923713989" q2="7.3196368745609837">
+    <iidm:line id="_046958b6-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="113" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-92.176132292006244" q1="-2.5568275731169319" p2="93.632067616930485" q2="7.3318347422942489">
         <iidm:alias>_04776270-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a96c8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9435,7 +9558,7 @@
             <iidm:temporaryLimit name="_d0737ab4-5a3a-46c8-8aeb-789313f0f332" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046f4c26-c766-11e1-8775-005056c00008" name="75-118" r="2.5264799999999998" x="8.3809430000000003" g1="0" b1="3.4377849999999998e-05" g2="0" b2="3.4377849999999998e-05" node1="48" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="39.309065021479569" q1="28.724741409892836" p2="-38.937041649139523" q2="-28.589306590618556">
+    <iidm:line id="_046f4c26-c766-11e1-8775-005056c00008" name="75-118" r="2.5264799999999998" x="8.3809430000000003" g1="0" b1="3.4377849999999998e-05" g2="0" b2="3.4377849999999998e-05" node1="48" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="39.183117978510452" q1="28.825382608686269" p2="-38.811711510010035" q2="-28.691959101250497">
         <iidm:alias>_04619088-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04814d8a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9443,7 +9566,7 @@
             <iidm:temporaryLimit name="_173dc7ff-ae18-4410-b2e1-a4c2abac8ff6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c3954-c766-11e1-8775-005056c00008" name="94-96" r="4.6870560000000001" x="15.1414566" g1="0" b1="6.60009e-05" g2="0" b2="6.60009e-05" node1="49" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="38.340219866378781" q1="-13.111329853953663" p2="-37.894676834067013" q2="12.307902059693685">
+    <iidm:line id="_045c3954-c766-11e1-8775-005056c00008" name="94-96" r="4.6870560000000001" x="15.1414566" g1="0" b1="6.60009e-05" g2="0" b2="6.60009e-05" node1="49" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="38.406984024330413" q1="-12.911945209310542" p2="-37.961179096373968" q2="12.110575067726032">
         <iidm:alias>_046ba2a0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0472ce94-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9451,7 +9574,7 @@
             <iidm:temporaryLimit name="_efde58bf-c92e-496d-b558-d0095a271083" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04518af7-c766-11e1-8775-005056c00008" name="62-67" r="4.4953919999999998" x="20.38608" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="39" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="-2.4931108125372967" q1="-18.361315551129675" p2="2.5681584453936108" q2="15.556492967419915">
+    <iidm:line id="_04518af7-c766-11e1-8775-005056c00008" name="62-67" r="4.4953919999999998" x="20.38608" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="39" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="-2.5075105393390738" q1="-18.357792111602748" p2="2.5825460892379337" q2="15.552915727347024">
         <iidm:alias>_04544a10-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04814d86-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9459,7 +9582,7 @@
             <iidm:temporaryLimit name="_8a81d4ae-2bc8-4038-8650-27a6150946b1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0452c375-c766-11e1-8775-005056c00008" name="47-49" r="3.3279839999999998" x="10.890000000000001" g1="0" b1="4.6028449999999998e-05" g2="0" b2="4.6028449999999998e-05" node1="30" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="114" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="17.149557030204772" q1="-22.885314159490971" p2="-17.004676721717168" q2="21.691317814913361">
+    <iidm:line id="_0452c375-c766-11e1-8775-005056c00008" name="47-49" r="3.3279839999999998" x="10.890000000000001" g1="0" b1="4.6028449999999998e-05" g2="0" b2="4.6028449999999998e-05" node1="30" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="114" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="17.050975518912391" q1="-22.816322223627459" p2="-16.907292329312135" q2="21.61836735737031">
         <iidm:alias>_0465fd54-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0471e431-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9467,7 +9590,7 @@
             <iidm:temporaryLimit name="_8d6a074c-900d-4a37-830c-5da4c1de1ab5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046c17d9-c766-11e1-8775-005056c00008" name="100-106" r="10.54152" x="39.900959999999998" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="76" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="59.397287111057636" q1="10.058875112243555" p2="-57.230657053273774" q2="-7.92164653487281">
+    <iidm:line id="_046c17d9-c766-11e1-8775-005056c00008" name="100-106" r="10.54152" x="39.900959999999998" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="76" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="59.39916084139233" q1="10.05872205297911" p2="-57.232403353779503" q2="-7.9210111452564469">
         <iidm:alias>_045d98e5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0480d851-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9475,7 +9598,7 @@
             <iidm:temporaryLimit name="_3154dc30-b0e5-4570-8e52-9333bae20ef2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046b2d77-c766-11e1-8775-005056c00008" name="77-78" r="0.655142" x="2.1605759999999998" g1="0" b1="3.6271800000000001e-05" g2="0" b2="3.6271800000000001e-05" node1="66" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044fb634-c766-11e1-8775-005056c00008" p1="43.834792274577694" q1="4.050387497758841" p2="-43.762110086590752" q2="-5.078698652513097">
+    <iidm:line id="_046b2d77-c766-11e1-8775-005056c00008" name="77-78" r="0.655142" x="2.1605759999999998" g1="0" b1="3.6271800000000001e-05" g2="0" b2="3.6271800000000001e-05" node1="66" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044fb634-c766-11e1-8775-005056c00008" p1="43.742418657693008" q1="3.9482720327841494" p2="-43.670054085710206" q2="-4.9772928452990426">
         <iidm:alias>_046ed6fb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04893cc3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9483,7 +9606,7 @@
             <iidm:temporaryLimit name="_cce754c5-b9d5-4105-a431-32da96e4a6cf" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c8776-c766-11e1-8775-005056c00008" name="6-7" r="0.79976199999999997" x="3.6241919999999999" g1="0" b1="1.5782850000000001e-05" g2="0" b2="1.5782850000000001e-05" node1="21" voltageLevelId1="_044f6818-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047eb571-c766-11e1-8775-005056c00008" p1="43.097497432899971" q1="-7.6672981060358882" p2="-43.007825456162266" q2="7.5355572847078349">
+    <iidm:line id="_045c8776-c766-11e1-8775-005056c00008" name="6-7" r="0.79976199999999997" x="3.6241919999999999" g1="0" b1="1.5782850000000001e-05" g2="0" b2="1.5782850000000001e-05" node1="21" voltageLevelId1="_044f6818-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047eb571-c766-11e1-8775-005056c00008" p1="38.652759807764731" q1="-5.7106218207743895" p2="-38.581384920197678" q2="5.495490448458952">
         <iidm:alias>_046efe08-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04720b4a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9491,7 +9614,7 @@
             <iidm:temporaryLimit name="_361a9cc3-fb33-4037-9b9a-c20adb90b66b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047ba839-c766-11e1-8775-005056c00008" name="77-80" r="5.1226560000000001" x="18.295200000000001" g1="0" b1="6.5426999999999995e-05" g2="0" b2="6.5426999999999995e-05" node1="67" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="76" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-46.01104546835596" q1="-23.093007148932077" p2="46.770966351556964" q2="23.427848314159373">
+    <iidm:line id="_047ba839-c766-11e1-8775-005056c00008" name="77-80" r="5.1226560000000001" x="18.295200000000001" g1="0" b1="6.5426999999999995e-05" g2="0" b2="6.5426999999999995e-05" node1="67" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="76" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-46.107100044507128" q1="-23.192898398881592" p2="46.871112980535379" q2="23.542676874076367">
         <iidm:alias>_047c6b85-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0480b148-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9499,7 +9622,7 @@
             <iidm:temporaryLimit name="_da00c66f-a882-4938-923b-f2455f7f9a81" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04592c16-c766-11e1-8775-005056c00008" name="78-79" r="0.95135000000000003" x="4.2514560000000001" g1="0" b1="1.8595050000000001e-05" g2="0" b2="1.8595050000000001e-05" node1="22" voltageLevelId1="_044fb634-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04481510-c766-11e1-8775-005056c00008" p1="-27.238261492072141" q1="-20.921527262824114" p2="27.301873307646346" q2="20.552934872340479">
+    <iidm:line id="_04592c16-c766-11e1-8775-005056c00008" name="78-79" r="0.95135000000000003" x="4.2514560000000001" g1="0" b1="1.8595050000000001e-05" g2="0" b2="1.8595050000000001e-05" node1="22" voltageLevelId1="_044fb634-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04481510-c766-11e1-8775-005056c00008" p1="-27.330351657825002" q1="-21.022951950992681" p2="27.394482332499376" q2="20.656821524178934">
         <iidm:alias>_0453add6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045b7605-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9507,7 +9630,7 @@
             <iidm:temporaryLimit name="_ba4abe9d-8490-4c19-b19b-c9d2c3597fc9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047b3301-c766-11e1-8775-005056c00008" name="103-104" r="8.1195839999999997" x="27.599615100000001" g1="0" b1="0.00011679295" g2="0" b2="0.00011679295" node1="40" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="33.050215440396435" q1="13.982938989750393" p2="-32.433418380069149" q2="-15.879296174421299">
+    <iidm:line id="_047b3301-c766-11e1-8775-005056c00008" name="103-104" r="8.1195839999999997" x="27.599615100000001" g1="0" b1="0.00011679295" g2="0" b2="0.00011679295" node1="40" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="33.049687940752399" q1="13.983141989713502" p2="-32.432903942842103" q2="-15.879543906791607">
         <iidm:alias>_0459a142-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045d98e6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9515,7 +9638,7 @@
             <iidm:temporaryLimit name="_2320da74-eda7-4f7f-ade9-1ed0e994f3af" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045e5c32-c766-11e1-8775-005056c00008" name="95-96" r="2.9795039999999999" x="9.5309279999999994" g1="0" b1="4.2298000000000001e-05" g2="0" b2="4.2298000000000001e-05" node1="21" voltageLevelId1="_044f4108-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="14.736174764028636" q1="-25.096603916849126" p2="-14.590587848726466" q2="24.13999484212756">
+    <iidm:line id="_045e5c32-c766-11e1-8775-005056c00008" name="95-96" r="2.9795039999999999" x="9.5309279999999994" g1="0" b1="4.2298000000000001e-05" g2="0" b2="4.2298000000000001e-05" node1="21" voltageLevelId1="_044f4108-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="14.795676982704723" q1="-24.922949107334428" p2="-14.651208569173916" q2="23.963663096615441">
         <iidm:alias>_04597a34-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04801509-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9523,7 +9646,7 @@
             <iidm:temporaryLimit name="_3bc03415-e95f-47a7-8e92-01089d304a9c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045ed169-c766-11e1-8775-005056c00008" name="77-80" r="2.9620799999999998" x="8.4506409999999992" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="68" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="77" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-100.40271025741086" q1="-42.585071216930515" p2="102.38067636690043" q2="43.30281079977734">
+    <iidm:line id="_045ed169-c766-11e1-8775-005056c00008" name="77-80" r="2.9620799999999998" x="8.4506409999999992" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="68" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="77" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-100.61971086836621" q1="-42.783526040177719" p2="102.60832801007457" q2="43.532320721214873">
         <iidm:alias>_0464289a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04828605-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9531,7 +9654,7 @@
             <iidm:temporaryLimit name="_f93b6d4c-39fa-4f6f-a42d-c63a4cf21a67" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047f78c2-c766-11e1-8775-005056c00008" name="5-11" r="3.5370720000000002" x="11.8831682" g1="0" b1="4.987375e-05" g2="0" b2="4.987375e-05" node1="48" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="88.609619961388105" q1="8.7832623531051208" p2="-87.026825138575262" q2="-5.1974225704473644">
+    <iidm:line id="_047f78c2-c766-11e1-8775-005056c00008" name="5-11" r="3.5370720000000002" x="11.8831682" g1="0" b1="4.987375e-05" g2="0" b2="4.987375e-05" node1="48" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="83.23844883501593" q1="10.78337815958923" p2="-81.833628436543222" q2="-7.7978809151826187">
         <iidm:alias>_045bc426-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0476c633-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9539,7 +9662,7 @@
             <iidm:temporaryLimit name="_3bc4ab96-7a0d-4e18-b9f5-d89f63a82f0a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04845ac7-c766-11e1-8775-005056c00008" name="71-72" r="7.7711040000000002" x="31.363201100000001" g1="0" b1="0.00012752525" g2="0" b2="0.00012752525" node1="29" voltageLevelId1="_04664b78-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="-12.972740380887831" q1="-1.9729154780064668" p2="13.049967581581704" q2="-2.0610299954886901">
+    <iidm:line id="_04845ac7-c766-11e1-8775-005056c00008" name="71-72" r="7.7711040000000002" x="31.363201100000001" g1="0" b1="0.00012752525" g2="0" b2="0.00012752525" node1="29" voltageLevelId1="_04664b78-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="-12.277403088725494" q1="-2.4408457743872525" p2="12.346557758977198" q2="-1.6302175589711685">
         <iidm:alias>_04642891-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046b0661-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9547,7 +9670,7 @@
             <iidm:temporaryLimit name="_bcb69c6e-125e-449c-acb3-a4deb151668d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047343c2-c766-11e1-8775-005056c00008" name="66-67" r="3.9029759999999998" x="17.685359999999999" g1="0" b1="7.6962800000000001e-05" g2="0" b2="7.6962800000000001e-05" node1="50" voltageLevelId1="_047147f4-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="30.867234635090472" q1="21.05805406477625" p2="-30.568053933136397" q2="-22.556449249237009">
+    <iidm:line id="_047343c2-c766-11e1-8775-005056c00008" name="66-67" r="3.9029759999999998" x="17.685359999999999" g1="0" b1="7.6962800000000001e-05" g2="0" b2="7.6962800000000001e-05" node1="50" voltageLevelId1="_047147f4-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="30.881781482780102" q1="21.055194456490756" p2="-30.582442908260138" q2="-22.552872168279173">
         <iidm:alias>_0465af34-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04860874-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9555,7 +9678,7 @@
             <iidm:temporaryLimit name="_b4b8a31d-dc3c-4b51-88ad-a22e070eb96c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04569409-c766-11e1-8775-005056c00008" name="34-43" r="7.1961120000000003" x="29.289743399999999" g1="0" b1="0.0001212695" g2="0" b2="0.0001212695" node1="40" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_045e8349-c766-11e1-8775-005056c00008" p1="12.586581806493793" q1="-7.2310962312045532" p2="-12.500481433957978" q2="3.7755773972183264">
+    <iidm:line id="_04569409-c766-11e1-8775-005056c00008" name="34-43" r="7.1961120000000003" x="29.289743399999999" g1="0" b1="0.0001212695" g2="0" b2="0.0001212695" node1="40" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_045e8349-c766-11e1-8775-005056c00008" p1="12.869159873088796" q1="-7.3337378834188183" p2="-12.779182722321364" q2="3.8957350372370683">
         <iidm:alias>_04500454-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04505274-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9563,7 +9686,7 @@
             <iidm:temporaryLimit name="_5585c67a-0839-48e6-8847-4393e1e9b9c7" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04817498-c766-11e1-8775-005056c00008" name="52-53" r="7.0567200000000003" x="28.488240000000001" g1="0" b1="0.00011644859999999999" g2="0" b2="0.00011644859999999999" node1="21" voltageLevelId1="_04806326-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04876804-c766-11e1-8775-005056c00008" p1="13.385875785886677" q1="0.95651574963682051" p2="-13.302905798573592" q2="-4.2877109662930675">
+    <iidm:line id="_04817498-c766-11e1-8775-005056c00008" name="52-53" r="7.0567200000000003" x="28.488240000000001" g1="0" b1="0.00011644859999999999" g2="0" b2="0.00011644859999999999" node1="21" voltageLevelId1="_04806326-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04876804-c766-11e1-8775-005056c00008" p1="13.392511147970207" q1="0.95422374113249897" p2="-13.309467605104834" q2="-4.2851057326703659">
         <iidm:alias>_045115c7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0472a784-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9571,7 +9694,7 @@
             <iidm:temporaryLimit name="_e7c9dfab-fb45-4470-964f-4ba9e391f60b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044b7078-c766-11e1-8775-005056c00008" name="105-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="49" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="23" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="26.894706842671223" q1="1.3279263190045714" p2="-26.476232673860238" q2="-4.1903632648009737">
+    <iidm:line id="_044b7078-c766-11e1-8775-005056c00008" name="105-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="49" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="23" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="26.894491996761666" q1="1.3280049663902207" p2="-26.476024081732135" q2="-4.1904632252416913">
         <iidm:alias>_0452c378-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0481c2b7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9579,7 +9702,7 @@
             <iidm:temporaryLimit name="_fff133bf-25fd-46b2-b144-a227c31ee882" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048ac367-c766-11e1-8775-005056c00008" name="100-101" r="4.8264480000000001" x="21.9890881" g1="0" b1="9.4123049999999997e-05" g2="0" b2="9.4123049999999997e-05" node1="77" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046ed6f7-c766-11e1-8775-005056c00008" p1="-21.797768937010925" q1="24.734000837317726" p2="22.112105579362741" q2="-26.607871570691366">
+    <iidm:line id="_048ac367-c766-11e1-8775-005056c00008" name="100-101" r="4.8264480000000001" x="21.9890881" g1="0" b1="9.4123049999999997e-05" g2="0" b2="9.4123049999999997e-05" node1="77" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046ed6f7-c766-11e1-8775-005056c00008" p1="-21.832020175702251" q1="24.763941573202864" p2="22.147181090641091" q2="-26.633972924774341">
         <iidm:alias>_044afb45-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b5fa2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9587,7 +9710,7 @@
             <iidm:temporaryLimit name="_217e3c95-24b5-438f-a721-d2257e1a43b4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0481c2b1-c766-11e1-8775-005056c00008" name="56-57" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="57" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="-30.803833593517847" q1="-5.4733979494400797" p2="31.16876144778956" q2="4.2622220152219912">
+    <iidm:line id="_0481c2b1-c766-11e1-8775-005056c00008" name="56-57" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="57" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="-30.820301207598018" q1="-5.4654375684058563" p2="31.185585592306808" q2="4.2552704105881158">
         <iidm:alias>_045e0e12-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0487dd35-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9595,7 +9718,7 @@
             <iidm:temporaryLimit name="_f5547027-3d48-4a53-937b-bd5ba63ef70d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047a6fb7-c766-11e1-8775-005056c00008" name="47-69" r="14.705855400000001" x="48.403869999999998" g1="0" b1="0.00020351240000000001" g2="0" b2="0.00020351240000000001" node1="31" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="57" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-84.043365952679324" q1="26.045393066838589" p2="90.558284350138436" q2="-12.05012159816015">
+    <iidm:line id="_047a6fb7-c766-11e1-8775-005056c00008" name="47-69" r="14.705855400000001" x="48.403869999999998" g1="0" b1="0.00020351240000000001" g2="0" b2="0.00020351240000000001" node1="31" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="57" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-83.833798719104763" q1="25.928094748718888" p2="90.313852806496314" q2="-12.04776061298482">
         <iidm:alias>_04758db9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0485ba56-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9603,7 +9726,7 @@
             <iidm:temporaryLimit name="_e9fec217-cf6f-4d39-9495-26ed10c05100" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0453fbf0-c766-11e1-8775-005056c00008" name="110-111" r="3.8332799999999998" x="13.1551189" g1="0" b1="5.7392100000000002e-05" g2="0" b2="5.7392100000000002e-05" node1="40" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_046a1c00-c766-11e1-8775-005056c00008" p1="-39.41058158403488" q1="-20.537150123096222" p2="39.878105531155583" q2="20.269095709179979">
+    <iidm:line id="_0453fbf0-c766-11e1-8775-005056c00008" name="110-111" r="3.8332799999999998" x="13.1551189" g1="0" b1="5.7392100000000002e-05" g2="0" b2="5.7392100000000002e-05" node1="40" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_046a1c00-c766-11e1-8775-005056c00008" p1="-39.404130720234761" q1="-20.539405252731008" p2="39.871553434103227" q2="20.271003322296956">
         <iidm:alias>_0447c6f5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04812675-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9611,7 +9734,7 @@
             <iidm:temporaryLimit name="_ea48fee0-31b6-4990-a332-25d08b7d731f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04778984-c766-11e1-8775-005056c00008" name="41-42" r="7.14384" x="23.522401800000001" g1="0" b1="9.8714400000000005e-05" g2="0" b2="9.8714400000000005e-05" node1="21" voltageLevelId1="_048c4a08-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="-10.671076465994911" q1="-10.791228748992571" p2="10.774503027819335" q2="8.3115750726967335">
+    <iidm:line id="_04778984-c766-11e1-8775-005056c00008" name="41-42" r="7.14384" x="23.522401800000001" g1="0" b1="9.8714400000000005e-05" g2="0" b2="9.8714400000000005e-05" node1="21" voltageLevelId1="_048c4a08-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="-10.463115462826323" q1="-10.908745090049646" p2="10.565488828010022" q2="8.4266917698996782">
         <iidm:alias>_044d1e2a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046512f1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9619,7 +9742,7 @@
             <iidm:temporaryLimit name="_063af52c-fe10-4c1e-85d4-dd80dcc1d2f9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04653a08-c766-11e1-8775-005056c00008" name="80-99" r="7.9104960000000002" x="35.893439999999998" g1="0" b1="0.00015668044999999999" g2="0" b2="0.00015668044999999999" node1="78" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04644fa4-c766-11e1-8775-005056c00008" p1="1.9091538821663478" q1="6.7010528275708889" p2="-1.8685049629306658" q2="-12.309920195708996">
+    <iidm:line id="_04653a08-c766-11e1-8775-005056c00008" name="80-99" r="7.9104960000000002" x="35.893439999999998" g1="0" b1="0.00015668044999999999" g2="0" b2="0.00015668044999999999" node1="78" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04644fa4-c766-11e1-8775-005056c00008" p1="1.9160424865016303" q1="6.6994485200167349" p2="-1.8753955098130852" q2="-12.308326404265232">
         <iidm:alias>_04773b69-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0477b092-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9627,7 +9750,7 @@
             <iidm:temporaryLimit name="_c05229ce-6abb-4209-ad4f-0dcd4a070f28" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04581aa5-c766-11e1-8775-005056c00008" name="54-59" r="8.7642720000000001" x="39.953229999999998" g1="0" b1="0.0001716024" g2="0" b2="0.0001716024" node1="58" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-19.646183468553382" q1="-10.519543000050515" p2="19.892545752365926" q2="6.0146938463356232">
+    <iidm:line id="_04581aa5-c766-11e1-8775-005056c00008" name="54-59" r="8.7642720000000001" x="39.953229999999998" g1="0" b1="0.0001716024" g2="0" b2="0.0001716024" node1="58" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-19.628857783131686" q1="-10.524148720823371" p2="19.874884357001676" q2="6.0177687565694633">
         <iidm:alias>_0457cc82-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045cae81-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9635,7 +9758,7 @@
             <iidm:temporaryLimit name="_ac528cbe-6fc1-41dd-ba9d-d8b7a4c77576" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04690a93-c766-11e1-8775-005056c00008" name="92-94" r="8.3809430000000003" x="27.529920000000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="67" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="65.180641178216959" q1="-16.423831946849173" p2="-62.990833143097106" q2="19.651771454555451">
+    <iidm:line id="_04690a93-c766-11e1-8775-005056c00008" name="92-94" r="8.3809430000000003" x="27.529920000000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="67" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="65.238724843455003" q1="-16.361308968908752" p2="-63.045851064164118" q2="19.600206381673189">
         <iidm:alias>_044c33c1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0483706b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9643,7 +9766,7 @@
             <iidm:temporaryLimit name="_6ac84228-6b04-4b10-b560-29655c8e93b4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046009e3-c766-11e1-8775-005056c00008" name="37-39" r="5.5931040000000003" x="18.469439999999999" g1="0" b1="7.7479350000000006e-05" g2="0" b2="7.7479350000000006e-05" node1="57" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046bf0c7-c766-11e1-8775-005056c00008" p1="66.842731202232699" q1="18.474615779508063" p2="-65.122810362584019" q2="-15.1367024594688">
+    <iidm:line id="_046009e3-c766-11e1-8775-005056c00008" name="37-39" r="5.5931040000000003" x="18.469439999999999" g1="0" b1="7.7479350000000006e-05" g2="0" b2="7.7479350000000006e-05" node1="57" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046bf0c7-c766-11e1-8775-005056c00008" p1="67.080030193236965" q1="18.423504860001923" p2="-65.348678803083146" q2="-15.046581326057904">
         <iidm:alias>_044c33c9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04789afa-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9651,7 +9774,7 @@
             <iidm:temporaryLimit name="_2ccdc288-c132-40d1-a928-3887bec4ff67" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0458b6e8-c766-11e1-8775-005056c00008" name="46-47" r="6.6211200000000003" x="22.12848" g1="0" b1="9.0679499999999998e-05" g2="0" b2="9.0679499999999998e-05" node1="33" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_0457f396-c766-11e1-8775-005056c00008" p1="-32.493947430467088" q1="1.2759803783392369" p2="32.894293464476142" q2="-3.1600787681326818">
+    <iidm:line id="_0458b6e8-c766-11e1-8775-005056c00008" name="46-47" r="6.6211200000000003" x="22.12848" g1="0" b1="9.0679499999999998e-05" g2="0" b2="9.0679499999999998e-05" node1="33" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_0457f396-c766-11e1-8775-005056c00008" p1="-32.385695569092235" q1="1.2183494018623717" p2="32.783275917337455" q2="-3.1117722485523225">
         <iidm:alias>_04507980-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0464c4da-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9659,7 +9782,7 @@
             <iidm:temporaryLimit name="_06ca3245-2668-448f-a5c6-961924217a5c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044f8f22-c766-11e1-8775-005056c00008" name="82-83" r="1.9514879999999999" x="6.3858959999999998" g1="0" b1="0.0001089302" g2="0" b2="0.0001089302" node1="31" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728074-c766-11e1-8775-005056c00008" p1="-66.786732821102831" q1="38.193649229372042" p2="67.490949197148936" q2="-39.523680720897737">
+    <iidm:line id="_044f8f22-c766-11e1-8775-005056c00008" name="82-83" r="1.9514879999999999" x="6.3858959999999998" g1="0" b1="0.0001089302" g2="0" b2="0.0001089302" node1="31" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728074-c766-11e1-8775-005056c00008" p1="-66.397262127650663" q1="39.529742685630012" p2="67.109200141449776" q2="-40.826622187346004">
         <iidm:alias>_047a48a6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b3891-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9667,7 +9790,7 @@
             <iidm:temporaryLimit name="_dfbd2f07-76ab-41e3-910f-dc706979ea4b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045cfca6-c766-11e1-8775-005056c00008" name="108-109" r="1.82952" x="5.0181120000000004" g1="0" b1="2.1809000000000001e-05" g2="0" b2="2.1809000000000001e-05" node1="21" voltageLevelId1="_046c65f4-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b7b99-c766-11e1-8775-005056c00008" p1="20.776678315932674" q1="-0.52835402364079587" p2="-20.727417300825934" q2="-0.034260747266461056">
+    <iidm:line id="_045cfca6-c766-11e1-8775-005056c00008" name="108-109" r="1.82952" x="5.0181120000000004" g1="0" b1="2.1809000000000001e-05" g2="0" b2="2.1809000000000001e-05" node1="21" voltageLevelId1="_046c65f4-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b7b99-c766-11e1-8775-005056c00008" p1="20.779879810143658" q1="-0.5294898300884765" p2="-20.730603557946722" q2="-0.033083014830265038">
         <iidm:alias>_04481514-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04716f00-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9675,7 +9798,7 @@
             <iidm:temporaryLimit name="_11451cec-81c7-4f83-a7db-df7dcaffa94e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04784cd5-c766-11e1-8775-005056c00008" name="70-74" r="6.9870239999999999" x="23.051952400000001" g1="0" b1="9.6648299999999994e-05" g2="0" b2="9.6648299999999994e-05" node1="48" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047dcb11-c766-11e1-8775-005056c00008" p1="23.820808187147204" q1="9.2070892446108719" p2="-23.537202696259808" q2="-11.454755728535721">
+    <iidm:line id="_04784cd5-c766-11e1-8775-005056c00008" name="70-74" r="6.9870239999999999" x="23.051952400000001" g1="0" b1="9.6648299999999994e-05" g2="0" b2="9.6648299999999994e-05" node1="48" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047dcb11-c766-11e1-8775-005056c00008" p1="23.525019233175371" q1="9.3774371419202556" p2="-23.245756781475819" q2="-11.640084023684523">
         <iidm:alias>_045e5c33-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046ab84b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9683,7 +9806,7 @@
             <iidm:temporaryLimit name="_37a5cc00-bd7f-4ec7-a77c-e140e23450d2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04747c40-c766-11e1-8775-005056c00008" name="77-82" r="5.1923519999999996" x="14.8626719" g1="0" b1="0.0002345615" g2="0" b2="0.0002345615" node1="69" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_046512f8-c766-11e1-8775-005056c00008" p1="-27.745667251506216" q1="30.68506325330539" p2="28.332680604808097" q2="-37.054353221969315">
+    <iidm:line id="_04747c40-c766-11e1-8775-005056c00008" name="77-82" r="5.1923519999999996" x="14.8626719" g1="0" b1="0.0002345615" g2="0" b2="0.0002345615" node1="69" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_046512f8-c766-11e1-8775-005056c00008" p1="-27.547216301771815" q1="31.377449744077651" p2="28.145544899893473" q2="-37.706858566994264">
         <iidm:alias>_0451b202-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0452ea84-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9691,7 +9814,7 @@
             <iidm:temporaryLimit name="_e9798d58-b518-4fab-984c-c72076dfc2ae" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045e3524-c766-11e1-8775-005056c00008" name="23-24" r="2.3522400000000001" x="8.5726080000000007" g1="0" b1="0.00014290635" g2="0" b2="0.00014290635" node1="39" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_048c22fa-c766-11e1-8775-005056c00008" p1="57.433944569467776" q1="-10.303583832003497" p2="-56.980475438827725" q2="6.9925230386258868">
+    <iidm:line id="_045e3524-c766-11e1-8775-005056c00008" name="23-24" r="2.3522400000000001" x="8.5726080000000007" g1="0" b1="0.00014290635" g2="0" b2="0.00014290635" node1="39" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_048c22fa-c766-11e1-8775-005056c00008" p1="55.875187081301583" q1="-9.8863335045025416" p2="-55.447447838941407" q2="6.4697088475436022">
         <iidm:alias>_046cb413-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f9fd3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9699,7 +9822,7 @@
             <iidm:temporaryLimit name="_e8ec73b8-1ecf-4d18-9ef9-80eabf3a4969" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0474f177-c766-11e1-8775-005056c00008" name="15-17" r="2.2999679999999998" x="7.6142880000000002" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="48" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-154.56910629918352" q1="-18.585679426019443" p2="158.10536370704568" q2="26.152434301999349">
+    <iidm:line id="_0474f177-c766-11e1-8775-005056c00008" name="15-17" r="2.2999679999999998" x="7.6142880000000002" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="48" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-164.21501524249067" q1="-15.322543969232139" p2="168.18595230172187" q2="24.326505008939602">
         <iidm:alias>_044c5ad2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046931a7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9707,7 +9830,7 @@
             <iidm:temporaryLimit name="_2ceac3d1-f73d-43db-8d37-9e329f1787bb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0483be84-c766-11e1-8775-005056c00008" name="8-30" r="2.0860400000000001" x="24.393599999999999" g1="0" b1="0.00053099175999999997" g2="0" b2="0.00053099175999999997" node1="30" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="38" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="86.338982125113091" q1="24.317331901035232" p2="-85.913259120423476" q2="-69.863218859771777">
+    <iidm:line id="_0483be84-c766-11e1-8775-005056c00008" name="8-30" r="2.0860400000000001" x="24.393599999999999" g1="0" b1="0.00053099175999999997" g2="0" b2="0.00053099175999999997" node1="30" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="38" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="103.377132153605" q1="18.913864058609299" p2="-102.83730122187065" q2="-63.453969883768082">
         <iidm:alias>_0454e651-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04801506-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9715,7 +9838,7 @@
             <iidm:temporaryLimit name="_ca795ad3-97e5-4416-aaba-53cce27f6434" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0488eea6-c766-11e1-8775-005056c00008" name="49-69" r="17.16264" x="56.453762099999999" g1="0" b1="0.00023760329999999999" g2="0" b2="0.00023760329999999999" node1="115" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-75.705171846783855" q1="26.77225577178881" p2="81.986522887478415" q2="-14.89521418576823">
+    <iidm:line id="_0488eea6-c766-11e1-8775-005056c00008" name="49-69" r="17.16264" x="56.453762099999999" g1="0" b1="0.00023760329999999999" g2="0" b2="0.00023760329999999999" node1="115" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-75.506450883297489" q1="26.64824210999932" p2="81.752407106267796" q2="-14.887626803890496">
         <iidm:alias>_04492681-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046735d6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9723,7 +9846,7 @@
             <iidm:temporaryLimit name="_c42dc3ef-3a2e-4070-8efb-78e5c0cd5554" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047566a0-c766-11e1-8775-005056c00008" name="13-15" r="12.9634562" x="42.584255200000001" g1="0" b1="0.00017986685000000001" g2="0" b2="0.00017986685000000001" node1="21" voltageLevelId1="_04851e1b-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="15.687890811537105" q1="-1.5826086156806389" p2="-15.489624699203505" q2="-3.5084666940399218">
+    <iidm:line id="_047566a0-c766-11e1-8775-005056c00008" name="13-15" r="12.9634562" x="42.584255200000001" g1="0" b1="0.00017986685000000001" g2="0" b2="0.00017986685000000001" node1="21" voltageLevelId1="_04851e1b-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="11.288710464818079" q1="-0.22866707741099718" p2="-11.181124892718923" q2="-5.1644765254702634">
         <iidm:alias>_04662461-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04865694-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9731,7 +9854,7 @@
             <iidm:temporaryLimit name="_ad988fd9-9270-4230-95a2-1858f32259df" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0476c63a-c766-11e1-8775-005056c00008" name="69-70" r="5.2271999999999998" x="22.12848" g1="0" b1="0.00035009184999999998" g2="0" b2="0.00035009184999999998" node1="59" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="75.313564672416035" q1="20.15668559847925" p2="-73.525550755218106" q2="-25.029083728672401">
+    <iidm:line id="_0476c63a-c766-11e1-8775-005056c00008" name="69-70" r="5.2271999999999998" x="22.12848" g1="0" b1="0.00035009184999999998" g2="0" b2="0.00035009184999999998" node1="59" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="76.1904595773305" q1="19.901704830718092" p2="-74.369033617047378" q2="-24.634558057646665">
         <iidm:alias>_047e193a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b1184-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9739,7 +9862,7 @@
             <iidm:temporaryLimit name="_519e3ecb-3561-4d11-ac6b-172a0b4b09b2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04520028-c766-11e1-8775-005056c00008" name="19-20" r="4.3908480000000001" x="20.38608" g1="0" b1="8.5514249999999999e-05" g2="0" b2="8.5514249999999999e-05" node1="39" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b2d70-c766-11e1-8775-005056c00008" p1="-14.828350562524188" q1="2.4480179899900674" p2="14.894954549305787" q2="-4.7765438938490155">
+    <iidm:line id="_04520028-c766-11e1-8775-005056c00008" name="19-20" r="4.3908480000000001" x="20.38608" g1="0" b1="8.5514249999999999e-05" g2="0" b2="8.5514249999999999e-05" node1="39" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b2d70-c766-11e1-8775-005056c00008" p1="-12.758501019911758" q1="1.4271566629197419" p2="12.806948789721689" q2="-3.8427648508999241">
         <iidm:alias>_0472f5a9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04745537-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9747,7 +9870,7 @@
             <iidm:temporaryLimit name="_b88528bf-cb1c-4c00-ad79-d5937197d40c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04862f83-c766-11e1-8775-005056c00008" name="94-95" r="2.2999679999999998" x="7.5620159999999998" g1="0" b1="3.1852600000000001e-05" g2="0" b2="3.1852600000000001e-05" node1="51" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f4108-c766-11e1-8775-005056c00008" p1="57.184943733354579" q1="6.3099747290564752" p2="-56.735550851881023" q2="-5.9026252735915818">
+    <iidm:line id="_04862f83-c766-11e1-8775-005056c00008" name="94-95" r="2.2999679999999998" x="7.5620159999999998" g1="0" b1="3.1852600000000001e-05" g2="0" b2="3.1852600000000001e-05" node1="51" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f4108-c766-11e1-8775-005056c00008" p1="57.245869565965727" q1="6.488798445186343" p2="-56.795040617275795" q2="-6.0762603430438507">
         <iidm:alias>_044ca8f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04837060-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9755,7 +9878,7 @@
             <iidm:temporaryLimit name="_b70e76a1-6e79-4fb6-b487-dffa9bfeab7b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047b0bf6-c766-11e1-8775-005056c00008" name="12-16" r="3.6938879999999998" x="14.5316162" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="68" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046f7338-c766-11e1-8775-005056c00008" p1="16.55852257797865" q1="7.2442132424974366" p2="-16.484339415960729" q2="-9.0277578456375593">
+    <iidm:line id="_047b0bf6-c766-11e1-8775-005056c00008" name="12-16" r="3.6938879999999998" x="14.5316162" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="68" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046f7338-c766-11e1-8775-005056c00008" p1="9.5662838791727989" q1="8.9008549860613506" p2="-9.5250762466751997" q2="-10.814216367721412">
         <iidm:alias>_0450798a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045c8772-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9763,7 +9886,7 @@
             <iidm:temporaryLimit name="_af73f526-c58b-40e7-8e1c-14f05a39f6a2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04524e47-c766-11e1-8775-005056c00008" name="100-103" r="2.7878400000000001" x="9.1476000000000006" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="78" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0475b4c0-c766-11e1-8775-005056c00008" p1="115.35446062442828" q1="-20.634893163875329" p2="-113.24661816454589" q2="22.045488389330231">
+    <iidm:line id="_04524e47-c766-11e1-8775-005056c00008" name="100-103" r="2.7878400000000001" x="9.1476000000000006" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="78" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0475b4c0-c766-11e1-8775-005056c00008" p1="115.36495427100728" q1="-20.637397217567393" p2="-113.25672383937284" q2="22.049264427857793">
         <iidm:alias>_04684744-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048aea71-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9771,7 +9894,7 @@
             <iidm:temporaryLimit name="_1631e50b-21a3-470b-803b-f9665b6fcd60" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04682038-c766-11e1-8775-005056c00008" name="27-32" r="3.9900959999999999" x="13.1551189" g1="0" b1="5.5268600000000001e-05" g2="0" b2="5.5268600000000001e-05" node1="40" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="18.072317578186972" q1="-3.5921796413551283" p2="-17.9906690588865" q2="2.0618176465357121">
+    <iidm:line id="_04682038-c766-11e1-8775-005056c00008" name="27-32" r="3.9900959999999999" x="13.1551189" g1="0" b1="5.5268600000000001e-05" g2="0" b2="5.5268600000000001e-05" node1="40" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="16.010114040228991" q1="-2.3918577066919693" p2="-15.947092794598353" q2="0.79500923217116093">
         <iidm:alias>_0455347a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479ac63-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9779,7 +9902,7 @@
             <iidm:temporaryLimit name="_52eb4b09-42bb-4106-ac26-fe1059639d3a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0482fb31-c766-11e1-8775-005056c00008" name="59-61" r="5.7150720000000002" x="26.1360016" g1="0" b1="0.0001113407" g2="0" b2="0.0001113407" node1="68" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-100.70491974103244" q1="22.22362391529288" p2="104.32985619155579" q2="-9.4490554351189289">
+    <iidm:line id="_0482fb31-c766-11e1-8775-005056c00008" name="59-61" r="5.7150720000000002" x="26.1360016" g1="0" b1="0.0001113407" g2="0" b2="0.0001113407" node1="68" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-100.68562636942262" q1="22.215956667956938" p2="104.30912402832398" q2="-9.4479683369193488">
         <iidm:alias>_044a10e9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0473b8f5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9787,7 +9910,7 @@
             <iidm:temporaryLimit name="_b5a7dea0-bfce-4548-a04d-7bb7b6d9f80a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047d55e3-c766-11e1-8775-005056c00008" name="100-104" r="7.8582239999999999" x="35.544960000000003" g1="0" b1="0.00015524565000000001" g2="0" b2="0.00015524565000000001" node1="79" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="54.993845878785208" q1="10.981188518046297" p2="-53.592306944911257" q2="-9.9875796022913956">
+    <iidm:line id="_047d55e3-c766-11e1-8775-005056c00008" name="100-104" r="7.8582239999999999" x="35.544960000000003" g1="0" b1="0.00015524565000000001" g2="0" b2="0.00015524565000000001" node1="79" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="54.996115646564988" q1="10.980994160454195" p2="-53.594470445699258" q2="-9.9869050065512202">
         <iidm:alias>_04636547-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048aea76-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9795,7 +9918,7 @@
             <iidm:temporaryLimit name="_17a10cd0-b653-4dcf-bdc3-4d5005ea9591" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04653a02-c766-11e1-8775-005056c00008" name="75-77" r="10.4718237" x="34.830577900000002" g1="0" b1="0.00014284895" g2="0" b2="0.00014284895" node1="49" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-36.128613986866817" q1="-7.1430868494127013" p2="36.981102139473876" q2="5.1451224377787597">
+    <iidm:line id="_04653a02-c766-11e1-8775-005056c00008" name="75-77" r="10.4718237" x="34.830577900000002" g1="0" b1="0.00014284895" g2="0" b2="0.00014284895" node1="49" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-36.297762682882606" q1="-7.0082569239575783" p2="37.157290164119019" q2="5.0344079737753473">
         <iidm:alias>_04642894-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04720b47-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9803,7 +9926,7 @@
             <iidm:temporaryLimit name="_6f81df11-7e71-4b6e-a6ee-a8c5f72f4ba5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04483c2a-c766-11e1-8775-005056c00008" name="23-32" r="5.5234079999999999" x="20.089872400000001" g1="0" b1="0.00033660465000000001" g2="0" b2="0.00033660465000000001" node1="40" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="83.204527756827346" q1="5.0466697741282482" p2="-80.972633576081591" q2="-8.2631793264953117">
+    <iidm:line id="_04483c2a-c766-11e1-8775-005056c00008" name="23-32" r="5.5234079999999999" x="20.089872400000001" g1="0" b1="0.00033660465000000001" g2="0" b2="0.00033660465000000001" node1="40" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="79.3546078659042" q1="5.7988899535820817" p2="-77.320440658224229" q2="-9.7613400441941689">
         <iidm:alias>_044b978a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0461dea6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9811,7 +9934,7 @@
             <iidm:temporaryLimit name="_a8f6a7d2-e58d-4671-a776-97be7291355e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048719e5-c766-11e1-8775-005056c00008" name="96-97" r="3.0143520000000001" x="15.42024" g1="0" b1="6.8870549999999994e-05" g2="0" b2="6.8870549999999994e-05" node1="50" voltageLevelId1="_045a1672-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="3.2030189157393267" q1="-25.318360571780442" p2="-3.0978342877660547" q2="23.463731640677011">
+    <iidm:line id="_048719e5-c766-11e1-8775-005056c00008" name="96-97" r="3.0143520000000001" x="15.42024" g1="0" b1="6.8870549999999994e-05" g2="0" b2="6.8870549999999994e-05" node1="50" voltageLevelId1="_045a1672-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="3.1633894951937829" q1="-25.49691000776545" p2="-3.0566294372359315" q2="23.651655398466652">
         <iidm:alias>_0451b207-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04828601-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9819,7 +9942,7 @@
             <iidm:temporaryLimit name="_ea6d39aa-df95-4d3e-b7b6-a800e552e72a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048481d0-c766-11e1-8775-005056c00008" name="25-27" r="5.5408330000000001" x="28.401121100000001" g1="0" b1="0.000506198385" g2="0" b2="0.000506198385" node1="30" voltageLevelId1="_04728079-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0476c639-c766-11e1-8775-005056c00008" p1="154.69417427163611" q1="30.680632930329054" p2="-147.32094876488449" q2="-10.869658965929302">
+    <iidm:line id="_048481d0-c766-11e1-8775-005056c00008" name="25-27" r="5.5408330000000001" x="28.401121100000001" g1="0" b1="0.000506198385" g2="0" b2="0.000506198385" node1="30" voltageLevelId1="_04728079-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0476c639-c766-11e1-8775-005056c00008" p1="149.0057067462397" q1="29.43931379530218" p2="-142.15926717385386" q2="-12.355835969884673">
         <iidm:alias>_046d2947-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04725960-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9827,7 +9950,7 @@
             <iidm:temporaryLimit name="_d9d53af2-5ffa-4f2a-a4e6-ed22371332d6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04885268-c766-11e1-8775-005056c00008" name="110-112" r="4.3037280000000004" x="11.1513615" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="41" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="13" voltageLevelId2="_04784cd1-c766-11e1-8775-005056c00008" p1="69.354412897694075" q1="11.007376174172439" p2="-68.000021821098599" q2="-13.000005921489555">
+    <iidm:line id="_04885268-c766-11e1-8775-005056c00008" name="110-112" r="4.3037280000000004" x="11.1513615" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="41" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="13" voltageLevelId2="_04784cd1-c766-11e1-8775-005056c00008" p1="69.354426630164298" q1="11.007380998267591" p2="-68.000034870046321" q2="-13.000008381482161">
         <iidm:alias>_04611b55-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0481c2ba-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9835,7 +9958,7 @@
             <iidm:temporaryLimit name="_d50299b9-a055-408a-aa1e-2e93a715120f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0484a8e4-c766-11e1-8775-005056c00008" name="89-92" r="1.7249760000000001" x="8.7991200000000003" g1="0" b1="0.00015725434999999999" g2="0" b2="0.00015725434999999999" node1="57" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="68" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="228.44543102665776" q1="-3.2679285359613397" p2="-223.33014356144062" q2="23.911182768170548">
+    <iidm:line id="_0484a8e4-c766-11e1-8775-005056c00008" name="89-92" r="1.7249760000000001" x="8.7991200000000003" g1="0" b1="0.00015725434999999999" g2="0" b2="0.00015725434999999999" node1="57" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="68" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="228.57646169720579" q1="-3.1779843975255795" p2="-223.45531376558432" q2="23.851408716833177">
         <iidm:alias>_04481517-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04808a3c-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9843,7 +9966,7 @@
             <iidm:temporaryLimit name="_eee9ca2b-764f-4ab8-a745-405338044743" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04689568-c766-11e1-8775-005056c00008" name="49-54" r="15.1414566" x="50.703842199999997" g1="0" b1="0.00020948120000000001" g2="0" b2="0.00020948120000000001" node1="116" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="46.523474538926848" q1="9.6246213667511036" p2="-44.583375000034522" q2="-10.291528814482614">
+    <iidm:line id="_04689568-c766-11e1-8775-005056c00008" name="49-54" r="15.1414566" x="50.703842199999997" g1="0" b1="0.00020948120000000001" g2="0" b2="0.00020948120000000001" node1="116" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="46.542561491333643" q1="9.6214719252244283" p2="-44.601062910187359" q2="-10.283694890130526">
         <iidm:alias>_046030f0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04605808-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9851,7 +9974,7 @@
             <iidm:temporaryLimit name="_690202a4-aad2-4ad3-8842-961b39e37709" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046c8d04-c766-11e1-8775-005056c00008" name="40-41" r="2.5264799999999998" x="8.4854880000000001" g1="0" b1="3.5066600000000001e-05" g2="0" b2="3.5066600000000001e-05" node1="40" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048c4a08-c766-11e1-8775-005056c00008" p1="26.475717739834657" q1="-1.3441220388718293" p2="-26.349971105638829" q2="0.78175765306815748">
+    <iidm:line id="_046c8d04-c766-11e1-8775-005056c00008" name="40-41" r="2.5264799999999998" x="8.4854880000000001" g1="0" b1="3.5066600000000001e-05" g2="0" b2="3.5066600000000001e-05" node1="40" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048c4a08-c766-11e1-8775-005056c00008" p1="26.688765032458132" q1="-1.4526441639681171" p2="-26.560885361484932" q2="0.89794024381876092">
         <iidm:alias>_045cae80-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a2194-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9859,7 +9982,7 @@
             <iidm:temporaryLimit name="_34f2ef7c-32da-4444-b989-d02f5f931c50" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046735d5-c766-11e1-8775-005056c00008" name="39-40" r="3.206016" x="10.54152" g1="0" b1="4.4536249999999999e-05" g2="0" b2="4.4536249999999999e-05" node1="22" voltageLevelId1="_046bf0c7-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="38.103621281337745" q1="4.1236847124707117" p2="-37.776010556319122" q2="-4.3170479516142253">
+    <iidm:line id="_046735d5-c766-11e1-8775-005056c00008" name="39-40" r="3.206016" x="10.54152" g1="0" b1="4.4536249999999999e-05" g2="0" b2="4.4536249999999999e-05" node1="22" voltageLevelId1="_046bf0c7-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="38.326967335904612" q1="4.0318479317421287" p2="-37.995570278693279" q2="-4.2120646866502272">
         <iidm:alias>_045115c1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048badc2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9867,7 +9990,7 @@
             <iidm:temporaryLimit name="_38d58455-5205-46bb-8e44-c66873f62938" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0470d2c4-c766-11e1-8775-005056c00008" name="89-92" r="6.8476319999999999" x="27.5473423" g1="0" b1="0.00011880164999999999" g2="0" b2="0.00011880164999999999" node1="58" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="72.064204515795822" q1="-5.8591690123713072" p2="-70.037989557587068" q2="9.8931858017694765">
+    <iidm:line id="_0470d2c4-c766-11e1-8775-005056c00008" name="89-92" r="6.8476319999999999" x="27.5473423" g1="0" b1="0.00011880164999999999" g2="0" b2="0.00011880164999999999" node1="58" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="72.106964860937452" q1="-5.8328637751510897" p2="-70.078428515168071" q2="9.8764276271454534">
         <iidm:alias>_04690a97-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04690a98-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9875,7 +9998,7 @@
             <iidm:temporaryLimit name="_0cce41c7-b99f-4fec-93d2-73ea24433fa1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0479ac60-c766-11e1-8775-005056c00008" name="33-37" r="7.2309599999999996" x="24.742080000000001" g1="0" b1="0.00010502754999999999" g2="0" b2="0.00010502754999999999" node1="21" voltageLevelId1="_0456bb11-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="42.186501208836411" q1="-21.657197407024913" p2="-41.156418339660796" q2="21.914819552445479">
+    <iidm:line id="_0479ac60-c766-11e1-8775-005056c00008" name="33-37" r="7.2309599999999996" x="24.742080000000001" g1="0" b1="0.00010502754999999999" g2="0" b2="0.00010502754999999999" node1="21" voltageLevelId1="_0456bb11-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="43.231024564185958" q1="-21.846905170017635" p2="-42.154720242071392" q2="22.264247778004954">
         <iidm:alias>_04716f08-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0483be89-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9883,7 +10006,7 @@
             <iidm:temporaryLimit name="_343677c6-7477-4bf6-a12c-2c7e4a684d6f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048c4a00-c766-11e1-8775-005056c00008" name="105-108" r="4.5476640000000002" x="12.249072099999999" g1="0" b1="5.2915499999999998e-05" g2="0" b2="5.2915499999999998e-05" node1="50" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_046c65f4-c766-11e1-8775-005056c00008" p1="22.923866288847684" q1="-0.83947444159632734" p2="-22.776679160515371" q2="-0.47164660222573584">
+    <iidm:line id="_048c4a00-c766-11e1-8775-005056c00008" name="105-108" r="4.5476640000000002" x="12.249072099999999" g1="0" b1="5.2915499999999998e-05" g2="0" b2="5.2915499999999998e-05" node1="50" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_046c65f4-c766-11e1-8775-005056c00008" p1="22.927109803194519" q1="-0.84049772859524863" p2="-22.7798810304635" q2="-0.47051098018535409">
         <iidm:alias>_046adf53-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04795e46-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9891,7 +10014,7 @@
             <iidm:temporaryLimit name="_74cf84b9-e14f-4f81-9e8b-3a791cd474a0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04631724-c766-11e1-8775-005056c00008" name="34-37" r="0.44605400000000001" x="1.637856" g1="0" b1="2.8236900000000001e-05" g2="0" b2="2.8236900000000001e-05" node1="41" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-54.333556812432427" q1="-37.413628738880234" p2="54.456887800806761" q2="36.979496762612072">
+    <iidm:line id="_04631724-c766-11e1-8775-005056c00008" name="34-37" r="0.44605400000000001" x="1.637856" g1="0" b1="2.8236900000000001e-05" g2="0" b2="2.8236900000000001e-05" node1="41" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-53.564953910649947" q1="-37.699042535501768" p2="53.6865877691462" q2="37.259146991653644">
         <iidm:alias>_04592c19-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04719611-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9899,7 +10022,7 @@
             <iidm:temporaryLimit name="_8e90bf2e-3be4-41be-a84e-c1d4e709f8a1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04814d85-c766-11e1-8775-005056c00008" name="61-62" r="1.435738" x="6.5514239999999999" g1="0" b1="2.812215e-05" g2="0" b2="2.812215e-05" node1="40" voltageLevelId1="_0448d867-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="60.107376672573523" q1="-18.207320970444847" p2="-59.780533725999895" q2="18.726550154881345">
+    <iidm:line id="_04814d85-c766-11e1-8775-005056c00008" name="61-62" r="1.435738" x="6.5514239999999999" g1="0" b1="2.812215e-05" g2="0" b2="2.812215e-05" node1="40" voltageLevelId1="_0448d867-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="60.086060491857417" q1="-18.203240426414379" p2="-59.759442849899571" q2="18.721441423323753">
         <iidm:alias>_045a3d85-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047abdd8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9907,7 +10030,7 @@
             <iidm:temporaryLimit name="_39a23399-348e-44d9-8032-8fc62e6c7d63" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046a4318-c766-11e1-8775-005056c00008" name="101-102" r="4.2863040000000003" x="19.5148811" g1="0" b1="8.4366399999999999e-05" g2="0" b2="8.4366399999999999e-05" node1="22" voltageLevelId1="_046ed6f7-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="-44.111988102988022" q1="11.608006505563598" p2="44.642357243413642" q2="-12.072169987573279">
+    <iidm:line id="_046a4318-c766-11e1-8775-005056c00008" name="101-102" r="4.2863040000000003" x="19.5148811" g1="0" b1="8.4366399999999999e-05" g2="0" b2="8.4366399999999999e-05" node1="22" voltageLevelId1="_046ed6f7-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="-44.147069452271062" q1="11.634103339468407" p2="44.678412823269014" q2="-12.09362742954721">
         <iidm:alias>_04878f1b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04885261-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9915,7 +10038,7 @@
             <iidm:temporaryLimit name="_0501dacc-29fc-44a2-8cad-31a20b011d25" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c81e3-c766-11e1-8775-005056c00008" name="26-30" r="3.8671600000000002" x="41.624000000000002" g1="0" b1="0.00093801650000000002" g2="0" b2="0.00093801650000000002" node1="21" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="223.62697792153381" q1="-2.0065265718487879" p2="-219.59306490169786" q2="-44.710881768243596">
+    <iidm:line id="_044c81e3-c766-11e1-8775-005056c00008" name="26-30" r="3.8671600000000002" x="41.624000000000002" g1="0" b1="0.00093801650000000002" g2="0" b2="0.00093801650000000002" node1="21" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="237.3659850761602" q1="-5.792060878439365" p2="-232.86603946395525" q2="-36.302696567017236">
         <iidm:alias>_0463654b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04747c4a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9923,7 +10046,7 @@
             <iidm:temporaryLimit name="_c95a66fd-913c-48c7-b8ef-cf3007c60af6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048915b9-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="41" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="117" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-53.802086503370738" q1="-18.431425570204237" p2="56.462240394539798" q2="22.331157311056455">
+    <iidm:line id="_048915b9-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="41" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="117" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-53.594188433845936" q1="-18.54960737345333" p2="56.239059619379063" q2="22.381326375468021">
         <iidm:alias>_044bbe98-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0456e224-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9931,7 +10054,7 @@
             <iidm:temporaryLimit name="_6cd83bc2-204f-44d5-afd4-fbfef8d2146f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c5ad6-c766-11e1-8775-005056c00008" name="105-106" r="2.4393600000000002" x="9.5309279999999994" g1="0" b1="4.1150150000000001e-05" g2="0" b2="4.1150150000000001e-05" node1="51" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="9.6424576518354748" q1="6.1367576803690715" p2="-9.6215318907090754" q2="-7.3840338521121458">
+    <iidm:line id="_044c5ad6-c766-11e1-8775-005056c00008" name="105-106" r="2.4393600000000002" x="9.5309279999999994" g1="0" b1="4.1150150000000001e-05" g2="0" b2="4.1150150000000001e-05" node1="51" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="9.640940075943508" q1="6.1373079803826149" p2="-9.6200175859816834" q2="-7.3845967893462747">
         <iidm:alias>_04505270-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04531190-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9939,7 +10062,7 @@
             <iidm:temporaryLimit name="_487e1317-48f9-4747-b931-f3f79e95f55a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048badc5-c766-11e1-8775-005056c00008" name="60-61" r="0.45999400000000001" x="2.3522400000000001" g1="0" b1="4.1781450000000003e-05" g2="0" b2="4.1781450000000003e-05" node1="30" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-169.24948800106625" q1="15.888365955901573" p2="170.02462066581472" q2="-13.362453066164406">
+    <iidm:line id="_048badc5-c766-11e1-8775-005056c00008" name="60-61" r="0.45999400000000001" x="2.3522400000000001" g1="0" b1="4.1781450000000003e-05" g2="0" b2="4.1781450000000003e-05" node1="30" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-169.22288785982107" q1="15.88458643804462" p2="169.9977753509672" q2="-13.359927801700083">
         <iidm:alias>_04793734-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048a4e31-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9947,7 +10070,7 @@
             <iidm:temporaryLimit name="_3c55a929-a755-409b-af5f-bae188892af1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044cd003-c766-11e1-8775-005056c00008" name="23-25" r="2.7181440000000001" x="13.9391994" g1="0" b1="0.00024793390000000002" g2="0" b2="0.00024793390000000002" node1="41" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="-206.5447547784276" q1="-10.25781789058955" p2="213.2039965129897" q2="35.3241101892283">
+    <iidm:line id="_044cd003-c766-11e1-8775-005056c00008" name="23-25" r="2.7181440000000001" x="13.9391994" g1="0" b1="0.00024793390000000002" g2="0" b2="0.00024793390000000002" node1="41" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="-198.89278945669875" q1="-11.586033232315453" p2="205.05613488277211" q2="34.098940224329333">
         <iidm:alias>_045ed161-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0473b8f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9955,7 +10078,7 @@
             <iidm:temporaryLimit name="_9658628a-596f-41a9-96a7-c5a8aaf5400c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0457a574-c766-11e1-8775-005056c00008" name="19-34" r="13.102848099999999" x="43.037277199999998" g1="0" b1="0.00018135905000000001" g2="0" b2="0.00018135905000000001" node1="40" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0483be8b-c766-11e1-8775-005056c00008" p1="54.840472348847946" q1="-16.816673779132483" p2="-52.119945952435963" q2="20.120825229050144">
+    <iidm:line id="_0457a574-c766-11e1-8775-005056c00008" name="19-34" r="13.102848099999999" x="43.037277199999998" g1="0" b1="0.00018135905000000001" g2="0" b2="0.00018135905000000001" node1="40" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0483be8b-c766-11e1-8775-005056c00008" p1="56.104311281720854" q1="-16.828856397850039" p2="-53.265466462181543" q2="20.522165834622626">
         <iidm:alias>_04502b61-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04686e5b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9963,7 +10086,7 @@
             <iidm:temporaryLimit name="_b69ab61b-751d-487a-a538-2d47eea7572e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04595326-c766-11e1-8775-005056c00008" name="59-60" r="5.5234079999999999" x="25.264800000000001" g1="0" b1="0.00010789715" g2="0" b2="0.00010789715" node1="69" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_045cfca4-c766-11e1-8775-005056c00008" p1="-89.060072334647671" q1="19.098813045050122" p2="91.794612502660897" q2="-10.266518074155123">
+    <iidm:line id="_04595326-c766-11e1-8775-005056c00008" name="59-60" r="5.5234079999999999" x="25.264800000000001" g1="0" b1="0.00010789715" g2="0" b2="0.00010789715" node1="69" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_045cfca4-c766-11e1-8775-005056c00008" p1="-89.042360999065593" q1="19.092054975264166" p2="91.775777924349214" q2="-10.264899217434362">
         <iidm:alias>_04611b57-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0463b366-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9971,7 +10094,7 @@
             <iidm:temporaryLimit name="_a38d4859-b54a-482f-a2ad-0b4ce4c4da2a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045a8ba1-c766-11e1-8775-005056c00008" name="15-19" r="2.0908799999999998" x="6.865056" g1="0" b1="2.8983e-05" g2="0" b2="2.8983e-05" node1="50" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="34.498438115948048" q1="10.218543982801959" p2="-34.324962171168814" q2="-10.551761460604139">
+    <iidm:line id="_045a8ba1-c766-11e1-8775-005056c00008" name="15-19" r="2.0908799999999998" x="6.865056" g1="0" b1="2.8983e-05" g2="0" b2="2.8983e-05" node1="50" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="33.831342483017437" q1="10.299016883681238" p2="-33.663742414359668" q2="-10.651799469212181">
         <iidm:alias>_047629f1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0481e9c1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9979,7 +10102,7 @@
             <iidm:temporaryLimit name="_15d16bd2-d87c-4584-93d2-b294dc1be116" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04513cd6-c766-11e1-8775-005056c00008" name="90-91" r="4.4256960000000003" x="14.566463499999999" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="31" voltageLevelId1="_047d07c3-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044f8f29-c766-11e1-8775-005056c00008" p1="4.3931083834818407" q1="-16.353037750006425" p2="-4.3223374411145006" q2="14.597608099396183">
+    <iidm:line id="_04513cd6-c766-11e1-8775-005056c00008" name="90-91" r="4.4256960000000003" x="14.566463499999999" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="31" voltageLevelId1="_047d07c3-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044f8f29-c766-11e1-8775-005056c00008" p1="4.4174789396003149" q1="-16.342857053913797" p2="-4.3467329434026105" q2="14.587432261433522">
         <iidm:alias>_045f94b9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04627ae1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9987,7 +10110,7 @@
             <iidm:temporaryLimit name="_7d2a67fb-9d8c-4745-a67e-ce6ade5e520e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0487b623-c766-11e1-8775-005056c00008" name="22-23" r="5.9590079999999999" x="27.704158799999998" g1="0" b1="0.00011593205" g2="0" b2="0.00011593205" node1="21" voltageLevelId1="_04773b6a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_047f9fdb-c766-11e1-8775-005056c00008" p1="-57.648093405685849" q1="-10.548753014878214" p2="58.906845732024237" q2="12.515134504142358">
+    <iidm:line id="_0487b623-c766-11e1-8775-005056c00008" name="22-23" r="5.9590079999999999" x="27.704158799999998" g1="0" b1="0.00011593205" g2="0" b2="0.00011593205" node1="21" voltageLevelId1="_04773b6a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_047f9fdb-c766-11e1-8775-005056c00008" p1="-55.4941726012961" q1="-11.13509741524693" p2="56.663096590206209" q2="12.673549765307927">
         <iidm:alias>_045e0e18-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0477b095-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9995,7 +10118,7 @@
             <iidm:temporaryLimit name="_6477d99a-dd64-4083-8f56-1396610879f0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048b1189-c766-11e1-8775-005056c00008" name="83-85" r="7.4923200000000003" x="25.787520000000001" g1="0" b1="9.9862250000000004e-05" g2="0" b2="9.9862250000000004e-05" node1="32" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-54.930568202150297" q1="18.474116376974877" p2="56.478540859894451" q2="-16.448110588312026">
+    <iidm:line id="_048b1189-c766-11e1-8775-005056c00008" name="83-85" r="7.4923200000000003" x="25.787520000000001" g1="0" b1="9.9862250000000004e-05" g2="0" b2="9.9862250000000004e-05" node1="32" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-54.758297966035705" q1="19.234111624601574" p2="56.316004312322868" q2="-17.161486182612787">
         <iidm:alias>_0455d0b1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0462c906-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10003,7 +10126,7 @@
             <iidm:temporaryLimit name="_38cb3e5b-af1a-4684-aa2f-242826ed460c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045868c5-c766-11e1-8775-005056c00008" name="17-31" r="8.2589760000000005" x="27.233711199999998" g1="0" b1="0.00011449725" g2="0" b2="0.00011449725" node1="60" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="13.303295185941055" q1="3.1412017545775424" p2="-13.203567033183122" q2="-6.5989673432547038">
+    <iidm:line id="_045868c5-c766-11e1-8775-005056c00008" name="17-31" r="8.2589760000000005" x="27.233711199999998" g1="0" b1="0.00011449725" g2="0" b2="0.00011449725" node1="60" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="17.876390924746158" q1="2.0645962373871636" p2="-17.7113708213111" q2="-5.3082729538689737">
         <iidm:alias>_04544a16-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0467f924-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10011,7 +10134,7 @@
             <iidm:temporaryLimit name="_9066b19a-f404-42c3-88ce-51d375f6fdb5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0488c796-c766-11e1-8775-005056c00008" name="89-90" r="9.0256319999999999" x="32.75712" g1="0" b1="0.00015151515000000001" g2="0" b2="0.00015151515000000001" node1="59" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="59.710042557965146" q1="9.2549194879716516" p2="-57.808666466979616" q2="-7.4423091718434637">
+    <iidm:line id="_0488c796-c766-11e1-8775-005056c00008" name="89-90" r="9.0256319999999999" x="32.75712" g1="0" b1="0.00015151515000000001" g2="0" b2="0.00015151515000000001" node1="59" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="59.719159679966005" q1="9.2605867865944536" p2="-57.81715627107846" q2="-7.4456318893059255">
         <iidm:alias>_0459ef61-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04837069-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10019,7 +10142,7 @@
             <iidm:temporaryLimit name="_924b4a0b-bef5-432a-ad87-ab5c10d9c019" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0462c907-c766-11e1-8775-005056c00008" name="70-75" r="7.4574720000000001" x="24.56784" g1="0" b1="0.0001033058" g2="0" b2="0.0001033058" node1="50" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="9.2711076338045029" q1="6.8650892299891995" p2="-9.2003683240707321" q2="-10.060919146921904">
+    <iidm:line id="_0462c907-c766-11e1-8775-005056c00008" name="70-75" r="7.4574720000000001" x="24.56784" g1="0" b1="0.0001033058" g2="0" b2="0.0001033058" node1="50" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="8.9036646321275192" q1="7.0836446421209329" p2="-8.8342107105233207" q2="-10.284271908621182">
         <iidm:alias>_04649dc9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04784cdb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10027,7 +10150,7 @@
             <iidm:temporaryLimit name="_d432d118-553c-4f4c-a734-e98e0762ec40" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045fbbc3-c766-11e1-8775-005056c00008" name="50-57" r="8.2589760000000005" x="23.34816" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="22" voltageLevelId1="_044d1e26-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="44.124300445541259" q1="6.74096242705662" p2="-43.168747151545951" q2="-7.2622160120957071">
+    <iidm:line id="_045fbbc3-c766-11e1-8775-005056c00008" name="50-57" r="8.2589760000000005" x="23.34816" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="22" voltageLevelId1="_044d1e26-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="44.141819953665461" q1="6.735988318515389" p2="-43.185570895117799" q2="-7.2552641002556912">
         <iidm:alias>_04500455-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0468e383-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10035,7 +10158,7 @@
             <iidm:temporaryLimit name="_2f32bda4-7275-4485-9901-12f8cff9e4a1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044b9789-c766-11e1-8775-005056c00008" name="5-6" r="2.0734560000000002" x="9.4089600000000004" g1="0" b1="4.0920549999999999e-05" g2="0" b2="4.0920549999999999e-05" node1="49" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f6818-c766-11e1-8775-005056c00008" p1="96.223409905665108" q1="18.003413735458203" p2="-95.101169738250007" q2="-14.335290996283495">
+    <iidm:line id="_044b9789-c766-11e1-8775-005056c00008" name="5-6" r="2.0734560000000002" x="9.4089600000000004" g1="0" b1="4.0920549999999999e-05" g2="0" b2="4.0920549999999999e-05" node1="49" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f6818-c766-11e1-8775-005056c00008" p1="91.68401061561336" q1="19.528783618620388" p2="-90.656336868917847" q2="-16.291900110827513">
         <iidm:alias>_044a5f01-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0455d0b2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10043,7 +10166,7 @@
             <iidm:temporaryLimit name="_b3b0e81b-a434-4e9c-ad94-1161ff47b077" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04720b41-c766-11e1-8775-005056c00008" name="55-59" r="8.2572340000000004" x="37.600994100000001" g1="0" b1="0.00016201790000000001" g2="0" b2="0.00016201790000000001" node1="30" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-24.174860842329597" q1="-11.540381711728697" p2="24.523195811570314" q2="7.8330007910416573">
+    <iidm:line id="_04720b41-c766-11e1-8775-005056c00008" name="55-59" r="8.2572340000000004" x="37.600994100000001" g1="0" b1="0.00016201790000000001" g2="0" b2="0.00016201790000000001" node1="30" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-24.158043124846262" q1="-11.545106670305806" p2="24.505997088167273" q2="7.8359918283748078">
         <iidm:alias>_04656113-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04675ce4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10051,7 +10174,7 @@
             <iidm:temporaryLimit name="_6db0d250-4a2e-4169-abf0-f842aeca485d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048963d9-c766-11e1-8775-005056c00008" name="1-2" r="5.2794720000000002" x="17.4065762" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="22" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_045d4ac5-c766-11e1-8775-005056c00008" p1="-10.393112623872975" q1="-10.795192262700191" p2="10.459082669249144" q2="8.6391182895562668">
+    <iidm:line id="_048963d9-c766-11e1-8775-005056c00008" name="1-2" r="5.2794720000000002" x="17.4065762" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="22" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_045d4ac5-c766-11e1-8775-005056c00008" p1="-11.393559564183144" q1="-10.264609761182475" p2="11.463373160462105" q2="8.1200255766950953">
         <iidm:alias>_044b9786-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04845acb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10059,7 +10182,7 @@
             <iidm:temporaryLimit name="_9f39cb45-314c-445e-b177-909854a9ce45" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0484f709-c766-11e1-8775-005056c00008" name="11-12" r="1.0367280000000001" x="3.4151039999999999" g1="0" b1="1.4405399999999999e-05" g2="0" b2="1.4405399999999999e-05" node1="40" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="40.034372160744653" q1="-28.251452622705781" p2="-39.888512992471348" q2="28.241505926206699">
+    <iidm:line id="_0484f709-c766-11e1-8775-005056c00008" name="11-12" r="1.0367280000000001" x="3.4151039999999999" g1="0" b1="1.4405399999999999e-05" g2="0" b2="1.4405399999999999e-05" node1="40" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="34.71130023207558" q1="-24.419006320894159" p2="-34.602072487751137" q2="24.28816681163989">
         <iidm:alias>_0456e227-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04880440-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10067,7 +10190,7 @@
             <iidm:temporaryLimit name="_70fad3e1-4529-4a7f-9e6c-8ab249d65460" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044bbe91-c766-11e1-8775-005056c00008" name="8-9" r="1.18096" x="14.762" g1="0" b1="0.001200413215" g2="0" b2="0.001200413215" node1="31" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_045c8779-c766-11e1-8775-005056c00008" p1="-486.87866376595952" q1="-85.24961753253919" p2="492.61807771463168" q2="35.941314328359653">
+    <iidm:line id="_044bbe91-c766-11e1-8775-005056c00008" name="8-9" r="1.18096" x="14.762" g1="0" b1="0.001200413215" g2="0" b2="0.001200413215" node1="31" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_045c8779-c766-11e1-8775-005056c00008" p1="-486.83326684974082" q1="-82.641210266722553" p2="492.54489301644543" q2="32.614298845617597">
         <iidm:alias>_04745535-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048a7548-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="2000">
@@ -10075,7 +10198,7 @@
             <iidm:temporaryLimit name="_205e5d8a-f05a-479d-adaa-3514f48f6857" acceptableDuration="60" value="2400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04566cf8-c766-11e1-8775-005056c00008" name="64-65" r="1.30196" x="14.6168" g1="0" b1="0.000392562" g2="0" b2="0.000392562" node1="35" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-157.22584683342282" q1="-33.965048215300378" p2="157.90370334855004" q2="3.5728595572519088">
+    <iidm:line id="_04566cf8-c766-11e1-8775-005056c00008" name="64-65" r="1.30196" x="14.6168" g1="0" b1="0.000392562" g2="0" b2="0.000392562" node1="35" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-157.18609628575047" q1="-33.967575003536801" p2="157.86361401090031" q2="3.5715457153623884">
         <iidm:alias>_044a10e2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04793738-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10083,7 +10206,7 @@
             <iidm:temporaryLimit name="_8cee2b62-2953-439b-ba4b-4a48d55116c0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046783f3-c766-11e1-8775-005056c00008" name="54-56" r="0.47915999999999997" x="1.6639919999999999" g1="0" b1="2.1005500000000001e-05" g2="0" b2="2.1005500000000001e-05" node1="60" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="29.588084244398782" q1="2.6890676112589635" p2="-29.561411409557138" q2="-3.2632387208770695">
+    <iidm:line id="_046783f3-c766-11e1-8775-005056c00008" name="54-56" r="0.47915999999999997" x="1.6639919999999999" g1="0" b1="2.1005500000000001e-05" g2="0" b2="2.1005500000000001e-05" node1="60" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="29.600197181799999" q1="2.6882373591903539" p2="-29.573502882398046" q2="-3.262333792693628">
         <iidm:alias>_0460f444-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d2949-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10091,7 +10214,7 @@
             <iidm:temporaryLimit name="_640627c7-0672-413e-8dc8-c9965709a5cb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04670ec6-c766-11e1-8775-005056c00008" name="84-85" r="5.2620480000000001" x="11.1687832" g1="0" b1="3.541095e-05" g2="0" b2="3.541095e-05" node1="21" voltageLevelId1="_047b0bf4-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-44.56837237034248" q1="13.863653820423952" p2="45.275541633025249" q2="-13.525273765159652">
+    <iidm:line id="_04670ec6-c766-11e1-8775-005056c00008" name="84-85" r="5.2620480000000001" x="11.1687832" g1="0" b1="3.541095e-05" g2="0" b2="3.541095e-05" node1="21" voltageLevelId1="_047b0bf4-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-44.367514085657369" q1="14.353456129633441" p2="45.076710281263338" q2="-14.005142586525283">
         <iidm:alias>_0453fbf5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046512f7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10099,7 +10222,7 @@
             <iidm:temporaryLimit name="_8b888209-5038-4b98-80fc-062b5ea55747" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0460cd36-c766-11e1-8775-005056c00008" name="34-36" r="1.51763" x="4.669632" g1="0" b1="1.6299349999999998e-05" g2="0" b2="1.6299349999999998e-05" node1="43" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="34.8215490462931" q1="11.034268420625391" p2="-34.691365820317486" q2="-11.139521465896252">
+    <iidm:line id="_0460cd36-c766-11e1-8775-005056c00008" name="34-36" r="1.51763" x="4.669632" g1="0" b1="1.6299349999999998e-05" g2="0" b2="1.6299349999999998e-05" node1="43" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="34.90970223674082" q1="11.009682145127067" p2="-34.778905576200636" q2="-11.112773166915762">
         <iidm:alias>_046a6a26-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0487b620-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10107,7 +10230,7 @@
             <iidm:temporaryLimit name="_c0a08025-3a61-4d24-9944-f3ef0b079f64" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04549836-c766-11e1-8775-005056c00008" name="24-70" r="0.38507000000000002" x="71.699759999999998" g1="0" b1="0.00029264234999999998" g2="0" b2="0.00029264234999999998" node1="32" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="18.613001897413113" q1="-1.3978509345666876" p2="-18.604994350538288" q2="-7.113582719103495">
+    <iidm:line id="_04549836-c766-11e1-8775-005056c00008" name="24-70" r="0.38507000000000002" x="71.699759999999998" g1="0" b1="0.00029264234999999998" g2="0" b2="0.00029264234999999998" node1="32" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="17.801504572320919" q1="-1.2181344550605144" p2="-17.794139817893612" q2="-7.4265332171984753">
         <iidm:alias>_04549834-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04854522-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10115,7 +10238,7 @@
             <iidm:temporaryLimit name="_32793450-bbfd-4dcd-a911-89e199600780" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0452273a-c766-11e1-8775-005056c00008" name="85-86" r="6.0983999999999998" x="21.431519999999999" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="50" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0484f70a-c766-11e1-8775-005056c00008" p1="21.23312683989618" q1="12.279443329845607" p2="-20.998261246820373" q2="-14.002459410864368">
+    <iidm:line id="_0452273a-c766-11e1-8775-005056c00008" name="85-86" r="6.0983999999999998" x="21.431519999999999" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="50" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0484f70a-c766-11e1-8775-005056c00008" p1="21.281948491215431" q1="16.351816870051373" p2="-20.997894138877914" q2="-17.87481800905406">
         <iidm:alias>_044afb43-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479fa85-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10123,7 +10246,7 @@
             <iidm:temporaryLimit name="_2ec4bef5-7abb-4f52-bb62-49ee474d672b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0450eeb5-c766-11e1-8775-005056c00008" name="16-17" r="7.9104960000000002" x="31.380622899999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="22" voltageLevelId1="_046f7338-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-8.5187333290590015" q1="-0.97429024610370496" p2="8.5538228171522448" q2="-3.3658660017983912">
+    <iidm:line id="_0450eeb5-c766-11e1-8775-005056c00008" name="16-17" r="7.9104960000000002" x="31.380622899999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="22" voltageLevelId1="_046f7338-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-15.480468699103813" q1="0.81052101270526666" p2="15.598239657666218" q2="-4.824296441423698">
         <iidm:alias>_044ef2ea-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04837066-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10131,7 +10254,7 @@
             <iidm:temporaryLimit name="_9280074c-8555-49ff-9e62-8ed8f7d95060" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048a4e33-c766-11e1-8775-005056c00008" name="62-66" r="8.3983679999999996" x="37.984317799999999" g1="0" b1="0.00016586315" g2="0" b2="0.00016586315" node1="41" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-15.279173951074801" q1="-21.570132619319658" p2="15.561888259663464" q2="16.816671370529814">
+    <iidm:line id="_048a4e33-c766-11e1-8775-005056c00008" name="62-66" r="8.3983679999999996" x="37.984317799999999" g1="0" b1="0.00016586315" g2="0" b2="0.00016586315" node1="41" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-15.293641771767309" q1="-21.566372958085907" p2="15.576502353555261" q2="16.813575280026509">
         <iidm:alias>_046e13a9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a96c7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10139,7 +10262,7 @@
             <iidm:temporaryLimit name="_ace48562-0a49-4b76-ae82-c896a00b04f9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0478e913-c766-11e1-8775-005056c00008" name="76-77" r="7.736256" x="25.787520000000001" g1="0" b1="0.00010560145" g2="0" b2="0.00010560145" node1="21" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-62.109764667594604" q1="-21.351745498537479" p2="64.251812767659771" q2="25.022237926264257">
+    <iidm:line id="_0478e913-c766-11e1-8775-005056c00008" name="76-77" r="7.736256" x="25.787520000000001" g1="0" b1="0.00010560145" g2="0" b2="0.00010560145" node1="21" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-62.235843787612609" q1="-21.250508328364141" p2="64.384110627050021" q2="24.942490010811113">
         <iidm:alias>_044b9785-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04725965-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10147,7 +10270,7 @@
             <iidm:temporaryLimit name="_3f744dba-88dc-4d89-90d4-a6f196054b28" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048badc1-c766-11e1-8775-005056c00008" name="60-62" r="2.1431520000000002" x="9.7748640000000009" g1="0" b1="4.2125800000000002e-05" g2="0" b2="4.2125800000000002e-05" node1="32" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="-0.54507911981838464" q1="-8.6218448919960977" p2="0.5529071364209126" q2="7.2049251960135967">
+    <iidm:line id="_048badc1-c766-11e1-8775-005056c00008" name="60-62" r="2.1431520000000002" x="9.7748640000000009" g1="0" b1="4.2125800000000002e-05" g2="0" b2="4.2125800000000002e-05" node1="32" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="-0.55285273111876976" q1="-8.6196845674715998" p2="0.56067754643089007" q2="7.2027497115528512">
         <iidm:alias>_045b7600-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04720b44-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10155,7 +10278,7 @@
             <iidm:temporaryLimit name="_43f91aaf-c5f4-4995-85a2-37afac616331" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0472a780-c766-11e1-8775-005056c00008" name="27-28" r="3.3332109999999999" x="14.89752" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="42" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04819ba0-c766-11e1-8775-005056c00008" p1="34.416752891196424" q1="-1.0353553901765844" p2="-34.174750397456407" q2="0.10759173935383157">
+    <iidm:line id="_0472a780-c766-11e1-8775-005056c00008" name="27-28" r="3.3332109999999999" x="14.89752" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="42" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04819ba0-c766-11e1-8775-005056c00008" p1="32.440309941653908" q1="-1.2819379158898669" p2="-32.225998267904785" q2="0.22257966398204679">
         <iidm:alias>_04531198-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0475188b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10163,7 +10286,7 @@
             <iidm:temporaryLimit name="_2c20e8bd-84e6-4a1e-b88e-071f631327cb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c81e1-c766-11e1-8775-005056c00008" name="45-46" r="6.9695999999999998" x="23.626943600000001" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="31" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="34" voltageLevelId2="_048a7544-c766-11e1-8775-005056c00008" p1="-33.845973340365546" q1="-6.702298886390734" p2="34.330729117434885" q2="5.0642548415111603">
+    <iidm:line id="_044c81e1-c766-11e1-8775-005056c00008" name="45-46" r="6.9695999999999998" x="23.626943600000001" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="31" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="34" voltageLevelId2="_048a7544-c766-11e1-8775-005056c00008" p1="-33.705058664200351" q1="-6.7509046564085002" p2="34.186081932929469" q2="5.1002079713765305">
         <iidm:alias>_04561ed6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045c877a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10171,7 +10294,7 @@
             <iidm:temporaryLimit name="_6ad31f7e-233f-4801-898f-9ffc883ec724" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c1249-c766-11e1-8775-005056c00008" name="18-19" r="1.949746" x="8.5900320000000008" g1="0" b1="3.2770900000000002e-05" g2="0" b2="3.2770900000000002e-05" node1="22" voltageLevelId1="_04689563-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="51.022653947321054" q1="0.50231247027559822" p2="-50.697878020411395" q2="-0.089505465141739848">
+    <iidm:line id="_045c1249-c766-11e1-8775-005056c00008" name="18-19" r="1.949746" x="8.5900320000000008" g1="0" b1="3.2770900000000002e-05" g2="0" b2="3.2770900000000002e-05" node1="22" voltageLevelId1="_04689563-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="55.081902127222207" q1="-0.38537583132400299" p2="-54.703636236731278" q2="1.0335365888515142">
         <iidm:alias>_046b066b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047ae4e0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10179,7 +10302,7 @@
             <iidm:temporaryLimit name="_a025c9d8-58f9-4320-a1fe-73ecc68d4147" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044a5f09-c766-11e1-8775-005056c00008" name="9-10" r="1.2487200000000001" x="15.584800700000001" g1="0" b1="0.0012706611300000001" g2="0" b2="0.0012706611300000001" node1="21" voltageLevelId1="_045c8779-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_044f4102-c766-11e1-8775-005056c00008" p1="-492.61807771463185" q1="-35.941314328359319" p2="498.47624982654679" q2="-24.721527058846871">
+    <iidm:line id="_044a5f09-c766-11e1-8775-005056c00008" name="9-10" r="1.2487200000000001" x="15.584800700000001" g1="0" b1="0.0012706611300000001" g2="0" b2="0.0012706611300000001" node1="21" voltageLevelId1="_045c8779-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_044f4102-c766-11e1-8775-005056c00008" p1="-492.54489301644543" q1="-32.614298845618158" p2="498.39423901235148" q2="-28.298430019830967">
         <iidm:alias>_04614262-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04834957-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="2000">
@@ -10187,7 +10310,7 @@
             <iidm:temporaryLimit name="_b7fac0a3-c5af-48b9-af49-261fd8d46e00" acceptableDuration="60" value="2400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0480b14b-c766-11e1-8775-005056c00008" name="85-88" r="3.4847999999999999" x="17.772480000000002" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="51" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0470f9d2-c766-11e1-8775-005056c00008" p1="-63.129555196482812" q1="5.0253697698599273" p2="63.979765216162811" q2="-3.3261781566409407">
+    <iidm:line id="_0480b14b-c766-11e1-8775-005056c00008" name="85-88" r="3.4847999999999999" x="17.772480000000002" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="51" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0470f9d2-c766-11e1-8775-005056c00008" p1="-63.030146681381581" q1="3.587416094466561" p2="63.878706343598665" q2="-1.8870215984663736">
         <iidm:alias>_047602e2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04765105-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10195,7 +10318,7 @@
             <iidm:temporaryLimit name="_51646744-d343-42b5-8ba7-fcedc7cc3a98" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04486330-c766-11e1-8775-005056c00008" name="69-77" r="5.3840159999999999" x="17.598240000000001" g1="0" b1="0.00029786500000000002" g2="0" b2="0.00029786500000000002" node1="60" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="32.370442867169629" q1="17.956794791049685" p2="-31.90866449841004" q2="-27.225022780357772">
+    <iidm:line id="_04486330-c766-11e1-8775-005056c00008" name="69-77" r="5.3840159999999999" x="17.598240000000001" g1="0" b1="0.00029786500000000002" g2="0" b2="0.00029786500000000002" node1="60" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="32.475505306226118" q1="18.071261831090986" p2="-32.010205030740913" q2="-27.32650812595357">
         <iidm:alias>_046205b9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479d379-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10203,7 +10326,7 @@
             <iidm:temporaryLimit name="_76311a15-b79a-4439-a7ce-47afa8fa6fe2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04553477-c766-11e1-8775-005056c00008" name="11-13" r="3.8768400000000001" x="12.7369442" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="41" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04851e1b-c766-11e1-8775-005056c00008" p1="50.325053799540356" q1="14.718146171754643" p2="-49.690545822572574" q2="-14.419473507219447">
+    <iidm:line id="_04553477-c766-11e1-8775-005056c00008" name="11-13" r="3.8768400000000001" x="12.7369442" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="41" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04851e1b-c766-11e1-8775-005056c00008" p1="45.836906144397446" q1="15.772017462874203" p2="-45.293722947777518" q2="-15.775263476114437">
         <iidm:alias>_0479fa89-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0485452a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10211,7 +10334,7 @@
             <iidm:temporaryLimit name="_efbf8de7-4b84-4834-bb7c-6250b6072211" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04488a45-c766-11e1-8775-005056c00008" name="103-105" r="9.3218399999999999" x="28.314" g1="0" b1="0.0001170799" g2="0" b2="0.0001170799" node1="42" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="43.796923507651336" q1="12.535076726082384" p2="-42.678882943058923" q2="-13.121140612242122">
+    <iidm:line id="_04488a45-c766-11e1-8775-005056c00008" name="103-105" r="9.3218399999999999" x="28.314" g1="0" b1="0.0001170799" g2="0" b2="0.0001170799" node1="42" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="43.796811122186803" q1="12.535169424608913" p2="-42.678774508021476" q2="-13.121245693410147">
         <iidm:alias>_044f8f24-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04611b58-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10219,7 +10342,7 @@
             <iidm:temporaryLimit name="_22b6919a-a7a0-49fc-9e90-329069c55055" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046009e6-c766-11e1-8775-005056c00008" name="45-49" r="11.918016400000001" x="32.408639999999998" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="32" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="118" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-40.847496440016137" q1="-7.8273638309714215" p2="42.050912360449644" q2="6.6213466033541861">
+    <iidm:line id="_046009e6-c766-11e1-8775-005056c00008" name="45-49" r="11.918016400000001" x="32.408639999999998" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="32" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="118" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-40.709189505566393" q1="-7.8898832211006829" p2="41.905130133551594" q2="6.6635391729119853">
         <iidm:alias>_044ca8f9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047dcb1b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10227,7 +10350,7 @@
             <iidm:temporaryLimit name="_8b91f4fd-4038-45b7-870c-fbc08592b95a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046a6a27-c766-11e1-8775-005056c00008" name="88-89" r="2.4219360000000001" x="12.4058876" g1="0" b1="5.549815e-05" g2="0" b2="5.549815e-05" node1="22" voltageLevelId1="_0470f9d2-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-111.97891436502651" q1="-6.6735246836429116" p2="113.79199015113639" q2="14.051905048931317">
+    <iidm:line id="_046a6a27-c766-11e1-8775-005056c00008" name="88-89" r="2.4219360000000001" x="12.4058876" g1="0" b1="5.549815e-05" g2="0" b2="5.549815e-05" node1="22" voltageLevelId1="_0470f9d2-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-111.87774541092155" q1="-8.1126409109576993" p2="113.6940779585847" q2="15.509672060744343">
         <iidm:alias>_045ef879-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04649dc1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10235,7 +10358,7 @@
             <iidm:temporaryLimit name="_970bc323-73bf-440d-a3c5-00aebc3a1992" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048a7540-c766-11e1-8775-005056c00008" name="80-98" r="4.1469120000000004" x="18.817920000000001" g1="0" b1="8.20707e-05" g2="0" b2="8.20707e-05" node1="79" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04773b62-c766-11e1-8775-005056c00008" p1="11.314587197675809" q1="11.998177129939732" p2="-11.246047063389323" q2="-14.731495306355525">
+    <iidm:line id="_048a7540-c766-11e1-8775-005056c00008" name="80-98" r="4.1469120000000004" x="18.817920000000001" g1="0" b1="8.20707e-05" g2="0" b2="8.20707e-05" node1="79" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04773b62-c766-11e1-8775-005056c00008" p1="11.321444929561466" q1="11.996554467900687" p2="-11.252880317332972" q2="-14.729762504865215">
         <iidm:alias>_045338a2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04887972-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10243,7 +10366,7 @@
             <iidm:temporaryLimit name="_cb084dc7-1b26-415f-9495-4695df661912" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04640183-c766-11e1-8775-005056c00008" name="91-92" r="6.7430880000000002" x="22.163329999999998" g1="0" b1="9.3778700000000004e-05" g2="0" b2="9.3778700000000004e-05" node1="22" voltageLevelId1="_044f8f29-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="-5.6776119358413251" q1="-14.597608056519668" p2="5.7610180362974894" q2="11.734528551415515">
+    <iidm:line id="_04640183-c766-11e1-8775-005056c00008" name="91-92" r="6.7430880000000002" x="22.163329999999998" g1="0" b1="9.3778700000000004e-05" g2="0" b2="9.3778700000000004e-05" node1="22" voltageLevelId1="_044f8f29-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="-5.6532188950745352" q1="-14.587432193604835" p2="5.7364079155400107" q2="11.723894473578484">
         <iidm:alias>_04492680-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_044c5ad5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10251,7 +10374,7 @@
             <iidm:temporaryLimit name="_3a165a76-f6ba-461b-84d6-159a5e0b5077" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0474a358-c766-11e1-8775-005056c00008" name="7-12" r="1.501949" x="5.9241599999999996" g1="0" b1="2.5080350000000001e-05" g2="0" b2="2.5080350000000001e-05" node1="22" voltageLevelId1="_047eb571-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="24.006985422279275" q1="-9.5357046196997999" p2="-23.948873347703916" q2="8.9092436275727298">
+    <iidm:line id="_0474a358-c766-11e1-8775-005056c00008" name="7-12" r="1.501949" x="5.9241599999999996" g1="0" b1="2.5080350000000001e-05" g2="0" b2="2.5080350000000001e-05" node1="22" voltageLevelId1="_047eb571-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="19.58056984872205" q1="-7.4956333958490173" p2="-19.542398346005228" q2="6.7902352376007515">
         <iidm:alias>_046ab848-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0477feb7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10259,7 +10382,7 @@
             <iidm:temporaryLimit name="_b19bc945-cc51-4d77-8eaa-3f6afe2d9316" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04765108-c766-11e1-8775-005056c00008" name="99-100" r="3.13632" x="14.165711399999999" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_04644fa4-c766-11e1-8775-005056c00008" node2="80" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-40.131461292443362" q1="12.309920221811183" p2="40.441295227155813" q2="-13.151267294561702">
+    <iidm:line id="_04765108-c766-11e1-8775-005056c00008" name="99-100" r="3.13632" x="14.165711399999999" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_04644fa4-c766-11e1-8775-005056c00008" node2="80" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-40.124579386747364" q1="12.308326445274805" p2="40.434310226267058" q2="-13.150139892185111">
         <iidm:alias>_0471e436-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047e4040-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10267,7 +10390,7 @@
             <iidm:temporaryLimit name="_a9e283ed-fcad-4f4c-ab57-8531875bb098" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047b8128-c766-11e1-8775-005056c00008" name="114-115" r="0.400752" x="1.8120959999999999" g1="0" b1="7.9201000000000006e-06" g2="0" b2="7.9201000000000006e-06" node1="22" voltageLevelId1="_04791027-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="-1.7279608675120417" q1="2.8744529949101909" p2="1.7282594012796144" q2="-3.1281508991336713">
+    <iidm:line id="_047b8128-c766-11e1-8775-005056c00008" name="114-115" r="0.400752" x="1.8120959999999999" g1="0" b1="7.9201000000000006e-06" g2="0" b2="7.9201000000000006e-06" node1="22" voltageLevelId1="_04791027-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="-0.60803041078333431" q1="2.2973336906688013" p2="0.60818553011492849" q2="-2.5524000925827037">
         <iidm:alias>_046c17d3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d0233-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10275,7 +10398,7 @@
             <iidm:temporaryLimit name="_c59e4022-b1c0-4811-a32e-f54656bff32d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046931a5-c766-11e1-8775-005056c00008" name="83-84" r="10.890000000000001" x="22.999680000000001" g1="0" b1="7.4035799999999993e-05" g2="0" b2="7.4035799999999993e-05" node1="33" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b0bf4-c766-11e1-8775-005056c00008" p1="-32.559832833597419" q1="20.558493907169879" p2="33.568759813615046" q2="-20.863241698109501">
+    <iidm:line id="_046931a5-c766-11e1-8775-005056c00008" name="83-84" r="10.890000000000001" x="22.999680000000001" g1="0" b1="7.4035799999999993e-05" g2="0" b2="7.4035799999999993e-05" node1="33" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b0bf4-c766-11e1-8775-005056c00008" p1="-32.35029875161009" q1="21.075442660729642" p2="33.367956074329896" q2="-21.3529847113256">
         <iidm:alias>_0465d645-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479102b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10283,7 +10406,7 @@
             <iidm:temporaryLimit name="_1268eb09-e233-44ce-b8af-22dc30eb16ad" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047ae4ea-c766-11e1-8775-005056c00008" name="14-15" r="10.367279999999999" x="33.976799999999997" g1="0" b1="0.0001440542" g2="0" b2="0.0001440542" node1="21" voltageLevelId1="_047b8129-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="21.9131772330262" q1="5.3724612179964284" p2="-21.576760449834914" q2="-8.9340051058638856">
+    <iidm:line id="_047ae4ea-c766-11e1-8775-005056c00008" name="14-15" r="10.367279999999999" x="33.976799999999997" g1="0" b1="0.0001440542" g2="0" b2="0.0001440542" node1="21" voltageLevelId1="_047b8129-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="16.93519765000503" q1="6.7414200245050138" p2="-16.704799492742115" q2="-10.651953871751402">
         <iidm:alias>_0449e9d9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046ed6fa-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10291,7 +10414,7 @@
             <iidm:temporaryLimit name="_9c0c454b-ecc3-40f6-b505-f32fec412522" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046e3ab2-c766-11e1-8775-005056c00008" name="80-96" r="6.2029439999999996" x="31.711680000000001" g1="0" b1="0.0001417585" g2="0" b2="0.0001417585" node1="80" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="4.5908854051104004" q1="26.216437772555761" p2="-4.309274087274928" q2="-29.858763845463933">
+    <iidm:line id="_046e3ab2-c766-11e1-8775-005056c00008" name="80-96" r="6.2029439999999996" x="31.711680000000001" g1="0" b1="0.0001417585" g2="0" b2="0.0001417585" node1="80" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="4.6330368902137504" q1="26.415716032058441" p2="-4.3474949865918573" q2="-30.036176237273395">
         <iidm:alias>_045338a4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04865695-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10299,7 +10422,7 @@
             <iidm:temporaryLimit name="_1432f4d6-9299-4b0d-bd7f-16e059f9de66" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04893cc4-c766-11e1-8775-005056c00008" name="56-59" r="13.9914722" x="41.643360000000001" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="59" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-20.130617170255352" q1="-7.6773002548765383" p2="20.51250042149627" q2="3.7753665031119135">
+    <iidm:line id="_04893cc4-c766-11e1-8775-005056c00008" name="56-59" r="13.9914722" x="41.643360000000001" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="59" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-20.115555912756804" q1="-7.6832611384249505" p2="20.496959528096614" q2="3.7799007847453479">
         <iidm:alias>_046b5484-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04798557-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10307,7 +10430,7 @@
             <iidm:temporaryLimit name="_193f6952-4267-4cc8-a541-726c095028ba" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c1243-c766-11e1-8775-005056c00008" name="92-100" r="11.290752400000001" x="51.400799999999997" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="71" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="36.850468413626224" q1="-17.280438746700494" p2="-35.803284170545382" q2="17.2963938936476">
+    <iidm:line id="_045c1243-c766-11e1-8775-005056c00008" name="92-100" r="11.290752400000001" x="51.400799999999997" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="71" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="36.887678205709541" q1="-17.29997857564587" p2="-35.838177459747683" q2="17.326717152133988">
         <iidm:alias>_045e8348-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045ed164-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10315,7 +10438,7 @@
             <iidm:temporaryLimit name="_579249ce-1c81-4d29-8d3f-5fc627a18f99" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0474a356-c766-11e1-8775-005056c00008" name="43-44" r="10.593792000000001" x="42.7584953" g1="0" b1="0.00017412765" g2="0" b2="0.00017412765" node1="22" voltageLevelId1="_045e8349-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04544a15-c766-11e1-8775-005056c00008" p1="-5.5093663008450786" q1="-10.781956924824238" p2="5.5731765319238713" q2="5.407791661205489">
+    <iidm:line id="_0474a356-c766-11e1-8775-005056c00008" name="43-44" r="10.593792000000001" x="42.7584953" g1="0" b1="0.00017412765" g2="0" b2="0.00017412765" node1="22" voltageLevelId1="_045e8349-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04544a15-c766-11e1-8775-005056c00008" p1="-5.2320452233116574" q1="-10.903011456911473" p2="5.2952060806149612" q2="5.5275101785275904">
         <iidm:alias>_04642899-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047b0bf2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10323,7 +10446,7 @@
             <iidm:temporaryLimit name="_3d2cb4b5-ee82-4866-9855-4a5f4803cd3b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04627ae6-c766-11e1-8775-005056c00008" name="109-110" r="4.8438720000000002" x="13.2770882" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="22" voltageLevelId1="_046b7b99-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="12.727413927283484" q1="-2.965741126335387" p2="-12.67698584585761" q2="1.2576148629326629">
+    <iidm:line id="_04627ae6-c766-11e1-8775-005056c00008" name="109-110" r="4.8438720000000002" x="13.2770882" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="22" voltageLevelId1="_046b7b99-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="12.730598676051889" q1="-2.9669194139033088" p2="-12.680144517140718" q2="1.2588648987263382">
         <iidm:alias>_0466e7b5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a6fbb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10331,7 +10454,7 @@
             <iidm:temporaryLimit name="_6fc48d8d-05f8-4104-a6a2-3686d430a091" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0478c207-c766-11e1-8775-005056c00008" name="68-81" r="0.84699999999999998" x="9.7767990000000005" g1="0" b1="0.00083471078000000004" g2="0" b2="0.00083471078000000004" node1="38" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_048a272b-c766-11e1-8775-005056c00008" p1="-151.75961892504637" q1="-3.7377184900301232" p2="152.18719005352878" q2="-71.568975484716063">
+    <iidm:line id="_0478c207-c766-11e1-8775-005056c00008" name="68-81" r="0.84699999999999998" x="9.7767990000000005" g1="0" b1="0.00083471078000000004" g2="0" b2="0.00083471078000000004" node1="38" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_048a272b-c766-11e1-8775-005056c00008" p1="-151.15305917094884" q1="-3.801037046985595" p2="151.57732226884798" q2="-71.544320724626303">
         <iidm:alias>_044a37f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045b4ef6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10339,7 +10462,7 @@
             <iidm:temporaryLimit name="_191836a1-39cd-402b-8dcf-4f3867c45bd0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0467d215-c766-11e1-8775-005056c00008" name="85-89" r="4.1643359999999996" x="30.143518400000001" g1="0" b1="0.00013487144999999999" g2="0" b2="0.00013487144999999999" node1="52" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-83.856817616218748" q1="-2.330554706889659" p2="85.631655010893851" q2="10.578864160463835">
+    <iidm:line id="_0467d215-c766-11e1-8775-005056c00008" name="85-89" r="4.1643359999999996" x="30.143518400000001" g1="0" b1="0.00013487144999999999" g2="0" b2="0.00013487144999999999" node1="52" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-83.643543043142841" q1="-3.7715843649155909" p2="85.419227377210476" q2="12.037620438151556">
         <iidm:alias>_047629f9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0478e915-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10347,7 +10470,7 @@
             <iidm:temporaryLimit name="_66cbdeeb-a4e4-4bfc-aec1-9fb7a2d2b6bc" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044a37f2-c766-11e1-8775-005056c00008" name="89-90" r="4.1469120000000004" x="17.371727" g1="0" b1="0.00030417815" g2="0" b2="0.00030417815" node1="62" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="112.74585226344655" q1="21.235127546163557" p2="-109.58393301867797" q2="-18.204429987600808">
+    <iidm:line id="_044a37f2-c766-11e1-8775-005056c00008" name="89-90" r="4.1469120000000004" x="17.371727" g1="0" b1="0.00030417815" g2="0" b2="0.00030417815" node1="62" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="112.76281471042289" q1="21.24650172398848" p2="-109.5998522588129" q2="-18.211297921601869">
         <iidm:alias>_045386c2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048719e9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10355,7 +10478,7 @@
             <iidm:temporaryLimit name="_8489e809-6588-4ed2-a9a4-43c44a0d47da" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04658820-c766-11e1-8775-005056c00008" name="98-100" r="6.9173280000000004" x="31.188960999999999" g1="0" b1="0.0001365932" g2="0" b2="0.0001365932" node1="22" voltageLevelId1="_04773b62-c766-11e1-8775-005056c00008" node2="82" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-22.753919520866955" q1="6.731508894973846" p2="22.982430276252867" q2="-10.655400317838494">
+    <iidm:line id="_04658820-c766-11e1-8775-005056c00008" name="98-100" r="6.9173280000000004" x="31.188960999999999" g1="0" b1="0.0001365932" g2="0" b2="0.0001365932" node1="22" voltageLevelId1="_04773b62-c766-11e1-8775-005056c00008" node2="82" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-22.747092806390771" q1="6.7297743612761582" p2="22.975473583750659" q2="-10.654253510142633">
         <iidm:alias>_046f4c22-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046fe865-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10363,7 +10486,7 @@
             <iidm:temporaryLimit name="_620beaaf-63c8-4020-bea5-c3609c0eaadf" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c5ada-c766-11e1-8775-005056c00008" name="28-29" r="4.1294880000000003" x="16.430831900000001" g1="0" b1="6.8296599999999999e-05" g2="0" b2="6.8296599999999999e-05" node1="22" voltageLevelId1="_04819ba0-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04588fd5-c766-11e1-8775-005056c00008" p1="17.174539423800002" q1="-7.1077365398545815" p2="-17.089641854063313" q2="5.2417695717660502">
+    <iidm:line id="_044c5ada-c766-11e1-8775-005056c00008" name="28-29" r="4.1294880000000003" x="16.430831900000001" g1="0" b1="6.8296599999999999e-05" g2="0" b2="6.8296599999999999e-05" node1="22" voltageLevelId1="_04819ba0-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04588fd5-c766-11e1-8775-005056c00008" p1="15.224809474430595" q1="-5.0124804545831001" p2="-15.161735382817248" q2="3.0535043158095103">
         <iidm:alias>_0461697a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04697fc1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10371,7 +10494,13 @@
             <iidm:temporaryLimit name="_6748d0d0-aec8-4b7b-a9ab-be6aecda7c5d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0468e382-c766-11e1-8775-005056c00008" name="3-5" r="4.1991839999999998" x="18.817920000000001" g1="0" b1="8.1496799999999995e-05" g2="0" b2="8.1496799999999995e-05" node1="31" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-72.576994478078532" q1="-15.754273281075909" p2="73.972110224172837" q2="19.216230460754851">
+    <iidm:line id="_044c5ada-c766-11e1-8775-005056c00008-1" name="28-29-open-ended" r="4.1294880000000003" x="16.430831900000001" g1="0" b1="6.8296599999999999e-05" g2="0" b2="6.8296599999999999e-05" node1="25" voltageLevelId1="_04819ba0-c766-11e1-8775-005056c00008" node2="25" voltageLevelId2="_04588fd5-c766-11e1-8775-005056c00008" p1="0.00031226737844620772" q1="-2.2107007961728442" p2="0" q2="0">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_accb8136-1faf-4399-9787-3cd567284fd2-1" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_6748d0d0-aec8-4b7b-a9ab-be6aecda7c5d-1" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0468e382-c766-11e1-8775-005056c00008" name="3-5" r="4.1991839999999998" x="18.817920000000001" g1="0" b1="8.1496799999999995e-05" g2="0" b2="8.1496799999999995e-05" node1="31" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-70.253405447366688" q1="-16.928912325743685" p2="71.571719176640201" q2="20.042786040530792">
         <iidm:alias>_046b0668-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04742e24-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10379,7 +10508,7 @@
             <iidm:temporaryLimit name="_828ca44c-560b-4f94-b825-21e237285fae" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0447c6f1-c766-11e1-8775-005056c00008" name="82-96" r="2.8226879999999999" x="9.2347199999999994" g1="0" b1="0.00015610649999999999" g2="0" b2="0.00015610649999999999" node1="33" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="-15.544983969781454" q1="-8.8524370210090932" p2="15.592106589297291" q2="3.729615057457198">
+    <iidm:line id="_0447c6f1-c766-11e1-8775-005056c00008" name="82-96" r="2.8226879999999999" x="9.2347199999999994" g1="0" b1="0.00015610649999999999" g2="0" b2="0.00015610649999999999" node1="33" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="-15.747240572715985" q1="-9.5669572305458868" p2="15.797098211542909" q2="4.4592497260485722">
         <iidm:alias>_0478e91a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0480d856-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10387,7 +10516,7 @@
             <iidm:temporaryLimit name="_233b7735-85f4-4a6f-9d87-15129fe42ef5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0483e594-c766-11e1-8775-005056c00008" name="38-65" r="4.3608399999999996" x="47.7224" g1="0" b1="0.0010805785" g2="0" b2="0.0010805785" node1="29" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-165.78772214431129" q1="-93.418035703829545" p2="168.95968497865888" q2="30.904241850996822">
+    <iidm:line id="_0483e594-c766-11e1-8775-005056c00008" name="38-65" r="4.3608399999999996" x="47.7224" g1="0" b1="0.0010805785" g2="0" b2="0.0010805785" node1="29" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-164.40464260924469" q1="-93.828425950095067" p2="167.53282096490938" q2="30.84035145996009">
         <iidm:alias>_04638c56-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d5054-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10395,7 +10524,7 @@
             <iidm:temporaryLimit name="_990ce3c5-c90c-41b9-abee-fb803d9df3a5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04784cd4-c766-11e1-8775-005056c00008" name="106-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_04479fe8-c766-11e1-8775-005056c00008" node2="24" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="23.852169243717753" q1="-0.6943306062476382" p2="-23.523781171802298" q2="-2.4553299088890883">
+    <iidm:line id="_04784cd4-c766-11e1-8775-005056c00008" name="106-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_04479fe8-c766-11e1-8775-005056c00008" node2="24" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="23.852393275585047" q1="-0.69440596564034496" p2="-23.523999119096146" q2="-2.4552328247695079">
         <iidm:alias>_04483c21-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f0395-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10403,7 +10532,7 @@
             <iidm:temporaryLimit name="_1372c3b0-62d7-47d7-a8c0-ed8e10bc1f1a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046f9a43-c766-11e1-8775-005056c00008" name="27-115" r="2.8575360000000001" x="12.9111843" g1="0" b1="5.6588600000000002e-05" g2="0" b2="5.6588600000000002e-05" node1="43" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="23.830429220814437" q1="2.4967516681511004" p2="-23.728915118817046" q2="-3.8721968874350128">
+    <iidm:line id="_046f9a43-c766-11e1-8775-005056c00008" name="27-115" r="2.8575360000000001" x="12.9111843" g1="0" b1="5.6588600000000002e-05" g2="0" b2="5.6588600000000002e-05" node1="43" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="22.703079837863775" q1="3.0278723617310583" p2="-22.610370581401718" q2="-4.4487587914678448">
         <iidm:alias>_046d0238-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048c22f4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10411,7 +10540,7 @@
             <iidm:temporaryLimit name="_64cfd0fb-1d8e-45d2-a52f-469238dfc0c6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04529c61-c766-11e1-8775-005056c00008" name="12-14" r="3.7461600000000002" x="12.3187675" g1="0" b1="5.2112050000000002e-05" g2="0" b2="5.2112050000000002e-05" node1="71" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b8129-c766-11e1-8775-005056c00008" p1="36.210680006643223" q1="5.5905956134629422" p2="-35.913832503422711" q2="-6.372539190672363">
+    <iidm:line id="_04529c61-c766-11e1-8775-005056c00008" name="12-14" r="3.7461600000000002" x="12.3187675" g1="0" b1="5.2112050000000002e-05" g2="0" b2="5.2112050000000002e-05" node1="71" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b8129-c766-11e1-8775-005056c00008" p1="31.162543861400859" q1="6.7255172966176557" p2="-30.936795162271935" q2="-7.7416100743512777">
         <iidm:alias>_045fbbc1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047bf65b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10419,7 +10548,7 @@
             <iidm:temporaryLimit name="_efe2501d-bcee-42ff-a037-3d8a280487b0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0463da77-c766-11e1-8775-005056c00008" name="76-118" r="2.8575360000000001" x="9.4786560000000009" g1="0" b1="3.8911849999999999e-05" g2="0" b2="3.8911849999999999e-05" node1="22" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="-5.8925585828822777" q1="-14.650305193833715" p2="5.9358212928457732" q2="13.588381651343703">
+    <iidm:line id="_0463da77-c766-11e1-8775-005056c00008" name="76-118" r="2.8575360000000001" x="9.4786560000000009" g1="0" b1="3.8911849999999999e-05" g2="0" b2="3.8911849999999999e-05" node1="22" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="-5.766771540520649" q1="-14.751799492629925" p2="5.8103012797559268" q2="13.690890366406824">
         <iidm:alias>_046931a0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04806320-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10427,7 +10556,7 @@
             <iidm:temporaryLimit name="_2ae204bf-78cc-49cb-b886-a933b33057e4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046931a3-c766-11e1-8775-005056c00008" name="74-75" r="2.1431520000000002" x="7.0741440000000004" g1="0" b1="2.9671699999999999e-05" g2="0" b2="2.9671699999999999e-05" node1="23" voltageLevelId1="_047dcb11-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="-44.465531297937105" q1="-4.4787860878683281" p2="44.731446709434067" q2="4.395679437443885">
+    <iidm:line id="_046931a3-c766-11e1-8775-005056c00008" name="74-75" r="2.1431520000000002" x="7.0741440000000004" g1="0" b1="2.9671699999999999e-05" g2="0" b2="2.9671699999999999e-05" node1="23" voltageLevelId1="_047dcb11-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="-44.757610807749025" q1="-4.2929691217898007" p2="45.026786997627802" q2="4.2205858561126002">
         <iidm:alias>_044f4103-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04638c58-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10435,7 +10564,7 @@
             <iidm:temporaryLimit name="_e822432e-79af-4bba-8f40-5250468f81a0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045ed162-c766-11e1-8775-005056c00008" name="3-12" r="8.4332159999999998" x="27.878398900000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="32" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-7.3006902061818275" q1="-10.316106266391936" p2="7.3640406637850697" q2="6.6159532761398072">
+    <iidm:line id="_045ed162-c766-11e1-8775-005056c00008" name="3-12" r="8.4332159999999998" x="27.878398900000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="32" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-8.6145356391927326" q1="-9.6412886119423469" p2="8.682944406849785" q2="5.9561033376242918">
         <iidm:alias>_047a48a1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047b5a14-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10443,7 +10572,7 @@
             <iidm:temporaryLimit name="_c437e52c-43d7-4ae9-87ad-dc19396dc6ff" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04499bb6-c766-11e1-8775-005056c00008" name="49-51" r="8.468064" x="23.8708782" g1="0" b1="9.81405e-05" g2="0" b2="9.81405e-05" node1="119" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04542300-c766-11e1-8775-005056c00008" p1="76.837034071824917" q1="18.666122223628108" p2="-73.912290612323389" q2="-13.812770455136597">
+    <iidm:line id="_04499bb6-c766-11e1-8775-005056c00008" name="49-51" r="8.468064" x="23.8708782" g1="0" b1="9.81405e-05" g2="0" b2="9.81405e-05" node1="119" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04542300-c766-11e1-8775-005056c00008" p1="76.858916582555977" q1="18.66263474694108" p2="-73.932683526852429" q2="-13.805075161676852">
         <iidm:alias>_0487dd38-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b1180-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10451,7 +10580,7 @@
             <iidm:temporaryLimit name="_90dcdbe1-437b-443f-b0b5-c2353f7c6954" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04839779-c766-11e1-8775-005056c00008" name="40-42" r="9.6703209999999995" x="31.885919999999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="42" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="-0.75531419841781933" q1="-9.2485193280292357" p2="0.79289494916539094" q2="5.5366006534012291">
+    <iidm:line id="_04839779-c766-11e1-8775-005056c00008" name="40-42" r="9.6703209999999995" x="31.885919999999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="42" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="-0.54202382631599111" q1="-9.3626920395613968" p2="0.58060781125340599" q2="5.6556401357928925">
         <iidm:alias>_044974a9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04616975-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10459,7 +10588,7 @@
             <iidm:temporaryLimit name="_9b8510fa-bd0e-4e63-8f4c-0e5443a3eb63" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0484a8e1-c766-11e1-8775-005056c00008" name="32-113" r="10.71576" x="35.370719999999999" g1="0" b1="0.00014864555000000001" g2="0" b2="0.00014864555000000001" node1="52" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="4.4077161748666018" q1="-10.339272138875607" p2="-4.3534784063348413" q2="5.618408834259756">
+    <iidm:line id="_0484a8e1-c766-11e1-8775-005056c00008" name="32-113" r="10.71576" x="35.370719999999999" g1="0" b1="0.00014864555000000001" g2="0" b2="0.00014864555000000001" node1="52" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="0.22221585749051101" q1="-8.7964177548992719" p2="-0.19542978232655081" q2="3.9771567226431541">
         <iidm:alias>_04723258-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0482860a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10467,7 +10596,7 @@
             <iidm:temporaryLimit name="_336bfd86-a922-4154-9e06-cd87382cdc5f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04898ae4-c766-11e1-8775-005056c00008" name="51-58" r="4.4431200000000004" x="12.5278568" g1="0" b1="5.1308550000000002e-05" g2="0" b2="5.1308550000000002e-05" node1="31" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="25.301216145016998" q1="0.49211309409819376" p2="-25.125697205029162" q2="-1.6518043957144937">
+    <iidm:line id="_04898ae4-c766-11e1-8775-005056c00008" name="51-58" r="4.4431200000000004" x="12.5278568" g1="0" b1="5.1308550000000002e-05" g2="0" b2="5.1308550000000002e-05" node1="31" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="25.314888318039397" q1="0.48644866763924849" p2="-25.139183280119614" q2="-1.6456074231409101">
         <iidm:alias>_044778d4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04789af1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10475,7 +10604,7 @@
             <iidm:temporaryLimit name="_2be10dec-f0ac-470d-83f7-a2a4e70f3491" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046efe04-c766-11e1-8775-005056c00008" name="29-31" r="1.8817919999999999" x="5.7673439999999996" g1="0" b1="2.3817700000000001e-05" g2="0" b2="2.3817700000000001e-05" node1="22" voltageLevelId1="_04588fd5-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="-6.910424805501572" q1="-9.2417880901614655" p2="6.9251159677255476" q2="8.5137501666165516">
+    <iidm:line id="_046efe04-c766-11e1-8775-005056c00008" name="29-31" r="1.8817919999999999" x="5.7673439999999996" g1="0" b1="2.3817700000000001e-05" g2="0" b2="2.3817700000000001e-05" node1="22" voltageLevelId1="_04588fd5-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="-8.8385592841275891" q1="-7.0535861739576351" p2="8.8528140615989717" q2="6.3237821646518162">
         <iidm:alias>_04492688-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047cb9a5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10483,7 +10612,7 @@
             <iidm:temporaryLimit name="_f0e21213-6535-44a7-89b6-3063f8738d6b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044a10e4-c766-11e1-8775-005056c00008" name="65-68" r="0.66791999999999996" x="7.7439999999999998" g1="0" b1="0.00065909092999999995" g2="0" b2="0.00065909092999999995" node1="41" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0449e9d2-c766-11e1-8775-005056c00008" p1="-166.65640973973379" q1="24.325848484820035" p2="167.07957788101305" q2="-83.453891252107667">
+    <iidm:line id="_044a10e4-c766-11e1-8775-005056c00008" name="65-68" r="0.66791999999999996" x="7.7439999999999998" g1="0" b1="0.00065909092999999995" g2="0" b2="0.00065909092999999995" node1="41" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0449e9d2-c766-11e1-8775-005056c00008" p1="-165.06940780657925" q1="24.121276468870285" p2="165.48506749760548" q2="-83.336622244203525">
         <iidm:alias>_0461dea7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047629f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10491,7 +10620,7 @@
             <iidm:temporaryLimit name="_ab31cd46-6d0c-4d9c-95f1-396a45a237e1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046b7b92-c766-11e1-8775-005056c00008" name="49-54" r="12.719519999999999" x="50.355361899999998" g1="0" b1="0.00021177684999999999" g2="0" b2="0.00021177684999999999" node1="120" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="46.7710295531489" q1="11.850845243019766" p2="-45.079209564212874" q2="-12.395270195286729">
+    <iidm:line id="_046b7b92-c766-11e1-8775-005056c00008" name="49-54" r="12.719519999999999" x="50.355361899999998" g1="0" b1="0.00021177684999999999" g2="0" b2="0.00021177684999999999" node1="120" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="46.790595861236397" q1="11.848470945385214" p2="-45.097555869097881" q2="-12.388066484095505">
         <iidm:alias>_0462f017-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047120e1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10499,7 +10628,7 @@
             <iidm:temporaryLimit name="_1bf78539-b6fa-4d8b-ba8e-9b5970019be6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04607f15-c766-11e1-8775-005056c00008" name="70-71" r="1.536797" x="6.1855200000000004" g1="0" b1="2.5195149999999999e-05" g2="0" b2="2.5195149999999999e-05" node1="52" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04664b78-c766-11e1-8775-005056c00008" p1="-6.9639932684205945" q1="-3.9308374294609281" p2="6.9695297055628487" q2="3.1012379703392408">
+    <iidm:line id="_04607f15-c766-11e1-8775-005056c00008" name="70-71" r="1.536797" x="6.1855200000000004" g1="0" b1="2.5195149999999999e-05" g2="0" b2="2.5195149999999999e-05" node1="52" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04664b78-c766-11e1-8775-005056c00008" p1="-6.2691754834247204" q1="-4.401843424781374" p2="6.27419375717355" q2="3.5697924743881297">
         <iidm:alias>_04486336-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f51b4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10507,7 +10636,7 @@
             <iidm:temporaryLimit name="_08ff3ae4-d1dd-49f7-9eda-32ffc8eb0010" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c5ad7-c766-11e1-8775-005056c00008" name="55-56" r="0.85029100000000002" x="2.631024" g1="0" b1="1.0732300000000001e-05" g2="0" b2="1.0732300000000001e-05" node1="31" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="-28.687139698110229" q1="-7.0045730466532357" p2="28.734037843743206" q2="6.8103267207727693">
+    <iidm:line id="_044c5ad7-c766-11e1-8775-005056c00008" name="55-56" r="0.85029100000000002" x="2.631024" g1="0" b1="1.0732300000000001e-05" g2="0" b2="1.0732300000000001e-05" node1="31" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="-28.69954049194472" q1="-7.0005735074680855" p2="28.746474089664144" q2="6.8064370462952173">
         <iidm:alias>_04558294-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045868c2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10515,7 +10644,7 @@
             <iidm:temporaryLimit name="_94316214-afd8-4c0d-bca4-916acb92af85" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048a2725-c766-11e1-8775-005056c00008" name="35-37" r="1.9166399999999999" x="8.6597279999999994" g1="0" b1="3.7821399999999997e-05" g2="0" b2="3.7821399999999997e-05" node1="21" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-29.360385734442907" q1="-14.662831379244617" p2="29.492089388940013" q2="14.077071769896044">
+    <iidm:line id="_048a2725-c766-11e1-8775-005056c00008" name="35-37" r="1.9166399999999999" x="8.6597279999999994" g1="0" b1="3.7821399999999997e-05" g2="0" b2="3.7821399999999997e-05" node1="21" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-29.279594143602161" q1="-14.694384897166007" p2="29.410892337899259" q2="14.107419807632668">
         <iidm:alias>_0471bd29-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04808a30-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10523,7 +10652,7 @@
             <iidm:temporaryLimit name="_4ea6b532-d914-4b0c-97ee-9f02a14a40b3" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04614263-c766-11e1-8775-005056c00008" name="4-5" r="0.30666199999999999" x="1.3904350000000001" g1="0" b1="6.0261499999999999e-06" g2="0" b2="6.0261499999999999e-06" node1="22" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-113.49812300025874" q1="-18.346365252137293" p2="113.727939402269" q2="19.175120299259184">
+    <iidm:line id="_04614263-c766-11e1-8775-005056c00008" name="4-5" r="0.30666199999999999" x="1.3904350000000001" g1="0" b1="6.0261499999999999e-06" g2="0" b2="6.0261499999999999e-06" node1="22" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-108.74336736904304" q1="-20.178412720132961" p2="108.95565567579072" q2="20.927309560144">
         <iidm:alias>_04529c66-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04753f92-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10531,7 +10660,7 @@
             <iidm:temporaryLimit name="_2a95fb2b-6661-46e7-a9f6-fe63c1b7433c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0451b208-c766-11e1-8775-005056c00008" name="20-21" r="3.1885919999999999" x="14.7929754" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_046b2d70-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0460f448-c766-11e1-8775-005056c00008" p1="-32.897537826262393" q1="1.775826349520506" p2="33.122950869064113" q2="-2.6499478692877867">
+    <iidm:line id="_0451b208-c766-11e1-8775-005056c00008" name="20-21" r="3.1885919999999999" x="14.7929754" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_046b2d70-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0460f448-c766-11e1-8775-005056c00008" p1="-30.813309506968423" q1="0.84099848765303886" p2="31.01003433611665" q2="-1.8523338705301766">
         <iidm:alias>_046c65f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048c22f6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10539,7 +10668,7 @@
             <iidm:temporaryLimit name="_4b67f5f5-f0e1-4bfb-9d57-4d3474720a45" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047d55e4-c766-11e1-8775-005056c00008" name="104-105" r="1.731946" x="6.5862720000000001" g1="0" b1="2.8294300000000001e-05" g2="0" b2="2.8294300000000001e-05" node1="32" voltageLevelId1="_0483977a-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="48.025713722340853" q1="0.86686498141269053" p2="-47.782155696204995" q2="-0.86448258795211175">
+    <iidm:line id="_047d55e4-c766-11e1-8775-005056c00008" name="104-105" r="1.731946" x="6.5862720000000001" g1="0" b1="2.8294300000000001e-05" g2="0" b2="2.8294300000000001e-05" node1="32" voltageLevelId1="_0483977a-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="48.027355639237499" q1="0.86643346589429271" p2="-47.783781084586096" q2="-0.86398819727982745">
         <iidm:alias>_0451d910-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046c65f2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10547,7 +10676,7 @@
             <iidm:temporaryLimit name="_1ca40dc7-6736-4fa8-b4cb-ca696949e421" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046dc589-c766-11e1-8775-005056c00008" name="44-45" r="3.9029759999999998" x="15.699023199999999" g1="0" b1="6.4279149999999996e-05" g2="0" b2="6.4279149999999996e-05" node1="23" voltageLevelId1="_04544a15-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_045d23b4-c766-11e1-8775-005056c00008" p1="-21.576670277166908" q1="-3.8943056262123381" p2="21.688152207543638" q2="2.1943264892759342">
+    <iidm:line id="_046dc589-c766-11e1-8775-005056c00008" name="44-45" r="3.9029759999999998" x="15.699023199999999" g1="0" b1="6.4279149999999996e-05" g2="0" b2="6.4279149999999996e-05" node1="23" voltageLevelId1="_04544a15-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_045d23b4-c766-11e1-8775-005056c00008" p1="-21.299221910338751" q1="-4.0153029180388318" p2="21.408077727029532" q2="2.3048554398886756">
         <iidm:alias>_04518afa-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04667287-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10555,7 +10684,7 @@
             <iidm:temporaryLimit name="_ba738481-ddba-4ebe-a218-8aad0b537f5b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04642896-c766-11e1-8775-005056c00008" name="4-11" r="3.641616" x="11.9877129" g1="0" b1="5.0160700000000002e-05" g2="0" b2="5.0160700000000002e-05" node1="23" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="74.492994041395121" q1="6.3437354330754818" p2="-73.336177826350607" q2="-4.2712295652171965">
+    <iidm:line id="_04642896-c766-11e1-8775-005056c00008" name="4-11" r="3.641616" x="11.9877129" g1="0" b1="5.0160700000000002e-05" g2="0" b2="5.0160700000000002e-05" node1="23" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="69.738443688687241" q1="8.1758881102388354" p2="-68.718864496689235" q2="-6.5574772503335561">
         <iidm:alias>_0455f7c5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04803c17-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10563,7 +10692,7 @@
             <iidm:temporaryLimit name="_b1d87c24-e527-4174-aa04-cd0b9de271ea" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047d07c0-c766-11e1-8775-005056c00008" name="92-93" r="4.4953919999999998" x="14.775551800000001" g1="0" b1="6.2557400000000005e-05" g2="0" b2="6.2557400000000005e-05" node1="72" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04789af0-c766-11e1-8775-005056c00008" p1="70.611830276714699" q1="-12.79565124683438" p2="-69.261564048462219" q2="15.113105906072381">
+    <iidm:line id="_047d07c0-c766-11e1-8775-005056c00008" name="92-93" r="4.4953919999999998" x="14.775551800000001" g1="0" b1="6.2557400000000005e-05" g2="0" b2="6.2557400000000005e-05" node1="72" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04789af0-c766-11e1-8775-005056c00008" p1="70.670149503626973" q1="-12.73257233800955" p2="-69.317960737000391" q2="15.056708787686679">
         <iidm:alias>_044a5f07-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047602e5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10571,7 +10700,7 @@
             <iidm:temporaryLimit name="_4e1daf8e-7708-4b96-8d3f-67f58f2505f9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044f4109-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="43" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="121" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-53.802086503370738" q1="-18.431425570204237" p2="56.462240394539798" q2="22.331157311056455">
+    <iidm:line id="_044f4109-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="43" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="121" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-53.594188433845936" q1="-18.54960737345333" p2="56.239059619379063" q2="22.381326375468021">
         <iidm:alias>_046958b0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04758db0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10579,7 +10708,7 @@
             <iidm:temporaryLimit name="_c58940cb-bd36-4dfc-9615-11716dd652a7" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046e61c8-c766-11e1-8775-005056c00008" name="69-75" r="7.0567200000000003" x="21.257280000000002" g1="0" b1="0.00035583104999999999" g2="0" b2="0.00035583104999999999" node1="61" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="89.083155405494182" q1="24.619969120041716" p2="-85.713365764792442" q2="-26.917131819376124">
+    <iidm:line id="_046e61c8-c766-11e1-8775-005056c00008" name="69-75" r="7.0567200000000003" x="21.257280000000002" g1="0" b1="0.00035583104999999999" g2="0" b2="0.00035583104999999999" node1="61" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="89.474156401853662" q1="24.530241952816535" p2="-86.080089529429216" q2="-26.754282433257217">
         <iidm:alias>_046d294a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048ac362-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10587,7 +10716,7 @@
             <iidm:temporaryLimit name="_3c9a454c-10ee-4c72-a059-77f723f5b7c7" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0463da71-c766-11e1-8775-005056c00008" name="79-80" r="2.7181440000000001" x="12.2664957" g1="0" b1="5.3661600000000001e-05" g2="0" b2="5.3661600000000001e-05" node1="23" voltageLevelId1="_04481510-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-66.302037301854597" q1="-32.269232537184074" p2="67.1292172984042" q2="34.042708772654464">
+    <iidm:line id="_0463da71-c766-11e1-8775-005056c00008" name="79-80" r="2.7181440000000001" x="12.2664957" g1="0" b1="5.3661600000000001e-05" g2="0" b2="5.3661600000000001e-05" node1="23" voltageLevelId1="_04481510-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-66.394660431414948" q1="-32.376955929315194" p2="67.224929186226234" q2="34.164549602169132">
         <iidm:alias>_0464ebe9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04662468-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10595,7 +10724,7 @@
             <iidm:temporaryLimit name="_270a7d04-9ff9-4178-8b72-b610735a72ac" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044fdd41-c766-11e1-8775-005056c00008" name="51-52" r="3.5370720000000002" x="10.2453117" g1="0" b1="4.0059699999999999e-05" g2="0" b2="4.0059699999999999e-05" node1="32" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04806326-c766-11e1-8775-005056c00008" p1="31.611110272534344" q1="5.3206855638055197" p2="-31.385834747715208" q2="-5.9564966680640268">
+    <iidm:line id="_044fdd41-c766-11e1-8775-005056c00008" name="51-52" r="3.5370720000000002" x="10.2453117" g1="0" b1="4.0059699999999999e-05" g2="0" b2="4.0059699999999999e-05" node1="32" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04806326-c766-11e1-8775-005056c00008" p1="31.617832463747934" q1="5.3186562000467301" p2="-31.392468452715867" q2="-5.9542036535125309">
         <iidm:alias>_045115c2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0464ebe5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10603,7 +10732,7 @@
             <iidm:temporaryLimit name="_9d1eb182-ceb5-426e-9440-5f4d426a31cb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c3958-c766-11e1-8775-005056c00008" name="53-54" r="4.5825120000000004" x="21.257280000000002" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="22" voltageLevelId1="_04876804-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="-9.6970659184303454" q1="-6.7122663150954107" p2="9.7330885131219862" q2="4.0804735021434846">
+    <iidm:line id="_045c3958-c766-11e1-8775-005056c00008" name="53-54" r="4.5825120000000004" x="21.257280000000002" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="22" voltageLevelId1="_04876804-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="-9.6905038320941745" q1="-6.7148708038126088" p2="9.7264972763839488" q2="4.0829468158293984">
         <iidm:alias>_044f6817-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0455f7c6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10611,7 +10740,7 @@
             <iidm:temporaryLimit name="_735ac8df-6a6a-43f0-86f2-49d3280c9a3b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044ef2e1-c766-11e1-8775-005056c00008" name="54-55" r="2.9446560000000002" x="12.3187675" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="63" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04767817-c766-11e1-8775-005056c00008" p1="10.158395005595336" q1="1.7052490590446583" p2="-10.137994942589154" q2="-3.45504226518685">
+    <iidm:line id="_044ef2e1-c766-11e1-8775-005056c00008" name="54-55" r="2.9446560000000002" x="12.3187675" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="63" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04767817-c766-11e1-8775-005056c00008" p1="10.16283155909726" q1="1.70459226258791" p2="-10.142415430571935" q2="-3.4543178646838402">
         <iidm:alias>_04640181-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047dcb17-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10619,7 +10748,7 @@
             <iidm:temporaryLimit name="_52aadf8d-53f2-4827-8c70-421bdf1ba822" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0456e226-c766-11e1-8775-005056c00008" name="80-97" r="3.1885919999999999" x="16.2740154" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="82" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="12.10216899444776" q1="30.81847253276716" p2="-11.902047600734241" q2="-32.463612879727194">
+    <iidm:line id="_0456e226-c766-11e1-8775-005056c00008" name="80-97" r="3.1885919999999999" x="16.2740154" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="82" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="12.145740559738979" q1="31.018967063126524" p2="-11.943249564742663" q2="-32.651532745195475">
         <iidm:alias>_04479fe9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047df222-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10627,7 +10756,7 @@
             <iidm:temporaryLimit name="_fece5807-6af8-4161-8de8-8f8473d92f11" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0487b624-c766-11e1-8775-005056c00008" name="103-110" r="6.8058139999999998" x="31.5897121" g1="0" b1="0.00013228879999999999" g2="0" b2="0.00013228879999999999" node1="43" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="57.708482784055661" q1="18.498457788990379" p2="-56.266857311334448" q2="-16.2607891021588">
+    <iidm:line id="_0487b624-c766-11e1-8775-005056c00008" name="103-110" r="6.8058139999999998" x="31.5897121" g1="0" b1="0.00013228879999999999" g2="0" b2="0.00013228879999999999" node1="43" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="57.711943967710525" q1="18.498149389574142" p2="-56.27017072229166" q2="-16.259795048673769">
         <iidm:alias>_046a9139-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b3895-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10635,7 +10764,7 @@
             <iidm:temporaryLimit name="_3eacc034-737e-41de-a7b6-b610d3bd0921" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045338a8-c766-11e1-8775-005056c00008" name="56-58" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="61" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="-13.061333577373022" q1="-0.68238535164147596" p2="13.125714117369858" q2="-1.3481885090520851">
+    <iidm:line id="_045338a8-c766-11e1-8775-005056c00008" name="56-58" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="61" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="-13.074686421848746" q1="-0.67580734921994445" p2="13.139200651593741" q2="-1.3543851473666768">
         <iidm:alias>_0451d915-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04817494-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10643,7 +10772,7 @@
             <iidm:temporaryLimit name="_0d0c3ec5-798a-48a4-9bc8-d19c57128a13" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04854529-c766-11e1-8775-005056c00008" name="15-33" r="6.6211200000000003" x="21.675455100000001" g1="0" b1="9.1655200000000003e-05" g2="0" b2="9.1655200000000003e-05" node1="52" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456bb11-c766-11e1-8775-005056c00008" p1="67.116462441422215" q1="-9.2018296804783599" p2="-65.193525987396484" q2="12.652617269022196">
+    <iidm:line id="_04854529-c766-11e1-8775-005056c00008" name="15-33" r="6.6211200000000003" x="21.675455100000001" g1="0" b1="9.1655200000000003e-05" g2="0" b2="9.1655200000000003e-05" node1="52" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456bb11-c766-11e1-8775-005056c00008" p1="68.227716420438114" q1="-9.183298630335349" p2="-66.242043939777346" q2="12.839720664982693">
         <iidm:alias>_0448d862-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047d2ed5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10651,7 +10780,7 @@
             <iidm:temporaryLimit name="_5b0395f4-534d-4975-a1af-e0b6ef439193" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04649dc2-c766-11e1-8775-005056c00008" name="35-36" r="0.39029799999999998" x="1.7772479999999999" g1="0" b1="7.6905500000000004e-06" g2="0" b2="7.6905500000000004e-06" node1="22" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="-3.6657959711236776" q1="5.6509431852423333" p2="3.6669779356683292" q2="-5.8827493812641993">
+    <iidm:line id="_04649dc2-c766-11e1-8775-005056c00008" name="35-36" r="0.39029799999999998" x="1.7772479999999999" g1="0" b1="7.6905500000000004e-06" g2="0" b2="7.6905500000000004e-06" node1="22" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="-3.7500480770017184" q1="5.6809209162288985" p2="3.7512552568960604" q2="-5.9124828627729151">
         <iidm:alias>_044c0cb5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0456e225-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10659,7 +10788,7 @@
             <iidm:temporaryLimit name="_74c4b341-7b99-4a81-b88a-2ed3b0c4b1de" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0470d2c9-c766-11e1-8775-005056c00008" name="37-40" r="10.3324327" x="29.272320000000001" g1="0" b1="0.0001205234" g2="0" b2="0.0001205234" node1="61" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="56.152432091992651" q1="10.649137221501528" p2="-53.98624126837754" q2="-8.1145937858904418">
+    <iidm:line id="_0470d2c9-c766-11e1-8775-005056c00008" name="37-40" r="10.3324327" x="29.272320000000001" g1="0" b1="0.0001205234" g2="0" b2="0.0001205234" node1="61" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="56.381852551034328" q1="10.584645395884658" p2="-54.198712379436863" q2="-8.0001955787342922">
         <iidm:alias>_045b9d10-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046a4317-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10667,7 +10796,7 @@
             <iidm:temporaryLimit name="_e98d56fe-a54b-45e4-acff-0ac310beb3dd" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044e56a2-c766-11e1-8775-005056c00008" name="48-49" r="3.1188959999999999" x="8.7991200000000003" g1="0" b1="3.6099649999999999e-05" g2="0" b2="3.6099649999999999e-05" node1="23" voltageLevelId1="_044778d3-c766-11e1-8775-005056c00008" node2="122" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-28.854446042734672" q1="1.3212289386574361" p2="28.998133441930936" q2="-2.2321540987631052">
+    <iidm:line id="_044e56a2-c766-11e1-8775-005056c00008" name="48-49" r="3.1188959999999999" x="8.7991200000000003" g1="0" b1="3.6099649999999999e-05" g2="0" b2="3.6099649999999999e-05" node1="23" voltageLevelId1="_044778d3-c766-11e1-8775-005056c00008" node2="122" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-28.821255632989345" q1="1.3106944971323899" p2="28.964606819250015" q2="-2.2225693883973081">
         <iidm:alias>_0454bf49-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0460a623-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10675,7 +10804,7 @@
             <iidm:temporaryLimit name="_f2e58700-2366-46e0-8408-9472d85acd23" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047eb573-c766-11e1-8775-005056c00008" name="56-59" r="14.3748007" x="43.734237700000001" g1="0" b1="0.0001632805" g2="0" b2="0.0001632805" node1="62" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-19.176838407885981" q1="-7.714002847019036" p2="19.534123201631701" q2="3.4522594858753801">
+    <iidm:line id="_047eb573-c766-11e1-8775-005056c00008" name="56-59" r="14.3748007" x="43.734237700000001" g1="0" b1="0.0001632805" g2="0" b2="0.0001632805" node1="62" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-19.162428771903485" q1="-7.7195964536265151" p2="19.519264824801191" q2="3.4564888484776639">
         <iidm:alias>_0468bc78-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048915b0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10683,7 +10812,7 @@
             <iidm:temporaryLimit name="_89654167-95a6-4c76-aad7-63a881116e17" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046f9a4b-c766-11e1-8775-005056c00008" name="94-100" r="3.1014719999999998" x="10.105919999999999" g1="0" b1="0.00017332415000000001" g2="0" b2="0.00017332415000000001" node1="52" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-6.1325191503334544" q1="-51.966329182843729" p2="6.5784619157290916" q2="47.353414606692368">
+    <iidm:line id="_046f9a4b-c766-11e1-8775-005056c00008" name="94-100" r="3.1014719999999998" x="10.105919999999999" g1="0" b1="0.00017332415000000001" g2="0" b2="0.00017332415000000001" node1="52" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-6.1499430923382237" q1="-52.240875198428824" p2="6.6010305456081966" q2="47.645739244146242">
         <iidm:alias>_04812676-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048a2722-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10691,7 +10820,7 @@
             <iidm:temporaryLimit name="_216c0f3b-03e8-4b7d-96fc-a5f891331f7f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046735d0-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="123" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-92.283009380530672" q1="-2.5274493311252875" p2="93.742309923713989" q2="7.3196368745609837">
+    <iidm:line id="_046735d0-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="123" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-92.176132292006244" q1="-2.5568275731169319" p2="93.632067616930485" q2="7.3318347422942489">
         <iidm:alias>_04570934-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b3894-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10699,7 +10828,7 @@
             <iidm:temporaryLimit name="_32655e4f-e7da-46b0-a908-b601224ddb73" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046d294b-c766-11e1-8775-005056c00008" name="21-22" r="3.641616" x="16.901281399999998" g1="0" b1="7.0592299999999998e-05" g2="0" b2="7.0592299999999998e-05" node1="22" voltageLevelId1="_0460f448-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04773b6a-c766-11e1-8775-005056c00008" p1="-47.124034753271765" q1="-5.3510845185729625" p2="47.647997760395036" q2="5.5486733170412794">
+    <iidm:line id="_046d294b-c766-11e1-8775-005056c00008" name="21-22" r="3.641616" x="16.901281399999998" g1="0" b1="7.0592299999999998e-05" g2="0" b2="7.0592299999999998e-05" node1="22" voltageLevelId1="_0460f448-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04773b6a-c766-11e1-8775-005056c00008" p1="-45.013670198259817" q1="-6.1511288638788573" p2="45.492649435765152" q2="6.1338278420103185">
         <iidm:alias>_044a37f0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_044be5a2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10707,7 +10836,7 @@
             <iidm:temporaryLimit name="_bafaeace-e459-4dc2-87a0-467a9ea25f8d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_6a131803-f462-47e2-bc21-bda919364fe9" name="reactor1" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="36" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="37" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="-2.2204460492503131e-14" q1="-83.151384217233556" p2="2.4980018054066022e-14" q2="92.151023628993073">
+    <iidm:line id="_6a131803-f462-47e2-bc21-bda919364fe9" name="reactor1" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="36" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="37" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="-3.0531133177191805e-14" q1="-83.151390907434546" p2="2.7755575615628914e-14" q2="92.151031043287801">
         <iidm:alias>_04531196-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_ca0adad2-ffe3-4efa-b56b-7d333b8ae18f</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10715,7 +10844,7 @@
             <iidm:temporaryLimit name="_ae4eadea-f3fc-4ac6-8899-c1698ece7a89" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_9803b364-2a93-4f21-94b7-8bdbe27a16f2" name="reactor2" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="38" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="3.0308894283237464e-09" q1="27.470166871037261" p2="-3.030888734434356e-09" q2="-26.585236520925591">
+    <iidm:line id="_9803b364-2a93-4f21-94b7-8bdbe27a16f2" name="reactor2" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="38" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="3.5390958219583268e-08" q1="27.469422175351717" p2="-3.5390958566527964e-08" q2="-26.584539875961532">
         <iidm:alias>_0461b792-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_afe0e60b-3870-44fb-ba93-a056228f9636</iidm:alias>
     </iidm:line>

--- a/tests/main_sa/reference/launch/line_contingency/outputIIDM.xml
+++ b/tests/main_sa/reference/launch/line_contingency/outputIIDM.xml
@@ -31,8 +31,8 @@
                     <iidm:alias>_bea273f1-1e21-476d-b0d0-92dd6cb9a2d4</iidm:alias>
                     <iidm:alias>_c94e6b68-da6c-43d1-94fd-09ad60c74134</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_047abdd7-c766-11e1-8775-005056c00008-BREAKER" name="BREAKER-Jay LD" kind="BREAKER" retained="true" open="false" node1="0" node2="8"/>
                 <iidm:internalConnection node1="7" node2="0"/>
-                <iidm:internalConnection node1="8" node2="0"/>
                 <iidm:internalConnection node1="9" node2="1"/>
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="4"/>
@@ -47,9 +47,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="124.57600856510108" angle="7.4304451985468569" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.70914608999902" angle="-3.5675439636302397" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047abdd7-c766-11e1-8775-005056c00008" name="Jay LD" loadType="UNDEFINED" p0="14" q0="8" node="8" p="13.993798525258441" q="7.9940947056924392">
+            <iidm:load id="_047abdd7-c766-11e1-8775-005056c00008" name="Jay LD" loadType="UNDEFINED" p0="14" q0="8" node="8" p="13.995266389630132" q="7.995492307763592">
                 <iidm:alias>_04590500-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -139,12 +139,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="127.49597014122573" angle="11.095707282791558" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="127.75235590874658" angle="-0.1232104078812096" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045b00d5-c766-11e1-8775-005056c00008" name="Madison LD" loadType="UNDEFINED" p0="62" q0="13" node="14" p="61.957252264812709" q="12.985064708916161">
+            <iidm:load id="_045b00d5-c766-11e1-8775-005056c00008" name="Madison LD" loadType="UNDEFINED" p0="62" q0="13" node="14" p="61.969623710328882" q="12.989386363680049">
                 <iidm:alias>_045b27e3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_04689566-c766-11e1-8775-005056c00008" name="Madison NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="15" p="8.9937946836018448" q="0">
+            <iidm:load id="_04689566-c766-11e1-8775-005056c00008" name="Madison NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="15" p="8.9955905385961277" q="0">
                 <iidm:alias>_04765100-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -272,16 +272,16 @@
                 <iidm:internalConnection node1="61" node2="12"/>
                 <iidm:internalConnection node1="62" node2="15"/>
                 <iidm:internalConnection node1="63" node2="18"/>
-                <iidm:bus v="126.06000135163058" angle="-7.4893933373947288" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63"/>
+                <iidm:bus v="126.06000481388762" angle="-18.509689787413215" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_046c3ee7-c766-11e1-8775-005056c00008" name="Torrey SM" energySource="THERMAL" minP="20" maxP="80" ratedS="100" voltageRegulatorOn="true" targetP="48" targetV="126.06" targetQ="0" node="21" p="-53.150167420159946" q="-7.265047684684613">
+            <iidm:generator id="_046c3ee7-c766-11e1-8775-005056c00008" name="Torrey SM" energySource="THERMAL" minP="20" maxP="80" ratedS="100" voltageRegulatorOn="true" targetP="48" targetV="126.06" targetQ="0" node="21" p="-53.141574262000368" q="-7.2761333028638369">
                 <iidm:alias>_047147f3-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_b97aee41-3115-4cfd-9071-b52fb44d0b66"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_5005c073-28d1-4a7d-b257-649dec43ec73"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-30" maxQ="85"/>
             </iidm:generator>
-            <iidm:load id="_044afb44-c766-11e1-8775-005056c00008" name="Torrey LD" loadType="UNDEFINED" p0="113" q0="32" node="20" p="113.00000181739949" q="32.000000857769685">
+            <iidm:load id="_044afb44-c766-11e1-8775-005056c00008" name="Torrey LD" loadType="UNDEFINED" p0="113" q0="32" node="20" p="113.00000647274277" q="32.000003054981903">
                 <iidm:alias>_04522737-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -332,9 +332,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="123.83963003533923" angle="8.3388106744659627" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="123.83062324401473" angle="-2.7414838967402688" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04481515-c766-11e1-8775-005056c00008" name="Darrah LD" loadType="UNDEFINED" p0="68" q0="36" node="8" p="68.000244243684691" q="36.00021550939158">
+            <iidm:load id="_04481515-c766-11e1-8775-005056c00008" name="Darrah LD" loadType="UNDEFINED" p0="68" q0="36" node="8" p="68.000558799436433" q="36.000493059676856">
                 <iidm:alias>_044e7db8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -385,9 +385,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.46450027382099" angle="22.729420310095936" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.45866113421161" angle="11.674189164424398" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044c0cb3-c766-11e1-8775-005056c00008" name="Smythe LD" loadType="UNDEFINED" p0="5" q0="3" node="8" p="4.9999728063874951" q="2.9999728064367939">
+            <iidm:load id="_044c0cb3-c766-11e1-8775-005056c00008" name="Smythe LD" loadType="UNDEFINED" p0="5" q0="3" node="8" p="4.9999729989465687" q="2.999972998995172">
                 <iidm:alias>_045163e8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -514,9 +514,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="125.90823055546622" angle="-7.6616941203619646" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="125.90820051282051" angle="-18.682061954607828" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0450a093-c766-11e1-8775-005056c00008" name="Sunnysde LD" loadType="UNDEFINED" p0="84" q0="18" node="20" p="84.000006004154827" q="18.00000214434106">
+            <iidm:load id="_0450a093-c766-11e1-8775-005056c00008" name="Sunnysde LD" loadType="UNDEFINED" p0="84" q0="18" node="20" p="84.000008850757297" q="18.000003160984861">
                 <iidm:alias>_045f4695-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -568,12 +568,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="126.73071638558821" angle="8.2171700731285231" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="126.73637158113587" angle="-2.8826773381458834" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044b2251-c766-11e1-8775-005056c00008" name="Bellefnt LD" loadType="UNDEFINED" p0="68" q0="27" node="8" p="67.999595210909618" q="26.999732125398186">
+            <iidm:load id="_044b2251-c766-11e1-8775-005056c00008" name="Bellefnt LD" loadType="UNDEFINED" p0="68" q0="27" node="8" p="68.000323383699453" q="27.000214004257984">
                 <iidm:alias>_04622cc1-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0449e9d5-c766-11e1-8775-005056c00008" name="Bellefnt SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.40300000000001" targetDeadband="1" node="9" q="-11.065804713691426">
+            <iidm:shunt id="_0449e9d5-c766-11e1-8775-005056c00008" name="Bellefnt SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.40300000000001" targetDeadband="1" node="9" q="-11.066792330389148">
                 <iidm:alias>_047bcf48-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_6cc38790-c6a6-4309-99f4-a3258e24e785"/>
                 <iidm:shuntLinearModel bPerSection="0.00013779999999999999" gPerSection="0" maximumSectionCount="10"/>
@@ -665,12 +665,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="126.06592828572953" angle="8.389810385827408" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="126.06591415470838" angle="-2.672005001269619" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04682035-c766-11e1-8775-005056c00008" name="Fieldale LD" loadType="UNDEFINED" p0="39" q0="30" node="14" p="39.000005990161959" q="30.000007679695205">
+            <iidm:load id="_04682035-c766-11e1-8775-005056c00008" name="Fieldale LD" loadType="UNDEFINED" p0="39" q0="30" node="14" p="39.000007909650684" q="30.000010140578485">
                 <iidm:alias>_0478c20a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_045c6067-c766-11e1-8775-005056c00008" name="Fieldale SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.066" targetDeadband="1" node="15" q="-5.4670606864426894">
+            <iidm:shunt id="_045c6067-c766-11e1-8775-005056c00008" name="Fieldale SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.066" targetDeadband="1" node="15" q="-5.467059460811833">
                 <iidm:alias>_0451b209-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_2d222dd9-7306-4afd-baa5-fd303b0eeb40"/>
                 <iidm:shuntLinearModel bPerSection="6.8800000000000005e-05" gPerSection="0" maximumSectionCount="10"/>
@@ -780,7 +780,7 @@
                 <iidm:internalConnection node1="51" node2="9"/>
                 <iidm:internalConnection node1="52" node2="12"/>
                 <iidm:internalConnection node1="53" node2="15"/>
-                <iidm:bus v="138.01493830412369" angle="4.3075426818691387" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
+                <iidm:bus v="138.01489050681408" angle="-6.7147626951016344" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="_047f0391-c766-11e1-8775-005056c00008" name="Muskngum SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="392" targetV="138.59999099999999" targetQ="0" node="18" p="-0" q="-0">
                 <iidm:alias>_047eb572-c766-11e1-8775-005056c00008</iidm:alias>
@@ -789,7 +789,7 @@
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
-            <iidm:load id="_047e1936-c766-11e1-8775-005056c00008" name="Muskngum LD" loadType="UNDEFINED" p0="39" q0="18" node="17" p="38.999756308012302" q="17.999812545015281">
+            <iidm:load id="_047e1936-c766-11e1-8775-005056c00008" name="Muskngum LD" loadType="UNDEFINED" p0="39" q0="18" node="17" p="38.999757139875605" q="17.99981318490747">
                 <iidm:alias>_046e88d5-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -876,9 +876,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="221.10000254423986" angle="9.4732734557703662" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="221.10000883871095" angle="-1.5525109454899984" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0458ddf1-c766-11e1-8775-005056c00008" name="Muskngum SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="391" targetV="221.09999999999999" targetQ="0" node="14" p="-432.95240544338623" q="-159.96732070663109">
+            <iidm:generator id="_0458ddf1-c766-11e1-8775-005056c00008" name="Muskngum SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="391" targetV="221.09999999999999" targetQ="0" node="14" p="-432.88240700921136" q="-159.82014129430189">
                 <iidm:alias>_04522732-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_5036c3a5-56f9-489c-9ecb-8c15aa7c70c5"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_12b01822-ca11-4cf8-a6b4-2f8ff805ca20"/>
@@ -886,7 +886,7 @@
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045cae83-c766-11e1-8775-005056c00008" name="65-66" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="42" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="273.47995590504064" q1="97.450447980841687" p2="-273.47995590504064" q2="-70.457027313696827">
+        <iidm:twoWindingsTransformer id="_045cae83-c766-11e1-8775-005056c00008" name="65-66" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="42" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="273.29618415851996" q1="97.434987058538738" p2="-273.29618415851991" q2="-70.474712517344543">
             <iidm:alias>_044b2254-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_044b4964-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_045645e1-c766-11e1-8775-005056c00008</iidm:alias>
@@ -961,9 +961,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="123.99683216158495" angle="5.5007188177673809" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.06707014193688" angle="-5.3638882179032752" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0453d4e2-c766-11e1-8775-005056c00008" name="Adams LD" loadType="UNDEFINED" p0="18" q0="3" node="8" p="17.993360446727088" q="2.9981559064235466">
+            <iidm:load id="_0453d4e2-c766-11e1-8775-005056c00008" name="Adams LD" loadType="UNDEFINED" p0="18" q0="3" node="8" p="17.9949359788619" q="2.9985934593809382">
                 <iidm:alias>_0448ff77-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1053,16 +1053,16 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="133.31999748744235" angle="14.131192266882017" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="133.32000192565815" angle="3.0697517046132798" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_046bf0c4-c766-11e1-8775-005056c00008" name="Claytor SM" energySource="THERMAL" minP="0" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="40" targetV="133.31999200000001" targetQ="0" node="15" p="-44.291806183466626" q="-83.07077631023661">
+            <iidm:generator id="_046bf0c4-c766-11e1-8775-005056c00008" name="Claytor SM" energySource="THERMAL" minP="0" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="40" targetV="133.31999200000001" targetQ="0" node="15" p="-44.284645218333637" q="-83.074459291546603">
                 <iidm:alias>_0460a627-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e56da2eb-bb6a-4133-953c-40073c5bc5f4"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_d41be6b4-155e-4c8f-b46b-16b50c49f0f4"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-60" maxQ="170"/>
             </iidm:generator>
-            <iidm:load id="_048433b6-c766-11e1-8775-005056c00008" name="Claytor LD" loadType="UNDEFINED" p0="23" q0="16" node="14" p="23.00000142001781" q="16.000001646397497">
+            <iidm:load id="_048433b6-c766-11e1-8775-005056c00008" name="Claytor LD" loadType="UNDEFINED" p0="23" q0="16" node="14" p="23.000002568521101" q="16.000002977995589">
                 <iidm:alias>_0480ff6b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1133,12 +1133,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="129.73718464034962" angle="-4.3434119671908222" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="129.73333741072872" angle="-15.342878188874449" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0449e9d7-c766-11e1-8775-005056c00008" name="N.Newark LD" loadType="UNDEFINED" p0="53" q0="22" node="11" p="52.997455168194975" q="21.998239452715968">
+            <iidm:load id="_0449e9d7-c766-11e1-8775-005056c00008" name="N.Newark LD" loadType="UNDEFINED" p0="53" q0="22" node="11" p="52.997651366236632" q="21.998375183032731">
                 <iidm:alias>_04531191-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_04684741-c766-11e1-8775-005056c00008" name="N.Newark SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.32300000000001" targetDeadband="1" node="12" q="-9.6614170830039949">
+            <iidm:shunt id="_04684741-c766-11e1-8775-005056c00008" name="N.Newark SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.32300000000001" targetDeadband="1" node="12" q="-9.6608440917067142">
                 <iidm:alias>_04607f19-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_eae61817-d3cb-488f-a1f3-13bc8e31431b"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -1191,9 +1191,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.88981903093941" angle="11.271623327911563" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.9953564209452" angle="0.035040799403042971" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0448d86a-c766-11e1-8775-005056c00008" name="Hillsbro NegG LD" loadType="UNDEFINED" p0="12" q0="0" node="8" p="11.997709991140461" q="0">
+            <iidm:load id="_0448d86a-c766-11e1-8775-005056c00008" name="Hillsbro NegG LD" loadType="UNDEFINED" p0="12" q0="0" node="8" p="11.998408635219917" q="0">
                 <iidm:alias>_044ef2e8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1244,9 +1244,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="125.32853991547648" angle="-6.0227450473020063" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="125.2852737536024" angle="-16.957777970218562" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047dcb12-c766-11e1-8775-005056c00008" name="S.Kenton LD" loadType="UNDEFINED" p0="18" q0="7" node="8" p="17.996889423165292" q="6.9979840015219468">
+            <iidm:load id="_047dcb12-c766-11e1-8775-005056c00008" name="S.Kenton LD" loadType="UNDEFINED" p0="18" q0="7" node="8" p="17.99711373827774" q="6.9981293748003646">
                 <iidm:alias>_0451b205-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1281,6 +1281,9 @@
                     <iidm:alias>_8ef85f09-3622-4a12-87bf-fefcecc01e4a</iidm:alias>
                     <iidm:alias>_a0244ab3-80e5-4c20-b201-a142d50e6ec1</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_dffdb415-95a8-496a-ad1a-93cdeb444fae-1" name="DISCONNECTOR723-1" kind="DISCONNECTOR" retained="false" open="false" node1="24" node2="25"/>
+                <iidm:switch id="_aa063f2e-1205-4d1a-a549-3ccc5b31e65d-1" name="BREAKER362-1" kind="BREAKER" retained="false" open="false" node1="23" node2="24"/>
+                <iidm:switch id="_28b3e895-483c-478d-a5a3-7b9d7c9e11f3-1" name="DISCONNECTOR724-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="23"/>
                 <iidm:internalConnection node1="7" node2="0"/>
                 <iidm:internalConnection node1="8" node2="0"/>
                 <iidm:internalConnection node1="9" node2="1"/>
@@ -1297,9 +1300,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="125.2092118824993" angle="21.236712790955366" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.1793127816079" angle="10.277719229224795" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044afb49-c766-11e1-8775-005056c00008" name="Hazard LD" loadType="UNDEFINED" p0="21" q0="10" node="8" p="20.998299625577875" q="9.9986505329138993">
+            <iidm:load id="_044afb49-c766-11e1-8775-005056c00008" name="Hazard LD" loadType="UNDEFINED" p0="21" q0="10" node="8" p="20.997925521896271" q="9.9983536430205575">
                 <iidm:alias>_045e5c31-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1320,6 +1323,9 @@
                     <iidm:alias>_2a61ce12-8d9c-4aae-8bc7-c8f820ecae6c</iidm:alias>
                     <iidm:alias>_a3d5e8cc-be34-4d4a-a586-ce582737826b</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_83a05cd7-017e-4e7a-bc5e-a01ee9681f9f-1" name="DISCONNECTOR725-1" kind="DISCONNECTOR" retained="false" open="false" node1="14" node2="15"/>
+                <iidm:switch id="_cf4393c0-21c2-4e35-b330-c1acda2647ba-1" name="BREAKER363-1" kind="BREAKER" retained="false" open="true" node1="13" node2="14"/>
+                <iidm:switch id="_b9ab29b9-3d90-4536-8d1a-7757d8c22ae4-1" name="DISCONNECTOR726-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="13"/>
                 <iidm:internalConnection node1="4" node2="0"/>
                 <iidm:internalConnection node1="5" node2="0"/>
                 <iidm:internalConnection node1="6" node2="1"/>
@@ -1329,14 +1335,14 @@
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="3"/>
-                <iidm:bus v="31.302302970624826" angle="21.236712790955366" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="31.044828195401973" angle="10.2777192292248" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13"/>
             </iidm:nodeBreakerTopology>
             <iidm:staticVarCompensator id="_047fc6e6-c766-11e1-8775-005056c00008" name="Pinevlle SVC" bMin="-10" bMax="10" voltageSetpoint="33.494999999999997" regulationMode="VOLTAGE" node="5" p="0" q="0">
                 <iidm:alias>_046ab846-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_98f667da-02d1-4a31-b826-44314a1fbbfe"/>
             </iidm:staticVarCompensator>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045e3525-c766-11e1-8775-005056c00008" name="86-87" r="0.30796918750000002" x="2.2585859312499998" g="0" b="-0.0040863184000000004" ratedU1="132" ratedU2="33" node1="22" voltageLevelId1="_0484f70a-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_04555b88-c766-11e1-8775-005056c00008" p1="0" q1="4.0039144029879719" p2="-2.7261023256703831e-14" q2="1.2002684062935592e-14">
+        <iidm:twoWindingsTransformer id="_045e3525-c766-11e1-8775-005056c00008" name="86-87" r="0.30796918750000002" x="2.2585859312499998" g="0" b="-0.0040863184000000004" ratedU1="132" ratedU2="33" node1="22" voltageLevelId1="_0484f70a-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_04555b88-c766-11e1-8775-005056c00008" p1="-2.9577035265404561e-14" q1="3.9383174954730844" p2="2.7048312894766807e-14" q2="-9.0628272064390434e-14">
             <iidm:alias>_0452755a-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04682034-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_048c7110-c766-11e1-8775-005056c00008</iidm:alias>
@@ -1412,6 +1418,82 @@
                 <iidm:temporaryLimit name="_257d56c1-d70a-4a96-b85c-d928ade03ad4" acceptableDuration="60" value="12246"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
+        <iidm:twoWindingsTransformer id="_045e3525-c766-11e1-8775-005056c00008-1" name="86-87-open-ended" r="0.30796918750000002" x="2.2585859312499998" g="0" b="-0.0040863184000000004" ratedU1="132" ratedU2="33" node1="25" voltageLevelId1="_0484f70a-c766-11e1-8775-005056c00008" node2="15" voltageLevelId2="_04555b88-c766-11e1-8775-005056c00008" p1="0" q1="3.9383174954730418" p2="0" q2="0">
+            <iidm:alias>_0452755a-c766-11e1-8775-005056c00008-1</iidm:alias>
+            <iidm:alias>_04682034-c766-11e1-8775-005056c00008-1</iidm:alias>
+            <iidm:alias>_048c7110-c766-11e1-8775-005056c00008-1</iidm:alias>
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="31" loadTapChangingCapabilities="false">
+                <iidm:step r="-78.460970487743992" x="-78.460970487743992" g="364.27347129590328" b="364.27347129590328" rho="0.4641016"/>
+                <iidm:step r="-76.770985444658564" x="-76.770985444658564" g="330.49609255595948" b="330.49609255595948" rho="0.48196488000000004"/>
+                <iidm:step r="-75.017181047101431" x="-75.017181047101431" g="300.27508580410921" b="300.27508580410921" rho="0.49982816000000002"/>
+                <iidm:step r="-73.199557295072623" x="-73.199557295072623" g="273.1281647135425" b="273.1281647135425" rho="0.51769144000000011"/>
+                <iidm:step r="-71.318114188572153" x="-71.318114188572153" g="248.65210975826625" b="248.65210975826625" rho="0.53555472000000004"/>
+                <iidm:step r="-69.372851727600008" x="-69.372851727600008" g="226.50770848984379" b="226.50770848984379" rho="0.55341799999999997"/>
+                <iidm:step r="-67.363769912156158" x="-67.363769912156158" g="206.40793906293555" b="206.40793906293555" rho="0.57128128"/>
+                <iidm:step r="-65.290868742240633" x="-65.290868742240633" g="188.10862264852744" b="188.10862264852744" rho="0.58914456000000004"/>
+                <iidm:step r="-63.154148217853432" x="-63.154148217853432" g="171.40097232995538" b="171.40097232995538" rho="0.60700784000000008"/>
+                <iidm:step r="-60.953608338994556" x="-60.953608338994556" g="156.10561116167679" b="156.10561116167679" rho="0.62487112"/>
+                <iidm:step r="-58.689249105663997" x="-58.689249105663997" g="142.06773741726079" b="142.06773741726079" rho="0.64273440000000004"/>
+                <iidm:step r="-56.361070517861769" x="-56.361070517861769" g="129.15319231405709" b="129.15319231405709" rho="0.66059767999999996"/>
+                <iidm:step r="-53.969072575587838" x="-53.969072575587838" g="117.24524269951107" b="117.24524269951107" rho="0.67846096"/>
+                <iidm:step r="-51.51325527884223" x="-51.51325527884223" g="106.24193390397649" b="106.24193390397649" rho="0.69632424000000004"/>
+                <iidm:step r="-48.993618627624947" x="-48.993618627624947" g="96.053900138385018" b="96.053900138385018" rho="0.71418752000000008"/>
+                <iidm:step r="-46.410162621936003" x="-46.410162621936003" g="86.602544237115268" b="86.602544237115268" rho="0.7320508"/>
+                <iidm:step r="-43.762887261775354" x="-43.762887261775354" g="77.81851722275475" b="77.81851722275475" rho="0.74991407999999993"/>
+                <iidm:step r="-41.051792547143037" x="-41.051792547143037" g="69.640442552852292" b="69.640442552852292" rho="0.76777735999999996"/>
+                <iidm:step r="-38.276878478039045" x="-38.276878478039045" g="62.013841060226049" b="62.013841060226049" rho="0.78564064"/>
+                <iidm:step r="-35.438145054463355" x="-35.438145054463355" g="54.890221299184191" b="54.890221299184191" rho="0.80350392000000004"/>
+                <iidm:step r="-32.53559227641599" x="-32.53559227641599" g="48.2263068397802" b="48.2263068397802" rho="0.82136720000000008"/>
+                <iidm:step r="-29.569220143896956" x="-29.569220143896956" g="41.983377444222199" b="41.983377444222199" rho="0.83923048"/>
+                <iidm:step r="-26.53902865690624" x="-26.53902865690624" g="36.126705339843348" b="36.126705339843348" rho="0.85709376000000004"/>
+                <iidm:step r="-23.445017815443848" x="-23.445017815443848" g="30.625071218648301" b="30.625071218648301" rho="0.87495704000000007"/>
+                <iidm:step r="-20.287187619509762" x="-20.287187619509762" g="25.450347332714429" b="25.450347332714429" rho="0.89282032000000011"/>
+                <iidm:step r="-17.06553806910399" x="-17.06553806910399" g="20.577137262099331" b="20.577137262099331" rho="0.91068360000000004"/>
+                <iidm:step r="-13.780069164226571" x="-13.780069164226571" g="15.982463718828566" b="15.982463718828566" rho="0.92854687999999996"/>
+                <iidm:step r="-10.430780904877434" x="-10.430780904877434" g="11.645497203453271" b="11.645497203453271" rho="0.94641016"/>
+                <iidm:step r="-7.0176732910566368" x="-7.0176732910566368" g="7.5473195169912355" b="7.5473195169912355" rho="0.96427344000000004"/>
+                <iidm:step r="-3.5407463227641656" x="-3.5407463227641656" g="3.6707171036300279" b="3.6707171036300279" rho="0.98213671999999985"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1"/>
+                <iidm:step r="3.6045656772358381" x="3.6045656772358381" g="-3.4791571719583358" b="-3.4791571719583358" rho="1.01786328"/>
+                <iidm:step r="7.272950708943382" x="7.272950708943382" g="-6.7798551833225922" b="-6.7798551833225922" rho="1.0357265600000001"/>
+                <iidm:step r="11.005155095122543" x="11.005155095122543" g="-9.9140937064517427" b="-9.9140937064517427" rho="1.0535898399999999"/>
+                <iidm:step r="14.801178835773431" x="14.801178835773431" g="-12.892880531259154" b="-12.892880531259154" rho="1.0714531199999999"/>
+                <iidm:step r="18.661021930895984" x="18.661021930895984" g="-15.726328348801433" b="-15.726328348801433" rho="1.0893164"/>
+                <iidm:step r="22.584684380490238" x="22.584684380490238" g="-18.423740693731116" b="-18.423740693731116" rho="1.10717968"/>
+                <iidm:step r="26.572166184556178" x="26.572166184556178" g="-20.993688411566747" b="-20.993688411566747" rho="1.12504296"/>
+                <iidm:step r="30.623467343093779" x="30.623467343093779" g="-23.444077826121855" b="-23.444077826121855" rho="1.1429062400000001"/>
+                <iidm:step r="34.738587856103067" x="34.738587856103067" g="-25.782211620922489" b="-25.782211620922489" rho="1.1607695200000001"/>
+                <iidm:step r="38.917527723583987" x="38.917527723583987" g="-28.014843311220961" b="-28.014843311220961" rho="1.1786327999999999"/>
+                <iidm:step r="43.16028694553664" x="43.16028694553664" g="-30.148226066322692" b="-30.148226066322692" rho="1.19649608"/>
+                <iidm:step r="47.466865521960955" x="47.466865521960955" g="-32.188156542116317" b="-32.188156542116317" rho="1.21435936"/>
+                <iidm:step r="51.837263452856973" x="51.837263452856973" g="-34.140014298236885" b="-34.140014298236885" rho="1.23222264"/>
+                <iidm:step r="56.271480738224653" x="56.271480738224653" g="-36.0087973009527" b="-36.0087973009527" rho="1.2500859200000001"/>
+                <iidm:step r="60.769517378063973" x="60.769517378063973" g="-37.799153949786998" b="-37.799153949786998" rho="1.2679491999999999"/>
+                <iidm:step r="65.331373372375026" x="65.331373372375026" g="-39.515412011505823" b="-39.515412011505823" rho="1.2858124799999999"/>
+                <iidm:step r="69.957048721157761" x="69.957048721157761" g="-41.161604798123854" b="-41.161604798123854" rho="1.30367576"/>
+                <iidm:step r="74.646543424412172" x="74.646543424412172" g="-42.741494884907091" b="-42.741494884907091" rho="1.32153904"/>
+                <iidm:step r="79.399857482138245" x="79.399857482138245" g="-44.258595629064871" b="-44.258595629064871" rho="1.33940232"/>
+                <iidm:step r="84.216990894335964" x="84.216990894335964" g="-45.716190719151165" b="-45.716190719151165" rho="1.3572655999999998"/>
+                <iidm:step r="89.097943661005473" x="89.097943661005473" g="-47.11735195848069" b="-47.11735195848069" rho="1.3751288800000001"/>
+                <iidm:step r="94.04271578214653" x="94.04271578214653" g="-48.464955462553469" b="-48.464955462553469" rho="1.3929921599999999"/>
+                <iidm:step r="99.051307257759348" x="99.051307257759348" g="-49.761696430103783" b="-49.761696430103783" rho="1.41085544"/>
+                <iidm:step r="104.12371808784383" x="104.12371808784383" g="-51.010102629540867" b="-51.010102629540867" rho="1.42871872"/>
+                <iidm:step r="109.25994827240002" x="109.25994827240002" g="-52.212546726893493" b="-52.212546726893493" rho="1.446582"/>
+                <iidm:step r="114.45999781142788" x="114.45999781142788" g="-53.371257567609966" b="-53.371257567609966" rho="1.4644452800000001"/>
+                <iidm:step r="119.72386670492732" x="119.72386670492732" g="-54.488330512455207" b="-54.488330512455207" rho="1.4823085599999999"/>
+                <iidm:step r="125.05155495289854" x="125.05155495289854" g="-55.565736917068101" b="-55.565736917068101" rho="1.5001718399999999"/>
+                <iidm:step r="130.44306255534144" x="130.44306255534144" g="-56.605332835313817" b="-56.605332835313817" rho="1.51803512"/>
+                <iidm:step r="135.89838951225599" x="135.89838951225599" g="-57.608867018227542" b="-57.608867018227542" rho="1.5358984"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="2186">
+                <iidm:temporaryLimit name="_580d3b53-5508-4d8d-97cc-4ea463e0cdb9-1" acceptableDuration="900" value="2514"/>
+                <iidm:temporaryLimit name="_a867e68a-58d1-49cb-955f-bb8e59cf2a11-1" acceptableDuration="60" value="3061"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="8747">
+                <iidm:temporaryLimit name="_1a7f23f9-e2c0-46a6-a93c-687f2209e33d-1" acceptableDuration="900" value="10059"/>
+                <iidm:temporaryLimit name="_257d56c1-d70a-4a96-b85c-d928ade03ad4-1" acceptableDuration="60" value="12246"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
     </iidm:substation>
     <iidm:substation id="_045beb3a-c766-11e1-8775-005056c00008" name="Minas Tirith" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
         <iidm:voltageLevel id="_048a9c58-c766-11e1-8775-005056c00008" name="MNT132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -1460,12 +1542,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="132.72377843871442" angle="11.982139196869833" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="132.84755644910246" angle="0.16373978788277363" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0447ee05-c766-11e1-8775-005056c00008" name="NwCarlsl NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="8" p="8.9994557546352905" q="0">
+            <iidm:load id="_0447ee05-c766-11e1-8775-005056c00008" name="NwCarlsl NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="8" p="8.9995978213897541" q="0">
                 <iidm:alias>_04731cb7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_047a48a8-c766-11e1-8775-005056c00008" name="NwCarlsl LD" loadType="UNDEFINED" p0="30" q0="12" node="9" p="29.998185848784303" q="11.998790590235215">
+            <iidm:load id="_047a48a8-c766-11e1-8775-005056c00008" name="NwCarlsl LD" loadType="UNDEFINED" p0="30" q0="12" node="9" p="29.998659404632516" q="11.999106283067638">
                 <iidm:alias>_044c0cb9-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1516,9 +1598,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.62191576110305" angle="9.4084896980614463" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.62189619960881" angle="-1.6530920509393685" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044ecbd1-c766-11e1-8775-005056c00008" name="Blaine LD" loadType="UNDEFINED" p0="2" q0="1" node="8" p="2.0000004918415137" q="1.0000004098679616">
+            <iidm:load id="_044ecbd1-c766-11e1-8775-005056c00008" name="Blaine LD" loadType="UNDEFINED" p0="2" q0="1" node="8" p="2.0000005897263589" q="1.0000004914386806">
                 <iidm:alias>_04700f74-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1569,9 +1651,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="133.18520318042516" angle="15.424801642820443" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="133.16042577404045" angle="4.3644943309549271" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046b7b95-c766-11e1-8775-005056c00008" name="Sundial LD" loadType="UNDEFINED" p0="15" q0="9" node="8" p="14.999900907917899" q="8.9999009081361034">
+            <iidm:load id="_046b7b95-c766-11e1-8775-005056c00008" name="Sundial LD" loadType="UNDEFINED" p0="15" q0="9" node="8" p="14.999895331036015" q="8.9998953312794718">
                 <iidm:alias>_046efe07-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1622,9 +1704,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.69359721723532" angle="7.1682122815302591" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.74396681294921" angle="-4.4803151535545203" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045645e2-c766-11e1-8775-005056c00008" name="Riversde LD" loadType="UNDEFINED" p0="51" q0="27" node="8" p="50.99864406688949" q="26.998803599034904">
+            <iidm:load id="_045645e2-c766-11e1-8775-005056c00008" name="Riversde LD" loadType="UNDEFINED" p0="51" q0="27" node="8" p="50.998996282224198" q="26.999114372478399">
                 <iidm:alias>_0476ed4b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1675,9 +1757,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.69878109967132" angle="10.369131842918332" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.87481388481633" angle="-0.78154116769440329" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04887973-c766-11e1-8775-005056c00008" name="Randolph LD" loadType="UNDEFINED" p0="10" q0="5" node="8" p="9.9955148752032414" q="4.9962629548178983">
+            <iidm:load id="_04887973-c766-11e1-8775-005056c00008" name="Randolph LD" loadType="UNDEFINED" p0="10" q0="5" node="8" p="9.9966258213014143" q="4.9971885006819763">
                 <iidm:alias>_0462f018-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1728,9 +1810,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.48483419456981" angle="-6.8628366988268876" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.48459517694907" angle="-17.882283283606657" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0477627b-c766-11e1-8775-005056c00008" name="WNwPhil2 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="11.999996257614381" q="2.9999984406728206">
+            <iidm:load id="_0477627b-c766-11e1-8775-005056c00008" name="WNwPhil2 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="11.999996045589462" q="2.9999983523291234">
                 <iidm:alias>_045841b6-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1800,9 +1882,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="126.73057812823774" angle="10.138690137737646" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="126.73055737160007" angle="-0.9226815883720485" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0476781a-c766-11e1-8775-005056c00008" name="Cloverdl LD" loadType="UNDEFINED" p0="43" q0="16" node="11" p="43.000011853105256" q="16.000007350763624">
+            <iidm:load id="_0476781a-c766-11e1-8775-005056c00008" name="Cloverdl LD" loadType="UNDEFINED" p0="43" q0="16" node="11" p="43.000013953892697" q="16.000008653577801">
                 <iidm:alias>_0481749a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1872,9 +1954,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="128.11690924187963" angle="11.507959278986943" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="128.11689919132772" angle="0.44657238631376828" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046b0665-c766-11e1-8775-005056c00008" name="Hancock LD" loadType="UNDEFINED" p0="38" q0="25" node="11" p="38.000006739252846" q="25.000007389532058">
+            <iidm:load id="_046b0665-c766-11e1-8775-005056c00008" name="Hancock LD" loadType="UNDEFINED" p0="38" q0="25" node="11" p="38.000008613736" q="25.000009444886679">
                 <iidm:alias>_0464c4d5-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1926,12 +2008,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="128.66422164944049" angle="-5.4731313081459412" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="128.65035859553441" angle="-16.45574855284498" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044bbe92-c766-11e1-8775-005056c00008" name="WMVernon LD" loadType="UNDEFINED" p0="16" q0="8" node="8" p="15.998630237326045" q="7.9988585636791303">
+            <iidm:load id="_044bbe92-c766-11e1-8775-005056c00008" name="WMVernon LD" loadType="UNDEFINED" p0="16" q0="8" node="8" p="15.998731756931761" q="7.9989431587010271">
                 <iidm:alias>_04500452-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_047825c8-c766-11e1-8775-005056c00008" name="WMVernon SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.21199999999999" targetDeadband="1" node="9" q="-9.5022726293447484">
+            <iidm:shunt id="_047825c8-c766-11e1-8775-005056c00008" name="WMVernon SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.21199999999999" targetDeadband="1" node="9" q="-9.5002250761200102">
                 <iidm:alias>_047084aa-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_2a6c1dcd-201b-4911-83b2-c16acc50a0f4"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -1965,9 +2047,9 @@
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="3"/>
-                <iidm:bus v="230.99998883776559" angle="34.601350442797219" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="230.99998532353558" angle="22.470243549919616" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_045868c0-c766-11e1-8775-005056c00008" name="Breed SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="450" targetV="230.99998500000001" targetQ="0" node="5" p="-498.28281956399945" q="23.169859165286198">
+            <iidm:generator id="_045868c0-c766-11e1-8775-005056c00008" name="Breed SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="450" targetV="230.99998500000001" targetQ="0" node="5" p="-498.20225870625342" q="26.946318694000563">
                 <iidm:alias>_045b7606-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_f26d4eb3-ebdb-4025-8080-f856ce656b42"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_7566f2a7-61eb-42fe-a59a-8276257fdbc6"/>
@@ -2041,9 +2123,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="127.47359674514624" angle="-5.7581410987812882" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="127.47325352657461" angle="-16.776906763744385" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044d1e22-c766-11e1-8775-005056c00008" name="Newcmrst LD" loadType="UNDEFINED" p0="17" q0="8" node="11" p="16.999990961345361" q="7.9999929108603638">
+            <iidm:load id="_044d1e22-c766-11e1-8775-005056c00008" name="Newcmrst LD" loadType="UNDEFINED" p0="17" q0="8" node="11" p="16.999990230106697" q="7.9999923373400534">
                 <iidm:alias>_048a754b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2113,9 +2195,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="138.5999951231409" angle="24.582756818535753" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="138.59999100630455" angle="12.862662547319658" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_045ab2b0-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="220" targetV="138.59999099999999" targetQ="0" node="11" p="-243.60493400906643" q="-50.208263608390212">
+            <iidm:generator id="_045ab2b0-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="220" targetV="138.59999099999999" targetQ="0" node="11" p="-243.56554870083502" q="-46.987975234464599">
                 <iidm:alias>_046ba2a5-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_56975783-9739-40fc-8ec1-e1de8cb06c9a"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b8449cd9-5a17-497e-bf04-70f728b0f9f2"/>
@@ -2168,9 +2250,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="223.30000593950282" angle="26.893708525919031" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="223.30000003796977" angle="14.922491153199275" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0483224a-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="314" targetV="223.30000000000001" targetQ="0" node="8" p="-347.69067854021296" q="-24.05998588597167">
+            <iidm:generator id="_0483224a-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="314" targetV="223.30000000000001" targetQ="0" node="8" p="-347.63446496391907" q="-19.34234670114645">
                 <iidm:alias>_045cd594-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_05df66ba-3f64-40cb-8b18-c66d26c4e2c1"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_c1d29442-5f57-41d1-bb60-4b74b4994c20"/>
@@ -2178,7 +2260,7 @@
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045b7604-c766-11e1-8775-005056c00008" name="26-25" r="0" x="6.6559680000000006" g="0" b="0" ratedU1="220" ratedU2="132" node1="22" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="117.18478553837576" q1="22.54553495578126" p2="-117.18478553837568" q2="-17.679208590268576">
+        <iidm:twoWindingsTransformer id="_045b7604-c766-11e1-8775-005056c00008" name="26-25" r="0" x="6.6559680000000006" g="0" b="0" ratedU1="220" ratedU2="132" node1="22" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="104.45653697208657" q1="22.059823867739503" p2="-104.45653697208657" q2="-18.164936452132867">
             <iidm:alias>_0447c6f3-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0463b364-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04803c1c-c766-11e1-8775-005056c00008</iidm:alias>
@@ -2321,9 +2403,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="136.62000190944167" angle="14.828929619551399" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="136.62000602133594" angle="3.7684852155647932" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_048aea70-c766-11e1-8775-005056c00008" name="Sporn SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="513.43743900000004" targetV="136.62" targetQ="-62.132553100000003" node="20" p="-568.52678838808663" q="50.154163766504169">
+            <iidm:generator id="_048aea70-c766-11e1-8775-005056c00008" name="Sporn SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="513.43743900000004" targetV="136.62" targetQ="-62.132553100000003" node="20" p="-568.43487069812056" q="50.466572349993363">
                 <iidm:alias>_04555b84-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_27799004-aa1e-4889-ba95-ee6fdae64895"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_827a9c80-183d-4e33-9e73-ef0aab3dfb13"/>
@@ -2413,9 +2495,9 @@
                 <iidm:internalConnection node1="39" node2="9"/>
                 <iidm:internalConnection node1="40" node2="12"/>
                 <iidm:internalConnection node1="41" node2="3"/>
-                <iidm:bus v="219.70611649454597" angle="11.023127228217485" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41"/>
+                <iidm:bus v="219.70695623216679" angle="-0.017712193280935366" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41"/>
             </iidm:nodeBreakerTopology>
-            <iidm:danglingLine id="_0482fb33-c766-11e1-8775-005056c00008" name="68-116" p0="184" q0="0" r="0.16456000000000001" x="1.9601999999999999" g="0" b="0.00033884300000000002" ucteXnodeCode="XWE_BR21" node="41" p="184.11557519154462" q="-14.979571767632343">
+            <iidm:danglingLine id="_0482fb33-c766-11e1-8775-005056c00008" name="68-116" p0="184" q0="0" r="0.16456000000000001" x="1.9601999999999999" g="0" b="0.00033884300000000002" ucteXnodeCode="XWE_BR21" node="41" p="184.11558522837132" q="-14.979707159080263">
                 <iidm:alias>_0459c855-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_04684742-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_5631ccc0-d9d2-11e2-bb49-005056c00008</iidm:alias>
@@ -2428,7 +2510,7 @@
                 </iidm:currentLimits>
             </iidm:danglingLine>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_044f6815-c766-11e1-8775-005056c00008" name="68-69" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-198.31277111166526" q1="102.11066045084101" p2="198.31277111166523" q2="-85.973811027797396">
+        <iidm:twoWindingsTransformer id="_044f6815-c766-11e1-8775-005056c00008" name="68-69" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-197.29344588166086" q1="102.05506294662831" p2="197.29344588166089" q2="-86.052803534231899">
             <iidm:alias>_047e8e67-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04840ca7-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0487dd39-c766-11e1-8775-005056c00008</iidm:alias>
@@ -2535,9 +2617,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="131.60564554681798" angle="2.9732524130737317" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="131.6056522580397" angle="-8.0508317349378782" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04547126-c766-11e1-8775-005056c00008" name="Natrium LD" loadType="UNDEFINED" p0="77" q0="14" node="14" p="76.999906514104737" q="13.999971670952293">
+            <iidm:load id="_04547126-c766-11e1-8775-005056c00008" name="Natrium LD" loadType="UNDEFINED" p0="77" q0="14" node="14" p="76.999909962302965" q="13.999972715860022">
                 <iidm:alias>_047b3307-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2588,9 +2670,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="123.83127953636935" angle="-5.0741477638175265" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="123.77017966158465" angle="-15.976401909242512" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045d4ac9-c766-11e1-8775-005056c00008" name="Sterling LD" loadType="UNDEFINED" p0="31" q0="17" node="8" p="30.992972659626165" q="16.993577647363761">
+            <iidm:load id="_045d4ac9-c766-11e1-8775-005056c00008" name="Sterling LD" loadType="UNDEFINED" p0="31" q0="17" node="8" p="30.993480414098912" q="16.9940416564298">
                 <iidm:alias>_0477b094-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2698,9 +2780,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="130.29520502752601" angle="17.967825550103331" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="130.27270209889906" angle="6.9089616194231382" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0466246a-c766-11e1-8775-005056c00008" name="Switchbk LD" loadType="UNDEFINED" p0="30" q0="16" node="17" p="29.99972090775238" q="15.999751918771427">
+            <iidm:load id="_0466246a-c766-11e1-8775-005056c00008" name="Switchbk LD" loadType="UNDEFINED" p0="30" q0="16" node="17" p="29.999711430009938" q="15.999743494164619">
                 <iidm:alias>_04882b59-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2751,9 +2833,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="135.08660293618402" angle="15.235160137897299" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="135.08662889394787" angle="4.1747280816033632" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046adf5a-c766-11e1-8775-005056c00008" name="Bradley LD" loadType="UNDEFINED" p0="34" q0="8" node="8" p="33.999982154624881" q="7.9999930018149019">
+            <iidm:load id="_046adf5a-c766-11e1-8775-005056c00008" name="Bradley LD" loadType="UNDEFINED" p0="34" q0="8" node="8" p="33.999984542274611" q="7.999993938147826">
                 <iidm:alias>_04555b85-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2788,6 +2870,9 @@
                     <iidm:alias>_7f359893-b7c5-41b0-ada8-8df06cf7a8e6</iidm:alias>
                     <iidm:alias>_a4edf081-2fb2-4da4-94db-98a2a596247f</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_312f25f3-55bc-4417-848c-236d31d823f4-1" name="DISCONNECTOR524-1" kind="DISCONNECTOR" retained="false" open="false" node1="24" node2="25"/>
+                <iidm:switch id="_686e884a-a0b1-454e-b7d1-33c7ad46f89f-1" name="BREAKER262-1" kind="BREAKER" retained="false" open="false" node1="23" node2="24"/>
+                <iidm:switch id="_346a5319-3ec2-40a2-aefd-38dfacbbe97c-1" name="DISCONNECTOR523-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="23"/>
                 <iidm:internalConnection node1="7" node2="0"/>
                 <iidm:internalConnection node1="8" node2="0"/>
                 <iidm:internalConnection node1="9" node2="1"/>
@@ -2804,9 +2889,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.72323755132612" angle="8.4357179302141532" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.04546597044323" angle="-2.6049998289062315" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047a48a2-c766-11e1-8775-005056c00008" name="Mullin LD" loadType="UNDEFINED" p0="17" q0="7" node="8" p="16.991167637523528" q="6.9939396245709666">
+            <iidm:load id="_047a48a2-c766-11e1-8775-005056c00008" name="Mullin LD" loadType="UNDEFINED" p0="17" q0="7" node="8" p="16.993768365688261" q="6.9957239107932434">
                 <iidm:alias>_0474553a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2972,16 +3057,16 @@
                 <iidm:internalConnection node1="81" node2="18"/>
                 <iidm:internalConnection node1="82" node2="21"/>
                 <iidm:internalConnection node1="83" node2="24"/>
-                <iidm:bus v="134.24399334969962" angle="17.671756752059252" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
+                <iidm:bus v="134.24399781186858" angle="6.6106399961761948" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_044cd00a-c766-11e1-8775-005056c00008" name="Glen Lyn SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="252" targetV="134.243988" targetQ="0" node="27" p="-279.03837895583973" q="-83.970974255995884">
+            <iidm:generator id="_044cd00a-c766-11e1-8775-005056c00008" name="Glen Lyn SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="252" targetV="134.243988" targetQ="0" node="27" p="-278.99326487550195" q="-84.322872647594181">
                 <iidm:alias>_045e5c30-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e54b499b-436c-4b89-9803-b1d75e2fa364"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_32c8ab65-80f7-4c17-b3f5-ff075cce0ba5"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
-            <iidm:load id="_04566cf5-c766-11e1-8775-005056c00008" name="Glen Lyn LD" loadType="UNDEFINED" p0="37" q0="18" node="26" p="37.000002211706729" q="18.000001793275761">
+            <iidm:load id="_04566cf5-c766-11e1-8775-005056c00008" name="Glen Lyn LD" loadType="UNDEFINED" p0="37" q0="18" node="26" p="37.00000405648494" q="18.000003289041956">
                 <iidm:alias>_04577e64-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3032,9 +3117,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.55453610253718" angle="9.6218305517830309" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.63038124880953" angle="-2.0700931471381478" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044ea4c0-c766-11e1-8775-005056c00008" name="Kankakee LD" loadType="UNDEFINED" p0="52" q0="22" node="8" p="51.998189451766997" q="21.998723346191333">
+            <iidm:load id="_044ea4c0-c766-11e1-8775-005056c00008" name="Kankakee LD" loadType="UNDEFINED" p0="52" q0="22" node="8" p="51.998675563350197" q="21.999066110291114">
                 <iidm:alias>_047e6758-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3143,12 +3228,12 @@
                 <iidm:internalConnection node1="51" node2="9"/>
                 <iidm:internalConnection node1="52" node2="12"/>
                 <iidm:internalConnection node1="53" node2="15"/>
-                <iidm:bus v="127.42281329861309" angle="10.405736502639101" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
+                <iidm:bus v="127.42280493467807" angle="-0.65569028845281097" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0484cffb-c766-11e1-8775-005056c00008" name="Roanoke LD" loadType="UNDEFINED" p0="31" q0="26" node="17" p="31.000004104579581" q="26.000005737584615">
+            <iidm:load id="_0484cffb-c766-11e1-8775-005056c00008" name="Roanoke LD" loadType="UNDEFINED" p0="31" q0="26" node="17" p="31.000005636785122" q="26.000007879377534">
                 <iidm:alias>_0454983a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0489d903-c766-11e1-8775-005056c00008" name="Roanoke SC" sectionCount="5" voltageRegulatorOn="true" targetV="127.423" targetDeadband="1" node="18" q="-18.639586204575327">
+            <iidm:shunt id="_0489d903-c766-11e1-8775-005056c00008" name="Roanoke SC" sectionCount="5" voltageRegulatorOn="true" targetV="127.423" targetDeadband="1" node="18" q="-18.639583757599326">
                 <iidm:alias>_0476c638-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_5be38d1a-9d01-42d8-b8bb-e9a26cfbcf1a"/>
                 <iidm:shuntLinearModel bPerSection="0.0002296" gPerSection="0" maximumSectionCount="10"/>
@@ -3240,12 +3325,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="120.60503981105656" angle="-10.277216215524184" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="120.57411386654368" angle="-21.24884371884577" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047a219a-c766-11e1-8775-005056c00008" name="Howard LD" loadType="UNDEFINED" p0="37" q0="23" node="14" p="36.992319323884651" q="22.992043093394567">
+            <iidm:load id="_047a219a-c766-11e1-8775-005056c00008" name="Howard LD" loadType="UNDEFINED" p0="37" q0="23" node="14" p="36.992652810655294" q="22.992388550928396">
                 <iidm:alias>_04882b51-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_04488a49-c766-11e1-8775-005056c00008" name="Howard NegG LD" loadType="UNDEFINED" p0="59" q0="0" node="15" p="58.987752435383634" q="0">
+            <iidm:load id="_04488a49-c766-11e1-8775-005056c00008" name="Howard NegG LD" loadType="UNDEFINED" p0="59" q0="0" node="15" p="58.988284211585466" q="0">
                 <iidm:alias>_046d9e74-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3295,7 +3380,7 @@
                 <iidm:internalConnection node1="19" node2="6"/>
                 <iidm:internalConnection node1="20" node2="3"/>
                 <iidm:internalConnection node1="21" node2="6"/>
-                <iidm:bus v="218.77271736335075" angle="12.820289680075486" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
+                <iidm:bus v="218.7731610320763" angle="1.7721774383127251" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_046efe09-c766-11e1-8775-005056c00008" name="CRI132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -3458,20 +3543,20 @@
                 <iidm:internalConnection node1="81" node2="18"/>
                 <iidm:internalConnection node1="82" node2="21"/>
                 <iidm:internalConnection node1="83" node2="24"/>
-                <iidm:bus v="137.28000328724508" angle="15.724128590908563" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
+                <iidm:bus v="137.28000770489527" angle="4.6640997728942146" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_045868c1-c766-11e1-8775-005056c00008" name="CabinCrk SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="477" targetV="137.28" targetQ="0" node="27" p="-528.17978873783943" q="-140.06720280116738">
+            <iidm:generator id="_045868c1-c766-11e1-8775-005056c00008" name="CabinCrk SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="477" targetV="137.28" targetQ="0" node="27" p="-528.09439422862863" q="-140.88967769334911">
                 <iidm:alias>_0487dd36-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_a6ec9760-88da-48df-a23f-7877e7c85ccd"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_e6131af8-c298-413b-84e3-4e21c3b6b06f"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-225" maxQ="640"/>
             </iidm:generator>
-            <iidm:load id="_04747c44-c766-11e1-8775-005056c00008" name="CabinCrk LD" loadType="UNDEFINED" p0="130" q0="26" node="26" p="130.00000466938221" q="26.000001556460759">
+            <iidm:load id="_04747c44-c766-11e1-8775-005056c00008" name="CabinCrk LD" loadType="UNDEFINED" p0="130" q0="26" node="26" p="130.00001094445363" q="26.000003648151321">
                 <iidm:alias>_046a9138-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_0488c79b-c766-11e1-8775-005056c00008" name="81-80" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="21" voltageLevelId1="_048a272b-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-151.44482730418096" q1="71.53888949222879" p2="151.44482730418099" q2="-62.362566517011246">
+        <iidm:twoWindingsTransformer id="_0488c79b-c766-11e1-8775-005056c00008" name="81-80" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="21" voltageLevelId1="_048a272b-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-150.82417800716468" q1="71.513704851256747" p2="150.82417800716468" q2="-62.399962745397715">
             <iidm:alias>_044974a0-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_045a3d83-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_046adf57-c766-11e1-8775-005056c00008</iidm:alias>
@@ -3551,12 +3636,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="134.74729435113386" angle="-1.052774590816276" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="134.74741245021903" angle="-12.068729104733748" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04524e4a-c766-11e1-8775-005056c00008" name="Zanesvll LD" loadType="UNDEFINED" p0="20" q0="11" node="8" p="19.999999343330053" q="10.999999398052559">
+            <iidm:load id="_04524e4a-c766-11e1-8775-005056c00008" name="Zanesvll LD" loadType="UNDEFINED" p0="20" q0="11" node="8" p="20.000000695337018" q="11.000000637392276">
                 <iidm:alias>_045c1240-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_048b5fa9-c766-11e1-8775-005056c00008" name="Zanesvll SC" sectionCount="5" voltageRegulatorOn="true" targetV="134.72300000000001" targetDeadband="1" node="9" q="-15.633033501392903">
+            <iidm:shunt id="_048b5fa9-c766-11e1-8775-005056c00008" name="Zanesvll SC" sectionCount="5" voltageRegulatorOn="true" targetV="134.72300000000001" targetDeadband="1" node="9" q="-15.633060904507346">
                 <iidm:alias>_04736ad5-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_99c6c4ad-5247-4058-96d4-ee8495103e85"/>
                 <iidm:shuntLinearModel bPerSection="0.00017220000000000001" gPerSection="0" maximumSectionCount="10"/>
@@ -3609,9 +3694,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.77511164357267" angle="20.720365037384148" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.7595261069095" angle="9.664021395290403" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044ca8f2-c766-11e1-8775-005056c00008" name="Tazewell LD" loadType="UNDEFINED" p0="12" q0="7" node="8" p="11.999889738359323" q="6.9998928015110078">
+            <iidm:load id="_044ca8f2-c766-11e1-8775-005056c00008" name="Tazewell LD" loadType="UNDEFINED" p0="12" q0="7" node="8" p="11.999887917600759" q="6.9998910313400025">
                 <iidm:alias>_04542305-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3662,9 +3747,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="119.84272160173786" angle="-8.5389017089252288" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="119.78557193882278" angle="-19.465883812970926" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04778989-c766-11e1-8775-005056c00008" name="NwLibrty LD" loadType="UNDEFINED" p0="27" q0="11" node="8" p="26.993129400784397" q="10.995335174036009">
+            <iidm:load id="_04778989-c766-11e1-8775-005056c00008" name="NwLibrty LD" loadType="UNDEFINED" p0="27" q0="11" node="8" p="26.993488959697693" q="10.995579278641397">
                 <iidm:alias>_0483e592-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3697,12 +3782,12 @@
                 <iidm:internalConnection node1="11" node2="2"/>
                 <iidm:internalConnection node1="12" node2="3"/>
                 <iidm:internalConnection node1="13" node2="3"/>
-                <iidm:bus v="122.60530117687317" angle="5.7426530804054963" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13"/>
+                <iidm:bus v="122.6052862844908" angle="-5.3191630866698869" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0463da70-c766-11e1-8775-005056c00008" name="Danville LD" loadType="UNDEFINED" p0="25" q0="13" node="5" p="25.000004067259106" q="13.000003524958084">
+            <iidm:load id="_0463da70-c766-11e1-8775-005056c00008" name="Danville LD" loadType="UNDEFINED" p0="25" q0="13" node="5" p="25.000005295447203" q="13.000004589387897">
                 <iidm:alias>_0488eeab-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_0448b150-c766-11e1-8775-005056c00008" name="Danville NegG LD" loadType="UNDEFINED" p0="43" q0="0" node="6" p="43.000006995685666" q="0">
+            <iidm:load id="_0448b150-c766-11e1-8775-005056c00008" name="Danville NegG LD" loadType="UNDEFINED" p0="43" q0="0" node="6" p="43.000009108169188" q="0">
                 <iidm:alias>_0457cc88-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3753,9 +3838,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.59331661436823" angle="26.500699852241997" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.45634525438791" angle="15.461644860783593" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045cae82-c766-11e1-8775-005056c00008" name="Fremont LD" loadType="UNDEFINED" p0="48" q0="10" node="8" p="47.999218645754873" q="9.9997286979147795">
+            <iidm:load id="_045cae82-c766-11e1-8775-005056c00008" name="Fremont LD" loadType="UNDEFINED" p0="48" q0="10" node="8" p="47.99909541881938" q="9.9996859112853507">
                 <iidm:alias>_045f4693-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3901,9 +3986,9 @@
                 <iidm:internalConnection node1="70" node2="15"/>
                 <iidm:internalConnection node1="71" node2="18"/>
                 <iidm:internalConnection node1="72" node2="21"/>
-                <iidm:bus v="132.3528904172999" angle="13.420146651337891" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
+                <iidm:bus v="132.33422806669151" angle="2.3556761273344105" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0448d863-c766-11e1-8775-005056c00008" name="Turner LD" loadType="UNDEFINED" p0="61" q0="28" node="23" p="60.999956613673014" q="27.999966808282313">
+            <iidm:load id="_0448d863-c766-11e1-8775-005056c00008" name="Turner LD" loadType="UNDEFINED" p0="61" q0="28" node="23" p="60.999980712093915" q="27.999985244226412">
                 <iidm:alias>_046e3ab3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3938,6 +4023,9 @@
                     <iidm:alias>_0b877750-4384-4ec3-bb38-08ee5ccf16d3</iidm:alias>
                     <iidm:alias>_1ed822d3-f3ab-4432-80f0-4c55ae3b4b78</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_3be2355e-0065-43df-a264-57a295042faa-1" name="DISCONNECTOR526-1" kind="DISCONNECTOR" retained="false" open="false" node1="24" node2="25"/>
+                <iidm:switch id="_2463ff2c-7690-4dd6-bf44-039f9f475bb1-1" name="BREAKER263-1" kind="BREAKER" retained="false" open="true" node1="23" node2="24"/>
+                <iidm:switch id="_ddcf7aac-e7c3-45e9-bd81-6146e951addd-1" name="DISCONNECTOR525-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="23"/>
                 <iidm:internalConnection node1="7" node2="0"/>
                 <iidm:internalConnection node1="8" node2="0"/>
                 <iidm:internalConnection node1="9" node2="1"/>
@@ -3954,9 +4042,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.11595653458853" angle="6.4058243786538229" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.1970059254987" angle="-4.4114289475570674" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047d7cf6-c766-11e1-8775-005056c00008" name="Grant LD" loadType="UNDEFINED" p0="24" q0="4" node="8" p="23.998276745942011" q="3.9995213297741259">
+            <iidm:load id="_047d7cf6-c766-11e1-8775-005056c00008" name="Grant LD" loadType="UNDEFINED" p0="24" q0="4" node="8" p="23.999252196741665" q="3.9997922790301379">
                 <iidm:alias>_0481e9c0-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4026,9 +4114,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="220.97968056993693" angle="18.005575471556888" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="221.45504142395154" angle="5.903603533560573" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04867dab-c766-11e1-8775-005056c00008" name="Olive NegG LD" loadType="UNDEFINED" p0="28" q0="0" node="11" p="27.996826771584004" q="0">
+            <iidm:load id="_04867dab-c766-11e1-8775-005056c00008" name="Olive NegG LD" loadType="UNDEFINED" p0="28" q0="0" node="11" p="27.997696831797487" q="0">
                 <iidm:alias>_048433b8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4134,15 +4222,15 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="133.17751778771219" angle="12.474343410056361" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="133.30949113992591" angle="0.63272597847398382" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:shunt id="_0447c6f6-c766-11e1-8775-005056c00008" name="Olive SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.67599999999999" targetDeadband="1" node="17" q="-40.72243285644533">
+            <iidm:shunt id="_0447c6f6-c766-11e1-8775-005056c00008" name="Olive SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.67599999999999" targetDeadband="1" node="17" q="-40.803181302655815">
                 <iidm:alias>_045e8340-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_c701959a-91c1-4a35-9a37-71fb790426ca"/>
                 <iidm:shuntLinearModel bPerSection="0.00045919999999999999" gPerSection="0" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_04575750-c766-11e1-8775-005056c00008" name="8-5" r="0" x="4.6522079999999999" g="0" b="0" ratedU1="220" ratedU2="132" node1="32" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="371.41856666589757" q1="59.300008562448426" p2="-371.41856666589752" q2="-22.976869896773387">
+        <iidm:twoWindingsTransformer id="_04575750-c766-11e1-8775-005056c00008" name="8-5" r="0" x="4.6522079999999999" g="0" b="0" ratedU1="220" ratedU2="132" node1="32" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="355.09952298588985" q1="62.361484109259166" p2="-355.09952298588985" q2="-29.129984587217635">
             <iidm:alias>_045eaa55-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_046b2d74-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04745533-c766-11e1-8775-005056c00008</iidm:alias>
@@ -4213,9 +4301,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.77736755971966" angle="19.650928815952494" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.77393078788666" angle="8.592798555015067" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047b0bf0-c766-11e1-8775-005056c00008" name="Wythe LD" loadType="UNDEFINED" p0="22" q0="15" node="8" p="21.999916521495404" q="14.999905138182942">
+            <iidm:load id="_047b0bf0-c766-11e1-8775-005056c00008" name="Wythe LD" loadType="UNDEFINED" p0="22" q0="15" node="8" p="21.999917805669469" q="14.999906597467991">
                 <iidm:alias>_0479d376-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4266,9 +4354,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="123.89985758235315" angle="-5.1041378270431839" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="123.83903280502389" angle="-16.007035620364334" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0458ddf5-c766-11e1-8775-005056c00008" name="WestLima LD" loadType="UNDEFINED" p0="33" q0="9" node="8" p="32.992524060568385" q="8.9966021023294189">
+            <iidm:load id="_0458ddf5-c766-11e1-8775-005056c00008" name="WestLima LD" loadType="UNDEFINED" p0="33" q0="9" node="8" p="32.99306255469488" q="8.9968468367496079">
                 <iidm:alias>_04492686-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4376,9 +4464,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="128.45057874647472" angle="22.56279524925316" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="128.11542495217742" angle="11.532753276020602" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044b2257-c766-11e1-8775-005056c00008" name="BeaverCk LD" loadType="UNDEFINED" p0="24" q0="15" node="17" p="23.999203839945412" q="14.999170675780421">
+            <iidm:load id="_044b2257-c766-11e1-8775-005056c00008" name="BeaverCk LD" loadType="UNDEFINED" p0="24" q0="15" node="17" p="23.999059381409911" q="14.999020201769111">
                 <iidm:alias>_045868c4-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4437,6 +4525,9 @@
                     <iidm:alias>_2b636cdd-aa2f-4a65-92fc-12b4fc392e5f</iidm:alias>
                     <iidm:alias>_c96e50b9-ea15-4421-b6c8-bd9c9158a69a</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_e5318967-afcc-4fcc-b0de-d5f2522a95a6-1" name="DISCONNECTOR699-1" kind="DISCONNECTOR" retained="false" open="false" node1="43" node2="44"/>
+                <iidm:switch id="_e9f91b69-a29b-44ea-aa0f-cff86ee80320-1" name="BREAKER350-1" kind="BREAKER" retained="true" open="true" node1="42" node2="43"/>
+                <iidm:switch id="_ad86e83d-6334-4dd8-b642-b4c16d65329a-1" name="DISCONNECTOR700-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="42"/>
                 <iidm:internalConnection node1="13" node2="0"/>
                 <iidm:internalConnection node1="14" node2="1"/>
                 <iidm:internalConnection node1="15" node2="2"/>
@@ -4466,7 +4557,7 @@
                 <iidm:internalConnection node1="39" node2="9"/>
                 <iidm:internalConnection node1="40" node2="12"/>
                 <iidm:internalConnection node1="41" node2="3"/>
-                <iidm:bus v="214.48577908368662" angle="15.565564274449294" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41"/>
+                <iidm:bus v="215.53446964248138" angle="2.9892736081597655" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_047bcf46-c766-11e1-8775-005056c00008" name="STN132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -4546,6 +4637,9 @@
                     <iidm:alias>_4aab41d6-d1b6-4dbe-a6aa-cb7ccd941912</iidm:alias>
                     <iidm:alias>_e9315b98-af75-40bb-bf8e-05bd03d43db5</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_b8b0b9a9-af8b-41d2-a4f8-940637e63f70-1" name="DISCONNECTOR701-1" kind="DISCONNECTOR" retained="false" open="false" node1="64" node2="65"/>
+                <iidm:switch id="_0b78ffaa-9859-4658-af17-c8d355633556-1" name="BREAKER351-1" kind="BREAKER" retained="true" open="false" node1="63" node2="64"/>
+                <iidm:switch id="_9dfeeaef-5c49-4c2c-97b1-03876970bee4-1" name="DISCONNECTOR702-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="63"/>
                 <iidm:internalConnection node1="19" node2="0"/>
                 <iidm:internalConnection node1="20" node2="0"/>
                 <iidm:internalConnection node1="21" node2="1"/>
@@ -4590,9 +4684,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="129.34019354949271" angle="8.7801230012761735" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="129.29355833649743" angle="-1.6327052438698282" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045dbff4-c766-11e1-8775-005056c00008" name="Sorenson LD" loadType="UNDEFINED" p0="11" q0="3" node="20" p="10.99787199418056" q="2.9990327870036442">
+            <iidm:load id="_045dbff4-c766-11e1-8775-005056c00008" name="Sorenson LD" loadType="UNDEFINED" p0="11" q0="3" node="20" p="10.99846803310818" q="2.9993036837400662">
                 <iidm:alias>_044d4536-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4613,6 +4707,9 @@
                     <iidm:alias>_340082f1-db9c-446d-97df-80e45aa0058b</iidm:alias>
                     <iidm:alias>_90c04b95-703a-4bae-82b8-7edf3075aa24</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_4d08a684-cdcb-484a-a767-03b10f4ada7f-1" name="DISCONNECTOR735-1" kind="DISCONNECTOR" retained="false" open="false" node1="14" node2="15"/>
+                <iidm:switch id="_f468d841-1bf6-470e-85d4-55d34fab8bff-1" name="BREAKER368-1" kind="BREAKER" retained="true" open="false" node1="13" node2="14"/>
+                <iidm:switch id="_f193bd8f-badf-4600-82ac-f212d1f33534-1" name="DISCONNECTOR736-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="13"/>
                 <iidm:internalConnection node1="4" node2="0"/>
                 <iidm:internalConnection node1="5" node2="1"/>
                 <iidm:internalConnection node1="6" node2="2"/>
@@ -4622,13 +4719,13 @@
                 <iidm:internalConnection node1="10" node2="3"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="0"/>
-                <iidm:bus v="384.14206312091778" angle="15.342577280566902" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="389.08870131716668" angle="0" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15"/>
             </iidm:nodeBreakerTopology>
             <iidm:lccConverterStation id="_7393a68e-c4e6-48dd-9347-543858363fdb" name="Conv1" lossFactor="0" powerFactor="0.80000000000000004" node="12" p="10" q="6">
                 <iidm:alias>_739658a7-e08b-4395-8d79-93e87b7855e3</iidm:alias>
             </iidm:lccConverterStation>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_047120e9-c766-11e1-8775-005056c00008" name="30-17" r="0" x="6.7605125399999997" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_047b8123-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="303.02064577919799" q1="111.42612765917472" p2="-303.02064577919811" q2="-72.211717068720105">
+        <iidm:twoWindingsTransformer id="_047120e9-c766-11e1-8775-005056c00008" name="30-17" r="0" x="6.7605125399999997" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_047b8123-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="207.60041701300773" q1="116.2862483380552" p2="-207.6004170130077" q2="-95.192234716457691">
             <iidm:alias>_044f6811-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0463b36a-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_047d2ed8-c766-11e1-8775-005056c00008</iidm:alias>
@@ -4647,7 +4744,7 @@
                 <iidm:temporaryLimit name="_f62f2fc6-4b6c-4571-a8c5-40d6a89ac703" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_b08e9e50-4e0c-4ac0-9f21-4a27429caeb2" name="PowTrans1" r="0.4840000000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_3bbfa58a-a1ad-4b23-a526-3d76b096c1f4" node2="41" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="-10.000000654676242" q1="-6.0000001980284416" p2="10.001438623333261" q2="6.0539240226691371">
+        <iidm:twoWindingsTransformer id="_b08e9e50-4e0c-4ac0-9f21-4a27429caeb2" name="PowTrans1" r="0.4840000000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_3bbfa58a-a1ad-4b23-a526-3d76b096c1f4" node2="41" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="-133.64046748341337" q1="21.072719045582268" p2="133.82910975672479" q2="-13.998633796403192">
             <iidm:alias>_046ba2aa-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_a5bf9702-545a-437d-9663-773550202828</iidm:alias>
             <iidm:alias>_ee9505e1-96d7-49b3-9d1a-924397ffb27e</iidm:alias>
@@ -4667,6 +4764,32 @@
                 <iidm:temporaryLimit name="_611bb05e-9b9a-469c-b1d1-80a944c3ce2f" acceptableDuration="60" value="1400"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
+        <iidm:threeWindingsTransformer id="_86d83c7d-7826-4c16-b161-4ce17174e77f-1" name="T422" r1="-1.5199999809265099" x1="23.199999999999999" g1="0" b1="0" ratedU1="400" r2="2.0000000630528461" x2="19.999999999999996" g2="0" b2="0" ratedU2="220" r3="1.2000000564689806" x3="12" g3="0" b3="0" ratedU3="132" ratedU0="400" node1="15" voltageLevelId1="_3bbfa58a-a1ad-4b23-a526-3d76b096c1f4" node2="44" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" node3="65" voltageLevelId3="_047bcf46-c766-11e1-8775-005056c00008" p1="123.64046749295264" q1="-27.07271903985977" p2="0" q2="0" p3="-123.67432947418831" q3="30.797537855101847">
+            <iidm:alias>_1b2d419c-ac88-4dae-8dfe-2eb92d18c40a-1</iidm:alias>
+            <iidm:alias>_206474da-93c8-46b1-863f-9a308bfc2117-1</iidm:alias>
+            <iidm:alias>_9ac069ea-557b-4b8c-b12e-f9f2aecc3bf5-1</iidm:alias>
+            <iidm:alias>_ae46e10e-1fbe-4139-b493-ed8e2844ee8d-1</iidm:alias>
+            <iidm:ratioTapChanger1 lowTapPosition="1" tapPosition="11" targetDeadband="0" loadTapChangingCapabilities="true" regulating="false" targetV="220">
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.95238095238095233"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.96385542168674687"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.97560975609756106"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.98765432098765438"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0126582278481011"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0256410256410258"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0389610389610389"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0526315789473684"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0666666666666667"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0810810810810809"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.095890410958904"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.1111111111111112"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.1267605633802817"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.1428571428571428"/>
+            </iidm:ratioTapChanger1>
+            <iidm:currentLimits1 permanentLimit="500">
+                <iidm:temporaryLimit name="_3fd18f6e-749a-4fa7-af1b-b0c2d3952638-1" acceptableDuration="1800" value="533"/>
+            </iidm:currentLimits1>
+        </iidm:threeWindingsTransformer>
     </iidm:substation>
     <iidm:substation id="_04642898-c766-11e1-8775-005056c00008" name="Rómenna" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
         <iidm:voltageLevel id="_0457f394-c766-11e1-8775-005056c00008" name="RÓM132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -4905,16 +5028,16 @@
                 <iidm:internalConnection node1="121" node2="30"/>
                 <iidm:internalConnection node1="122" node2="33"/>
                 <iidm:internalConnection node1="123" node2="36"/>
-                <iidm:bus v="135.30000104182696" angle="-0.23413993373961983" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123"/>
+                <iidm:bus v="135.300004517801" angle="-11.251107811568632" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04859346-c766-11e1-8775-005056c00008" name="Philo SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="204" targetV="135.30000000000001" targetQ="0" node="39" p="-225.88821153567977" q="-175.32503599605801">
+            <iidm:generator id="_04859346-c766-11e1-8775-005056c00008" name="Philo SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="204" targetV="135.30000000000001" targetQ="0" node="39" p="-225.85169061350157" q="-175.28770826063101">
                 <iidm:alias>_048719e2-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e3753d6d-b894-4cce-b6fa-307c50dc107f"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_dff93c01-9c84-4c1f-8529-66c054ed9e37"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
-            <iidm:load id="_045163e2-c766-11e1-8775-005056c00008" name="Philo LD" loadType="UNDEFINED" p0="87" q0="30" node="38" p="87.000001004866348" q="30.000000577509393">
+            <iidm:load id="_045163e2-c766-11e1-8775-005056c00008" name="Philo LD" loadType="UNDEFINED" p0="87" q0="30" node="38" p="87.00000435752429" q="30.000002504324343">
                 <iidm:alias>_04513cd3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4965,9 +5088,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.79954675918205" angle="20.561453087370456" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.51342180477654" angle="9.5205228460694507" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04524e46-c766-11e1-8775-005056c00008" name="BetsyLne LD" loadType="UNDEFINED" p0="11" q0="7" node="8" p="10.999637996987209" q="6.9996160616224614">
+            <iidm:load id="_04524e46-c766-11e1-8775-005056c00008" name="BetsyLne LD" loadType="UNDEFINED" p0="11" q0="7" node="8" p="10.999579517566765" q="6.9995540394654112">
                 <iidm:alias>_04549830-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5020,15 +5143,15 @@
                 <iidm:internalConnection node1="22" node2="6"/>
                 <iidm:internalConnection node1="23" node2="3"/>
                 <iidm:internalConnection node1="24" node2="6"/>
-                <iidm:bus v="124.75915657857517" angle="7.4310750484254227" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24"/>
+                <iidm:bus v="124.75914130405346" angle="-3.6303250867601498" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04566cf3-c766-11e1-8775-005056c00008" name="Reusens NegG LD" loadType="UNDEFINED" p0="22" q0="0" node="8" p="22.000002599265908" q="0">
+            <iidm:load id="_04566cf3-c766-11e1-8775-005056c00008" name="Reusens NegG LD" loadType="UNDEFINED" p0="22" q0="0" node="8" p="22.000003678462747" q="0">
                 <iidm:alias>_0483be81-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_0482fb36-c766-11e1-8775-005056c00008" name="Reusens LD" loadType="UNDEFINED" p0="28" q0="12" node="9" p="28.000003308156611" q="12.0000023629691">
+            <iidm:load id="_0482fb36-c766-11e1-8775-005056c00008" name="Reusens LD" loadType="UNDEFINED" p0="28" q0="12" node="9" p="28.000004681679862" q="12.00000334405723">
                 <iidm:alias>_0486cbc1-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_04558293-c766-11e1-8775-005056c00008" name="Reusens SC" sectionCount="5" voltageRegulatorOn="true" targetV="124.76300000000001" targetDeadband="1" node="10" q="-5.3543074196679186">
+            <iidm:shunt id="_04558293-c766-11e1-8775-005056c00008" name="Reusens SC" sectionCount="5" voltageRegulatorOn="true" targetV="124.76300000000001" targetDeadband="1" node="10" q="-5.3543061085901229">
                 <iidm:alias>_04893ccc-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_99303cd3-6b53-4ee2-a5ce-fe8d5feeb304"/>
                 <iidm:shuntLinearModel bPerSection="6.8800000000000005e-05" gPerSection="0" maximumSectionCount="10"/>
@@ -5101,12 +5224,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="126.42436552290128" angle="24.760615680032192" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="126.42256813241863" angle="13.709622691746295" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045c8777-c766-11e1-8775-005056c00008" name="Holston NegG LD" loadType="UNDEFINED" p0="85" q0="0" node="11" p="84.999799174534346" q="0">
+            <iidm:load id="_045c8777-c766-11e1-8775-005056c00008" name="Holston NegG LD" loadType="UNDEFINED" p0="85" q0="0" node="11" p="84.999801995256249" q="0">
                 <iidm:alias>_0487dd31-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_0451d918-c766-11e1-8775-005056c00008" name="Holston LD" loadType="UNDEFINED" p0="78" q0="42" node="12" p="77.999815713102123" q="41.999834614452659">
+            <iidm:load id="_0451d918-c766-11e1-8775-005056c00008" name="Holston LD" loadType="UNDEFINED" p0="78" q0="42" node="12" p="77.999818301529274" q="41.999836937396466">
                 <iidm:alias>_0485ba54-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5214,9 +5337,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="127.73086993011438" angle="9.3063130529952378" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="127.73125284183358" angle="-1.7845501220960833" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04742e27-c766-11e1-8775-005056c00008" name="SthPoint LD" loadType="UNDEFINED" p0="47" q0="11" node="17" p="47.000002055456456" q="11.000000801773806">
+            <iidm:load id="_04742e27-c766-11e1-8775-005056c00008" name="SthPoint LD" loadType="UNDEFINED" p0="47" q0="11" node="17" p="47.000363905926498" q="11.000141949486622">
                 <iidm:alias>_047b3303-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5268,12 +5391,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="132.92316312887144" angle="13.434977248514613" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="132.91063499890603" angle="2.3719609339565055" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04716f06-c766-11e1-8775-005056c00008" name="CapitlHl LD" loadType="UNDEFINED" p0="39" q0="32" node="8" p="38.999980043970311" q="31.999972709707642">
+            <iidm:load id="_04716f06-c766-11e1-8775-005056c00008" name="CapitlHl LD" loadType="UNDEFINED" p0="39" q0="32" node="8" p="38.999989275997471" q="31.999985334698742">
                 <iidm:alias>_04700f70-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0466c0a0-c766-11e1-8775-005056c00008" name="CapitlHl SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.00200000000001" targetDeadband="1" node="9" q="-20.283515256019882">
+            <iidm:shunt id="_0466c0a0-c766-11e1-8775-005056c00008" name="CapitlHl SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.00200000000001" targetDeadband="1" node="9" q="-20.279691956392668">
                 <iidm:alias>_045e8346-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_99931a87-ee15-4fd0-b251-9556df7fe598"/>
                 <iidm:shuntLinearModel bPerSection="0.0002296" gPerSection="0" maximumSectionCount="10"/>
@@ -5326,9 +5449,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="132.06149730490742" angle="13.120161731803508" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="132.044919204438" angle="2.0560689903143698" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046efe03-c766-11e1-8775-005056c00008" name="Chemical LD" loadType="UNDEFINED" p0="71" q0="26" node="8" p="70.999940814416036" q="25.999963877353167">
+            <iidm:load id="_046efe03-c766-11e1-8775-005056c00008" name="Chemical LD" loadType="UNDEFINED" p0="71" q0="26" node="8" p="70.99996606251753" q="25.99997928698583">
                 <iidm:alias>_045d71d5-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5379,9 +5502,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.51522828304931" angle="9.0782935335837021" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.56133250829484" angle="-2.5560615242914011" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046a4319-c766-11e1-8775-005056c00008" name="JacksnRd LD" loadType="UNDEFINED" p0="19" q0="2" node="8" p="18.999590979053878" q="1.9999282424541995">
+            <iidm:load id="_046a4319-c766-11e1-8775-005056c00008" name="JacksnRd LD" loadType="UNDEFINED" p0="19" q0="2" node="8" p="18.999700257890691" q="1.9999474139415667">
                 <iidm:alias>_046c8d06-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5527,9 +5650,9 @@
                 <iidm:internalConnection node1="70" node2="15"/>
                 <iidm:internalConnection node1="71" node2="18"/>
                 <iidm:internalConnection node1="72" node2="21"/>
-                <iidm:bus v="130.60656056239606" angle="24.425207683004405" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
+                <iidm:bus v="130.59981768573152" angle="13.371477087487202" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0458ddf4-c766-11e1-8775-005056c00008" name="Saltvlle LD" loadType="UNDEFINED" p0="65" q0="10" node="23" p="64.999638636428941" q="9.999907342845793">
+            <iidm:load id="_0458ddf4-c766-11e1-8775-005056c00008" name="Saltvlle LD" loadType="UNDEFINED" p0="65" q0="10" node="23" p="64.999639450977824" q="9.9999075517037088">
                 <iidm:alias>_045645e4-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5599,9 +5722,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="131.51507232396369" angle="14.178418680486839" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="131.67777158950102" angle="2.8408543928907353" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0476ed42-c766-11e1-8775-005056c00008" name="Trenton NegG LD" loadType="UNDEFINED" p0="13" q0="0" node="11" p="12.996212936218196" q="0">
+            <iidm:load id="_0476ed42-c766-11e1-8775-005056c00008" name="Trenton NegG LD" loadType="UNDEFINED" p0="13" q0="0" node="11" p="12.997328301823682" q="0">
                 <iidm:alias>_0471e432-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5671,9 +5794,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="128.34011133793575" angle="8.100201739513869" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="128.40272041598669" angle="-3.5781959440323523" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044a5f08-c766-11e1-8775-005056c00008" name="HickryCk LD" loadType="UNDEFINED" p0="39" q0="10" node="11" p="38.998749041764697" q="9.9994654081794554">
+            <iidm:load id="_044a5f08-c766-11e1-8775-005056c00008" name="HickryCk LD" loadType="UNDEFINED" p0="39" q0="10" node="11" p="38.999075317203626" q="9.9996048395349">
                 <iidm:alias>_047d7cf3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5802,9 +5925,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="125.33784794768792" angle="-4.2533412930916832" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="125.27889038313039" angle="-15.158368459543526" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:shunt id="_0450eeb7-c766-11e1-8775-005056c00008" name="EastLima SC" sectionCount="5" voltageRegulatorOn="true" targetV="131.565" targetDeadband="1" node="20" q="-22.54324174390635">
+            <iidm:shunt id="_0450eeb7-c766-11e1-8775-005056c00008" name="EastLima SC" sectionCount="5" voltageRegulatorOn="true" targetV="131.565" targetDeadband="1" node="20" q="-22.522038539026756">
                 <iidm:alias>_044aad27-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_6c36f421-303e-4932-93a9-5b0ff86cb7d4"/>
                 <iidm:shuntLinearModel bPerSection="0.00028699999999999998" gPerSection="0" maximumSectionCount="10"/>
@@ -5892,16 +6015,16 @@
                 <iidm:internalConnection node1="41" node2="7"/>
                 <iidm:internalConnection node1="42" node2="12"/>
                 <iidm:internalConnection node1="43" node2="11"/>
-                <iidm:bus v="218.90662875289041" angle="6.7703702508309416" nodes="0,1,2,3,8,9,10,13,17,18,21,22,23,24,25,26,31,32,33,34,35,39,40"/>
-                <iidm:bus v="237.93768605998153" angle="-4.9792777497258172" nodes="11,15,37,43"/>
-                <iidm:bus v="226.19467473625627" angle="6.7703702533857228" nodes="12,16,38,42"/>
-                <iidm:bus v="214.70025154563999" angle="-4.9792777497258172" nodes="4,5,6,7,14,19,20,27,28,29,30,36,41"/>
+                <iidm:bus v="218.90682234415274" angle="-4.2547575167269125" nodes="0,1,2,3,8,9,10,13,17,18,21,22,23,24,25,26,31,32,33,34,35,39,40"/>
+                <iidm:bus v="237.93769285011385" angle="-16.002050465734069" nodes="11,15,37,43"/>
+                <iidm:bus v="226.19468120327809" angle="-4.2547575136702278" nodes="12,16,38,42"/>
+                <iidm:bus v="214.70025767263536" angle="-16.002050465734069" nodes="4,5,6,7,14,19,20,27,28,29,30,36,41"/>
             </iidm:nodeBreakerTopology>
-            <iidm:vscConverterStation id="_b46bfb8e-7af6-459e-acf3-53a42c943a7c" name="VSC2" voltageRegulatorOn="true" lossFactor="0.32362458" voltageSetpoint="218.47" reactivePowerSetpoint="0" node="42" p="-0" q="-27.475285846435249">
+            <iidm:vscConverterStation id="_b46bfb8e-7af6-459e-acf3-53a42c943a7c" name="VSC2" voltageRegulatorOn="true" lossFactor="0.32362458" voltageSetpoint="218.47" reactivePowerSetpoint="0" node="42" p="-0" q="-27.474579619155886">
                 <iidm:alias>_a168e701-bd48-4f66-8f0b-0f69b2545530</iidm:alias>
                 <iidm:minMaxReactiveLimits minQ="-1.7976931348623157e+308" maxQ="1.7976931348623157e+308"/>
             </iidm:vscConverterStation>
-            <iidm:vscConverterStation id="_b48ce7cf-abf5-413f-bc51-9e1d3103c9bd" name="VSC1" voltageRegulatorOn="true" lossFactor="0.32467531999999999" voltageSetpoint="213.53999999999999" reactivePowerSetpoint="0" node="43" p="-0" q="-92.151020935009058">
+            <iidm:vscConverterStation id="_b48ce7cf-abf5-413f-bc51-9e1d3103c9bd" name="VSC1" voltageRegulatorOn="true" lossFactor="0.32467531999999999" voltageSetpoint="213.53999999999999" reactivePowerSetpoint="0" node="43" p="-0" q="-92.151020935009171">
                 <iidm:alias>_071bb138-ff00-4874-8acc-a884aa5cf4a9</iidm:alias>
                 <iidm:minMaxReactiveLimits minQ="-1.7976931348623157e+308" maxQ="1.7976931348623157e+308"/>
             </iidm:vscConverterStation>
@@ -5969,7 +6092,7 @@
                 <iidm:internalConnection node1="29" node2="6"/>
                 <iidm:internalConnection node1="30" node2="9"/>
                 <iidm:internalConnection node1="31" node2="3"/>
-                <iidm:bus v="201.80615428769744" angle="-0.2611014590114174" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
+                <iidm:bus v="201.76431916855847" angle="-11.196617155351635" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_0448d867-c766-11e1-8775-005056c00008" name="EDO132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -6055,9 +6178,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="131.34000165839387" angle="4.3635821936351036" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="131.3400054265789" angle="-6.6609691598260268" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0472a789-c766-11e1-8775-005056c00008" name="W.Kammer SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="160" targetV="131.34" targetQ="0" node="14" p="-177.1672247338665" q="94.093551060428453">
+            <iidm:generator id="_0472a789-c766-11e1-8775-005056c00008" name="W.Kammer SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="160" targetV="131.34" targetQ="0" node="14" p="-177.13858087333455" q="94.090935625558856">
                 <iidm:alias>_04697fc0-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_17852426-f663-4add-9a2b-0a635d51f101"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b512ea0a-96d0-4a48-9de1-a5cf499bf0dd"/>
@@ -6206,16 +6329,16 @@
                 <iidm:internalConnection node1="71" node2="15"/>
                 <iidm:internalConnection node1="72" node2="18"/>
                 <iidm:internalConnection node1="73" node2="21"/>
-                <iidm:bus v="130.02000167211349" angle="-4.9792777497258163" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
+                <iidm:bus v="130.0200053825514" angle="-16.002050465734072" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04839777-c766-11e1-8775-005056c00008" name="Tidd SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="155" targetV="130.02000000000001" targetQ="0" node="24" p="-171.63074896093318" q="-94.87226968678182">
+            <iidm:generator id="_04839777-c766-11e1-8775-005056c00008" name="Tidd SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="155" targetV="130.02000000000001" targetQ="0" node="24" p="-171.60300022104283" q="-94.872818467466487">
                 <iidm:alias>_045fe2d8-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_d2a96d8d-65be-4fd6-a012-ceeeabd2bee6"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_29df1e0b-36ca-4536-97b4-6f98b84d49d8"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-90" maxQ="255"/>
             </iidm:generator>
-            <iidm:load id="_04798556-c766-11e1-8775-005056c00008" name="Tidd LD" loadType="UNDEFINED" p0="277" q0="113" node="23" p="277.00000534350988" q="113.00000363307234">
+            <iidm:load id="_04798556-c766-11e1-8775-005056c00008" name="Tidd LD" loadType="UNDEFINED" p0="277" q0="113" node="23" p="277.00001720081616" q="113.00001169489933">
                 <iidm:alias>_04502b62-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6245,13 +6368,13 @@
                 <iidm:internalConnection node1="10" node2="3"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="0"/>
-                <iidm:bus v="360.96780424394734" angle="0" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="360.89240423392255" angle="-10.935406982142585" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
             </iidm:nodeBreakerTopology>
             <iidm:lccConverterStation id="_9793118d-5ba1-4a9c-b2e0-db1d15be5913" name="Conv2" lossFactor="0" powerFactor="-0.75741000000000003" node="12" p="-10" q="8.6206896551724146">
                 <iidm:alias>_453bdc57-5855-4eb5-8712-d6a0255e0da8</iidm:alias>
             </iidm:lccConverterStation>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045c1248-c766-11e1-8775-005056c00008" name="38-37" r="0" x="6.5340005399999992" g="0" b="0" ratedU1="220" ratedU2="132" node1="30" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="172.94962799018055" q1="88.545274910198515" p2="-172.94962799018055" q2="-73.836747553150303">
+        <iidm:twoWindingsTransformer id="_045c1248-c766-11e1-8775-005056c00008" name="38-37" r="0" x="6.5340005399999992" g="0" b="0" ratedU1="220" ratedU2="132" node1="30" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="171.51463807739651" q1="89.068771570707696" p2="-171.51463807739646" q2="-74.510568474464023">
             <iidm:alias>_0453d4e8-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0477d7aa-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_047df228-c766-11e1-8775-005056c00008</iidm:alias>
@@ -6275,7 +6398,7 @@
                 <iidm:temporaryLimit name="_c97df399-5a91-4c8b-b72c-496cade334b5" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_0485ba57-c766-11e1-8775-005056c00008" name="64-61" r="0" x="4.669632" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="157.49826563586814" q1="60.53776518147135" p2="-157.49826563586811" q2="-53.060715419662664">
+        <iidm:twoWindingsTransformer id="_0485ba57-c766-11e1-8775-005056c00008" name="64-61" r="0" x="4.669632" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="157.46071151263499" q1="60.539494297327003" p2="-157.46071151263502" q2="-53.065509094337585">
             <iidm:alias>_04549831-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0472ce92-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0489d905-c766-11e1-8775-005056c00008</iidm:alias>
@@ -6301,7 +6424,7 @@
                 <iidm:temporaryLimit name="_f6b1a81c-eda7-4a08-b290-bd29a5ed9fa4" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_044cd007-c766-11e1-8775-005056c00008" name="63-59" r="0" x="6.7256646120000001" g="0" b="0" ratedU1="220" ratedU2="132" node1="41" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="73" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-4.163336342344337e-15" q1="83.15138392507447" p2="-1.1102230246251565e-14" q2="-80.568832305757681">
+        <iidm:twoWindingsTransformer id="_044cd007-c766-11e1-8775-005056c00008" name="63-59" r="0" x="6.7256646120000001" g="0" b="0" ratedU1="220" ratedU2="132" node1="41" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="73" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="7.4940054162198066e-14" q1="83.151388670929634" p2="-4.4408920985006262e-14" q2="-80.568836904213882">
             <iidm:alias>_044e7db4-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_046eafe5-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0488797a-c766-11e1-8775-005056c00008</iidm:alias>
@@ -6347,7 +6470,7 @@
                 <iidm:temporaryLimit name="_f2daef4d-6f1a-44d1-9c9b-228acff12575" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_ffd940c8-03c8-4dcf-ad46-62018a0d813d" name="PowTrans2" r="0.3932500000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_04f97116-552a-4a34-afd9-4862f62ac7aa" node2="31" voltageLevelId2="_04742e21-c766-11e1-8775-005056c00008" p1="9.9999999384673917" q1="-8.6206896021271398" p2="-9.9983039667921538" q2="8.6989652179079755">
+        <iidm:twoWindingsTransformer id="_ffd940c8-03c8-4dcf-ad46-62018a0d813d" name="PowTrans2" r="0.3932500000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_04f97116-552a-4a34-afd9-4862f62ac7aa" node2="31" voltageLevelId2="_04742e21-c766-11e1-8775-005056c00008" p1="10.000000431046647" q1="-8.6206896140425737" p2="-9.9983037505322123" q2="8.6989979454695074">
             <iidm:alias>_04479fea-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_c089eb25-9f67-4d82-88a8-635dd4808bae</iidm:alias>
             <iidm:alias>_ea8cd467-31f0-40dc-95d7-4064463724c4</iidm:alias>
@@ -6414,9 +6537,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="124.78825680218249" angle="-8.1518912326789383" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.78807504729548" angle="-19.171654590421777" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0481c2b3-c766-11e1-8775-005056c00008" name="Wooster LD" loadType="UNDEFINED" p0="23" q0="11" node="8" p="22.999991165743268" q="10.999992958202059">
+            <iidm:load id="_0481c2b3-c766-11e1-8775-005056c00008" name="Wooster LD" loadType="UNDEFINED" p0="23" q0="11" node="8" p="22.99999107000794" q="10.999992881891311">
                 <iidm:alias>_04614268-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6486,9 +6609,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="125.56954166440585" angle="-7.9139621527171755" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="125.56951015545829" angle="-18.934456301916395" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044974a8-c766-11e1-8775-005056c00008" name="Wagenhls LD" loadType="UNDEFINED" p0="63" q0="22" node="11" p="63.000004082833939" q="22.00000237625261">
+            <iidm:load id="_044974a8-c766-11e1-8775-005056c00008" name="Wagenhls LD" loadType="UNDEFINED" p0="63" q0="22" node="11" p="63.000006181419522" q="22.000003597651691">
                 <iidm:alias>_048481d4-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6539,9 +6662,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.26375327546405" angle="7.1415379741402631" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.32323235398036" angle="-4.2645189402215404" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047fedf2-c766-11e1-8775-005056c00008" name="Concord LD" loadType="UNDEFINED" p0="34" q0="16" node="8" p="33.997686891444346" q="15.998185838353205">
+            <iidm:load id="_047fedf2-c766-11e1-8775-005056c00008" name="Concord LD" loadType="UNDEFINED" p0="34" q0="16" node="8" p="33.998325705762241" q="15.998686849604194">
                 <iidm:alias>_046d9e75-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6649,9 +6772,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="127.18220950751869" angle="10.765888728861032" nodes="0,1,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,20,21,22,23,24,25,26,27,28,29,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,49,50,51,52"/>
+                <iidm:bus v="127.39225245204395" angle="-0.39122050190788232" nodes="0,1,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,20,21,22,23,24,25,26,27,28,29,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045f94ba-c766-11e1-8775-005056c00008" name="Delaware LD" loadType="UNDEFINED" p0="59" q0="23" node="17" p="58.953035050188952" q="22.969494146806028">
+            <iidm:load id="_045f94ba-c766-11e1-8775-005056c00008" name="Delaware LD" loadType="UNDEFINED" p0="59" q0="23" node="17" p="58.968550444241032" q="22.979570303643214">
                 <iidm:alias>_0463654a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6759,9 +6882,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="125.24713569432676" angle="4.908803713286674" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="125.20036406463868" angle="-5.7883164607265707" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04697fc9-c766-11e1-8775-005056c00008" name="FtWayne LD" loadType="UNDEFINED" p0="90" q0="30" node="17" p="89.984653092761278" q="29.991474425056726">
+            <iidm:load id="_04697fc9-c766-11e1-8775-005056c00008" name="FtWayne LD" loadType="UNDEFINED" p0="90" q0="30" node="17" p="89.988667356136702" q="29.993704351003132">
                 <iidm:alias>_044d1e25-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6812,9 +6935,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.01487873841117" angle="-5.9125895730185904" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.01465252112749" angle="-16.931836023858985" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0474f170-c766-11e1-8775-005056c00008" name="WNwPhil1 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="11.999998196551527" q="2.9999992485631748">
+            <iidm:load id="_0474f170-c766-11e1-8775-005056c00008" name="WNwPhil1 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="11.999998022356934" q="2.9999991759821012">
                 <iidm:alias>_0466c0a7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6885,12 +7008,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="129.61455407256651" angle="15.396768045202151" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="129.51031934961014" angle="4.3364454230457294" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044a5f05-c766-11e1-8775-005056c00008" name="Logan LD" loadType="UNDEFINED" p0="54" q0="27" node="11" p="53.999063971579439" q="26.999219980823145">
+            <iidm:load id="_044a5f05-c766-11e1-8775-005056c00008" name="Logan LD" loadType="UNDEFINED" p0="54" q0="27" node="11" p="53.99896969315445" q="26.99914141642261">
                 <iidm:alias>_04767811-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0475dbd6-c766-11e1-8775-005056c00008" name="Logan SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.41900000000001" targetDeadband="1" node="12" q="-19.286322656289951">
+            <iidm:shunt id="_0475dbd6-c766-11e1-8775-005056c00008" name="Logan SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.41900000000001" targetDeadband="1" node="12" q="-19.25531539510763">
                 <iidm:alias>_04577e67-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_a7768441-642e-48a2-b4a8-0ae06bebf676"/>
                 <iidm:shuntLinearModel bPerSection="0.0002296" gPerSection="0" maximumSectionCount="10"/>
@@ -6964,19 +7087,19 @@
                 <iidm:internalConnection node1="32" node2="3"/>
                 <iidm:internalConnection node1="33" node2="6"/>
                 <iidm:internalConnection node1="34" node2="9"/>
-                <iidm:bus v="132.66000080579317" angle="-1.798680563937588" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34"/>
+                <iidm:bus v="132.6600040635401" angle="-12.81080818786875" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04633e31-c766-11e1-8775-005056c00008" name="W.Lancst SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="19" targetV="132.66" targetQ="0" node="13" p="-21.038607937146644" q="1.4502044669335754">
+            <iidm:generator id="_04633e31-c766-11e1-8775-005056c00008" name="W.Lancst SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="19" targetV="132.66" targetQ="0" node="13" p="-21.035206478708478" q="1.4624064965852381">
                 <iidm:alias>_047bcf42-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_83fae784-1da1-4055-8108-ba978276d1b6"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_5f711f63-f631-45d3-b26c-33821ab2ee56"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-15" maxQ="45"/>
             </iidm:generator>
-            <iidm:load id="_048a9c51-c766-11e1-8775-005056c00008" name="W.Lancst LD" loadType="UNDEFINED" p0="28" q0="10" node="11" p="28.000000255113179" q="10.000000151853081">
+            <iidm:load id="_048a9c51-c766-11e1-8775-005056c00008" name="W.Lancst LD" loadType="UNDEFINED" p0="28" q0="10" node="11" p="28.000001286512031" q="10.000000765780984">
                 <iidm:alias>_044e7db6-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_045b00d9-c766-11e1-8775-005056c00008" name="W.Lancst SC" sectionCount="5" voltageRegulatorOn="true" targetV="132.66" targetDeadband="1" node="12" q="-10.101639917117208">
+            <iidm:shunt id="_045b00d9-c766-11e1-8775-005056c00008" name="W.Lancst SC" sectionCount="5" voltageRegulatorOn="true" targetV="132.66" targetDeadband="1" node="12" q="-10.101640413251488">
                 <iidm:alias>_04758db6-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_be267a3c-f7a7-4bdf-bb17-71b773247fbf"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -7086,9 +7209,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="129.87639697929788" angle="9.8455985453320025" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="129.89824791671973" angle="-1.2834827282677637" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045dbff2-c766-11e1-8775-005056c00008" name="Portsmth LD" loadType="UNDEFINED" p0="66" q0="20" node="17" p="65.998353365770299" q="19.999168373466816">
+            <iidm:load id="_045dbff2-c766-11e1-8775-005056c00008" name="Portsmth LD" loadType="UNDEFINED" p0="66" q0="20" node="17" p="65.999588785740826" q="19.999792316462049">
                 <iidm:alias>_0454bf45-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7159,16 +7282,16 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="127.64400767097132" angle="6.1528799191220456" nodes="0,1,4,5,6,7,8,9,10,11,12,13,15,16,17,18,19,20,23,24,25,26,27,28,29,30,32,33"/>
+                <iidm:bus v="127.64400024746938" angle="-4.584203351642075" nodes="0,1,4,5,6,7,8,9,10,11,12,13,15,16,17,18,19,20,23,24,25,26,27,28,29,30,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04856c34-c766-11e1-8775-005056c00008" name="DeerCrk SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="7" targetV="127.64400000000001" targetQ="0" node="12" p="-7.7510660821066599" q="-40.016561325359334">
+            <iidm:generator id="_04856c34-c766-11e1-8775-005056c00008" name="DeerCrk SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="7" targetV="127.64400000000001" targetQ="0" node="12" p="-7.7498129132083875" q="-38.524065293232077">
                 <iidm:alias>_0477d7a5-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e5a479a8-ab8d-4a54-bb52-376874ae2784"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b55d80d5-720f-46f9-897f-ff8c5eaf8b44"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-15" maxQ="45"/>
             </iidm:generator>
-            <iidm:load id="_04791028-c766-11e1-8775-005056c00008" name="DeerCrk LD" loadType="UNDEFINED" p0="43" q0="27" node="11" p="43.000003876231212" q="27.00000405652116">
+            <iidm:load id="_04791028-c766-11e1-8775-005056c00008" name="DeerCrk LD" loadType="UNDEFINED" p0="43" q0="27" node="11" p="43.000000125049148" q="27.000000130865391">
                 <iidm:alias>_04486337-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7219,9 +7342,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.6203154957187" angle="10.317160417177853" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.85475958822097" angle="-0.8682635546209152" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0462c904-c766-11e1-8775-005056c00008" name="Medford LD" loadType="UNDEFINED" p0="22" q0="7" node="8" p="21.98365806288589" q="6.9913359671946438">
+            <iidm:load id="_0462c904-c766-11e1-8775-005056c00008" name="Medford LD" loadType="UNDEFINED" p0="22" q0="7" node="8" p="21.988776816157184" q="6.994049323730021">
                 <iidm:alias>_0489b1f7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7310,9 +7433,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="131.95003791757267" angle="15.831626695985017" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="132.11606334282769" angle="4.440981381864427" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046205b5-c766-11e1-8775-005056c00008" name="CollCrnr LD" loadType="UNDEFINED" p0="7" q0="3" node="14" p="6.9981017144083726" q="2.9986442042915842">
+            <iidm:load id="_046205b5-c766-11e1-8775-005056c00008" name="CollCrnr LD" loadType="UNDEFINED" p0="7" q0="3" node="14" p="6.9987357999652486" q="2.9990970543368705">
                 <iidm:alias>_04486334-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7363,9 +7486,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.9279557415108" angle="16.548245488262197" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.89379808172308" angle="5.4885744312227533" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0483be82-c766-11e1-8775-005056c00008" name="Caldwell LD" loadType="UNDEFINED" p0="42" q0="31" node="8" p="41.999491921971" q="30.999374985897322">
+            <iidm:load id="_0483be82-c766-11e1-8775-005056c00008" name="Caldwell LD" loadType="UNDEFINED" p0="42" q0="31" node="8" p="41.999467856583642" q="30.999345381895381">
                 <iidm:alias>_045841b9-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7416,9 +7539,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.33150110400933" angle="9.0337250221990821" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.33148118916897" angle="-2.0279206418131959" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045f94b4-c766-11e1-8775-005056c00008" name="Franklin LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="8.0000019455914835" q="3.000001215994776">
+            <iidm:load id="_045f94b4-c766-11e1-8775-005056c00008" name="Franklin LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="8.00000233708497" q="3.0000014606782486">
                 <iidm:alias>_047da403-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7469,9 +7592,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="124.88629211271304" angle="5.6842518261876744" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.82817102543304" angle="-4.8639742195214142" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045f6da2-c766-11e1-8775-005056c00008" name="McKinley LD" loadType="UNDEFINED" p0="60" q0="34" node="8" p="59.988158131518219" q="33.988816748890585">
+            <iidm:load id="_045f6da2-c766-11e1-8775-005056c00008" name="McKinley LD" loadType="UNDEFINED" p0="60" q0="34" node="8" p="59.991351902298305" q="33.991832744591441">
                 <iidm:alias>_0465d641-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7618,19 +7741,19 @@
                 <iidm:internalConnection node1="71" node2="18"/>
                 <iidm:internalConnection node1="72" node2="21"/>
                 <iidm:internalConnection node1="73" node2="12"/>
-                <iidm:bus v="130.68001196535675" angle="8.5568285672591973" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
+                <iidm:bus v="130.68000800113376" angle="-2.9827615227320896" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_044ca8f0-c766-11e1-8775-005056c00008" name="TwinBrch SM" energySource="THERMAL" minP="50" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="85" targetV="130.68000799999999" targetQ="0" node="24" p="-94.120088139866581" q="-91.38693097671154">
+            <iidm:generator id="_044ca8f0-c766-11e1-8775-005056c00008" name="TwinBrch SM" energySource="THERMAL" minP="50" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="85" targetV="130.68000799999999" targetQ="0" node="24" p="-94.104871088958973" q="-87.33224594130354">
                 <iidm:alias>_04633e38-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_0f6ab5a4-6b72-42f4-92bc-1993e1ae58a3"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_668eb671-5c36-4351-a95d-53ca850581db"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-60" maxQ="170"/>
             </iidm:generator>
-            <iidm:load id="_048740f1-c766-11e1-8775-005056c00008" name="TwinBrch LD" loadType="UNDEFINED" p0="47" q0="10" node="23" p="47.000002139253425" q="10.000000758600516">
+            <iidm:load id="_048740f1-c766-11e1-8775-005056c00008" name="TwinBrch LD" loadType="UNDEFINED" p0="47" q0="10" node="23" p="47.000000000611657" q="10.0000000002169">
                 <iidm:alias>_044ecbda-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:danglingLine id="_045338a1-c766-11e1-8775-005056c00008" name="12-117" p0="20" q0="8" r="5.7324960000000003" x="24.393599999999999" g="0" b="0.00020546369999999999" ucteXnodeCode="XMO_TE32" node="73" p="20.161794839601875" q="5.1797258380355728">
+            <iidm:danglingLine id="_045338a1-c766-11e1-8775-005056c00008" name="12-117" p0="20" q0="8" r="5.7324960000000003" x="24.393599999999999" g="0" b="0.00020546369999999999" ucteXnodeCode="XMO_TE32" node="73" p="20.161793616287486" q="5.1797255239899158">
                 <iidm:alias>_044afb42-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_0457f391-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_5631f3d0-d9d2-11e2-bb49-005056c00008</iidm:alias>
@@ -7728,9 +7851,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="124.08689539928865" angle="4.1853240764946955" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="124.04838815238988" angle="-6.4984348152394151" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0479fa87-c766-11e1-8775-005056c00008" name="Lincoln LD" loadType="UNDEFINED" p0="45" q0="25" node="14" p="44.990703493838019" q="24.991392716701942">
+            <iidm:load id="_0479fa87-c766-11e1-8775-005056c00008" name="Lincoln LD" loadType="UNDEFINED" p0="45" q0="25" node="14" p="44.993051859300479" q="24.993566867510651">
                 <iidm:alias>_047fc6e2-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7781,9 +7904,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="134.64611575084473" angle="15.739452452455302" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="134.64613869115536" angle="4.6786488538719668" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044c81e4-c766-11e1-8775-005056c00008" name="Hinton NegG LD" loadType="UNDEFINED" p0="42" q0="0" node="8" p="41.999982207454316" q="0">
+            <iidm:load id="_044c81e4-c766-11e1-8775-005056c00008" name="Hinton NegG LD" loadType="UNDEFINED" p0="42" q0="0" node="8" p="41.999985059415849" q="0">
                 <iidm:alias>_04494d96-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7834,9 +7957,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.2384746112015" angle="7.8399490782527268" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.21693443320163" angle="-3.3457634173136888" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_048bfbe0-c766-11e1-8775-005056c00008" name="N. E. LD" loadType="UNDEFINED" p0="25" q0="10" node="8" p="24.998444893507642" q="9.9989632838350779">
+            <iidm:load id="_048bfbe0-c766-11e1-8775-005056c00008" name="N. E. LD" loadType="UNDEFINED" p0="25" q0="10" node="8" p="24.998904211521374" q="9.9992694850209887">
                 <iidm:alias>_0480b140-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7887,9 +8010,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.13888580587883" angle="-6.8366787788639272" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.13852750236174" angle="-17.855712882949302" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04854525-c766-11e1-8775-005056c00008" name="SCoshoct LD" loadType="UNDEFINED" p0="18" q0="5" node="8" p="17.999988706876746" q="4.9999947717032924">
+            <iidm:load id="_04854525-c766-11e1-8775-005056c00008" name="SCoshoct LD" loadType="UNDEFINED" p0="18" q0="5" node="8" p="17.999987858405827" q="4.9999943788928514">
                 <iidm:alias>_04747c42-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7940,9 +8063,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="125.04956025615419" angle="8.3931489881511574" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="125.04559610258441" angle="-2.692849706755045" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044aad24-c766-11e1-8775-005056c00008" name="WHuntngd LD" loadType="UNDEFINED" p0="33" q0="15" node="8" p="33.000053804061267" q="15.000040760674624">
+            <iidm:load id="_044aad24-c766-11e1-8775-005056c00008" name="WHuntngd LD" loadType="UNDEFINED" p0="33" q0="15" node="8" p="33.000264685952466" q="15.000200520197065">
                 <iidm:alias>_04784cd2-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7974,9 +8097,9 @@
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="3"/>
-                <iidm:bus v="129.36000569864166" angle="9.9464349271755061" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="129.3600100152853" angle="-1.1157033908521812" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0452ea80-c766-11e1-8775-005056c00008" name="DanRiver SM" energySource="THERMAL" minP="20" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="36" targetV="129.36000000000001" targetQ="0" node="5" p="-39.862625565119956" q="-20.273567340220033">
+            <iidm:generator id="_0452ea80-c766-11e1-8775-005056c00008" name="DanRiver SM" energySource="THERMAL" minP="20" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="36" targetV="129.36000000000001" targetQ="0" node="5" p="-39.856180696500267" q="-20.275435758011369">
                 <iidm:alias>_046a4316-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_fec62959-21c5-4921-90b2-7c85e9f3bfab"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_9db08c95-4586-4a2b-87e3-5a17c944b43a"/>
@@ -8049,9 +8172,9 @@
                 <iidm:internalConnection node1="29" node2="3"/>
                 <iidm:internalConnection node1="30" node2="9"/>
                 <iidm:internalConnection node1="31" node2="6"/>
-                <iidm:bus v="130.12605134801575" angle="9.9608653422854641" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
+                <iidm:bus v="130.16253270312438" angle="-1.1858679501090876" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
             </iidm:nodeBreakerTopology>
-            <iidm:danglingLine id="_044ef2e7-c766-11e1-8775-005056c00008" name="71-73" p0="6" q0="0" r="1.508918" x="7.9104960000000002" g="0" b="6.76079e-05" ucteXnodeCode="XMO_TE31" node="31" p="6.0032115209724433" q="-1.1279540366953051">
+            <iidm:danglingLine id="_044ef2e7-c766-11e1-8775-005056c00008" name="71-73" p0="6" q0="0" r="1.508918" x="7.9104960000000002" g="0" b="6.76079e-05" ucteXnodeCode="XMO_TE31" node="31" p="6.0032100014023779" q="-1.128605446732986">
                 <iidm:alias>_04670ec2-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_046b2d7a-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_26a070b9-db0c-47cd-9991-0a461576aec2</iidm:alias>
@@ -8111,9 +8234,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="134.29666110577247" angle="2.8922125244604957" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="134.29661380000971" angle="-8.1308988694422109" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0453add4-c766-11e1-8775-005056c00008" name="Summerfl LD" loadType="UNDEFINED" p0="28" q0="7" node="8" p="27.999908238138211" q="6.9999617659326869">
+            <iidm:load id="_0453add4-c766-11e1-8775-005056c00008" name="Summerfl LD" loadType="UNDEFINED" p0="28" q0="7" node="8" p="27.999908988690787" q="6.9999620786622456">
                 <iidm:alias>_04851e16-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8240,9 +8363,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="132.66000680180292" angle="31.087115659572454" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="132.66001115632471" angle="20.037065634704" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0489b1fa-c766-11e1-8775-005056c00008" name="ClinchRv SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="607" targetV="132.66" targetQ="0" node="20" p="-672.12815883410599" q="-45.97388601470027">
+            <iidm:generator id="_0489b1fa-c766-11e1-8775-005056c00008" name="ClinchRv SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="607" targetV="132.66" targetQ="0" node="20" p="-672.0194911882129" q="-49.02380614296343">
                 <iidm:alias>_04840caa-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_2621b09a-22e3-4630-b3bd-32c102e36741"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b0d662e5-64c9-4d59-b8e0-9b1ed175769b"/>
@@ -8297,9 +8420,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.4689355962395" angle="7.6279012517623599" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.48680202911549" angle="-3.9524788818472989" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0485e168-c766-11e1-8775-005056c00008" name="Pokagon LD" loadType="UNDEFINED" p0="20" q0="9" node="8" p="19.99980240823184" q="8.999851806661912">
+            <iidm:load id="_0485e168-c766-11e1-8775-005056c00008" name="Pokagon LD" loadType="UNDEFINED" p0="20" q0="9" node="8" p="19.999852526431898" q="8.9998893950957797">
                 <iidm:alias>_0462c902-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8350,9 +8473,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.04221261632642" angle="7.1596058140729903" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.04993799201702" angle="-4.1626526306423086" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04812679-c766-11e1-8775-005056c00008" name="GoshenJt LD" loadType="UNDEFINED" p0="14" q0="1" node="8" p="13.999360103212624" q="0.99992382297165583">
+            <iidm:load id="_04812679-c766-11e1-8775-005056c00008" name="GoshenJt LD" loadType="UNDEFINED" p0="14" q0="1" node="8" p="13.999537929952796" q="0.99994499226623268">
                 <iidm:alias>_045b9d17-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8403,9 +8526,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="118.01251613502941" angle="-11.021626153462767" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="117.96515580379237" angle="-21.970221976193894" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0489b1f2-c766-11e1-8775-005056c00008" name="S.Tiffin LD" loadType="UNDEFINED" p0="37" q0="10" node="8" p="36.990452896431918" q="9.9956998727933737">
+            <iidm:load id="_0489b1f2-c766-11e1-8775-005056c00008" name="S.Tiffin LD" loadType="UNDEFINED" p0="37" q0="10" node="8" p="36.990875476737088" q="9.9958901922612746">
                 <iidm:alias>_046476b8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8456,9 +8579,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="123.61139506260467" angle="-0.28857691758919463" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="123.53834276421082" angle="-11.083753326697874" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045cfca7-c766-11e1-8775-005056c00008" name="Haviland LD" loadType="UNDEFINED" p0="23" q0="9" node="8" p="22.996113146993665" q="8.9974652386623131">
+            <iidm:load id="_045cfca7-c766-11e1-8775-005056c00008" name="Haviland LD" loadType="UNDEFINED" p0="23" q0="9" node="8" p="22.996758614407849" q="8.9978861521822946">
                 <iidm:alias>_0482ad17-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8528,9 +8651,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="131.00718338176839" angle="3.0116631259553528" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="131.00722279412551" angle="-8.0126821774124402" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04555b82-c766-11e1-8775-005056c00008" name="SWKammer LD" loadType="UNDEFINED" p0="78" q0="3" node="11" p="77.999913802648692" q="2.9999944745307974">
+            <iidm:load id="_04555b82-c766-11e1-8775-005056c00008" name="SWKammer LD" loadType="UNDEFINED" p0="78" q0="3" node="11" p="77.999918394474108" q="2.999994768878369">
                 <iidm:alias>_0474ca6b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8638,9 +8761,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="130.40115920260018" angle="15.824083739656121" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="130.35321470498738" angle="4.7637614202385299" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04817492-c766-11e1-8775-005056c00008" name="Baileysv LD" loadType="UNDEFINED" p0="38" q0="15" node="17" p="37.999508148258471" q="14.999676414724055">
+            <iidm:load id="_04817492-c766-11e1-8775-005056c00008" name="Baileysv LD" loadType="UNDEFINED" p0="38" q0="15" node="17" p="37.999479593733597" q="14.999657629019236">
                 <iidm:alias>_0474f17b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8691,9 +8814,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.04623612312028" angle="24.294335688712124" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.04245799307543" angle="13.242220443029186" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0461b790-c766-11e1-8775-005056c00008" name="HolstonT NegG LD" loadType="UNDEFINED" p0="10" q0="0" node="8" p="9.9999629885090222" q="0">
+            <iidm:load id="_0461b790-c766-11e1-8775-005056c00008" name="HolstonT NegG LD" loadType="UNDEFINED" p0="10" q0="0" node="8" p="9.999963235333226" q="0">
                 <iidm:alias>_0464ebe7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8744,9 +8867,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.65395358474463" angle="10.34095845846168" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.8848993906568" angle="-0.84020955144925336" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044c81e5-c766-11e1-8775-005056c00008" name="WMedford LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="7.9939812098086458" q="2.9962391995904132">
+            <iidm:load id="_044c81e5-c766-11e1-8775-005056c00008" name="WMedford LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="7.9958793582376311" q="2.9974250411032188">
                 <iidm:alias>_04570939-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8836,12 +8959,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="124.67645167952151" angle="-4.5423212939052222" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="124.61555042095254" angle="-15.442380575423002" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04854520-c766-11e1-8775-005056c00008" name="Rockhill LD" loadType="UNDEFINED" p0="59" q0="26" node="14" p="58.987261529906512" q="25.990644734864681">
+            <iidm:load id="_04854520-c766-11e1-8775-005056c00008" name="Rockhill LD" loadType="UNDEFINED" p0="59" q0="26" node="14" p="58.988232710134369" q="25.991357932317516">
                 <iidm:alias>_0461b799-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0460cd38-c766-11e1-8775-005056c00008" name="Rockhill SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.81399999999999" targetDeadband="1" node="15" q="-12.482006735527039">
+            <iidm:shunt id="_0460cd38-c766-11e1-8775-005056c00008" name="Rockhill SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.81399999999999" targetDeadband="1" node="15" q="-12.469815431593728">
                 <iidm:alias>_048b86b4-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_069d84c6-bd26-4c26-ac6c-e801a0202a00"/>
                 <iidm:shuntLinearModel bPerSection="0.0001606" gPerSection="0" maximumSectionCount="10"/>
@@ -8914,12 +9037,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="128.70776515859029" angle="17.127949998875639" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="128.53134522342103" angle="6.0718221919305115" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047a48a5-c766-11e1-8775-005056c00008" name="Sprigg LD" loadType="UNDEFINED" p0="20" q0="10" node="11" p="19.999493136055275" q="9.9995776169476134">
+            <iidm:load id="_047a48a5-c766-11e1-8775-005056c00008" name="Sprigg LD" loadType="UNDEFINED" p0="20" q0="10" node="11" p="19.999430623409054" q="9.9995255240101937">
                 <iidm:alias>_0472ce97-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_04553478-c766-11e1-8775-005056c00008" name="Sprigg SC" sectionCount="5" voltageRegulatorOn="true" targetV="129.935" targetDeadband="1" node="12" q="-9.5087053781562076">
+            <iidm:shunt id="_04553478-c766-11e1-8775-005056c00008" name="Sprigg SC" sectionCount="5" voltageRegulatorOn="true" targetV="129.935" targetDeadband="1" node="12" q="-9.4826560486368425">
                 <iidm:alias>_045bc428-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_f4cdc674-4a66-4ab8-8d4f-552cb066e259"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -9011,12 +9134,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="118.47775537192862" angle="-10.094895983300827" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="118.42514778466283" angle="-21.034100642920581" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04819ba4-c766-11e1-8775-005056c00008" name="West End NegG LD" loadType="UNDEFINED" p0="46" q0="0" node="14" p="45.988056276590477" q="0">
+            <iidm:load id="_04819ba4-c766-11e1-8775-005056c00008" name="West End NegG LD" loadType="UNDEFINED" p0="46" q0="0" node="14" p="45.988614316427515" q="0">
                 <iidm:alias>_04627ae0-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_04555b89-c766-11e1-8775-005056c00008" name="West End LD" loadType="UNDEFINED" p0="20" q0="23" node="15" p="19.994807076778468" q="22.990047758611897">
+            <iidm:load id="_04555b89-c766-11e1-8775-005056c00008" name="West End LD" loadType="UNDEFINED" p0="20" q0="23" node="15" p="19.995049702794571" q="22.990512713190533">
                 <iidm:alias>_04592c18-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9067,9 +9190,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.08911214814981" angle="8.9250626552501444" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.08078438327146" angle="-1.5822062025367944" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046d0232-c766-11e1-8775-005056c00008" name="Deer Crk NegG LD" loadType="UNDEFINED" p0="6" q0="0" node="8" p="5.9982580690323442" q="0">
+            <iidm:load id="_046d0232-c766-11e1-8775-005056c00008" name="Deer Crk NegG LD" loadType="UNDEFINED" p0="6" q0="0" node="8" p="5.9988068303057727" q="0">
                 <iidm:alias>_0480150a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9139,9 +9262,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="133.91909820351538" angle="0.58510157683111497" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="133.92248232788629" angle="-10.436102098003371" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046c3ee3-c766-11e1-8775-005056c00008" name="Crooksvl LD" loadType="UNDEFINED" p0="34" q0="0" node="11" p="33.999556506124136" q="0">
+            <iidm:load id="_046c3ee3-c766-11e1-8775-005056c00008" name="Crooksvl LD" loadType="UNDEFINED" p0="34" q0="0" node="11" p="33.999588793581218" q="0">
                 <iidm:alias>_047e4047-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9192,9 +9315,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="132.05317286050845" angle="-2.6560350848857013" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="132.05297284881576" angle="-13.673791598680463" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046dc585-c766-11e1-8775-005056c00008" name="WCambrdg LD" loadType="UNDEFINED" p0="17" q0="4" node="8" p="16.999996977047253" q="3.999998814528404">
+            <iidm:load id="_046dc585-c766-11e1-8775-005056c00008" name="WCambrdg LD" loadType="UNDEFINED" p0="17" q0="4" node="8" p="16.999996836028345" q="3.9999987592268784">
                 <iidm:alias>_045dbff8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9283,9 +9406,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="130.23072722752147" angle="9.1173303370478678" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="130.29023186497389" angle="-2.4941780611949667" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_048b5fa5-c766-11e1-8775-005056c00008" name="SouthBnd LD" loadType="UNDEFINED" p0="70" q0="23" node="14" p="69.997815789256578" q="22.998803897033735">
+            <iidm:load id="_048b5fa5-c766-11e1-8775-005056c00008" name="SouthBnd LD" loadType="UNDEFINED" p0="70" q0="23" node="14" p="69.998419734987678" q="22.999134623291059">
                 <iidm:alias>_04522734-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9335,11 +9458,11 @@
                 <iidm:internalConnection node1="19" node2="6"/>
                 <iidm:internalConnection node1="20" node2="3"/>
                 <iidm:internalConnection node1="21" node2="6"/>
-                <iidm:bus v="227.75394666401951" angle="26.174592044980798" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
+                <iidm:bus v="228.00860371599541" angle="14.049160326907414" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:line id="_044cd006-c766-11e1-8775-005056c00008" name="31-32" r="5.1923519999999996" x="17.16264" g1="0" b1="7.20271e-05" g2="0" b2="7.20271e-05" node1="31" voltageLevelId1="_04636548-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="0" q1="0" p2="0" q2="0">
+    <iidm:line id="_044cd006-c766-11e1-8775-005056c00008" name="31-32" r="5.1923519999999996" x="17.16264" g1="0" b1="7.20271e-05" g2="0" b2="7.20271e-05" node1="31" voltageLevelId1="_04636548-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="0" q1="-0" p2="0" q2="-0">
         <iidm:alias>_04682030-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0471bd25-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9347,7 +9470,7 @@
             <iidm:temporaryLimit name="_de6da3cb-8cb5-4900-9c33-8ad45632b535" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045a3d89-c766-11e1-8775-005056c00008" name="2-12" r="3.2582879999999999" x="10.7331839" g1="0" b1="4.5110200000000001e-05" g2="0" b2="4.5110200000000001e-05" node1="21" voltageLevelId1="_045d4ac5-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-30.517501666656393" q1="-17.739785558307787" p2="30.758386263214138" q2="17.018418084088232">
+    <iidm:line id="_045a3d89-c766-11e1-8775-005056c00008" name="2-12" r="3.2582879999999999" x="10.7331839" g1="0" b1="4.5110200000000001e-05" g2="0" b2="4.5110200000000001e-05" node1="21" voltageLevelId1="_045d4ac5-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-31.476746297867781" q1="-17.220067140389517" p2="31.725866192826942" q2="16.525620658823115">
         <iidm:alias>_046adf51-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046fe868-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9355,7 +9478,7 @@
             <iidm:temporaryLimit name="_6bd63dd1-1344-4183-b7bd-af326919f4eb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04513cd7-c766-11e1-8775-005056c00008" name="32-114" r="2.3522400000000001" x="10.6634884" g1="0" b1="4.6717149999999997e-05" g2="0" b2="4.6717149999999997e-05" node1="49" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04791027-c766-11e1-8775-005056c00008" p1="12.017283145563026" q1="2.9354559262055888" p2="-11.994300794723374" q2="-4.336334120849628">
+    <iidm:line id="_04513cd7-c766-11e1-8775-005056c00008" name="32-114" r="2.3522400000000001" x="10.6634884" g1="0" b1="4.6717149999999997e-05" g2="0" b2="4.6717149999999997e-05" node1="49" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04791027-c766-11e1-8775-005056c00008" p1="12.612107060170269" q1="2.5674329281424115" p2="-12.587448750471781" q2="-3.9659469452876266">
         <iidm:alias>_046d0237-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0470d2c7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9363,7 +9486,7 @@
             <iidm:temporaryLimit name="_5f05650a-c63d-46e5-a426-2db4f036929f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045d71d4-c766-11e1-8775-005056c00008" name="24-72" r="8.5029120000000002" x="34.151040000000002" g1="0" b1="0.00014003675" g2="0" b2="0.00014003675" node1="30" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="24.785786797631648" q1="-5.5368791629526708" p2="-24.479006830003126" q2="1.9477927146655596">
+    <iidm:line id="_045d71d4-c766-11e1-8775-005056c00008" name="24-72" r="8.5029120000000002" x="34.151040000000002" g1="0" b1="0.00014003675" g2="0" b2="0.00014003675" node1="30" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="24.040086034831749" q1="-5.1768645460772929" p2="-23.752971040614092" q2="1.4989288436880732">
         <iidm:alias>_04667281-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d0234-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9371,7 +9494,7 @@
             <iidm:temporaryLimit name="_d2074163-ab09-4251-a1d7-6983091dc4f1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045f94b8-c766-11e1-8775-005056c00008" name="17-18" r="2.1431520000000002" x="8.7991200000000003" g1="0" b1="3.7247499999999999e-05" g2="0" b2="3.7247499999999999e-05" node1="57" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04689563-c766-11e1-8775-005056c00008" p1="109.2588565628414" q1="40.913331736970619" p2="-107.50850682178412" q2="-34.930979463000931">
+    <iidm:line id="_045f94b8-c766-11e1-8775-005056c00008" name="17-18" r="2.1431520000000002" x="8.7991200000000003" g1="0" b1="3.7247499999999999e-05" g2="0" b2="3.7247499999999999e-05" node1="57" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04689563-c766-11e1-8775-005056c00008" p1="113.35496690727737" q1="40.298275677582431" p2="-111.49295868056829" q2="-33.856498301003136">
         <iidm:alias>_045e0e17-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0485ba59-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9379,7 +9502,7 @@
             <iidm:temporaryLimit name="_2b6693c7-4e29-4c2c-91d0-3485bbe8fe87" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048963d8-c766-11e1-8775-005056c00008" name="17-113" r="1.590811" x="5.244624" g1="0" b1="2.2038549999999999e-05" g2="0" b2="2.2038549999999999e-05" node1="58" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="-5.6520001817389751" q1="7.5479220928223869" p2="5.6609977254037558" q2="-8.2541895299090093">
+    <iidm:line id="_048963d8-c766-11e1-8775-005056c00008" name="17-113" r="1.590811" x="5.244624" g1="0" b1="2.2038549999999999e-05" g2="0" b2="2.2038549999999999e-05" node1="58" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="-1.1110377610222684" q1="5.2152526192081066" p2="1.1141221362852212" q2="-5.9407015331759228">
         <iidm:alias>_045841b5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046958b4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9387,7 +9510,7 @@
             <iidm:temporaryLimit name="_786432da-fa4d-4751-a275-87d0e20529f1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0458ddf0-c766-11e1-8775-005056c00008" name="49-50" r="4.6522079999999999" x="13.102848099999999" g1="0" b1="5.3776400000000002e-05" g2="0" b2="5.3776400000000002e-05" node1="112" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044d1e26-c766-11e1-8775-005056c00008" p1="62.125935612982062" q1="11.702310856345335" p2="-61.104166391282774" q2="-10.74670954171237">
+    <iidm:line id="_0458ddf0-c766-11e1-8775-005056c00008" name="49-50" r="4.6522079999999999" x="13.102848099999999" g1="0" b1="5.3776400000000002e-05" g2="0" b2="5.3776400000000002e-05" node1="112" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044d1e26-c766-11e1-8775-005056c00008" p1="62.143424412245473" q1="11.698994859852609" p2="-61.121124306480176" q2="-10.741895531052556">
         <iidm:alias>_0464ebe8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f9fd8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9395,7 +9518,7 @@
             <iidm:temporaryLimit name="_1f0844a5-ea5c-42b2-abcb-6fac2c426092" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04535fb7-c766-11e1-8775-005056c00008" name="1-3" r="2.2476959999999999" x="7.3877759999999997" g1="0" b1="3.1049149999999997e-05" g2="0" b2="3.1049149999999997e-05" node1="21" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_047eb579-c766-11e1-8775-005056c00008" p1="-40.547957004925344" q1="-16.106897956310494" p2="40.812304768285678" q2="15.965967439824755">
+    <iidm:line id="_04535fb7-c766-11e1-8775-005056c00008" name="1-3" r="2.2476959999999999" x="7.3877759999999997" g1="0" b1="3.1049149999999997e-05" g2="0" b2="3.1049149999999997e-05" node1="21" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_047eb579-c766-11e1-8775-005056c00008" p1="-39.592624219197447" q1="-16.637277720847781" p2="39.848403657689587" q2="16.467289191352506">
         <iidm:alias>_044ef2e9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047c4474-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9403,7 +9526,7 @@
             <iidm:temporaryLimit name="_4ea43e34-67a3-42b8-9601-2189db7790d4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0478e912-c766-11e1-8775-005056c00008" name="92-102" r="2.1431520000000002" x="9.7400160000000007" g1="0" b1="4.2011000000000001e-05" g2="0" b2="4.2011000000000001e-05" node1="66" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="49.940417832519387" q1="-9.0341950892799279" p2="-49.618377620166868" q2="9.066080848576302">
+    <iidm:line id="_0478e912-c766-11e1-8775-005056c00008" name="92-102" r="2.1431520000000002" x="9.7400160000000007" g1="0" b1="4.2011000000000001e-05" g2="0" b2="4.2011000000000001e-05" node1="66" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="49.977041517058865" q1="-9.0531133265160317" p2="-49.65446850405408" q2="9.08755851296457">
         <iidm:alias>_045a1673-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0468bc79-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9411,7 +9534,7 @@
             <iidm:temporaryLimit name="_23cc194e-9273-46e9-a793-84a9c2911737" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04547127-c766-11e1-8775-005056c00008" name="93-94" r="3.8855520000000001" x="12.7543688" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="21" voltageLevelId1="_04789af0-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="57.209845611852941" q1="-22.097684244305686" p2="-56.351129983137227" q2="23.095854037652934">
+    <iidm:line id="_04547127-c766-11e1-8775-005056c00008" name="93-94" r="3.8855520000000001" x="12.7543688" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="21" voltageLevelId1="_04789af0-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="57.266526697769336" q1="-22.041369744963003" p2="-56.406655329633828" q2="23.043866679844381">
         <iidm:alias>_04500450-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047b0bfb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9419,7 +9542,7 @@
             <iidm:temporaryLimit name="_1a9fe09e-3f63-4904-8e36-aa38c5e16c59" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04791021-c766-11e1-8775-005056c00008" name="46-48" r="10.4718237" x="32.931359999999998" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044778d3-c766-11e1-8775-005056c00008" p1="-8.8324655915759323" q1="-7.9374400775750598" p2="8.897239250816936" q2="3.2982201630553201">
+    <iidm:line id="_04791021-c766-11e1-8775-005056c00008" name="46-48" r="10.4718237" x="32.931359999999998" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044778d3-c766-11e1-8775-005056c00008" p1="-8.799817630819188" q1="-7.9487554588822107" p2="8.864323613454026" q2="3.308689338091618">
         <iidm:alias>_0459ef69-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04640186-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9427,7 +9550,7 @@
             <iidm:temporaryLimit name="_467ba04d-dbad-4fe1-81c8-3bc87b41fcd1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046958b6-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="113" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-92.566894200537547" q1="-2.4504235348212626" p2="94.035153985074487" q2="7.2883476799120741">
+    <iidm:line id="_046958b6-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="113" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-92.464111321841088" q1="-2.4787209656408402" p2="93.929124003714733" q2="7.3000677204051252">
         <iidm:alias>_04776270-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a96c8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9435,7 +9558,7 @@
             <iidm:temporaryLimit name="_d0737ab4-5a3a-46c8-8aeb-789313f0f332" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046f4c26-c766-11e1-8775-005056c00008" name="75-118" r="2.5264799999999998" x="8.3809430000000003" g1="0" b1="3.4377849999999998e-05" g2="0" b2="3.4377849999999998e-05" node1="48" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="39.202703960259441" q1="28.728155848911218" p2="-38.831873690975726" q2="-28.596483059622081">
+    <iidm:line id="_046f4c26-c766-11e1-8775-005056c00008" name="75-118" r="2.5264799999999998" x="8.3809430000000003" g1="0" b1="3.4377849999999998e-05" g2="0" b2="3.4377849999999998e-05" node1="48" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="39.071229085571623" q1="28.831582274537805" p2="-38.701054776122213" q2="-28.70205474217925">
         <iidm:alias>_04619088-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04814d8a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9443,7 +9566,7 @@
             <iidm:temporaryLimit name="_173dc7ff-ae18-4410-b2e1-a4c2abac8ff6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c3954-c766-11e1-8775-005056c00008" name="94-96" r="4.6870560000000001" x="15.1414566" g1="0" b1="6.60009e-05" g2="0" b2="6.60009e-05" node1="49" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="38.268875230212068" q1="-13.09307290696764" p2="-37.824971591049504" q2="12.284299677917458">
+    <iidm:line id="_045c3954-c766-11e1-8775-005056c00008" name="94-96" r="4.6870560000000001" x="15.1414566" g1="0" b1="6.60009e-05" g2="0" b2="6.60009e-05" node1="49" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="38.336270772837182" q1="-12.893855058031656" p2="-37.89209187355825" q2="12.087183177126345">
         <iidm:alias>_046ba2a0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0472ce94-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9451,7 +9574,7 @@
             <iidm:temporaryLimit name="_efde58bf-c92e-496d-b558-d0095a271083" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04518af7-c766-11e1-8775-005056c00008" name="62-67" r="4.4953919999999998" x="20.38608" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="39" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="-2.4835951814313928" q1="-18.364507875626156" p2="2.5586584244085397" q2="15.559752847964784">
+    <iidm:line id="_04518af7-c766-11e1-8775-005056c00008" name="62-67" r="4.4953919999999998" x="20.38608" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="39" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="-2.4975634507838613" q1="-18.361100715204103" p2="2.5726149913751826" q2="15.556293591740539">
         <iidm:alias>_04544a10-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04814d86-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9459,7 +9582,7 @@
             <iidm:temporaryLimit name="_8a81d4ae-2bc8-4038-8650-27a6150946b1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0452c375-c766-11e1-8775-005056c00008" name="47-49" r="3.3279839999999998" x="10.890000000000001" g1="0" b1="4.6028449999999998e-05" g2="0" b2="4.6028449999999998e-05" node1="30" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="114" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="17.0588503301332" q1="-22.850160501376973" p2="-16.914835048927795" q2="21.653324557296074">
+    <iidm:line id="_0452c375-c766-11e1-8775-005056c00008" name="47-49" r="3.3279839999999998" x="10.890000000000001" g1="0" b1="4.6028449999999998e-05" g2="0" b2="4.6028449999999998e-05" node1="30" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="114" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="16.957921017102951" q1="-22.779962909495289" p2="-16.815123273456429" q2="21.579101112637971">
         <iidm:alias>_0465fd54-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0471e431-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9467,7 +9590,7 @@
             <iidm:temporaryLimit name="_8d6a074c-900d-4a37-830c-5da4c1de1ab5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046c17d9-c766-11e1-8775-005056c00008" name="100-106" r="10.54152" x="39.900959999999998" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="76" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="59.401672017691411" q1="10.058507120863283" p2="-57.234742888300481" q2="-7.920143676612752">
+    <iidm:line id="_046c17d9-c766-11e1-8775-005056c00008" name="100-106" r="10.54152" x="39.900959999999998" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="76" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="59.403505971317529" q1="10.058356349006042" p2="-57.236451873157421" q2="-7.9195191596082735">
         <iidm:alias>_045d98e5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0480d851-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9475,7 +9598,7 @@
             <iidm:temporaryLimit name="_3154dc30-b0e5-4570-8e52-9333bae20ef2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046b2d77-c766-11e1-8775-005056c00008" name="77-78" r="0.655142" x="2.1605759999999998" g1="0" b1="3.6271800000000001e-05" g2="0" b2="3.6271800000000001e-05" node1="66" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044fb634-c766-11e1-8775-005056c00008" p1="43.777135323365876" q1="4.0513530292375632" p2="-43.704639552475236" q2="-5.0802435015976082">
+    <iidm:line id="_046b2d77-c766-11e1-8775-005056c00008" name="77-78" r="0.655142" x="2.1605759999999998" g1="0" b1="3.6271800000000001e-05" g2="0" b2="3.6271800000000001e-05" node1="66" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044fb634-c766-11e1-8775-005056c00008" p1="43.681726835970835" q1="3.9499776549809464" p2="-43.609558005371341" q2="-4.9796083522970171">
         <iidm:alias>_046ed6fb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04893cc3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9483,7 +9606,7 @@
             <iidm:temporaryLimit name="_cce754c5-b9d5-4105-a431-32da96e4a6cf" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c8776-c766-11e1-8775-005056c00008" name="6-7" r="0.79976199999999997" x="3.6241919999999999" g1="0" b1="1.5782850000000001e-05" g2="0" b2="1.5782850000000001e-05" node1="21" voltageLevelId1="_044f6818-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047eb571-c766-11e1-8775-005056c00008" p1="42.872151553654525" q1="-8.1022022044255557" p2="-42.783028767349968" q2="7.968210771388887">
+    <iidm:line id="_045c8776-c766-11e1-8775-005056c00008" name="6-7" r="0.79976199999999997" x="3.6241919999999999" g1="0" b1="1.5782850000000001e-05" g2="0" b2="1.5782850000000001e-05" node1="21" voltageLevelId1="_044f6818-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047eb571-c766-11e1-8775-005056c00008" p1="38.620121610189038" q1="-6.1336834326637248" p2="-38.548606183499807" q2="5.9194000714671704">
         <iidm:alias>_046efe08-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04720b4a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9491,7 +9614,7 @@
             <iidm:temporaryLimit name="_361a9cc3-fb33-4037-9b9a-c20adb90b66b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047ba839-c766-11e1-8775-005056c00008" name="77-80" r="5.1226560000000001" x="18.295200000000001" g1="0" b1="6.5426999999999995e-05" g2="0" b2="6.5426999999999995e-05" node1="67" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="76" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-46.068617043910429" q1="-23.088245279316705" p2="46.830050219591683" q2="23.428521791286865">
+    <iidm:line id="_047ba839-c766-11e1-8775-005056c00008" name="77-80" r="5.1226560000000001" x="18.295200000000001" g1="0" b1="6.5426999999999995e-05" g2="0" b2="6.5426999999999995e-05" node1="67" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="76" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-46.167700014057878" q1="-23.187190317358315" p2="46.933298469149229" q2="23.542665936557228">
         <iidm:alias>_047c6b85-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0480b148-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9499,7 +9622,7 @@
             <iidm:temporaryLimit name="_da00c66f-a882-4938-923b-f2455f7f9a81" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04592c16-c766-11e1-8775-005056c00008" name="78-79" r="0.95135000000000003" x="4.2514560000000001" g1="0" b1="1.8595050000000001e-05" g2="0" b2="1.8595050000000001e-05" node1="22" voltageLevelId1="_044fb634-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04481510-c766-11e1-8775-005056c00008" p1="-27.295302031701716" q1="-20.919720131312133" p2="27.359081142772567" q2="20.551890444644116">
+    <iidm:line id="_04592c16-c766-11e1-8775-005056c00008" name="78-79" r="0.95135000000000003" x="4.2514560000000001" g1="0" b1="1.8595050000000001e-05" g2="0" b2="1.8595050000000001e-05" node1="22" voltageLevelId1="_044fb634-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04481510-c766-11e1-8775-005056c00008" p1="-27.390409961130818" q1="-21.02037027696478" p2="27.454715818461274" q2="20.655037894136655">
         <iidm:alias>_0453add6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045b7605-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9507,7 +9630,7 @@
             <iidm:temporaryLimit name="_ba4abe9d-8490-4c19-b19b-c9d2c3597fc9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047b3301-c766-11e1-8775-005056c00008" name="103-104" r="8.1195839999999997" x="27.599615100000001" g1="0" b1="0.00011679295" g2="0" b2="0.00011679295" node1="40" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="33.048952178294485" q1="13.983406639398371" p2="-32.432186380848812" q2="-15.87986895691682">
+    <iidm:line id="_047b3301-c766-11e1-8775-005056c00008" name="103-104" r="8.1195839999999997" x="27.599615100000001" g1="0" b1="0.00011679295" g2="0" b2="0.00011679295" node1="40" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="33.048430019550082" q1="13.983604379966033" p2="-32.431677126108227" q2="-15.880110397457308">
         <iidm:alias>_0459a142-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045d98e6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9515,7 +9638,7 @@
             <iidm:temporaryLimit name="_2320da74-eda7-4f7f-ade9-1ed0e994f3af" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045e5c32-c766-11e1-8775-005056c00008" name="95-96" r="2.9795039999999999" x="9.5309279999999994" g1="0" b1="4.2298000000000001e-05" g2="0" b2="4.2298000000000001e-05" node1="21" voltageLevelId1="_044f4108-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="14.674365699348185" q1="-25.078121178106151" p2="-14.529269740440864" q2="24.119908769557348">
+    <iidm:line id="_045e5c32-c766-11e1-8775-005056c00008" name="95-96" r="2.9795039999999999" x="9.5309279999999994" g1="0" b1="4.2298000000000001e-05" g2="0" b2="4.2298000000000001e-05" node1="21" voltageLevelId1="_044f4108-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="14.734420326945679" q1="-24.904628962093792" p2="-14.59043890644906" q2="23.943752633724095">
         <iidm:alias>_04597a34-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04801509-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9523,7 +9646,7 @@
             <iidm:temporaryLimit name="_3bc03415-e95f-47a7-8e92-01089d304a9c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045ed169-c766-11e1-8775-005056c00008" name="77-80" r="2.9620799999999998" x="8.4506409999999992" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="68" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="77" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-100.52396338010048" q1="-42.567163228642301" p2="102.50586577208958" q2="43.296203806744671">
+    <iidm:line id="_045ed169-c766-11e1-8775-005056c00008" name="77-80" r="2.9620799999999998" x="8.4506409999999992" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="68" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="77" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-100.74724736792136" q1="-42.763202917986867" p2="102.73999139052232" q2="43.523842927059896">
         <iidm:alias>_0464289a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04828605-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9531,7 +9654,7 @@
             <iidm:temporaryLimit name="_f93b6d4c-39fa-4f6f-a42d-c63a4cf21a67" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047f78c2-c766-11e1-8775-005056c00008" name="5-11" r="3.5370720000000002" x="11.8831682" g1="0" b1="4.987375e-05" g2="0" b2="4.987375e-05" node1="48" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="88.225172748336803" q1="8.3847306404291313" p2="-86.655768631875958" q2="-4.8425854756149382">
+    <iidm:line id="_047f78c2-c766-11e1-8775-005056c00008" name="5-11" r="3.5370720000000002" x="11.8831682" g1="0" b1="4.987375e-05" g2="0" b2="4.987375e-05" node1="48" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="83.096549224054144" q1="10.426890579528186" p2="-81.696755814429409" q2="-7.4570977298083774">
         <iidm:alias>_045bc426-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0476c633-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9539,7 +9662,7 @@
             <iidm:temporaryLimit name="_3bc4ab96-7a0d-4e18-b9f5-d89f63a82f0a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04845ac7-c766-11e1-8775-005056c00008" name="71-72" r="7.7711040000000002" x="31.363201100000001" g1="0" b1="0.00012752525" g2="0" b2="0.00012752525" node1="29" voltageLevelId1="_04664b78-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="-12.410610313236555" q1="-2.1110580058260475" p2="12.48129853793834" q2="-1.9477924050914346">
+    <iidm:line id="_04845ac7-c766-11e1-8775-005056c00008" name="71-72" r="7.7711040000000002" x="31.363201100000001" g1="0" b1="0.00012752525" g2="0" b2="0.00012752525" node1="29" voltageLevelId1="_04664b78-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="-11.691775396028925" q1="-2.5965418480329694" p2="11.754563174344664" q2="-1.4989293419411551">
         <iidm:alias>_04642891-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046b0661-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9547,7 +9670,7 @@
             <iidm:temporaryLimit name="_bcb69c6e-125e-449c-acb3-a4deb151668d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047343c2-c766-11e1-8775-005056c00008" name="66-67" r="3.9029759999999998" x="17.685359999999999" g1="0" b1="7.6962800000000001e-05" g2="0" b2="7.6962800000000001e-05" node1="50" voltageLevelId1="_047147f4-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="30.857651213741299" q1="21.060874197791364" p2="-30.558566802303815" q2="-22.559714605418247">
+    <iidm:line id="_047343c2-c766-11e1-8775-005056c00008" name="66-67" r="3.9029759999999998" x="17.685359999999999" g1="0" b1="7.6962800000000001e-05" g2="0" b2="7.6962800000000001e-05" node1="50" voltageLevelId1="_047147f4-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="30.871762083828742" q1="21.058111243057802" p2="-30.572524499255948" q2="-22.556255591617628">
         <iidm:alias>_0465af34-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04860874-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9555,7 +9678,7 @@
             <iidm:temporaryLimit name="_b4b8a31d-dc3c-4b51-88ad-a22e070eb96c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04569409-c766-11e1-8775-005056c00008" name="34-43" r="7.1961120000000003" x="29.289743399999999" g1="0" b1="0.0001212695" g2="0" b2="0.0001212695" node1="40" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_045e8349-c766-11e1-8775-005056c00008" p1="12.396217614035178" q1="-7.5282771936933859" p2="-12.310335671918892" q2="4.0879864145190412">
+    <iidm:line id="_04569409-c766-11e1-8775-005056c00008" name="34-43" r="7.1961120000000003" x="29.289743399999999" g1="0" b1="0.0001212695" g2="0" b2="0.0001212695" node1="40" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_045e8349-c766-11e1-8775-005056c00008" p1="12.676990578465292" q1="-7.6607355547063296" p2="-12.587051651456369" q2="4.2401136622480573">
         <iidm:alias>_04500454-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04505274-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9563,7 +9686,7 @@
             <iidm:temporaryLimit name="_5585c67a-0839-48e6-8847-4393e1e9b9c7" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04817498-c766-11e1-8775-005056c00008" name="52-53" r="7.0567200000000003" x="28.488240000000001" g1="0" b1="0.00011644859999999999" g2="0" b2="0.00011644859999999999" node1="21" voltageLevelId1="_04806326-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04876804-c766-11e1-8775-005056c00008" p1="13.378641682839355" q1="0.95902432714088448" p2="-13.295751819857561" q2="-4.2905610068833795">
+    <iidm:line id="_04817498-c766-11e1-8775-005056c00008" name="52-53" r="7.0567200000000003" x="28.488240000000001" g1="0" b1="0.00011644859999999999" g2="0" b2="0.00011644859999999999" node1="21" voltageLevelId1="_04806326-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04876804-c766-11e1-8775-005056c00008" p1="13.385065687109845" q1="0.95680572252687945" p2="-13.302104657428268" q2="-4.2880392913495236">
         <iidm:alias>_045115c7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0472a784-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9571,7 +9694,7 @@
             <iidm:temporaryLimit name="_e7c9dfab-fb45-4470-964f-4ba9e391f60b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044b7078-c766-11e1-8775-005056c00008" name="105-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="49" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="23" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="26.894184299442479" q1="1.3281092341895209" p2="-26.475725182430033" q2="-4.1905954922427071">
+    <iidm:line id="_044b7078-c766-11e1-8775-005056c00008" name="105-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="49" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="23" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="26.8939700423023" q1="1.3281863298664371" p2="-26.475517116853105" q2="-4.1906931614136553">
         <iidm:alias>_0452c378-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0481c2b7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9579,7 +9702,7 @@
             <iidm:temporaryLimit name="_fff133bf-25fd-46b2-b144-a227c31ee882" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048ac367-c766-11e1-8775-005056c00008" name="100-101" r="4.8264480000000001" x="21.9890881" g1="0" b1="9.4123049999999997e-05" g2="0" b2="9.4123049999999997e-05" node1="77" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046ed6f7-c766-11e1-8775-005056c00008" p1="-21.774781958859247" q1="24.723309390959415" p2="22.088699038054312" q2="-26.599110743944308">
+    <iidm:line id="_048ac367-c766-11e1-8775-005056c00008" name="100-101" r="4.8264480000000001" x="21.9890881" g1="0" b1="9.4123049999999997e-05" g2="0" b2="9.4123049999999997e-05" node1="77" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046ed6f7-c766-11e1-8775-005056c00008" p1="-21.809071822358881" q1="24.753270992714977" p2="22.123813363315541" q2="-26.625231639907149">
         <iidm:alias>_044afb45-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b5fa2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9587,7 +9710,7 @@
             <iidm:temporaryLimit name="_217e3c95-24b5-438f-a721-d2257e1a43b4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0481c2b1-c766-11e1-8775-005056c00008" name="56-57" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="57" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="-30.784898301168294" q1="-5.4825701685802342" p2="31.149416623898684" q2="4.2702357439461842">
+    <iidm:line id="_0481c2b1-c766-11e1-8775-005056c00008" name="56-57" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="57" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="-30.800838205764137" q1="-5.4748672292363993" p2="31.165701361711967" q2="4.2635085150613916">
         <iidm:alias>_045e0e12-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0487dd35-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9595,7 +9718,7 @@
             <iidm:temporaryLimit name="_f5547027-3d48-4a53-937b-bd5ba63ef70d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047a6fb7-c766-11e1-8775-005056c00008" name="47-69" r="14.705855400000001" x="48.403869999999998" g1="0" b1="0.00020351240000000001" g2="0" b2="0.00020351240000000001" node1="31" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="57" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-83.990460262720006" q1="26.015457765675325" p2="90.496562767592593" q2="-12.04924332022069">
+    <iidm:line id="_047a6fb7-c766-11e1-8775-005056c00008" name="47-69" r="14.705855400000001" x="48.403869999999998" g1="0" b1="0.00020351240000000001" g2="0" b2="0.00020351240000000001" node1="31" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="57" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-83.777937755102045" q1="25.896550774846695" p2="90.248712751251787" q2="-12.046800430173565">
         <iidm:alias>_04758db9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0485ba56-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9603,7 +9726,7 @@
             <iidm:temporaryLimit name="_e9fec217-cf6f-4d39-9495-26ed10c05100" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0453fbf0-c766-11e1-8775-005056c00008" name="110-111" r="3.8332799999999998" x="13.1551189" g1="0" b1="5.7392100000000002e-05" g2="0" b2="5.7392100000000002e-05" node1="40" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_046a1c00-c766-11e1-8775-005056c00008" p1="-39.395344725627311" q1="-20.542445109826925" p2="39.862629528272912" q2="20.273570683286295">
+    <iidm:line id="_0453fbf0-c766-11e1-8775-005056c00008" name="110-111" r="3.8332799999999998" x="13.1551189" g1="0" b1="5.7392100000000002e-05" g2="0" b2="5.7392100000000002e-05" node1="40" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_046a1c00-c766-11e1-8775-005056c00008" p1="-39.389002009436162" q1="-20.544656177303693" p2="39.856187329258717" q2="20.275440484216482">
         <iidm:alias>_0447c6f5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04812675-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9611,7 +9734,7 @@
             <iidm:temporaryLimit name="_ea48fee0-31b6-4990-a332-25d08b7d731f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04778984-c766-11e1-8775-005056c00008" name="41-42" r="7.14384" x="23.522401800000001" g1="0" b1="9.8714400000000005e-05" g2="0" b2="9.8714400000000005e-05" node1="21" voltageLevelId1="_048c4a08-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="-10.799770353472422" q1="-11.050552509027806" p2="10.907620997418837" q2="8.595021834981468">
+    <iidm:line id="_04778984-c766-11e1-8775-005056c00008" name="41-42" r="7.14384" x="23.522401800000001" g1="0" b1="9.8714400000000005e-05" g2="0" b2="9.8714400000000005e-05" node1="21" voltageLevelId1="_048c4a08-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="-10.594852468437074" q1="-11.192025131289132" p2="10.701965908725239" q2="8.7359065898043742">
         <iidm:alias>_044d1e2a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046512f1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9619,7 +9742,7 @@
             <iidm:temporaryLimit name="_063af52c-fe10-4c1e-85d4-dd80dcc1d2f9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04653a08-c766-11e1-8775-005056c00008" name="80-99" r="7.9104960000000002" x="35.893439999999998" g1="0" b1="0.00015668044999999999" g2="0" b2="0.00015668044999999999" node1="78" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04644fa4-c766-11e1-8775-005056c00008" p1="1.9859420702832999" q1="6.6832811673764345" p2="-1.9453115002477213" q2="-12.292240710798836">
+    <iidm:line id="_04653a08-c766-11e1-8775-005056c00008" name="80-99" r="7.9104960000000002" x="35.893439999999998" g1="0" b1="0.00015668044999999999" g2="0" b2="0.00015668044999999999" node1="78" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04644fa4-c766-11e1-8775-005056c00008" p1="1.9925680065471578" q1="6.6817483641969098" p2="-1.9519387709755156" q2="-12.290715120631615">
         <iidm:alias>_04773b69-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0477b092-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9627,7 +9750,7 @@
             <iidm:temporaryLimit name="_c05229ce-6abb-4209-ad4f-0dcd4a070f28" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04581aa5-c766-11e1-8775-005056c00008" name="54-59" r="8.7642720000000001" x="39.953229999999998" g1="0" b1="0.0001716024" g2="0" b2="0.0001716024" node1="58" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-19.674436773670479" q1="-10.512035180282005" p2="19.921347259469989" q2="6.0096851010246057">
+    <iidm:line id="_04581aa5-c766-11e1-8775-005056c00008" name="54-59" r="8.7642720000000001" x="39.953229999999998" g1="0" b1="0.0001716024" g2="0" b2="0.0001716024" node1="58" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-19.657700557751063" q1="-10.516483864594163" p2="19.904286191943712" q2="6.0126525858815842">
         <iidm:alias>_0457cc82-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045cae81-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9635,7 +9758,7 @@
             <iidm:temporaryLimit name="_ac528cbe-6fc1-41dd-ba9d-d8b7a4c77576" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04690a93-c766-11e1-8775-005056c00008" name="92-94" r="8.3809430000000003" x="27.529920000000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="67" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="65.126597183350967" q1="-16.415128040677722" p2="-62.940410793222725" q2="19.631094854638974">
+    <iidm:line id="_04690a93-c766-11e1-8775-005056c00008" name="92-94" r="8.3809430000000003" x="27.529920000000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="67" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="65.184975550941758" q1="-16.352656987202892" p2="-62.995706324345612" q2="19.57963871268025">
         <iidm:alias>_044c33c1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0483706b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9643,7 +9766,7 @@
             <iidm:temporaryLimit name="_6ac84228-6b04-4b10-b560-29655c8e93b4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046009e3-c766-11e1-8775-005056c00008" name="37-39" r="5.5931040000000003" x="18.469439999999999" g1="0" b1="7.7479350000000006e-05" g2="0" b2="7.7479350000000006e-05" node1="57" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046bf0c7-c766-11e1-8775-005056c00008" p1="66.644158150873253" q1="18.166087634214396" p2="-64.929099428065342" q2="-14.832601550519575">
+    <iidm:line id="_046009e3-c766-11e1-8775-005056c00008" name="37-39" r="5.5931040000000003" x="18.469439999999999" g1="0" b1="7.7479350000000006e-05" g2="0" b2="7.7479350000000006e-05" node1="57" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046bf0c7-c766-11e1-8775-005056c00008" p1="66.873430157311887" q1="18.08916932949904" p2="-65.146924041016007" q2="-14.715676013818294">
         <iidm:alias>_044c33c9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04789afa-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9651,7 +9774,7 @@
             <iidm:temporaryLimit name="_2ccdc288-c132-40d1-a928-3887bec4ff67" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0458b6e8-c766-11e1-8775-005056c00008" name="46-47" r="6.6211200000000003" x="22.12848" g1="0" b1="9.0679499999999998e-05" g2="0" b2="9.0679499999999998e-05" node1="33" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_0457f396-c766-11e1-8775-005056c00008" p1="-32.530788103399125" q1="1.2842532315641975" p2="32.932053315235585" q2="-3.1652973900930559">
+    <iidm:line id="_0458b6e8-c766-11e1-8775-005056c00008" name="46-47" r="6.6211200000000003" x="22.12848" g1="0" b1="9.0679499999999998e-05" g2="0" b2="9.0679499999999998e-05" node1="33" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_0457f396-c766-11e1-8775-005056c00008" p1="-32.421946598597522" q1="1.2261558500102328" p2="32.820427389392847" q2="-3.1165881078687687">
         <iidm:alias>_04507980-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0464c4da-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9659,7 +9782,7 @@
             <iidm:temporaryLimit name="_06ca3245-2668-448f-a5c6-961924217a5c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044f8f22-c766-11e1-8775-005056c00008" name="82-83" r="1.9514879999999999" x="6.3858959999999998" g1="0" b1="0.0001089302" g2="0" b2="0.0001089302" node1="31" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728074-c766-11e1-8775-005056c00008" p1="-66.702613702741516" q1="38.151337378532816" p2="67.405122882870955" q2="-39.487025351161883">
+    <iidm:line id="_044f8f22-c766-11e1-8775-005056c00008" name="82-83" r="1.9514879999999999" x="6.3858959999999998" g1="0" b1="0.0001089302" g2="0" b2="0.0001089302" node1="31" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728074-c766-11e1-8775-005056c00008" p1="-66.314255698011593" q1="39.487944452279656" p2="67.02450049045467" q2="-40.790433349020979">
         <iidm:alias>_047a48a6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b3891-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9667,7 +9790,7 @@
             <iidm:temporaryLimit name="_dfbd2f07-76ab-41e3-910f-dc706979ea4b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045cfca6-c766-11e1-8775-005056c00008" name="108-109" r="1.82952" x="5.0181120000000004" g1="0" b1="2.1809000000000001e-05" g2="0" b2="2.1809000000000001e-05" node1="21" voltageLevelId1="_046c65f4-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b7b99-c766-11e1-8775-005056c00008" p1="20.784216745157373" q1="-0.53102810599199302" p2="-20.734919824277565" q2="-0.031487535614895673">
+    <iidm:line id="_045cfca6-c766-11e1-8775-005056c00008" name="108-109" r="1.82952" x="5.0181120000000004" g1="0" b1="2.1809000000000001e-05" g2="0" b2="2.1809000000000001e-05" node1="21" voltageLevelId1="_046c65f4-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b7b99-c766-11e1-8775-005056c00008" p1="20.787359695719008" q1="-0.53214284164396797" p2="-20.738047804148493" q2="-0.030331519722000527">
         <iidm:alias>_04481514-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04716f00-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9675,7 +9798,7 @@
             <iidm:temporaryLimit name="_11451cec-81c7-4f83-a7db-df7dcaffa94e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04784cd5-c766-11e1-8775-005056c00008" name="70-74" r="6.9870239999999999" x="23.051952400000001" g1="0" b1="9.6648299999999994e-05" g2="0" b2="9.6648299999999994e-05" node1="48" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047dcb11-c766-11e1-8775-005056c00008" p1="23.58313043879604" q1="9.2330822474685519" p2="-23.303872773641132" q2="-11.494229523227117">
+    <iidm:line id="_04784cd5-c766-11e1-8775-005056c00008" name="70-74" r="6.9870239999999999" x="23.051952400000001" g1="0" b1="9.6648299999999994e-05" g2="0" b2="9.6648299999999994e-05" node1="48" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047dcb11-c766-11e1-8775-005056c00008" p1="23.276823316082659" q1="9.409419528387085" p2="-23.001998797104619" q2="-11.685880013093591">
         <iidm:alias>_045e5c33-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046ab84b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9683,7 +9806,7 @@
             <iidm:temporaryLimit name="_37a5cc00-bd7f-4ec7-a77c-e140e23450d2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04747c40-c766-11e1-8775-005056c00008" name="77-82" r="5.1923519999999996" x="14.8626719" g1="0" b1="0.0002345615" g2="0" b2="0.0002345615" node1="69" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_046512f8-c766-11e1-8775-005056c00008" p1="-27.674554451264893" q1="30.631182886687636" p2="28.259304118301355" q2="-37.006884685039417">
+    <iidm:line id="_04747c40-c766-11e1-8775-005056c00008" name="77-82" r="5.1923519999999996" x="14.8626719" g1="0" b1="0.0002345615" g2="0" b2="0.0002345615" node1="69" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_046512f8-c766-11e1-8775-005056c00008" p1="-27.478526123334696" q1="31.324572087711584" p2="28.074637593873465" q2="-37.660257555879106">
         <iidm:alias>_0451b202-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0452ea84-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9691,7 +9814,7 @@
             <iidm:temporaryLimit name="_e9798d58-b518-4fab-984c-c72076dfc2ae" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045e3524-c766-11e1-8775-005056c00008" name="23-24" r="2.3522400000000001" x="8.5726080000000007" g1="0" b1="0.00014290635" g2="0" b2="0.00014290635" node1="39" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_048c22fa-c766-11e1-8775-005056c00008" p1="56.234842674324767" q1="-10.380793864029897" p2="-55.799184936821156" q2="7.0086697722691769">
+    <iidm:line id="_045e3524-c766-11e1-8775-005056c00008" name="23-24" r="2.3522400000000001" x="8.5726080000000007" g1="0" b1="0.00014290635" g2="0" b2="0.00014290635" node1="39" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_048c22fa-c766-11e1-8775-005056c00008" p1="54.624885134294487" q1="-9.9368828316268232" p2="-54.21530441025466" q2="6.4573378244182553">
         <iidm:alias>_046cb413-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f9fd3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9699,7 +9822,7 @@
             <iidm:temporaryLimit name="_e8ec73b8-1ecf-4d18-9ef9-80eabf3a4969" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0474f177-c766-11e1-8775-005056c00008" name="15-17" r="2.2999679999999998" x="7.6142880000000002" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="48" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-148.92332294340946" q1="-19.486962238923685" p2="152.21987317924385" q2="26.27043859740094">
+    <iidm:line id="_0474f177-c766-11e1-8775-005056c00008" name="15-17" r="2.2999679999999998" x="7.6142880000000002" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="48" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-158.25991360902529" q1="-15.907621664048616" p2="161.96326406239058" q2="24.040882506986165">
         <iidm:alias>_044c5ad2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046931a7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9707,7 +9830,7 @@
             <iidm:temporaryLimit name="_2ceac3d1-f73d-43db-8d37-9e329f1787bb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0483be84-c766-11e1-8775-005056c00008" name="8-30" r="2.0860400000000001" x="24.393599999999999" g1="0" b1="0.00053099175999999997" g2="0" b2="0.00053099175999999997" node1="30" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="38" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="87.26364102623296" q1="27.197552472766652" p2="-86.817768259956779" q2="-72.340858383003976">
+    <iidm:line id="_0483be84-c766-11e1-8775-005056c00008" name="8-30" r="2.0860400000000001" x="24.393599999999999" g1="0" b1="0.00053099175999999997" g2="0" b2="0.00053099175999999997" node1="30" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="38" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="103.5401016747965" q1="21.384631819505707" p2="-102.98842692379971" q2="-65.641848521365148">
         <iidm:alias>_0454e651-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04801506-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9715,7 +9838,7 @@
             <iidm:temporaryLimit name="_ca795ad3-97e5-4416-aaba-53cce27f6434" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0488eea6-c766-11e1-8775-005056c00008" name="49-69" r="17.16264" x="56.453762099999999" g1="0" b1="0.00023760329999999999" g2="0" b2="0.00023760329999999999" node1="115" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-75.643615292312049" q1="26.733824579380773" p2="81.913990460936418" q2="-14.892886295464372">
+    <iidm:line id="_0488eea6-c766-11e1-8775-005056c00008" name="49-69" r="17.16264" x="56.453762099999999" g1="0" b1="0.00023760329999999999" g2="0" b2="0.00023760329999999999" node1="115" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-75.441919368319716" q1="26.608026794594785" p2="81.676407219269592" q2="-14.885134598677082">
         <iidm:alias>_04492681-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046735d6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9723,7 +9846,7 @@
             <iidm:temporaryLimit name="_c42dc3ef-3a2e-4070-8efb-78e5c0cd5554" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047566a0-c766-11e1-8775-005056c00008" name="13-15" r="12.9634562" x="42.584255200000001" g1="0" b1="0.00017986685000000001" g2="0" b2="0.00017986685000000001" node1="21" voltageLevelId1="_04851e1b-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="15.103824401207817" q1="-1.2001678991608928" p2="-14.91888234519152" q2="-3.9269856230768054">
+    <iidm:line id="_047566a0-c766-11e1-8775-005056c00008" name="13-15" r="12.9634562" x="42.584255200000001" g1="0" b1="0.00017986685000000001" g2="0" b2="0.00017986685000000001" node1="21" voltageLevelId1="_04851e1b-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="10.915420449805586" q1="0.24085102450197224" p2="-10.812175344120851" q2="-5.6369913476346598">
         <iidm:alias>_04662461-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04865694-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9731,7 +9854,7 @@
             <iidm:temporaryLimit name="_ad988fd9-9270-4230-95a2-1858f32259df" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0476c63a-c766-11e1-8775-005056c00008" name="69-70" r="5.2271999999999998" x="22.12848" g1="0" b1="0.00035009184999999998" g2="0" b2="0.00035009184999999998" node1="59" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="75.965458497384034" q1="20.186553337058061" p2="-74.14937953425958" q2="-24.938265618597164">
+    <iidm:line id="_0476c63a-c766-11e1-8775-005056c00008" name="69-70" r="5.2271999999999998" x="22.12848" g1="0" b1="0.00035009184999999998" g2="0" b2="0.00035009184999999998" node1="59" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="76.871762807739529" q1="19.922123362342052" p2="-75.020829851906285" q2="-24.528274701285934">
         <iidm:alias>_047e193a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b1184-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9739,7 +9862,7 @@
             <iidm:temporaryLimit name="_519e3ecb-3561-4d11-ac6b-172a0b4b09b2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04520028-c766-11e1-8775-005056c00008" name="19-20" r="4.3908480000000001" x="20.38608" g1="0" b1="8.5514249999999999e-05" g2="0" b2="8.5514249999999999e-05" node1="39" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b2d70-c766-11e1-8775-005056c00008" p1="-16.404084839073562" q1="2.9635713485112727" p2="16.486045549227534" q2="-5.21454999759308">
+    <iidm:line id="_04520028-c766-11e1-8775-005056c00008" name="19-20" r="4.3908480000000001" x="20.38608" g1="0" b1="8.5514249999999999e-05" g2="0" b2="8.5514249999999999e-05" node1="39" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b2d70-c766-11e1-8775-005056c00008" p1="-14.278303569223736" q1="1.7937568815509224" p2="14.339235528479321" q2="-4.1430418858970963">
         <iidm:alias>_0472f5a9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04745537-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9747,7 +9870,7 @@
             <iidm:temporaryLimit name="_b88528bf-cb1c-4c00-ad79-d5937197d40c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04862f83-c766-11e1-8775-005056c00008" name="94-95" r="2.2999679999999998" x="7.5620159999999998" g1="0" b1="3.1852600000000001e-05" g2="0" b2="3.1852600000000001e-05" node1="51" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f4108-c766-11e1-8775-005056c00008" p1="57.122300036270993" q1="6.3254528362475346" p2="-56.673858014341818" q2="-5.9212535572862173">
+    <iidm:line id="_04862f83-c766-11e1-8775-005056c00008" name="94-95" r="2.2999679999999998" x="7.5620159999999998" g1="0" b1="3.1852600000000001e-05" g2="0" b2="3.1852600000000001e-05" node1="51" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f4108-c766-11e1-8775-005056c00008" p1="57.183774877762794" q1="6.5041292466780947" p2="-56.733889101239221" q2="-6.0947157958674749">
         <iidm:alias>_044ca8f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04837060-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9755,7 +9878,7 @@
             <iidm:temporaryLimit name="_b70e76a1-6e79-4fb6-b487-dffa9bfeab7b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047b0bf6-c766-11e1-8775-005056c00008" name="12-16" r="3.6938879999999998" x="14.5316162" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="68" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046f7338-c766-11e1-8775-005056c00008" p1="16.775590437489303" q1="7.7414305769330172" p2="-16.698004863716147" q2="-9.5106171700342834">
+    <iidm:line id="_047b0bf6-c766-11e1-8775-005056c00008" name="12-16" r="3.6938879999999998" x="14.5316162" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="68" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046f7338-c766-11e1-8775-005056c00008" p1="10.062281954338431" q1="9.5739531038782797" p2="-10.015973245748535" q2="-11.465839764675653">
         <iidm:alias>_0450798a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045c8772-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9763,7 +9886,7 @@
             <iidm:temporaryLimit name="_af73f526-c58b-40e7-8e1c-14f05a39f6a2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04524e47-c766-11e1-8775-005056c00008" name="100-103" r="2.7878400000000001" x="9.1476000000000006" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="78" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0475b4c0-c766-11e1-8775-005056c00008" p1="115.37914342705307" q1="-20.640777475819512" p2="-113.27038735331318" q2="22.054370686037831">
+    <iidm:line id="_04524e47-c766-11e1-8775-005056c00008" name="100-103" r="2.7878400000000001" x="9.1476000000000006" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="78" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0475b4c0-c766-11e1-8775-005056c00008" p1="115.38943969318045" q1="-20.643231647441031" p2="-113.28030262655957" q2="22.05807462425836">
         <iidm:alias>_04684744-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048aea71-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9771,7 +9894,7 @@
             <iidm:temporaryLimit name="_1631e50b-21a3-470b-803b-f9665b6fcd60" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04682038-c766-11e1-8775-005056c00008" name="27-32" r="3.9900959999999999" x="13.1551189" g1="0" b1="5.5268600000000001e-05" g2="0" b2="5.5268600000000001e-05" node1="40" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="7.347954014414702" q1="-0.065812623798844339" p2="-7.3345305785268797" q2="-1.6823214409586014">
+    <iidm:line id="_04682038-c766-11e1-8775-005056c00008" name="27-32" r="3.9900959999999999" x="13.1551189" g1="0" b1="5.5268600000000001e-05" g2="0" b2="5.5268600000000001e-05" node1="40" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="6.2744395407858642" q1="0.70545263803758484" p2="-6.264182927440487" q2="-2.4705997246800342">
         <iidm:alias>_0455347a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479ac63-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9779,7 +9902,7 @@
             <iidm:temporaryLimit name="_52eb4b09-42bb-4106-ac26-fe1059639d3a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0482fb31-c766-11e1-8775-005056c00008" name="59-61" r="5.7150720000000002" x="26.1360016" g1="0" b1="0.0001113407" g2="0" b2="0.0001113407" node1="68" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-100.79276521750675" q1="22.25853511659259" p2="104.42425509092776" q2="-9.4539966946279197">
+    <iidm:line id="_0482fb31-c766-11e1-8775-005056c00008" name="59-61" r="5.7150720000000002" x="26.1360016" g1="0" b1="0.0001113407" g2="0" b2="0.0001113407" node1="68" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-100.77435739117273" q1="22.251217375694853" p2="104.40447327059343" q2="-9.45296268089891">
         <iidm:alias>_044a10e9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0473b8f5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9787,7 +9910,7 @@
             <iidm:temporaryLimit name="_b5a7dea0-bfce-4548-a04d-7bb7b6d9f80a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047d55e3-c766-11e1-8775-005056c00008" name="100-104" r="7.8582239999999999" x="35.544960000000003" g1="0" b1="0.00015524565000000001" g2="0" b2="0.00015524565000000001" node1="79" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="54.999167674356094" q1="10.980723711450288" p2="-53.597379033534999" q2="-9.9859837929442978">
+    <iidm:line id="_047d55e3-c766-11e1-8775-005056c00008" name="100-104" r="7.8582239999999999" x="35.544960000000003" g1="0" b1="0.00015524565000000001" g2="0" b2="0.00015524565000000001" node1="79" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="55.001391184796212" q1="10.980532361034733" p2="-53.599498282281957" q2="-9.9853206237180281">
         <iidm:alias>_04636547-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048aea76-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9795,7 +9918,7 @@
             <iidm:temporaryLimit name="_17a10cd0-b653-4dcf-bdc3-4d5005ea9591" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04653a02-c766-11e1-8775-005056c00008" name="75-77" r="10.4718237" x="34.830577900000002" g1="0" b1="0.00014284895" g2="0" b2="0.00014284895" node1="49" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-36.261565941264401" q1="-7.1279040832242293" p2="37.120300976103017" q2="5.1512310035656812">
+    <iidm:line id="_04653a02-c766-11e1-8775-005056c00008" name="75-77" r="10.4718237" x="34.830577900000002" g1="0" b1="0.00014284895" g2="0" b2="0.00014284895" node1="49" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-36.438010987184413" q1="-6.9891618703535192" p2="37.304131953424942" q2="5.0377469652382887">
         <iidm:alias>_04642894-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04720b47-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9803,7 +9926,7 @@
             <iidm:temporaryLimit name="_6f81df11-7e71-4b6e-a6ee-a8c5f72f4ba5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04483c2a-c766-11e1-8775-005056c00008" name="23-32" r="5.5234079999999999" x="20.089872400000001" g1="0" b1="0.00033660465000000001" g2="0" b2="0.00033660465000000001" node1="40" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="77.413638966579597" q1="7.4335301960297864" p2="-75.456393032267371" q2="-11.619834714820913">
+    <iidm:line id="_04483c2a-c766-11e1-8775-005056c00008" name="23-32" r="5.5234079999999999" x="20.089872400000001" g1="0" b1="0.00033660465000000001" g2="0" b2="0.00033660465000000001" node1="40" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="74.313638028325997" q1="7.7359229200366908" p2="-72.507448566603642" q2="-12.504409768007982">
         <iidm:alias>_044b978a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0461dea6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9811,7 +9934,7 @@
             <iidm:temporaryLimit name="_a8f6a7d2-e58d-4671-a776-97be7291355e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048719e5-c766-11e1-8775-005056c00008" name="96-97" r="3.0143520000000001" x="15.42024" g1="0" b1="6.8870549999999994e-05" g2="0" b2="6.8870549999999994e-05" node1="50" voltageLevelId1="_045a1672-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="3.1321593412489421" q1="-25.29928345486578" p2="-3.0272201750080336" q2="23.443357945894">
+    <iidm:line id="_048719e5-c766-11e1-8775-005056c00008" name="96-97" r="3.0143520000000001" x="15.42024" g1="0" b1="6.8870549999999994e-05" g2="0" b2="6.8870549999999994e-05" node1="50" voltageLevelId1="_045a1672-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="3.0924426466412669" q1="-25.477860016596519" p2="-2.9859283208461664" q2="23.631307907432486">
         <iidm:alias>_0451b207-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04828601-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9819,7 +9942,7 @@
             <iidm:temporaryLimit name="_ea6d39aa-df95-4d3e-b7b6-a800e552e72a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048481d0-c766-11e1-8775-005056c00008" name="25-27" r="5.5408330000000001" x="28.401121100000001" g1="0" b1="0.000506198385" g2="0" b2="0.000506198385" node1="30" voltageLevelId1="_04728079-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0476c639-c766-11e1-8775-005056c00008" p1="153.19933919489944" q1="31.73499586744817" p2="-145.93397045572794" q2="-12.446691961532633">
+    <iidm:line id="_048481d0-c766-11e1-8775-005056c00008" name="25-27" r="5.5408330000000001" x="28.401121100000001" g1="0" b1="0.000506198385" g2="0" b2="0.000506198385" node1="30" voltageLevelId1="_04728079-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0476c639-c766-11e1-8775-005056c00008" p1="147.90327136466038" q1="30.302858380779575" p2="-141.13151881630907" q2="-13.577851233486712">
         <iidm:alias>_046d2947-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04725960-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9827,7 +9950,7 @@
             <iidm:temporaryLimit name="_d9d53af2-5ffa-4f2a-a4e6-ed22371332d6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04885268-c766-11e1-8775-005056c00008" name="110-112" r="4.3037280000000004" x="11.1513615" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="41" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="13" voltageLevelId2="_04784cd1-c766-11e1-8775-005056c00008" p1="69.35440424601677" q1="11.007379229592734" p2="-68.000012515848368" q2="-13.000003242837337">
+    <iidm:line id="_04885268-c766-11e1-8775-005056c00008" name="110-112" r="4.3037280000000004" x="11.1513615" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="41" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="13" voltageLevelId2="_04784cd1-c766-11e1-8775-005056c00008" p1="69.354409232817872" q1="11.007382686753617" p2="-68.000016990544594" q2="-13.000004089488376">
         <iidm:alias>_04611b55-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0481c2ba-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9835,7 +9958,7 @@
             <iidm:temporaryLimit name="_d50299b9-a055-408a-aa1e-2e93a715120f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0484a8e4-c766-11e1-8775-005056c00008" name="89-92" r="1.7249760000000001" x="8.7991200000000003" g1="0" b1="0.00015725434999999999" g2="0" b2="0.00015725434999999999" node1="57" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="68" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="228.33534655026173" q1="-3.276131023861617" p2="-223.22498680307223" q2="23.894202851980818">
+    <iidm:line id="_0484a8e4-c766-11e1-8775-005056c00008" name="89-92" r="1.7249760000000001" x="8.7991200000000003" g1="0" b1="0.00015725434999999999" g2="0" b2="0.00015725434999999999" node1="57" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="68" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="228.46682247691686" q1="-3.1861884454857936" p2="-223.35058446653068" q2="23.834522141183083">
         <iidm:alias>_04481517-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04808a3c-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9843,7 +9966,7 @@
             <iidm:temporaryLimit name="_eee9ca2b-764f-4ab8-a745-405338044743" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04689568-c766-11e1-8775-005056c00008" name="49-54" r="15.1414566" x="50.703842199999997" g1="0" b1="0.00020948120000000001" g2="0" b2="0.00020948120000000001" node1="116" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="46.502172848647504" q1="9.6281365877933442" p2="-44.563634069678614" q2="-10.300270510882362">
+    <iidm:line id="_04689568-c766-11e1-8775-005056c00008" name="49-54" r="15.1414566" x="50.703842199999997" g1="0" b1="0.00020948120000000001" g2="0" b2="0.00020948120000000001" node1="116" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="46.520650242102604" q1="9.6250879086400083" p2="-44.580757766719145" q2="-10.292689120045868">
         <iidm:alias>_046030f0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04605808-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9851,7 +9974,7 @@
             <iidm:temporaryLimit name="_690202a4-aad2-4ad3-8842-961b39e37709" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046c8d04-c766-11e1-8775-005056c00008" name="40-41" r="2.5264799999999998" x="8.4854880000000001" g1="0" b1="3.5066600000000001e-05" g2="0" b2="3.5066600000000001e-05" node1="40" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048c4a08-c766-11e1-8775-005056c00008" p1="26.31554563337447" q1="-1.6160669734211783" p2="-26.190675567041261" q2="1.0548581269361277">
+    <iidm:line id="_046c8d04-c766-11e1-8775-005056c00008" name="40-41" r="2.5264799999999998" x="8.4854880000000001" g1="0" b1="3.5066600000000001e-05" g2="0" b2="3.5066600000000001e-05" node1="40" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048c4a08-c766-11e1-8775-005056c00008" p1="26.523028719775965" q1="-1.7493179121054303" p2="-26.396015360122512" q2="1.1961365097388821">
         <iidm:alias>_045cae80-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a2194-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9859,7 +9982,7 @@
             <iidm:temporaryLimit name="_34f2ef7c-32da-4444-b989-d02f5f931c50" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046735d5-c766-11e1-8775-005056c00008" name="39-40" r="3.206016" x="10.54152" g1="0" b1="4.4536249999999999e-05" g2="0" b2="4.4536249999999999e-05" node1="22" voltageLevelId1="_046bf0c7-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="37.935974783774547" q1="3.8372719771776551" p2="-37.61024947256135" q2="-4.0310693765149352">
+    <iidm:line id="_046735d5-c766-11e1-8775-005056c00008" name="39-40" r="3.206016" x="10.54152" g1="0" b1="4.4536249999999999e-05" g2="0" b2="4.4536249999999999e-05" node1="22" voltageLevelId1="_046bf0c7-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="38.153440793224554" q1="3.7200992114913403" p2="-37.823939945579497" q2="-3.9003175229723244">
         <iidm:alias>_045115c1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048badc2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9867,7 +9990,7 @@
             <iidm:temporaryLimit name="_38d58455-5205-46bb-8e44-c66873f62938" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0470d2c4-c766-11e1-8775-005056c00008" name="89-92" r="6.8476319999999999" x="27.5473423" g1="0" b1="0.00011880164999999999" g2="0" b2="0.00011880164999999999" node1="58" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="72.029344389002858" q1="-5.860016897843523" p2="-70.005081347679621" q2="9.8861465191256386">
+    <iidm:line id="_0470d2c4-c766-11e1-8775-005056c00008" name="89-92" r="6.8476319999999999" x="27.5473423" g1="0" b1="0.00011880164999999999" g2="0" b2="0.00011880164999999999" node1="58" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="72.072245176015301" q1="-5.833718993456527" p2="-70.045653697649499" q2="9.8694247913144402">
         <iidm:alias>_04690a97-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04690a98-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9875,7 +9998,7 @@
             <iidm:temporaryLimit name="_0cce41c7-b99f-4fec-93d2-73ea24433fa1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0479ac60-c766-11e1-8775-005056c00008" name="33-37" r="7.2309599999999996" x="24.742080000000001" g1="0" b1="0.00010502754999999999" g2="0" b2="0.00010502754999999999" node1="21" voltageLevelId1="_0456bb11-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="37.97052671980726" q1="-19.828556458358754" p2="-37.131067074162267" q2="19.446188568479521">
+    <iidm:line id="_0479ac60-c766-11e1-8775-005056c00008" name="33-37" r="7.2309599999999996" x="24.742080000000001" g1="0" b1="0.00010502754999999999" g2="0" b2="0.00010502754999999999" node1="21" voltageLevelId1="_0456bb11-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="39.035029335998175" q1="-20.120563930698044" p2="-38.150621936906369" q2="19.895441291514974">
         <iidm:alias>_04716f08-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0483be89-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9883,7 +10006,7 @@
             <iidm:temporaryLimit name="_343677c6-7477-4bf6-a12c-2c7e4a684d6f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048c4a00-c766-11e1-8775-005056c00008" name="105-108" r="4.5476640000000002" x="12.249072099999999" g1="0" b1="5.2915499999999998e-05" g2="0" b2="5.2915499999999998e-05" node1="50" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_046c65f4-c766-11e1-8775-005056c00008" p1="22.931502530546094" q1="-0.84188326924650236" p2="-22.784217278890313" q2="-0.46897228276187586">
+    <iidm:line id="_048c4a00-c766-11e1-8775-005056c00008" name="105-108" r="4.5476640000000002" x="12.249072099999999" g1="0" b1="5.2915499999999998e-05" g2="0" b2="5.2915499999999998e-05" node1="50" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_046c65f4-c766-11e1-8775-005056c00008" p1="22.934686525637058" q1="-0.84288736579403778" p2="-22.787360360715535" q2="-0.46785761195635106">
         <iidm:alias>_046adf53-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04795e46-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9891,7 +10014,7 @@
             <iidm:temporaryLimit name="_74cf84b9-e14f-4f81-9e8b-3a791cd474a0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04631724-c766-11e1-8775-005056c00008" name="34-37" r="0.44605400000000001" x="1.637856" g1="0" b1="2.8236900000000001e-05" g2="0" b2="2.8236900000000001e-05" node1="41" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-57.532204656628117" q1="-34.995872528655127" p2="57.661454555328731" q2="34.58795217781725">
+    <iidm:line id="_04631724-c766-11e1-8775-005056c00008" name="34-37" r="0.44605400000000001" x="1.637856" g1="0" b1="2.8236900000000001e-05" g2="0" b2="2.8236900000000001e-05" node1="41" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-56.75220802400824" q1="-35.33540918842931" p2="56.879702023602107" q2="34.921887309393263">
         <iidm:alias>_04592c19-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04719611-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9899,7 +10022,7 @@
             <iidm:temporaryLimit name="_8e90bf2e-3be4-41be-a84e-c1d4e709f8a1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04814d85-c766-11e1-8775-005056c00008" name="61-62" r="1.435738" x="6.5514239999999999" g1="0" b1="2.812215e-05" g2="0" b2="2.812215e-05" node1="40" voltageLevelId1="_0448d867-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="60.131241851283278" q1="-18.211584509523423" p2="-59.804147493056966" q2="18.731961052315942">
+    <iidm:line id="_04814d85-c766-11e1-8775-005056c00008" name="61-62" r="1.435738" x="6.5514239999999999" g1="0" b1="2.812215e-05" g2="0" b2="2.812215e-05" node1="40" voltageLevelId1="_0448d867-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="60.110603158088338" q1="-18.207642596171773" p2="-59.783726996081299" q2="18.72702340907713">
         <iidm:alias>_045a3d85-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047abdd8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9907,7 +10030,7 @@
             <iidm:temporaryLimit name="_39a23399-348e-44d9-8032-8fc62e6c7d63" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046a4318-c766-11e1-8775-005056c00008" name="101-102" r="4.2863040000000003" x="19.5148811" g1="0" b1="8.4366399999999999e-05" g2="0" b2="8.4366399999999999e-05" node1="22" voltageLevelId1="_046ed6f7-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="-44.08861597085459" q1="11.599205866695694" p2="44.618404717991034" q2="-12.066053606670618">
+    <iidm:line id="_046a4318-c766-11e1-8775-005056c00008" name="101-102" r="4.2863040000000003" x="19.5148811" g1="0" b1="8.4366399999999999e-05" g2="0" b2="8.4366399999999999e-05" node1="22" voltageLevelId1="_046ed6f7-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="-44.12373192471162" q1="11.625325533613687" p2="44.654495332477708" q2="-12.087531419912391">
         <iidm:alias>_04878f1b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04885261-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9915,7 +10038,7 @@
             <iidm:temporaryLimit name="_0501dacc-29fc-44a2-8cad-31a20b011d25" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c81e3-c766-11e1-8775-005056c00008" name="26-30" r="3.8671600000000002" x="41.624000000000002" g1="0" b1="0.00093801650000000002" g2="0" b2="0.00093801650000000002" node1="21" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="230.50591990892423" q1="1.51444165279363" p2="-226.20431614257458" q2="-45.13919329883943">
+    <iidm:line id="_044c81e3-c766-11e1-8775-005056c00008" name="26-30" r="3.8671600000000002" x="41.624000000000002" g1="0" b1="0.00093801650000000002" g2="0" b2="0.00093801650000000002" node1="21" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="243.17792753880249" q1="-2.7174765112424781" p2="-238.44109984593297" q2="-36.645766020286288">
         <iidm:alias>_0463654b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04747c4a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9923,7 +10046,7 @@
             <iidm:temporaryLimit name="_c95a66fd-913c-48c7-b8ef-cf3007c60af6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048915b9-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="41" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="117" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-53.908571119061286" q1="-18.704288616001364" p2="56.593317394426215" q2="22.725250522505089">
+    <iidm:line id="_048915b9-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="41" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="117" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-53.7018206911712" q1="-18.847455114101713" p2="56.372653283661613" q2="22.807402668631671">
         <iidm:alias>_044bbe98-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0456e224-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9931,7 +10054,7 @@
             <iidm:temporaryLimit name="_6cd83bc2-204f-44d5-afd4-fbfef8d2146f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c5ad6-c766-11e1-8775-005056c00008" name="105-106" r="2.4393600000000002" x="9.5309279999999994" g1="0" b1="4.1150150000000001e-05" g2="0" b2="4.1150150000000001e-05" node1="51" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="9.6388718179787745" q1="6.1380490229013391" p2="-9.6179537940450626" q2="-7.3853544656499501">
+    <iidm:line id="_044c5ad6-c766-11e1-8775-005056c00008" name="105-106" r="2.4393600000000002" x="9.5309279999999994" g1="0" b1="4.1150150000000001e-05" g2="0" b2="4.1150150000000001e-05" node1="51" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="9.6373797271412016" q1="6.1385884812618601" p2="-9.6164649184994122" q2="-7.3859061824122776">
         <iidm:alias>_04505270-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04531190-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9939,7 +10062,7 @@
             <iidm:temporaryLimit name="_487e1317-48f9-4747-b931-f3f79e95f55a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048badc5-c766-11e1-8775-005056c00008" name="60-61" r="0.45999400000000001" x="2.3522400000000001" g1="0" b1="4.1781450000000003e-05" g2="0" b2="4.1781450000000003e-05" node1="30" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-169.33408819248243" q1="15.897144408396379" p2="170.10999847850036" q2="-13.367253108505547">
+    <iidm:line id="_048badc5-c766-11e1-8775-005056c00008" name="60-61" r="0.45999400000000001" x="2.3522400000000001" g1="0" b1="4.1781450000000003e-05" g2="0" b2="4.1781450000000003e-05" node1="30" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-169.3085565122019" q1="15.893510790174236" p2="170.08423136583494" q2="-13.364823877656839">
         <iidm:alias>_04793734-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048a4e31-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9947,7 +10070,7 @@
             <iidm:temporaryLimit name="_3c55a929-a755-409b-af5f-bae188892af1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044cd003-c766-11e1-8775-005056c00008" name="23-25" r="2.7181440000000001" x="13.9391994" g1="0" b1="0.00024793390000000002" g2="0" b2="0.00024793390000000002" node1="41" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="-201.25593089954145" q1="-12.747396586289817" p2="207.59042924787065" q2="36.152471489165748">
+    <iidm:line id="_044cd003-c766-11e1-8775-005056c00008" name="23-25" r="2.7181440000000001" x="13.9391994" g1="0" b1="0.00024793390000000002" g2="0" b2="0.00024793390000000002" node1="41" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="-194.23018863778296" q1="-13.742379359350904" p2="200.11881339091735" q2="34.850053545797103">
         <iidm:alias>_045ed161-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0473b8f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9955,7 +10078,7 @@
             <iidm:temporaryLimit name="_9658628a-596f-41a9-96a7-c5a8aaf5400c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0457a574-c766-11e1-8775-005056c00008" name="19-34" r="13.102848099999999" x="43.037277199999998" g1="0" b1="0.00018135905000000001" g2="0" b2="0.00018135905000000001" node1="40" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0483be8b-c766-11e1-8775-005056c00008" p1="50.60463495894362" q1="-15.736669102185999" p2="-48.282866664110855" q2="17.751118451869115">
+    <iidm:line id="_0457a574-c766-11e1-8775-005056c00008" name="19-34" r="13.102848099999999" x="43.037277199999998" g1="0" b1="0.00018135905000000001" g2="0" b2="0.00018135905000000001" node1="40" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0483be8b-c766-11e1-8775-005056c00008" p1="51.86623214809709" q1="-15.849000592273782" p2="-49.430417650919964" q2="18.242529474820724">
         <iidm:alias>_04502b61-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04686e5b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9963,7 +10086,7 @@
             <iidm:temporaryLimit name="_b69ab61b-751d-487a-a538-2d47eea7572e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04595326-c766-11e1-8775-005056c00008" name="59-60" r="5.5234079999999999" x="25.264800000000001" g1="0" b1="0.00010789715" g2="0" b2="0.00010789715" node1="69" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_045cfca4-c766-11e1-8775-005056c00008" p1="-89.14392530275876" q1="19.130810249551672" p2="91.883785565791186" q2="-10.274175450938259">
+    <iidm:line id="_04595326-c766-11e1-8775-005056c00008" name="59-60" r="5.5234079999999999" x="25.264800000000001" g1="0" b1="0.00010789715" g2="0" b2="0.00010789715" node1="69" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_045cfca4-c766-11e1-8775-005056c00008" p1="-89.127040220548466" q1="19.124364790366101" p2="91.865828592661686" q2="-10.2726341811513">
         <iidm:alias>_04611b57-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0463b366-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9971,7 +10094,7 @@
             <iidm:temporaryLimit name="_a38d4859-b54a-482f-a2ad-0b4ce4c4da2a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045a8ba1-c766-11e1-8775-005056c00008" name="15-19" r="2.0908799999999998" x="6.865056" g1="0" b1="2.8983e-05" g2="0" b2="2.8983e-05" node1="50" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="32.108719832071223" q1="11.114121456483755" p2="-31.95346423955036" q2="-11.505284835203785">
+    <iidm:line id="_045a8ba1-c766-11e1-8775-005056c00008" name="15-19" r="2.0908799999999998" x="6.865056" g1="0" b1="2.8983e-05" g2="0" b2="2.8983e-05" node1="50" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="31.562005733173752" q1="11.115624440260854" p2="-31.411273735488127" q2="-11.521023853774407">
         <iidm:alias>_047629f1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0481e9c1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9979,7 +10102,7 @@
             <iidm:temporaryLimit name="_15d16bd2-d87c-4584-93d2-b294dc1be116" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04513cd6-c766-11e1-8775-005056c00008" name="90-91" r="4.4256960000000003" x="14.566463499999999" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="31" voltageLevelId1="_047d07c3-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044f8f29-c766-11e1-8775-005056c00008" p1="4.3745908150783563" q1="-16.350278207172188" p2="-4.3038887861642046" q2="14.594605226480162">
+    <iidm:line id="_04513cd6-c766-11e1-8775-005056c00008" name="90-91" r="4.4256960000000003" x="14.566463499999999" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="31" voltageLevelId1="_047d07c3-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044f8f29-c766-11e1-8775-005056c00008" p1="4.399041626407155" q1="-16.340112394465272" p2="-4.3283644438902966" q2="14.584444960315482">
         <iidm:alias>_045f94b9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04627ae1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9987,7 +10110,7 @@
             <iidm:temporaryLimit name="_7d2a67fb-9d8c-4745-a67e-ce6ade5e520e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0487b623-c766-11e1-8775-005056c00008" name="22-23" r="5.9590079999999999" x="27.704158799999998" g1="0" b1="0.00011593205" g2="0" b2="0.00011593205" node1="21" voltageLevelId1="_04773b6a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_047f9fdb-c766-11e1-8775-005056c00008" p1="-59.277957817892379" q1="-10.385699332286807" p2="60.609348695866416" q2="12.696018935542167">
+    <iidm:line id="_0487b623-c766-11e1-8775-005056c00008" name="22-23" r="5.9590079999999999" x="27.704158799999998" g1="0" b1="0.00011593205" g2="0" b2="0.00011593205" node1="21" voltageLevelId1="_04773b6a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_047f9fdb-c766-11e1-8775-005056c00008" p1="-57.056347646549654" q1="-11.084954803416721" p2="58.292930552969715" q2="12.944242976531543">
         <iidm:alias>_045e0e18-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0477b095-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9995,7 +10118,7 @@
             <iidm:temporaryLimit name="_6477d99a-dd64-4083-8f56-1396610879f0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048b1189-c766-11e1-8775-005056c00008" name="83-85" r="7.4923200000000003" x="25.787520000000001" g1="0" b1="9.9862250000000004e-05" g2="0" b2="9.9862250000000004e-05" node1="32" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-54.878910143401669" q1="18.455972151433052" p2="56.423949668115249" q2="-16.440130956712633">
+    <iidm:line id="_048b1189-c766-11e1-8775-005056c00008" name="83-85" r="7.4923200000000003" x="25.787520000000001" g1="0" b1="9.9862250000000004e-05" g2="0" b2="9.9862250000000004e-05" node1="32" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-54.707312702691013" q1="19.216198739786464" p2="56.262111711398546" q2="-17.153647741646871">
         <iidm:alias>_0455d0b1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0462c906-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10003,7 +10126,7 @@
             <iidm:temporaryLimit name="_38cb3e5b-af1a-4684-aa2f-242826ed460c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045868c5-c766-11e1-8775-005056c00008" name="17-31" r="8.2589760000000005" x="27.233711199999998" g1="0" b1="0.00011449725" g2="0" b2="0.00011449725" node1="60" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="27.861531516233757" q1="-1.6719399795520493" p2="-27.478263724107769" q2="-0.84516090401744592">
+    <iidm:line id="_045868c5-c766-11e1-8775-005056c00008" name="17-31" r="8.2589760000000005" x="27.233711199999998" g1="0" b1="0.00011449725" g2="0" b2="0.00011449725" node1="60" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="30.973316483350121" q1="-2.6718544619400615" p2="-30.499066030760364" q2="0.45614723194951218">
         <iidm:alias>_04544a16-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0467f924-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10011,7 +10134,7 @@
             <iidm:temporaryLimit name="_9066b19a-f404-42c3-88ce-51d375f6fdb5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0488c796-c766-11e1-8775-005056c00008" name="89-90" r="9.0256319999999999" x="32.75712" g1="0" b1="0.00015151515000000001" g2="0" b2="0.00015151515000000001" node1="59" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="59.703311834126119" q1="9.2545042658507324" p2="-57.802352943257475" q2="-7.4434223266482604">
+    <iidm:line id="_0488c796-c766-11e1-8775-005056c00008" name="89-90" r="9.0256319999999999" x="32.75712" g1="0" b1="0.00015151515000000001" g2="0" b2="0.00015151515000000001" node1="59" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="59.712447273524674" q1="9.2601688918310323" p2="-57.810859739142813" q2="-7.4467367060676946">
         <iidm:alias>_0459ef61-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04837069-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10019,7 +10142,7 @@
             <iidm:temporaryLimit name="_924b4a0b-bef5-432a-ad87-ab5c10d9c019" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0462c907-c766-11e1-8775-005056c00008" name="70-75" r="7.4574720000000001" x="24.56784" g1="0" b1="0.0001033058" g2="0" b2="0.0001033058" node1="50" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="8.9800244832784895" q1="6.9037077274706595" p2="-8.9113210739908304" q2="-10.105373630801681">
+    <iidm:line id="_0462c907-c766-11e1-8775-005056c00008" name="70-75" r="7.4574720000000001" x="24.56784" g1="0" b1="0.0001033058" g2="0" b2="0.0001033058" node1="50" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="8.5995025996695631" q1="7.1299593552020255" p2="-8.5320223795707513" q2="-10.336251425894826">
         <iidm:alias>_04649dc9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04784cdb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10027,7 +10150,7 @@
             <iidm:temporaryLimit name="_d432d118-553c-4f4c-a734-e98e0762ec40" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045fbbc3-c766-11e1-8775-005056c00008" name="50-57" r="8.2589760000000005" x="23.34816" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="22" voltageLevelId1="_044d1e26-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="44.104169343845342" q1="6.7467107431886166" p2="-43.149414878034342" q2="-7.270234978397963">
+    <iidm:line id="_045fbbc3-c766-11e1-8775-005056c00008" name="50-57" r="8.2589760000000005" x="23.34816" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="22" voltageLevelId1="_044d1e26-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="44.121127178773371" q1="6.7418968387300398" p2="-43.165699602568097" q2="-7.2635076374651577">
         <iidm:alias>_04500455-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0468e383-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10035,7 +10158,7 @@
             <iidm:temporaryLimit name="_2f32bda4-7275-4485-9901-12f8cff9e4a1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044b9789-c766-11e1-8775-005056c00008" name="5-6" r="2.0734560000000002" x="9.4089600000000004" g1="0" b1="4.0920549999999999e-05" g2="0" b2="4.0920549999999999e-05" node1="49" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f6818-c766-11e1-8775-005056c00008" p1="95.986428742863851" q1="17.537867122286311" p2="-94.870342187741883" q2="-13.896519604609377">
+    <iidm:line id="_044b9789-c766-11e1-8775-005056c00008" name="5-6" r="2.0734560000000002" x="9.4089600000000004" g1="0" b1="4.0920549999999999e-05" g2="0" b2="4.0920549999999999e-05" node1="49" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f6818-c766-11e1-8775-005056c00008" p1="91.644547856493659" q1="19.094553475566816" p2="-90.618797036546411" q2="-15.865382585801552">
         <iidm:alias>_044a5f01-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0455d0b2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10043,7 +10166,7 @@
             <iidm:temporaryLimit name="_b3b0e81b-a434-4e9c-ad94-1161ff47b077" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04720b41-c766-11e1-8775-005056c00008" name="55-59" r="8.2572340000000004" x="37.600994100000001" g1="0" b1="0.00016201790000000001" g2="0" b2="0.00016201790000000001" node1="30" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-24.201864754594087" q1="-11.532878316456092" p2="24.550813056262772" q2="7.8282889986404536">
+    <iidm:line id="_04720b41-c766-11e1-8775-005056c00008" name="55-59" r="8.2572340000000004" x="37.600994100000001" g1="0" b1="0.00016201790000000001" g2="0" b2="0.00016201790000000001" node1="30" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-24.185617381357542" q1="-11.537442714672192" p2="24.534197100738947" q2="7.8311761082045708">
         <iidm:alias>_04656113-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04675ce4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10051,7 +10174,7 @@
             <iidm:temporaryLimit name="_6db0d250-4a2e-4169-abf0-f842aeca485d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048963d9-c766-11e1-8775-005056c00008" name="1-2" r="5.2794720000000002" x="17.4065762" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="22" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_045d4ac5-c766-11e1-8775-005056c00008" p1="-10.450688306087569" q1="-10.891904332284497" p2="10.517698887674786" q2="8.7399340062228799">
+    <iidm:line id="_048963d9-c766-11e1-8775-005056c00008" name="1-2" r="5.2794720000000002" x="17.4065762" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="22" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_045d4ac5-c766-11e1-8775-005056c00008" p1="-11.406371985068253" q1="-10.361836586084237" p2="11.476893776100034" q2="8.2201777473798678">
         <iidm:alias>_044b9786-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04845acb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10059,7 +10182,7 @@
             <iidm:temporaryLimit name="_9f39cb45-314c-445e-b177-909854a9ce45" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0484f709-c766-11e1-8775-005056c00008" name="11-12" r="1.0367280000000001" x="3.4151039999999999" g1="0" b1="1.4405399999999999e-05" g2="0" b2="1.4405399999999999e-05" node1="40" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="39.939702188706292" q1="-29.263333035801548" p2="-39.790716729937074" q2="29.263787630307668">
+    <iidm:line id="_0484f709-c766-11e1-8775-005056c00008" name="11-12" r="1.0367280000000001" x="3.4151039999999999" g1="0" b1="1.4405399999999999e-05" g2="0" b2="1.4405399999999999e-05" node1="40" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="34.843385586294978" q1="-25.511147453681627" p2="-34.730252234085377" q2="25.393277690744227">
         <iidm:alias>_0456e227-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04880440-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10067,7 +10190,7 @@
             <iidm:temporaryLimit name="_70fad3e1-4529-4a7f-9e6c-8ab249d65460" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044bbe91-c766-11e1-8775-005056c00008" name="8-9" r="1.18096" x="14.762" g1="0" b1="0.001200413215" g2="0" b2="0.001200413215" node1="31" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_045c8779-c766-11e1-8775-005056c00008" p1="-486.67903344937946" q1="-86.497559415997245" p2="492.42599865702579" q2="37.448356823036399">
+    <iidm:line id="_044bbe91-c766-11e1-8775-005056c00008" name="8-9" r="1.18096" x="14.762" g1="0" b1="0.001200413215" g2="0" b2="0.001200413215" node1="31" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_045c8779-c766-11e1-8775-005056c00008" p1="-486.6373207822835" q1="-83.746116031846924" p2="492.35484671490599" q2="33.937132482543099">
         <iidm:alias>_04745535-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048a7548-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="2000">
@@ -10075,7 +10198,7 @@
             <iidm:temporaryLimit name="_205e5d8a-f05a-479d-adaa-3514f48f6857" acceptableDuration="60" value="2400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04566cf8-c766-11e1-8775-005056c00008" name="64-65" r="1.30196" x="14.6168" g1="0" b1="0.000392562" g2="0" b2="0.000392562" node1="35" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-157.49826559907035" q1="-33.947738907894539" p2="158.17844589224691" q2="3.581872460084945">
+    <iidm:line id="_04566cf8-c766-11e1-8775-005056c00008" name="64-65" r="1.30196" x="14.6168" g1="0" b1="0.000392562" g2="0" b2="0.000392562" node1="35" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-157.46071146860791" q1="-33.950127221596851" p2="158.14057113665231" q2="3.5806268255361693">
         <iidm:alias>_044a10e2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04793738-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10083,7 +10206,7 @@
             <iidm:temporaryLimit name="_8cee2b62-2953-439b-ba4b-4a48d55116c0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046783f3-c766-11e1-8775-005056c00008" name="54-56" r="0.47915999999999997" x="1.6639919999999999" g1="0" b1="2.1005500000000001e-05" g2="0" b2="2.1005500000000001e-05" node1="60" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="29.556752202927822" q1="2.696010017510448" p2="-29.530133977814732" q2="-3.2703709089543649">
+    <iidm:line id="_046783f3-c766-11e1-8775-005056c00008" name="54-56" r="0.47915999999999997" x="1.6639919999999999" g1="0" b1="2.1005500000000001e-05" g2="0" b2="2.1005500000000001e-05" node1="60" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="29.568405051431757" q1="2.6952287687341538" p2="-29.541766196016106" q2="-3.2695178761891057">
         <iidm:alias>_0460f444-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d2949-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10091,7 +10214,7 @@
             <iidm:temporaryLimit name="_640627c7-0672-413e-8dc8-c9965709a5cb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04670ec6-c766-11e1-8775-005056c00008" name="84-85" r="5.2620480000000001" x="11.1687832" g1="0" b1="3.541095e-05" g2="0" b2="3.541095e-05" node1="21" voltageLevelId1="_047b0bf4-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-44.532262457094099" q1="13.849613089975033" p2="45.238247959818445" q2="-13.513769339446863">
+    <iidm:line id="_04670ec6-c766-11e1-8775-005056c00008" name="84-85" r="5.2620480000000001" x="11.1687832" g1="0" b1="3.541095e-05" g2="0" b2="3.541095e-05" node1="21" voltageLevelId1="_047b0bf4-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-44.331864754803988" q1="14.339615124620607" p2="45.039887550312116" q2="-13.993815412213905">
         <iidm:alias>_0453fbf5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046512f7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10099,7 +10222,7 @@
             <iidm:temporaryLimit name="_8b888209-5038-4b98-80fc-062b5ea55747" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0460cd36-c766-11e1-8775-005056c00008" name="34-36" r="1.51763" x="4.669632" g1="0" b1="1.6299349999999998e-05" g2="0" b2="1.6299349999999998e-05" node1="43" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="34.431599638423101" q1="11.264403288077071" p2="-34.302900290559165" q2="-11.371703094653549">
+    <iidm:line id="_0460cd36-c766-11e1-8775-005056c00008" name="34-36" r="1.51763" x="4.669632" g1="0" b1="1.6299349999999998e-05" g2="0" b2="1.6299349999999998e-05" node1="43" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="34.517411628922687" q1="11.232076537337408" p2="-34.388081458720215" q2="-11.336941308271665">
         <iidm:alias>_046a6a26-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0487b620-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10107,7 +10230,7 @@
             <iidm:temporaryLimit name="_c0a08025-3a61-4d24-9944-f3ef0b079f64" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04549836-c766-11e1-8775-005056c00008" name="24-70" r="0.38507000000000002" x="71.699759999999998" g1="0" b1="0.00029264234999999998" g2="0" b2="0.00029264234999999998" node1="32" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="18.017189419622547" q1="-1.4717890606597048" p2="-18.009675440449012" q2="-7.1269737491261669">
+    <iidm:line id="_04549836-c766-11e1-8775-005056c00008" name="24-70" r="0.38507000000000002" x="71.699759999999998" g1="0" b1="0.00029264234999999998" g2="0" b2="0.00029264234999999998" node1="32" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="17.177892216624521" q1="-1.2804735987210347" p2="-17.171019381773895" q2="-7.4518622799689256">
         <iidm:alias>_04549834-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04854522-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10115,7 +10238,7 @@
             <iidm:temporaryLimit name="_32793450-bbfd-4dcd-a911-89e199600780" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0452273a-c766-11e1-8775-005056c00008" name="85-86" r="6.0983999999999998" x="21.431519999999999" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="50" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0484f70a-c766-11e1-8775-005056c00008" p1="21.233161541029475" q1="12.279494643934102" p2="-20.998298717082292" q2="-14.002565286814599">
+    <iidm:line id="_0452273a-c766-11e1-8775-005056c00008" name="85-86" r="6.0983999999999998" x="21.431519999999999" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="50" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0484f70a-c766-11e1-8775-005056c00008" p1="21.281975976190992" q1="16.351935598381644" p2="-20.997924160960284" q2="-17.874989235090055">
         <iidm:alias>_044afb43-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479fa85-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10123,7 +10246,7 @@
             <iidm:temporaryLimit name="_2ec4bef5-7abb-4f52-bb62-49ee474d672b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0450eeb5-c766-11e1-8775-005056c00008" name="16-17" r="7.9104960000000002" x="31.380622899999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="22" voltageLevelId1="_046f7338-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-8.3004406281531171" q1="-0.48834475934840993" p2="8.3345134827161509" q2="-3.8470659685076356">
+    <iidm:line id="_0450eeb5-c766-11e1-8775-005056c00008" name="16-17" r="7.9104960000000002" x="31.380622899999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="22" voltageLevelId1="_046f7338-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-14.982930795368517" q1="1.4665704246518851" p2="15.095769525364592" q2="-5.4871626965500218">
         <iidm:alias>_044ef2ea-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04837066-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10131,7 +10254,7 @@
             <iidm:temporaryLimit name="_9280074c-8555-49ff-9e62-8ed8f7d95060" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048a4e33-c766-11e1-8775-005056c00008" name="62-66" r="8.3983679999999996" x="37.984317799999999" g1="0" b1="0.00016586315" g2="0" b2="0.00016586315" node1="41" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-15.26960682672032" q1="-21.573483707522005" p2="15.552240281990956" q2="16.819645230852615">
+    <iidm:line id="_048a4e33-c766-11e1-8775-005056c00008" name="62-66" r="8.3983679999999996" x="37.984317799999999" g1="0" b1="0.00016586315" g2="0" b2="0.00016586315" node1="41" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-15.283640919170219" q1="-21.569847446082175" p2="15.56641631639093" q2="16.816652842810825">
         <iidm:alias>_046e13a9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a96c7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10139,7 +10262,7 @@
             <iidm:temporaryLimit name="_ace48562-0a49-4b76-ae82-c896a00b04f9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0478e913-c766-11e1-8775-005056c00008" name="76-77" r="7.736256" x="25.787520000000001" g1="0" b1="0.00010560145" g2="0" b2="0.00010560145" node1="21" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-62.211512853414618" q1="-21.341455691240675" p2="64.360047160627076" q2="25.033855087949629">
+    <iidm:line id="_0478e913-c766-11e1-8775-005056c00008" name="76-77" r="7.736256" x="25.787520000000001" g1="0" b1="0.00010560145" g2="0" b2="0.00010560145" node1="21" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-62.343134782096243" q1="-21.237359937731238" p2="64.49819135992675" q2="24.952257440936204">
         <iidm:alias>_044b9785-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04725965-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10147,7 +10270,7 @@
             <iidm:temporaryLimit name="_3f744dba-88dc-4d89-90d4-a6f196054b28" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048badc1-c766-11e1-8775-005056c00008" name="60-62" r="2.1431520000000002" x="9.7748640000000009" g1="0" b1="4.2125800000000002e-05" g2="0" b2="4.2125800000000002e-05" node1="32" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="-0.54961166290777408" q1="-8.6229634442459488" p2="0.5574425307847406" q2="7.2060589117178111">
+    <iidm:line id="_048badc1-c766-11e1-8775-005056c00008" name="60-62" r="2.1431520000000002" x="9.7748640000000009" g1="0" b1="4.2125800000000002e-05" g2="0" b2="4.2125800000000002e-05" node1="32" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="-0.55719207711203955" q1="-8.6208713719072083" p2="0.56501986007131877" q2="7.2039522597140984">
         <iidm:alias>_045b7600-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04720b44-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10155,7 +10278,7 @@
             <iidm:temporaryLimit name="_43f91aaf-c5f4-4995-85a2-37afac616331" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0472a780-c766-11e1-8775-005056c00008" name="27-28" r="3.3332109999999999" x="14.89752" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="42" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04819ba0-c766-11e1-8775-005056c00008" p1="49.590102207719184" q1="-4.3212324369466284" p2="-49.083584368846566" q2="4.5821385084811457">
+    <iidm:line id="_0472a780-c766-11e1-8775-005056c00008" name="27-28" r="3.3332109999999999" x="14.89752" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="42" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04819ba0-c766-11e1-8775-005056c00008" p1="46.436246465393673" q1="-4.3176281442661866" p2="-45.993622494443422" q2="4.2838408732623696">
         <iidm:alias>_04531198-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0475188b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10163,7 +10286,7 @@
             <iidm:temporaryLimit name="_2c20e8bd-84e6-4a1e-b88e-071f631327cb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c81e1-c766-11e1-8775-005056c00008" name="45-46" r="6.9695999999999998" x="23.626943600000001" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="31" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="34" voltageLevelId2="_048a7544-c766-11e1-8775-005056c00008" p1="-33.913861320195316" q1="-6.9305249912325673" p2="34.401859527385398" q2="5.3046224619883509">
+    <iidm:line id="_044c81e1-c766-11e1-8775-005056c00008" name="45-46" r="6.9695999999999998" x="23.626943600000001" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="31" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="34" voltageLevelId2="_048a7544-c766-11e1-8775-005056c00008" p1="-33.772590168652215" q1="-6.9999199812613915" p2="34.256966215301624" q2="5.3618333491237014">
         <iidm:alias>_04561ed6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045c877a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10171,7 +10294,7 @@
             <iidm:temporaryLimit name="_6ad31f7e-233f-4801-898f-9ffc883ec724" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c1249-c766-11e1-8775-005056c00008" name="18-19" r="1.949746" x="8.5900320000000008" g1="0" b1="3.2770900000000002e-05" g2="0" b2="3.2770900000000002e-05" node1="22" voltageLevelId1="_04689563-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="47.520349788594793" q1="0.94217968499072036" p2="-47.237787789093375" q2="-0.71299703908700784">
+    <iidm:line id="_045c1249-c766-11e1-8775-005056c00008" name="18-19" r="1.949746" x="8.5900320000000008" g1="0" b1="3.2770900000000002e-05" g2="0" b2="3.2770900000000002e-05" node1="22" voltageLevelId1="_04689563-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="51.501610907574701" q1="-0.13532944745948683" p2="-51.169703066053572" q2="0.58270473427293612">
         <iidm:alias>_046b066b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047ae4e0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10179,7 +10302,7 @@
             <iidm:temporaryLimit name="_a025c9d8-58f9-4320-a1fe-73ecc68d4147" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044a5f09-c766-11e1-8775-005056c00008" name="9-10" r="1.2487200000000001" x="15.584800700000001" g1="0" b1="0.0012706611300000001" g2="0" b2="0.0012706611300000001" node1="21" voltageLevelId1="_045c8779-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_044f4102-c766-11e1-8775-005056c00008" p1="-492.42599865702567" q1="-37.448356823035688" p2="498.28284436037507" q2="-23.169871892453298">
+    <iidm:line id="_044a5f09-c766-11e1-8775-005056c00008" name="9-10" r="1.2487200000000001" x="15.584800700000001" g1="0" b1="0.0012706611300000001" g2="0" b2="0.0012706611300000001" node1="21" voltageLevelId1="_045c8779-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_044f4102-c766-11e1-8775-005056c00008" p1="-492.35484671490622" q1="-33.937132482542907" p2="498.20225819178603" q2="-26.946316102370304">
         <iidm:alias>_04614262-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04834957-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="2000">
@@ -10187,7 +10310,7 @@
             <iidm:temporaryLimit name="_b7fac0a3-c5af-48b9-af49-261fd8d46e00" acceptableDuration="60" value="2400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0480b14b-c766-11e1-8775-005056c00008" name="85-88" r="3.4847999999999999" x="17.772480000000002" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="51" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0470f9d2-c766-11e1-8775-005056c00008" p1="-63.084191757268528" q1="5.0148664262107987" p2="63.933149828321298" q2="-3.3221000154193185">
+    <iidm:line id="_0480b14b-c766-11e1-8775-005056c00008" name="85-88" r="3.4847999999999999" x="17.772480000000002" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="51" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0470f9d2-c766-11e1-8775-005056c00008" p1="-62.985356073835732" q1="3.577050157820548" p2="63.83268154193" q2="-1.8829893493320538">
         <iidm:alias>_047602e2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04765105-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10195,7 +10318,7 @@
             <iidm:temporaryLimit name="_51646744-d343-42b5-8ba7-fcedc7cc3a98" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04486330-c766-11e1-8775-005056c00008" name="69-77" r="5.3840159999999999" x="17.598240000000001" g1="0" b1="0.00029786500000000002" g2="0" b2="0.00029786500000000002" node1="60" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="32.453529865430028" q1="17.948833410630254" p2="-31.990305856766067" q2="-27.212180038059863">
+    <iidm:line id="_04486330-c766-11e1-8775-005056c00008" name="69-77" r="5.3840159999999999" x="17.598240000000001" g1="0" b1="0.00029786500000000002" g2="0" b2="0.00029786500000000002" node1="60" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="32.557290921265611" q1="18.06373585827744" p2="-32.090558991092003" q2="-27.314145439689145">
         <iidm:alias>_046205b9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479d379-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10203,7 +10326,7 @@
             <iidm:temporaryLimit name="_76311a15-b79a-4439-a7ce-47afa8fa6fe2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04553477-c766-11e1-8775-005056c00008" name="11-13" r="3.8768400000000001" x="12.7369442" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="41" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04851e1b-c766-11e1-8775-005056c00008" p1="49.725044106224622" q1="15.061644359527074" p2="-49.101512174557342" q2="-14.798015859406568">
+    <iidm:line id="_04553477-c766-11e1-8775-005056c00008" name="11-13" r="3.8768400000000001" x="12.7369442" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="41" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04851e1b-c766-11e1-8775-005056c00008" p1="45.45263293209355" q1="16.223424718172229" p2="-44.913745865762856" q2="-16.239537618633385">
         <iidm:alias>_0479fa89-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0485452a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10211,7 +10334,7 @@
             <iidm:temporaryLimit name="_efbf8de7-4b84-4834-bb7c-6250b6072211" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04488a45-c766-11e1-8775-005056c00008" name="103-105" r="9.3218399999999999" x="28.314" g1="0" b1="0.0001170799" g2="0" b2="0.0001170799" node1="42" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="43.796632771531776" q1="12.535284934855737" p2="-42.678602333513169" q2="-13.121378577174825">
+    <iidm:line id="_04488a45-c766-11e1-8775-005056c00008" name="103-105" r="9.3218399999999999" x="28.314" g1="0" b1="0.0001170799" g2="0" b2="0.0001170799" node1="42" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="43.796517187654473" q1="12.535374643964831" p2="-42.678490756394403" q2="-13.121480345340627">
         <iidm:alias>_044f8f24-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04611b58-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10219,7 +10342,7 @@
             <iidm:temporaryLimit name="_22b6919a-a7a0-49fc-9e90-329069c55055" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046009e6-c766-11e1-8775-005056c00008" name="45-49" r="11.918016400000001" x="32.408639999999998" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="32" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="118" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-40.951574829579442" q1="-7.9613894171297437" p2="42.162985367949688" q2="6.7786494622755935">
+    <iidm:line id="_046009e6-c766-11e1-8775-005056c00008" name="45-49" r="11.918016400000001" x="32.408639999999998" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="32" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="118" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-40.81382630168978" q1="-8.0385437577323824" p2="42.017974070169679" q2="6.8361812328268519">
         <iidm:alias>_044ca8f9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047dcb1b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10227,7 +10350,7 @@
             <iidm:temporaryLimit name="_8b91f4fd-4038-45b7-870c-fbc08592b95a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046a6a27-c766-11e1-8775-005056c00008" name="88-89" r="2.4219360000000001" x="12.4058876" g1="0" b1="5.549815e-05" g2="0" b2="5.549815e-05" node1="22" voltageLevelId1="_0470f9d2-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-111.93236938702131" q1="-6.6776289807594535" p2="113.74392487168865" q2="14.048209543831247">
+    <iidm:line id="_046a6a27-c766-11e1-8775-005056c00008" name="88-89" r="2.4219360000000001" x="12.4058876" g1="0" b1="5.549815e-05" g2="0" b2="5.549815e-05" node1="22" voltageLevelId1="_0470f9d2-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-111.8317785491125" q1="-8.1166969672801645" p2="113.64660980367066" q2="15.506026155570421">
         <iidm:alias>_045ef879-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04649dc1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10235,7 +10358,7 @@
             <iidm:temporaryLimit name="_970bc323-73bf-440d-a3c5-00aebc3a1992" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048a7540-c766-11e1-8775-005056c00008" name="80-98" r="4.1469120000000004" x="18.817920000000001" g1="0" b1="8.20707e-05" g2="0" b2="8.20707e-05" node1="79" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04773b62-c766-11e1-8775-005056c00008" p1="11.391018382090706" q1="11.980193183122429" p2="-11.322203507956649" q2="-14.712270112405552">
+    <iidm:line id="_048a7540-c766-11e1-8775-005056c00008" name="80-98" r="4.1469120000000004" x="18.817920000000001" g1="0" b1="8.20707e-05" g2="0" b2="8.20707e-05" node1="79" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04773b62-c766-11e1-8775-005056c00008" p1="11.397613902329457" q1="11.978642223704606" p2="-11.328775191105454" q2="-14.710611659794056">
         <iidm:alias>_045338a2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04887972-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10243,7 +10366,7 @@
             <iidm:temporaryLimit name="_cb084dc7-1b26-415f-9495-4695df661912" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04640183-c766-11e1-8775-005056c00008" name="91-92" r="6.7430880000000002" x="22.163329999999998" g1="0" b1="9.3778700000000004e-05" g2="0" b2="9.3778700000000004e-05" node1="22" voltageLevelId1="_044f8f29-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="-5.6960744432636394" q1="-14.594605253865064" p2="5.7795335888222992" q2="11.731656209297697">
+    <iidm:line id="_04640183-c766-11e1-8775-005056c00008" name="91-92" r="6.7430880000000002" x="22.163329999999998" g1="0" b1="9.3778700000000004e-05" g2="0" b2="9.3778700000000004e-05" node1="22" voltageLevelId1="_044f8f29-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="-5.671599196918411" q1="-14.58444499583433" p2="5.7548407251027403" q2="11.721036586770753">
         <iidm:alias>_04492680-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_044c5ad5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10251,7 +10374,7 @@
             <iidm:temporaryLimit name="_3a165a76-f6ba-461b-84d6-159a5e0b5077" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0474a358-c766-11e1-8775-005056c00008" name="7-12" r="1.501949" x="5.9241599999999996" g1="0" b1="2.5080350000000001e-05" g2="0" b2="2.5080350000000001e-05" node1="22" voltageLevelId1="_047eb571-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="23.783437501414731" q1="-9.9681387492273377" p2="-23.725536346344064" q2="9.3409910280743738">
+    <iidm:line id="_0474a358-c766-11e1-8775-005056c00008" name="7-12" r="1.501949" x="5.9241599999999996" g1="0" b1="2.5080350000000001e-05" g2="0" b2="2.5080350000000001e-05" node1="22" voltageLevelId1="_047eb571-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="19.54890594338891" q1="-7.9193474855412882" p2="-19.510288391716717" q2="7.2158372983832582">
         <iidm:alias>_046ab848-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0477feb7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10259,7 +10382,7 @@
             <iidm:temporaryLimit name="_b19bc945-cc51-4d77-8eaa-3f6afe2d9316" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04765108-c766-11e1-8775-005056c00008" name="99-100" r="3.13632" x="14.165711399999999" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_04644fa4-c766-11e1-8775-005056c00008" node2="80" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-40.05467143919563" q1="12.292240697982427" p2="40.363357080384603" q2="-13.138777745776986">
+    <iidm:line id="_04765108-c766-11e1-8775-005056c00008" name="99-100" r="3.13632" x="14.165711399999999" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_04644fa4-c766-11e1-8775-005056c00008" node2="80" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-40.048047715858573" q1="12.290715103503617" p2="40.356634385389704" q2="-13.137699630437849">
         <iidm:alias>_0471e436-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047e4040-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10267,7 +10390,7 @@
             <iidm:temporaryLimit name="_a9e283ed-fcad-4f4c-ab57-8531875bb098" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047b8128-c766-11e1-8775-005056c00008" name="114-115" r="0.400752" x="1.8120959999999999" g1="0" b1="7.9201000000000006e-06" g2="0" b2="7.9201000000000006e-06" node1="22" voltageLevelId1="_04791027-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="4.0003331966642675" q1="1.3401141154478307" p2="-3.9998796312122602" q2="-1.5920919299667042">
+    <iidm:line id="_047b8128-c766-11e1-8775-005056c00008" name="114-115" r="0.400752" x="1.8120959999999999" g1="0" b1="7.9201000000000006e-06" g2="0" b2="7.9201000000000006e-06" node1="22" voltageLevelId1="_04791027-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="4.5915768451328862" q1="0.96852921870723574" p2="-4.5910221597682437" q2="-1.2209842045502477">
         <iidm:alias>_046c17d3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d0233-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10275,7 +10398,7 @@
             <iidm:temporaryLimit name="_c59e4022-b1c0-4811-a32e-f54656bff32d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046931a5-c766-11e1-8775-005056c00008" name="83-84" r="10.890000000000001" x="22.999680000000001" g1="0" b1="7.4035799999999993e-05" g2="0" b2="7.4035799999999993e-05" node1="33" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b0bf4-c766-11e1-8775-005056c00008" p1="-32.525705948475682" q1="20.54018086558516" p2="33.532624506222106" q2="-20.849229194142659">
+    <iidm:line id="_046931a5-c766-11e1-8775-005056c00008" name="83-84" r="10.890000000000001" x="22.999680000000001" g1="0" b1="7.4035799999999993e-05" g2="0" b2="7.4035799999999993e-05" node1="33" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b0bf4-c766-11e1-8775-005056c00008" p1="-32.316618659852999" q1="21.057365043859075" p2="33.332285252956567" q2="-21.339169201440956">
         <iidm:alias>_0465d645-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479102b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10283,7 +10406,7 @@
             <iidm:temporaryLimit name="_1268eb09-e233-44ce-b8af-22dc30eb16ad" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047ae4ea-c766-11e1-8775-005056c00008" name="14-15" r="10.367279999999999" x="33.976799999999997" g1="0" b1="0.0001440542" g2="0" b2="0.0001440542" node1="21" voltageLevelId1="_047b8129-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="21.216486881079796" q1="5.9079869784626107" p2="-20.893275186061292" q2="-9.50725273873765">
+    <iidm:line id="_047ae4ea-c766-11e1-8775-005056c00008" name="14-15" r="10.367279999999999" x="33.976799999999997" g1="0" b1="0.0001440542" g2="0" b2="0.0001440542" node1="21" voltageLevelId1="_047b8129-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="16.476373363241503" q1="7.3862971647903173" p2="-16.247771140417228" q2="-11.294227378053408">
         <iidm:alias>_0449e9d9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046ed6fa-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10291,7 +10414,7 @@
             <iidm:temporaryLimit name="_9c0c454b-ecc3-40f6-b505-f32fec412522" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046e3ab2-c766-11e1-8775-005056c00008" name="80-96" r="6.2029439999999996" x="31.711680000000001" g1="0" b1="0.0001417585" g2="0" b2="0.0001417585" node1="80" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="4.6618082820476916" q1="26.195983124500223" p2="-4.3803698049533768" q2="-29.839247750647207">
+    <iidm:line id="_046e3ab2-c766-11e1-8775-005056c00008" name="80-96" r="6.2029439999999996" x="31.711680000000001" g1="0" b1="0.0001417585" g2="0" b2="0.0001417585" node1="80" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="4.7040458905421234" q1="26.395287771045773" p2="-4.4186767550714157" q2="-30.016685402693067">
         <iidm:alias>_045338a4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04865695-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10299,7 +10422,7 @@
             <iidm:temporaryLimit name="_1432f4d6-9299-4b0d-bd7f-16e059f9de66" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04893cc4-c766-11e1-8775-005056c00008" name="56-59" r="13.9914722" x="41.643360000000001" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="59" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-20.154720988284115" q1="-7.6678489196446655" p2="20.537373763042012" q2="3.7682045315055368">
+    <iidm:line id="_04893cc4-c766-11e1-8775-005056c00008" name="56-59" r="13.9914722" x="41.643360000000001" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="59" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-20.140170192061767" q1="-7.6736076186176643" p2="20.522358869363398" q2="3.772582934473232">
         <iidm:alias>_046b5484-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04798557-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10307,7 +10430,7 @@
             <iidm:temporaryLimit name="_193f6952-4267-4cc8-a541-726c095028ba" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c1243-c766-11e1-8775-005056c00008" name="92-100" r="11.290752400000001" x="51.400799999999997" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="71" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="36.825958768478614" q1="-17.275368358414635" p2="-35.780089057191816" q2="17.285299444011706">
+    <iidm:line id="_045c1243-c766-11e1-8775-005056c00008" name="92-100" r="11.290752400000001" x="51.400799999999997" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="71" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="36.863205885563254" q1="-17.294926563664632" p2="-35.815018776558887" q2="17.315645925713891">
         <iidm:alias>_045e8348-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045ed164-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10315,7 +10438,7 @@
             <iidm:temporaryLimit name="_579249ce-1c81-4d29-8d3f-5fc627a18f99" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0474a356-c766-11e1-8775-005056c00008" name="43-44" r="10.593792000000001" x="42.7584953" g1="0" b1="0.00017412765" g2="0" b2="0.00017412765" node1="22" voltageLevelId1="_045e8349-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04544a15-c766-11e1-8775-005056c00008" p1="-5.68655214266487" q1="-11.085968900934011" p2="5.7553965394741056" q2="5.7461792306922961">
+    <iidm:line id="_0474a356-c766-11e1-8775-005056c00008" name="43-44" r="10.593792000000001" x="42.7584953" g1="0" b1="0.00017412765" g2="0" b2="0.00017412765" node1="22" voltageLevelId1="_045e8349-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04544a15-c766-11e1-8775-005056c00008" p1="-5.4100601779390702" q1="-11.238242812784147" p2="5.4786352081414185" q2="5.8998751546732944">
         <iidm:alias>_04642899-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047b0bf2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10323,7 +10446,7 @@
             <iidm:temporaryLimit name="_3d2cb4b5-ee82-4866-9855-4a5f4803cd3b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04627ae6-c766-11e1-8775-005056c00008" name="109-110" r="4.8438720000000002" x="13.2770882" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="22" voltageLevelId1="_046b7b99-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="12.734917710233457" q1="-2.9685136164121144" p2="-12.684428154859287" q2="1.2605573762183058">
+    <iidm:line id="_04627ae6-c766-11e1-8775-005056c00008" name="109-110" r="4.8438720000000002" x="13.2770882" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="22" voltageLevelId1="_046b7b99-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="12.738045165135775" q1="-2.9696698267409753" p2="-12.68752997985133" q2="1.2617843365125361">
         <iidm:alias>_0466e7b5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a6fbb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10331,7 +10454,7 @@
             <iidm:temporaryLimit name="_6fc48d8d-05f8-4104-a6a2-3686d430a091" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0478c207-c766-11e1-8775-005056c00008" name="68-81" r="0.84699999999999998" x="9.7767990000000005" g1="0" b1="0.00083471078000000004" g2="0" b2="0.00083471078000000004" node1="38" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_048a272b-c766-11e1-8775-005056c00008" p1="-151.02128110808408" q1="-3.814827767196785" p2="151.44482730418122" q2="-71.538889492229501">
+    <iidm:line id="_0478c207-c766-11e1-8775-005056c00008" name="68-81" r="0.84699999999999998" x="9.7767990000000005" g1="0" b1="0.00083471078000000004" g2="0" b2="0.00083471078000000004" node1="38" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_048a272b-c766-11e1-8775-005056c00008" p1="-150.40398183392313" q1="-3.8791512793861922" p2="150.82417800716462" q2="-71.513704851255923">
         <iidm:alias>_044a37f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045b4ef6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10339,7 +10462,7 @@
             <iidm:temporaryLimit name="_191836a1-39cd-402b-8dcf-4f3867c45bd0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0467d215-c766-11e1-8775-005056c00008" name="85-89" r="4.1643359999999996" x="30.143518400000001" g1="0" b1="0.00013487144999999999" g2="0" b2="0.00013487144999999999" node1="52" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-83.810371160714354" q1="-2.3396315407073875" p2="85.583212901777756" q2="10.573457143936182">
+    <iidm:line id="_0467d215-c766-11e1-8775-005056c00008" name="85-89" r="4.1643359999999996" x="30.143518400000001" g1="0" b1="0.00013487144999999999" g2="0" b2="0.00013487144999999999" node1="52" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-83.597678506625826" q1="-3.7805428956057154" p2="85.371393700942036" q2="12.032288299069">
         <iidm:alias>_047629f9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0478e915-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10347,7 +10470,7 @@
             <iidm:temporaryLimit name="_66cbdeeb-a4e4-4bfc-aec1-9fb7a2d2b6bc" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044a37f2-c766-11e1-8775-005056c00008" name="89-90" r="4.1469120000000004" x="17.371727" g1="0" b1="0.00030417815" g2="0" b2="0.00030417815" node1="62" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="112.73308217662428" q1="21.233896013701916" p2="-109.57185672046761" q2="-18.20613332430182">
+    <iidm:line id="_044a37f2-c766-11e1-8775-005056c00008" name="89-90" r="4.1469120000000004" x="17.371727" g1="0" b1="0.00030417815" g2="0" b2="0.00030417815" node1="62" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="112.75007965492559" q1="21.245266358727186" p2="-109.58780878748409" q2="-18.212986475848282">
         <iidm:alias>_045386c2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048719e9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10355,7 +10478,7 @@
             <iidm:temporaryLimit name="_8489e809-6588-4ed2-a9a4-43c44a0d47da" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04658820-c766-11e1-8775-005056c00008" name="98-100" r="6.9173280000000004" x="31.188960999999999" g1="0" b1="0.0001365932" g2="0" b2="0.0001365932" node1="22" voltageLevelId1="_04773b62-c766-11e1-8775-005056c00008" node2="82" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-22.677779142908939" q1="6.7122772167422431" p2="22.904843516681716" q2="-10.642699189970578">
+    <iidm:line id="_04658820-c766-11e1-8775-005056c00008" name="98-100" r="6.9173280000000004" x="31.188960999999999" g1="0" b1="0.0001365932" g2="0" b2="0.0001365932" node1="22" voltageLevelId1="_04773b62-c766-11e1-8775-005056c00008" node2="82" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-22.67121040314564" q1="6.7106179544720392" p2="22.898150200189505" q2="-10.641602742866851">
         <iidm:alias>_046f4c22-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046fe865-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10363,7 +10486,7 @@
             <iidm:temporaryLimit name="_620beaaf-63c8-4020-bea5-c3609c0eaadf" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c5ada-c766-11e1-8775-005056c00008" name="28-29" r="4.1294880000000003" x="16.430831900000001" g1="0" b1="6.8296599999999999e-05" g2="0" b2="6.8296599999999999e-05" node1="22" voltageLevelId1="_04819ba0-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04588fd5-c766-11e1-8775-005056c00008" p1="32.092428749982901" q1="-11.576054491977288" p2="-31.799346629350129" q2="10.541871482140047">
+    <iidm:line id="_044c5ada-c766-11e1-8775-005056c00008" name="28-29" r="4.1294880000000003" x="16.430831900000001" g1="0" b1="6.8296599999999999e-05" g2="0" b2="6.8296599999999999e-05" node1="22" voltageLevelId1="_04819ba0-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04588fd5-c766-11e1-8775-005056c00008" p1="28.999550469355889" q1="-9.0736279266908539" p2="-28.768134259203222" q2="7.7870898069630465">
         <iidm:alias>_0461697a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04697fc1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10371,7 +10494,13 @@
             <iidm:temporaryLimit name="_6748d0d0-aec8-4b7b-a9ab-be6aecda7c5d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0468e382-c766-11e1-8775-005056c00008" name="3-5" r="4.1991839999999998" x="18.817920000000001" g1="0" b1="8.1496799999999995e-05" g2="0" b2="8.1496799999999995e-05" node1="31" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-72.438527992733526" q1="-15.523843233947288" p2="73.827563858381367" q2="18.960771751897902">
+    <iidm:line id="_044c5ada-c766-11e1-8775-005056c00008-1" name="28-29-open-ended" r="4.1294880000000003" x="16.430831900000001" g1="0" b1="6.8296599999999999e-05" g2="0" b2="6.8296599999999999e-05" node1="25" voltageLevelId1="_04819ba0-c766-11e1-8775-005056c00008" node2="25" voltageLevelId2="_04588fd5-c766-11e1-8775-005056c00008" p1="0.0003115931732340085" q1="-2.2059277519732641" p2="0" q2="0">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_accb8136-1faf-4399-9787-3cd567284fd2-1" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_6748d0d0-aec8-4b7b-a9ab-be6aecda7c5d-1" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0468e382-c766-11e1-8775-005056c00008" name="3-5" r="4.1991839999999998" x="18.817920000000001" g1="0" b1="8.1496799999999995e-05" g2="0" b2="8.1496799999999995e-05" node1="31" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-70.219127053608759" q1="-16.699845291479534" p2="71.535006505729086" q2="19.804759748965537">
         <iidm:alias>_046b0668-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04742e24-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10379,7 +10508,7 @@
             <iidm:temporaryLimit name="_828ca44c-560b-4f94-b825-21e237285fae" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0447c6f1-c766-11e1-8775-005056c00008" name="82-96" r="2.8226879999999999" x="9.2347199999999994" g1="0" b1="0.00015610649999999999" g2="0" b2="0.00015610649999999999" node1="33" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="-15.555754771554611" q1="-8.8573501000375483" p2="15.602943227462546" q2="3.7346463053384236">
+    <iidm:line id="_0447c6f1-c766-11e1-8775-005056c00008" name="82-96" r="2.8226879999999999" x="9.2347199999999994" g1="0" b1="0.00015610649999999999" g2="0" b2="0.00015610649999999999" node1="33" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="-15.75935259582519" q1="-9.5715128536320044" p2="15.809284346550998" q2="4.4639520450948815">
         <iidm:alias>_0478e91a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0480d856-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10387,7 +10516,7 @@
             <iidm:temporaryLimit name="_233b7735-85f4-4a6f-9d87-15129fe42ef5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0483e594-c766-11e1-8775-005056c00008" name="38-65" r="4.3608399999999996" x="47.7224" g1="0" b1="0.0010805785" g2="0" b2="0.0010805785" node1="29" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-162.95132402338842" q1="-97.244240128106156" p2="166.09806536928323" q2="34.848627736229624">
+    <iidm:line id="_0483e594-c766-11e1-8775-005056c00008" name="38-65" r="4.3608399999999996" x="47.7224" g1="0" b1="0.0010805785" g2="0" b2="0.0010805785" node1="29" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-161.51633432686432" q1="-97.767769516177111" p2="164.62071436801929" q2="34.926821433569422">
         <iidm:alias>_04638c56-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d5054-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10395,7 +10524,7 @@
             <iidm:temporaryLimit name="_990ce3c5-c90c-41b9-abee-fb803d9df3a5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04784cd4-c766-11e1-8775-005056c00008" name="106-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_04479fe8-c766-11e1-8775-005056c00008" node2="24" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="23.852683947391828" q1="-0.69450887536857553" p2="-23.524281750164398" q2="-2.4550992031592509">
+    <iidm:line id="_04784cd4-c766-11e1-8775-005056c00008" name="106-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_04479fe8-c766-11e1-8775-005056c00008" node2="24" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="23.852901239095477" q1="-0.694582710371206" p2="-23.524493100866259" q2="-2.4550036260889851">
         <iidm:alias>_04483c21-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f0395-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10403,7 +10532,7 @@
             <iidm:temporaryLimit name="_1372c3b0-62d7-47d7-a8c0-ed8e10bc1f1a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046f9a43-c766-11e1-8775-005056c00008" name="27-115" r="2.8575360000000001" x="12.9111843" g1="0" b1="5.6588600000000002e-05" g2="0" b2="5.6588600000000002e-05" node1="43" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="18.044979994987706" q1="3.8487654536982303" p2="-17.983740945555244" q2="-5.3991980670792126">
+    <iidm:line id="_046f9a43-c766-11e1-8775-005056c00008" name="27-115" r="2.8575360000000001" x="12.9111843" g1="0" b1="5.6588600000000002e-05" g2="0" b2="5.6588600000000002e-05" node1="43" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="17.455680968459969" q1="4.200672807055664" p2="-17.397734424249386" q2="-5.7730480154331349">
         <iidm:alias>_046d0238-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048c22f4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10411,7 +10540,7 @@
             <iidm:temporaryLimit name="_64cfd0fb-1d8e-45d2-a52f-469238dfc0c6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04529c61-c766-11e1-8775-005056c00008" name="12-14" r="3.7461600000000002" x="12.3187675" g1="0" b1="5.2112050000000002e-05" g2="0" b2="5.2112050000000002e-05" node1="71" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b8129-c766-11e1-8775-005056c00008" p1="35.503051419239661" q1="6.0946493487098534" p2="-35.215847134692851" q2="-6.9079104094520378">
+    <iidm:line id="_04529c61-c766-11e1-8775-005056c00008" name="12-14" r="3.7461600000000002" x="12.3187675" g1="0" b1="5.2112050000000002e-05" g2="0" b2="5.2112050000000002e-05" node1="71" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b8129-c766-11e1-8775-005056c00008" p1="30.697548281201097" q1="7.3572677522189771" p2="-30.475911241880045" q2="-8.3862421537053109">
         <iidm:alias>_045fbbc1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047bf65b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10419,7 +10548,7 @@
             <iidm:temporaryLimit name="_efe2501d-bcee-42ff-a037-3d8a280487b0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0463da77-c766-11e1-8775-005056c00008" name="76-118" r="2.8575360000000001" x="9.4786560000000009" g1="0" b1="3.8911849999999999e-05" g2="0" b2="3.8911849999999999e-05" node1="22" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="-5.788732014707386" q1="-14.658759460205042" p2="5.8318196479901312" q2="13.596442406480765">
+    <iidm:line id="_0463da77-c766-11e1-8775-005056c00008" name="76-118" r="2.8575360000000001" x="9.4786560000000009" g1="0" b1="3.8911849999999999e-05" g2="0" b2="3.8911849999999999e-05" node1="22" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="-5.6574259209855429" q1="-14.763131905550985" p2="5.7007892460323442" q2="13.701854720615753">
         <iidm:alias>_046931a0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04806320-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10427,7 +10556,7 @@
             <iidm:temporaryLimit name="_2ae204bf-78cc-49cb-b886-a933b33057e4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046931a3-c766-11e1-8775-005056c00008" name="74-75" r="2.1431520000000002" x="7.0741440000000004" g1="0" b1="2.9671699999999999e-05" g2="0" b2="2.9671699999999999e-05" node1="23" voltageLevelId1="_047dcb11-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="-44.695722696603667" q1="-4.4396979114735915" p2="44.964394641317661" q2="4.3658872646705511">
+    <iidm:line id="_046931a3-c766-11e1-8775-005056c00008" name="74-75" r="2.1431520000000002" x="7.0741440000000004" g1="0" b1="2.9671699999999999e-05" g2="0" b2="2.9671699999999999e-05" node1="23" voltageLevelId1="_047dcb11-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="-44.998326031995731" q1="-4.2475409654230942" p2="45.270397153069602" q2="4.1849049301054198">
         <iidm:alias>_044f4103-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04638c58-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10435,7 +10564,7 @@
             <iidm:temporaryLimit name="_e822432e-79af-4bba-8f40-5250468f81a0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045ed162-c766-11e1-8775-005056c00008" name="3-12" r="8.4332159999999998" x="27.878398900000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="32" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-7.3725265230861554" q1="-10.441588689190965" p2="7.437544565009806" q2="6.7479303525245085">
+    <iidm:line id="_045ed162-c766-11e1-8775-005056c00008" name="3-12" r="8.4332159999999998" x="27.878398900000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="32" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-8.6283518382044022" q1="-9.7670487093183951" p2="8.6979213642471436" q2="6.0865639542916652">
         <iidm:alias>_047a48a1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047b5a14-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10443,7 +10572,7 @@
             <iidm:temporaryLimit name="_c437e52c-43d7-4ae9-87ad-dc19396dc6ff" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04499bb6-c766-11e1-8775-005056c00008" name="49-51" r="8.468064" x="23.8708782" g1="0" b1="9.81405e-05" g2="0" b2="9.81405e-05" node1="119" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04542300-c766-11e1-8775-005056c00008" p1="76.812160313545462" q1="18.670159549159337" p2="-73.889108325192794" q2="-13.821585770228923">
+    <iidm:line id="_04499bb6-c766-11e1-8775-005056c00008" name="49-51" r="8.468064" x="23.8708782" g1="0" b1="9.81405e-05" g2="0" b2="9.81405e-05" node1="119" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04542300-c766-11e1-8775-005056c00008" p1="76.83334308077329" q1="18.666784932925751" p2="-73.908849598494058" q2="-13.814139188540365">
         <iidm:alias>_0487dd38-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b1180-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10451,7 +10580,7 @@
             <iidm:temporaryLimit name="_90dcdbe1-437b-443f-b0b5-c2353f7c6954" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04839779-c766-11e1-8775-005056c00008" name="40-42" r="9.6703209999999995" x="31.885919999999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="42" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="-0.88878479298858359" q1="-9.5095572286252601" p2="0.92946173662926068" q2="5.8215191535133677">
+    <iidm:line id="_04839779-c766-11e1-8775-005056c00008" name="40-42" r="9.6703209999999995" x="31.885919999999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="42" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="-0.67878021011927758" q1="-9.6477205292626511" p2="0.72075159295778779" q2="5.9666145904111918">
         <iidm:alias>_044974a9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04616975-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10459,7 +10588,7 @@
             <iidm:temporaryLimit name="_9b8510fa-bd0e-4e63-8f4c-0e5443a3eb63" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0484a8e1-c766-11e1-8775-005056c00008" name="32-113" r="10.71576" x="35.370719999999999" g1="0" b1="0.00014864555000000001" g2="0" b2="0.00014864555000000001" node1="52" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="11.820721768121938" q1="-12.602633586970047" p2="-11.659254027850002" q2="8.2541906187773595">
+    <iidm:line id="_0484a8e1-c766-11e1-8775-005056c00008" name="32-113" r="10.71576" x="35.370719999999999" g1="0" b1="0.00014864555000000001" g2="0" b2="0.00014864555000000001" node1="52" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="7.1910341990978548" q1="-10.571934424085354" p2="-7.112928090901864" q2="5.9407015701778629">
         <iidm:alias>_04723258-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0482860a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10467,7 +10596,7 @@
             <iidm:temporaryLimit name="_336bfd86-a922-4154-9e06-cd87382cdc5f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04898ae4-c766-11e1-8775-005056c00008" name="51-58" r="4.4431200000000004" x="12.5278568" g1="0" b1="5.1308550000000002e-05" g2="0" b2="5.1308550000000002e-05" node1="31" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="25.285307310805965" q1="0.49867119053374831" p2="-25.110004734211195" q2="-1.6589812268039579">
+    <iidm:line id="_04898ae4-c766-11e1-8775-005056c00008" name="51-58" r="4.4431200000000004" x="12.5278568" g1="0" b1="5.1308550000000002e-05" g2="0" b2="5.1308550000000002e-05" node1="31" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="25.298540035626022" q1="0.49318909522853005" p2="-25.123057479329908" q2="-1.6529840673348644">
         <iidm:alias>_044778d4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04789af1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10475,7 +10604,7 @@
             <iidm:temporaryLimit name="_2be10dec-f0ac-470d-83f7-a2a4e70f3491" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046efe04-c766-11e1-8775-005056c00008" name="29-31" r="1.8817919999999999" x="5.7673439999999996" g1="0" b1="2.3817700000000001e-05" g2="0" b2="2.3817700000000001e-05" node1="22" voltageLevelId1="_04588fd5-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="7.8010692128099244" q1="-14.541391133156814" p2="-7.7706427646321794" q2="13.861723444887961">
+    <iidm:line id="_046efe04-c766-11e1-8775-005056c00008" name="29-31" r="1.8817919999999999" x="5.7673439999999996" g1="0" b1="2.3817700000000001e-05" g2="0" b2="2.3817700000000001e-05" node1="22" voltageLevelId1="_04588fd5-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="4.768882079617291" q1="-11.78688194127365" p2="-4.7511171834740917" q2="11.067918057582997">
         <iidm:alias>_04492688-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047cb9a5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10483,7 +10612,7 @@
             <iidm:temporaryLimit name="_f0e21213-6535-44a7-89b6-3063f8738d6b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044a10e4-c766-11e1-8775-005056c00008" name="65-68" r="0.66791999999999996" x="7.7439999999999998" g1="0" b1="0.00065909092999999995" g2="0" b2="0.00065909092999999995" node1="41" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0449e9d2-c766-11e1-8775-005056c00008" p1="-164.80406691678701" q1="24.086384850568017" p2="165.21847702820398" q2="-83.316260916010947">
+    <iidm:line id="_044a10e4-c766-11e1-8775-005056c00008" name="65-68" r="0.66791999999999996" x="7.7439999999999998" g1="0" b1="0.00065909092999999995" g2="0" b2="0.00065909092999999995" node1="41" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0449e9d2-c766-11e1-8775-005056c00008" p1="-163.17505275975756" q1="23.877731131302355" p2="163.58184248721238" q2="-83.196204508167028">
         <iidm:alias>_0461dea7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047629f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10491,7 +10620,7 @@
             <iidm:temporaryLimit name="_ab31cd46-6d0c-4d9c-95f1-396a45a237e1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046b7b92-c766-11e1-8775-005056c00008" name="49-54" r="12.719519999999999" x="50.355361899999998" g1="0" b1="0.00021177684999999999" g2="0" b2="0.00021177684999999999" node1="120" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="46.749192860138074" q1="11.853495384782416" p2="-45.058733896646068" q2="-12.403308501463872">
+    <iidm:line id="_046b7b92-c766-11e1-8775-005056c00008" name="49-54" r="12.719519999999999" x="50.355361899999998" g1="0" b1="0.00021177684999999999" g2="0" b2="0.00021177684999999999" node1="120" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="46.768134293414256" q1="11.851197097753674" p2="-45.07649486953494" q2="-12.396337268838179">
         <iidm:alias>_0462f017-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047120e1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10499,7 +10628,7 @@
             <iidm:temporaryLimit name="_1bf78539-b6fa-4d8b-ba8e-9b5970019be6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04607f15-c766-11e1-8775-005056c00008" name="70-71" r="1.536797" x="6.1855200000000004" g1="0" b1="2.5195149999999999e-05" g2="0" b2="2.5195149999999999e-05" node1="52" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04664b78-c766-11e1-8775-005056c00008" p1="-6.4024532041436526" q1="-4.0707192268917138" p2="6.4073987922639697" q2="3.2390120425220381">
+    <iidm:line id="_04607f15-c766-11e1-8775-005056c00008" name="70-71" r="1.536797" x="6.1855200000000004" g1="0" b1="2.5195149999999999e-05" g2="0" b2="2.5195149999999999e-05" node1="52" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04664b78-c766-11e1-8775-005056c00008" p1="-5.6840663824012481" q1="-4.5590341823737637" p2="5.6885653946265329" q2="3.7251472947662969">
         <iidm:alias>_04486336-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f51b4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10507,7 +10636,7 @@
             <iidm:temporaryLimit name="_08ff3ae4-d1dd-49f7-9eda-32ffc8eb0010" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c5ad7-c766-11e1-8775-005056c00008" name="55-56" r="0.85029100000000002" x="2.631024" g1="0" b1="1.0732300000000001e-05" g2="0" b2="1.0732300000000001e-05" node1="31" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="-28.668583988648084" q1="-7.0103338157039117" p2="28.715428966019079" q2="6.8159228140853294">
+    <iidm:line id="_044c5ad7-c766-11e1-8775-005056c00008" name="55-56" r="0.85029100000000002" x="2.631024" g1="0" b1="1.0732300000000001e-05" g2="0" b2="1.0732300000000001e-05" node1="31" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="-28.680569410610801" q1="-7.0064679076354315" p2="28.727448626304586" q2="6.8121630145112047">
         <iidm:alias>_04558294-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045868c2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10515,7 +10644,7 @@
             <iidm:temporaryLimit name="_94316214-afd8-4c0d-bca4-916acb92af85" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048a2725-c766-11e1-8775-005056c00008" name="35-37" r="1.9166399999999999" x="8.6597279999999994" g1="0" b1="3.7821399999999997e-05" g2="0" b2="3.7821399999999997e-05" node1="21" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-29.683637294177274" q1="-14.387258976042308" p2="29.817447492327698" q2="13.817076698703106">
+    <iidm:line id="_048a2725-c766-11e1-8775-005056c00008" name="35-37" r="1.9166399999999999" x="8.6597279999999994" g1="0" b1="3.7821399999999997e-05" g2="0" b2="3.7821399999999997e-05" node1="21" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-29.599526029736879" q1="-14.423084617794057" p2="29.732970294559756" q2="13.852377744719055">
         <iidm:alias>_0471bd29-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04808a30-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10523,7 +10652,7 @@
             <iidm:temporaryLimit name="_4ea6b532-d914-4b0c-97ee-9f02a14a40b3" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04614263-c766-11e1-8775-005056c00008" name="4-5" r="0.30666199999999999" x="1.3904350000000001" g1="0" b1="6.0261499999999999e-06" g2="0" b2="6.0261499999999999e-06" node1="22" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-113.15094756021473" q1="-17.993137504400387" p2="113.37940131631579" q2="18.815933238605727">
+    <iidm:line id="_04614263-c766-11e1-8775-005056c00008" name="4-5" r="0.30666199999999999" x="1.3904350000000001" g1="0" b1="6.0261499999999999e-06" g2="0" b2="6.0261499999999999e-06" node1="22" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-108.61166164609952" q1="-19.860277658738173" p2="108.82341939961304" q2="20.606962085813489">
         <iidm:alias>_04529c66-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04753f92-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10531,7 +10660,7 @@
             <iidm:temporaryLimit name="_2a95fb2b-6661-46e7-a9f6-fe63c1b7433c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0451b208-c766-11e1-8775-005056c00008" name="20-21" r="3.1885919999999999" x="14.7929754" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_046b2d70-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0460f448-c766-11e1-8775-005056c00008" p1="-34.479398477879656" q1="2.2164013742604611" p2="34.728027226818014" q2="-2.9778698740368856">
+    <iidm:line id="_0451b208-c766-11e1-8775-005056c00008" name="20-21" r="3.1885919999999999" x="14.7929754" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_046b2d70-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0460f448-c766-11e1-8775-005056c00008" p1="-32.334166395923056" q1="1.1444504175270678" p2="32.551654115449885" q2="-2.0535300208469538">
         <iidm:alias>_046c65f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048c22f6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10539,7 +10668,7 @@
             <iidm:temporaryLimit name="_4b67f5f5-f0e1-4bfb-9d57-4d3474720a45" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047d55e4-c766-11e1-8775-005056c00008" name="104-105" r="1.731946" x="6.5862720000000001" g1="0" b1="2.8294300000000001e-05" g2="0" b2="2.8294300000000001e-05" node1="32" voltageLevelId1="_0483977a-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="48.02955789476654" q1="0.86584587495976839" p2="-47.785961057547702" q2="-0.86331540790792061">
+    <iidm:line id="_047d55e4-c766-11e1-8775-005056c00008" name="104-105" r="1.731946" x="6.5862720000000001" g1="0" b1="2.8294300000000001e-05" g2="0" b2="2.8294300000000001e-05" node1="32" voltageLevelId1="_0483977a-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="48.031165380789467" q1="0.8654225077242127" p2="-47.787552330698126" q2="-0.86283025292524762">
         <iidm:alias>_0451d910-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046c65f2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10547,7 +10676,7 @@
             <iidm:temporaryLimit name="_1ca40dc7-6736-4fa8-b4cb-ca696949e421" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046dc589-c766-11e1-8775-005056c00008" name="44-45" r="3.9029759999999998" x="15.699023199999999" g1="0" b1="6.4279149999999996e-05" g2="0" b2="6.4279149999999996e-05" node1="23" voltageLevelId1="_04544a15-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_045d23b4-c766-11e1-8775-005056c00008" p1="-21.754026295568725" q1="-4.2427649754246097" p2="21.86798155918131" q2="2.5550918710495663">
+    <iidm:line id="_046dc589-c766-11e1-8775-005056c00008" name="44-45" r="3.9029759999999998" x="15.699023199999999" g1="0" b1="6.4279149999999996e-05" g2="0" b2="6.4279149999999996e-05" node1="23" voltageLevelId1="_04544a15-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_045d23b4-c766-11e1-8775-005056c00008" p1="-21.477366391924342" q1="-4.398593443420137" p2="21.588765458357162" q2="2.7009319534598037">
         <iidm:alias>_04518afa-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04667287-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10555,7 +10684,7 @@
             <iidm:temporaryLimit name="_ba738481-ddba-4ebe-a218-8aad0b537f5b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04642896-c766-11e1-8775-005056c00008" name="4-11" r="3.641616" x="11.9877129" g1="0" b1="5.0160700000000002e-05" g2="0" b2="5.0160700000000002e-05" node1="23" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="74.1533053346933" q1="5.9943487124676595" p2="-73.006794853169026" q2="-3.9545280132299658">
+    <iidm:line id="_04642896-c766-11e1-8775-005056c00008" name="4-11" r="3.641616" x="11.9877129" g1="0" b1="5.0160700000000002e-05" g2="0" b2="5.0160700000000002e-05" node1="23" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="69.613404727851361" q1="7.8611715252889072" p2="-68.597682300611865" q2="-6.2543140897863054">
         <iidm:alias>_0455f7c5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04803c17-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10563,7 +10692,7 @@
             <iidm:temporaryLimit name="_b1d87c24-e527-4174-aa04-cd0b9de271ea" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047d07c0-c766-11e1-8775-005056c00008" name="92-93" r="4.4953919999999998" x="14.775551800000001" g1="0" b1="6.2557400000000005e-05" g2="0" b2="6.2557400000000005e-05" node1="72" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04789af0-c766-11e1-8775-005056c00008" p1="70.557920707283998" q1="-12.787221462521261" p2="-69.209735536341171" q2="15.097791516229385">
+    <iidm:line id="_047d07c0-c766-11e1-8775-005056c00008" name="92-93" r="4.4953919999999998" x="14.775551800000001" g1="0" b1="6.2557400000000005e-05" g2="0" b2="6.2557400000000005e-05" node1="72" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04789af0-c766-11e1-8775-005056c00008" p1="70.616532548057734" q1="-12.724194135927036" p2="-69.266414974751513" q2="15.04147887667343">
         <iidm:alias>_044a5f07-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047602e5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10571,7 +10700,7 @@
             <iidm:temporaryLimit name="_4e1daf8e-7708-4b96-8d3f-67f58f2505f9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044f4109-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="43" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="121" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-53.908571119061286" q1="-18.704288616001364" p2="56.593317394426215" q2="22.725250522505089">
+    <iidm:line id="_044f4109-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="43" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="121" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-53.7018206911712" q1="-18.847455114101713" p2="56.372653283661613" q2="22.807402668631671">
         <iidm:alias>_046958b0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04758db0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10579,7 +10708,7 @@
             <iidm:temporaryLimit name="_c58940cb-bd36-4dfc-9615-11716dd652a7" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046e61c8-c766-11e1-8775-005056c00008" name="69-75" r="7.0567200000000003" x="21.257280000000002" g1="0" b1="0.00035583104999999999" g2="0" b2="0.00035583104999999999" node1="61" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="89.3844876276424" q1="24.626401232622189" p2="-85.99421390657362" q2="-26.86076615301516">
+    <iidm:line id="_046e61c8-c766-11e1-8775-005056c00008" name="69-75" r="7.0567200000000003" x="21.257280000000002" g1="0" b1="0.00035583104999999999" g2="0" b2="0.00035583104999999999" node1="61" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="89.787296497506745" q1="24.532319615742676" p2="-86.371957813427201" q2="-26.691215410098046">
         <iidm:alias>_046d294a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048ac362-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10587,7 +10716,7 @@
             <iidm:temporaryLimit name="_3c9a454c-10ee-4c72-a059-77f723f5b7c7" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0463da71-c766-11e1-8775-005056c00008" name="79-80" r="2.7181440000000001" x="12.2664957" g1="0" b1="5.3661600000000001e-05" g2="0" b2="5.3661600000000001e-05" node1="23" voltageLevelId1="_04481510-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-66.359061624752783" q1="-32.268347555978828" p2="67.187413794283145" q2="34.047132792375848">
+    <iidm:line id="_0463da71-c766-11e1-8775-005056c00008" name="79-80" r="2.7181440000000001" x="12.2664957" g1="0" b1="5.3661600000000001e-05" g2="0" b2="5.3661600000000001e-05" node1="23" voltageLevelId1="_04481510-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-66.454706157513556" q1="-32.375330419005678" p2="67.28620372762235" q2="34.168488932832844">
         <iidm:alias>_0464ebe9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04662468-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10595,7 +10724,7 @@
             <iidm:temporaryLimit name="_270a7d04-9ff9-4178-8b72-b610735a72ac" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044fdd41-c766-11e1-8775-005056c00008" name="51-52" r="3.5370720000000002" x="10.2453117" g1="0" b1="4.0059699999999999e-05" g2="0" b2="4.0059699999999999e-05" node1="32" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04806326-c766-11e1-8775-005056c00008" p1="31.603809977771157" q1="5.3229217034458527" p2="-31.378630472739498" q2="-5.959019078206099">
+    <iidm:line id="_044fdd41-c766-11e1-8775-005056c00008" name="51-52" r="3.5370720000000002" x="10.2453117" g1="0" b1="4.0059699999999999e-05" g2="0" b2="4.0059699999999999e-05" node1="32" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04806326-c766-11e1-8775-005056c00008" p1="31.610319034296253" q1="5.3209578938032935" p2="-31.385053867329287" q2="-5.9568000179489768">
         <iidm:alias>_045115c2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0464ebe5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10603,7 +10732,7 @@
             <iidm:temporaryLimit name="_9d1eb182-ceb5-426e-9440-5f4d426a31cb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c3958-c766-11e1-8775-005056c00008" name="53-54" r="4.5825120000000004" x="21.257280000000002" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="22" voltageLevelId1="_04876804-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="-9.7042394598997461" q1="-6.7094318979080105" p2="9.7402939928687502" q2="4.0777826489356066">
+    <iidm:line id="_045c3958-c766-11e1-8775-005056c00008" name="53-54" r="4.5825120000000004" x="21.257280000000002" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="22" voltageLevelId1="_04876804-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="-9.6978868361882853" q1="-6.7119533908674782" p2="9.7339131189527244" q2="4.0801770529434886">
         <iidm:alias>_044f6817-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0455f7c6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10611,7 +10740,7 @@
             <iidm:temporaryLimit name="_735ac8df-6a6a-43f0-86f2-49d3280c9a3b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044ef2e1-c766-11e1-8775-005056c00008" name="54-55" r="2.9446560000000002" x="12.3187675" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="63" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04767817-c766-11e1-8775-005056c00008" p1="10.14992545071631" q1="1.7068697045209431" p2="-10.129555682117344" q2="-3.4567901234130609">
+    <iidm:line id="_044ef2e1-c766-11e1-8775-005056c00008" name="54-55" r="2.9446560000000002" x="12.3187675" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="63" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04767817-c766-11e1-8775-005056c00008" p1="10.154205856163568" q1="1.7062373320364224" p2="-10.133820599886466" q2="-3.4560925511902596">
         <iidm:alias>_04640181-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047dcb17-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10619,7 +10748,7 @@
             <iidm:temporaryLimit name="_52aadf8d-53f2-4827-8c70-421bdf1ba822" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0456e226-c766-11e1-8775-005056c00008" name="80-97" r="3.1885919999999999" x="16.2740154" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="82" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="12.172874909492007" q1="30.798474121666509" p2="-11.972680892319799" q2="-32.443258782511712">
+    <iidm:line id="_0456e226-c766-11e1-8775-005056c00008" name="80-97" r="3.1885919999999999" x="16.2740154" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="82" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="12.21653134249379" q1="30.998995075446977" p2="-12.013967385003765" q2="-32.631203050802554">
         <iidm:alias>_04479fe9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047df222-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10627,7 +10756,7 @@
             <iidm:temporaryLimit name="_fece5807-6af8-4161-8de8-8f8473d92f11" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0487b624-c766-11e1-8775-005056c00008" name="103-110" r="6.8058139999999998" x="31.5897121" g1="0" b1="0.00013228879999999999" g2="0" b2="0.00013228879999999999" node1="43" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="57.716611200468115" q1="18.497721243292638" p2="-56.274638190320523" q2="-16.258437846349793">
+    <iidm:line id="_0487b624-c766-11e1-8775-005056c00008" name="103-110" r="6.8058139999999998" x="31.5897121" g1="0" b1="0.00013228879999999999" g2="0" b2="0.00013228879999999999" node1="43" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="57.720004700118352" q1="18.497417359460481" p2="-56.277886638954698" q2="-16.257460382229244">
         <iidm:alias>_046a9139-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b3895-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10635,7 +10764,7 @@
             <iidm:temporaryLimit name="_3eacc034-737e-41de-a7b6-b610d3bd0921" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045338a8-c766-11e1-8775-005056c00008" name="56-58" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="61" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="-13.045783334275141" q1="-0.68999970133478039" p2="13.11000841817509" q2="-1.3410172000905174">
+    <iidm:line id="_045338a8-c766-11e1-8775-005056c00008" name="56-58" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="61" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="-13.058706928248952" q1="-0.68363407023392175" p2="13.123061214039847" q2="-1.3470142321955065">
         <iidm:alias>_0451d915-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04817494-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10643,7 +10772,7 @@
             <iidm:temporaryLimit name="_0d0c3ec5-798a-48a4-9bc8-d19c57128a13" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04854529-c766-11e1-8775-005056c00008" name="15-33" r="6.6211200000000003" x="21.675455100000001" g1="0" b1="9.1655200000000003e-05" g2="0" b2="9.1655200000000003e-05" node1="52" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456bb11-c766-11e1-8775-005056c00008" p1="62.642110837675688" q1="-8.1843800201296695" p2="-60.966638733617494" q2="10.831094432895316">
+    <iidm:line id="_04854529-c766-11e1-8775-005056c00008" name="15-33" r="6.6211200000000003" x="21.675455100000001" g1="0" b1="9.1655200000000003e-05" g2="0" b2="9.1655200000000003e-05" node1="52" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456bb11-c766-11e1-8775-005056c00008" p1="63.76919181823181" q1="-8.2704852285586075" p2="-62.031786305897171" q2="11.122678509296897">
         <iidm:alias>_0448d862-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047d2ed5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10651,7 +10780,7 @@
             <iidm:temporaryLimit name="_5b0395f4-534d-4975-a1af-e0b6ef439193" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04649dc2-c766-11e1-8775-005056c00008" name="35-36" r="0.39029799999999998" x="1.7772479999999999" g1="0" b1="7.6905500000000004e-06" g2="0" b2="7.6905500000000004e-06" node1="22" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="-3.3088818613990725" q1="5.3906611634069108" p2="3.3099317639542067" q2="-5.6218676612246572">
+    <iidm:line id="_04649dc2-c766-11e1-8775-005056c00008" name="35-36" r="0.39029799999999998" x="1.7772479999999999" g1="0" b1="7.6905500000000004e-06" g2="0" b2="7.6905500000000004e-06" node1="22" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="-3.3935312683802143" q1="5.4262386613393243" p2="3.3946066165744289" q2="-5.6570970585803817">
         <iidm:alias>_044c0cb5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0456e225-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10659,7 +10788,7 @@
             <iidm:temporaryLimit name="_74c4b341-7b99-4a81-b88a-2ed3b0c4b1de" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0470d2c9-c766-11e1-8775-005056c00008" name="37-40" r="10.3324327" x="29.272320000000001" g1="0" b1="0.0001205234" g2="0" b2="0.0001205234" node1="61" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="55.957634865813418" q1="10.362684217842791" p2="-53.799362424409239" q2="-7.8333418827674901">
+    <iidm:line id="_0470d2c9-c766-11e1-8775-005056c00008" name="37-40" r="10.3324327" x="29.272320000000001" g1="0" b1="0.0001205234" g2="0" b2="0.0001205234" node1="61" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="56.179157538829237" q1="10.273731338363307" p2="-54.003958383964203" q2="-7.6931518486046322">
         <iidm:alias>_045b9d10-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046a4317-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10667,7 +10796,7 @@
             <iidm:temporaryLimit name="_e98d56fe-a54b-45e4-acff-0ac310beb3dd" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044e56a2-c766-11e1-8775-005056c00008" name="48-49" r="3.1188959999999999" x="8.7991200000000003" g1="0" b1="3.6099649999999999e-05" g2="0" b2="3.6099649999999999e-05" node1="23" voltageLevelId1="_044778d3-c766-11e1-8775-005056c00008" node2="122" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-28.897238667563407" q1="1.3348139803741361" p2="29.041360155902662" q2="-2.2445130312477946">
+    <iidm:line id="_044e56a2-c766-11e1-8775-005056c00008" name="48-49" r="3.1188959999999999" x="8.7991200000000003" g1="0" b1="3.6099649999999999e-05" g2="0" b2="3.6099649999999999e-05" node1="23" voltageLevelId1="_044778d3-c766-11e1-8775-005056c00008" node2="122" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-28.864324637023149" q1="1.324371109123184" p2="29.008112179042723" q2="-2.2350134819570844">
         <iidm:alias>_0454bf49-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0460a623-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10675,7 +10804,7 @@
             <iidm:temporaryLimit name="_f2e58700-2366-46e0-8408-9472d85acd23" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047eb573-c766-11e1-8775-005056c00008" name="56-59" r="14.3748007" x="43.734237700000001" g1="0" b1="0.0001632805" g2="0" b2="0.0001632805" node1="62" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-19.199898820655459" q1="-7.7051351613939261" p2="19.557903570173412" q2="3.4455811504299092">
+    <iidm:line id="_047eb573-c766-11e1-8775-005056c00008" name="56-59" r="14.3748007" x="43.734237700000001" g1="0" b1="0.0001632805" g2="0" b2="0.0001632805" node1="62" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-19.185977561718776" q1="-7.7105390344843903" p2="19.5435481079471" q2="3.4496650707513363">
         <iidm:alias>_0468bc78-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048915b0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10683,7 +10812,7 @@
             <iidm:temporaryLimit name="_89654167-95a6-4c76-aad7-63a881116e17" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046f9a4b-c766-11e1-8775-005056c00008" name="94-100" r="3.1014719999999998" x="10.105919999999999" g1="0" b1="0.00017332415000000001" g2="0" b2="0.00017332415000000001" node1="52" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-6.0993558226676958" q1="-51.959080611680072" p2="6.5450840610457224" q2="47.345404622249433">
+    <iidm:line id="_046f9a4b-c766-11e1-8775-005056c00008" name="94-100" r="3.1014719999999998" x="10.105919999999999" g1="0" b1="0.00017332415000000001" g2="0" b2="0.00017332415000000001" node1="52" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-6.1173962840595033" q1="-52.233522754747028" p2="6.5682677016052491" q2="47.637621524622851">
         <iidm:alias>_04812676-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048a2722-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10691,7 +10820,7 @@
             <iidm:temporaryLimit name="_216c0f3b-03e8-4b7d-96fc-a5f891331f7f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046735d0-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="123" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-92.566894200537547" q1="-2.4504235348212626" p2="94.035153985074487" q2="7.2883476799120741">
+    <iidm:line id="_046735d0-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="123" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-92.464111321841088" q1="-2.4787209656408402" p2="93.929124003714733" q2="7.3000677204051252">
         <iidm:alias>_04570934-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b3894-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10699,7 +10828,7 @@
             <iidm:temporaryLimit name="_32655e4f-e7da-46b0-a908-b601224ddb73" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046d294b-c766-11e1-8775-005056c00008" name="21-22" r="3.641616" x="16.901281399999998" g1="0" b1="7.0592299999999998e-05" g2="0" b2="7.0592299999999998e-05" node1="22" voltageLevelId1="_0460f448-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04773b6a-c766-11e1-8775-005056c00008" p1="-48.721819254568693" q1="-5.0162083267053887" p2="49.282448219512446" q2="5.3894473558318854">
+    <iidm:line id="_046d294b-c766-11e1-8775-005056c00008" name="21-22" r="3.641616" x="16.901281399999998" g1="0" b1="7.0592299999999998e-05" g2="0" b2="7.0592299999999998e-05" node1="22" voltageLevelId1="_0460f448-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04773b6a-c766-11e1-8775-005056c00008" p1="-46.546914745007506" q1="-5.9419548235978477" p2="47.05972604592116" q2="6.0877710131589753">
         <iidm:alias>_044a37f0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_044be5a2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10707,7 +10836,7 @@
             <iidm:temporaryLimit name="_bafaeace-e459-4dc2-87a0-467a9ea25f8d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_6a131803-f462-47e2-bc21-bda919364fe9" name="reactor1" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="36" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="37" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="1.1102230246251565e-14" q1="-83.151383925074384" p2="-1.2490009027033011e-14" q2="92.151023305212902">
+    <iidm:line id="_6a131803-f462-47e2-bc21-bda919364fe9" name="reactor1" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="36" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="37" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="-3.8857805861880479e-14" q1="-83.151388670929833" p2="4.163336342344337e-14" q2="92.151028564721713">
         <iidm:alias>_04531196-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_ca0adad2-ffe3-4efa-b56b-7d333b8ae18f</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10715,7 +10844,7 @@
             <iidm:temporaryLimit name="_ae4eadea-f3fc-4ac6-8899-c1698ece7a89" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_9803b364-2a93-4f21-94b7-8bdbe27a16f2" name="reactor2" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="38" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="3.6797755814665933e-08" q1="27.475286511171888" p2="-3.6797755467721238e-08" q2="-26.590026273577639">
+    <iidm:line id="_9803b364-2a93-4f21-94b7-8bdbe27a16f2" name="reactor2" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="38" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="4.4026933834762083e-08" q1="27.474581854905793" p2="-4.4026934181706778e-08" q2="-26.589367075730259">
         <iidm:alias>_0461b792-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_afe0e60b-3870-44fb-ba93-a056228f9636</iidm:alias>
     </iidm:line>

--- a/tests/main_sa/reference/launch/line_contingency_open_ended/outputIIDM.xml
+++ b/tests/main_sa/reference/launch/line_contingency_open_ended/outputIIDM.xml
@@ -31,7 +31,7 @@
                     <iidm:alias>_bea273f1-1e21-476d-b0d0-92dd6cb9a2d4</iidm:alias>
                     <iidm:alias>_c94e6b68-da6c-43d1-94fd-09ad60c74134</iidm:alias>
                 </iidm:switch>
-                <iidm:switch id="_047abdd7-c766-11e1-8775-005056c00008-BREAKER" name="BREAKER-Jay LD" kind="BREAKER" retained="true" open="true" node1="0" node2="8"/>
+                <iidm:switch id="_047abdd7-c766-11e1-8775-005056c00008-BREAKER" name="BREAKER-Jay LD" kind="BREAKER" retained="true" open="false" node1="0" node2="8"/>
                 <iidm:internalConnection node1="7" node2="0"/>
                 <iidm:internalConnection node1="9" node2="1"/>
                 <iidm:internalConnection node1="10" node2="2"/>
@@ -47,9 +47,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.00460477378802" angle="-2.8865023170678468" nodes="0,1,2,3,4,5,6,7,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.78104672538009" angle="-3.8299336945643434" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047abdd7-c766-11e1-8775-005056c00008" name="Jay LD" loadType="UNDEFINED" p0="14" q0="8" node="8" p="0" q="0">
+            <iidm:load id="_047abdd7-c766-11e1-8775-005056c00008" name="Jay LD" loadType="UNDEFINED" p0="14" q0="8" node="8" p="13.99836067627615" q="7.9984388002497839">
                 <iidm:alias>_04590500-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -139,12 +139,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="128.00466666497914" angle="-0.58466591852371985" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="127.82219409399505" angle="-0.59777355657981812" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045b00d5-c766-11e1-8775-005056c00008" name="Madison LD" loadType="UNDEFINED" p0="62" q0="13" node="14" p="62.017064759771444" q="13.005964038427845">
+            <iidm:load id="_045b00d5-c766-11e1-8775-005056c00008" name="Madison LD" loadType="UNDEFINED" p0="62" q0="13" node="14" p="61.982834139296081" q="12.994001731356782">
                 <iidm:alias>_045b27e3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_04689566-c766-11e1-8775-005056c00008" name="Madison NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="15" p="9.0024771425474679" q="0">
+            <iidm:load id="_04689566-c766-11e1-8775-005056c00008" name="Madison NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="15" p="8.997508181510721" q="0">
                 <iidm:alias>_04765100-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -272,16 +272,16 @@
                 <iidm:internalConnection node1="61" node2="12"/>
                 <iidm:internalConnection node1="62" node2="15"/>
                 <iidm:internalConnection node1="63" node2="18"/>
-                <iidm:bus v="126.06004191903422" angle="-19.453196159616766" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63"/>
+                <iidm:bus v="126.06000146678275" angle="-18.732748438145521" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_046c3ee7-c766-11e1-8775-005056c00008" name="Torrey SM" energySource="THERMAL" minP="20" maxP="80" ratedS="100" voltageRegulatorOn="true" targetP="48" targetV="126.06" targetQ="0" node="21" p="-52.972604726432827" q="-7.3968276989235786">
+            <iidm:generator id="_046c3ee7-c766-11e1-8775-005056c00008" name="Torrey SM" energySource="THERMAL" minP="20" maxP="80" ratedS="100" voltageRegulatorOn="true" targetP="48" targetV="126.06" targetQ="0" node="21" p="-53.142265016692548" q="-7.2795939181334717">
                 <iidm:alias>_047147f3-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_b97aee41-3115-4cfd-9071-b52fb44d0b66"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_5005c073-28d1-4a7d-b257-649dec43ec73"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-30" maxQ="85"/>
             </iidm:generator>
-            <iidm:load id="_044afb44-c766-11e1-8775-005056c00008" name="Torrey LD" loadType="UNDEFINED" p0="113" q0="32" node="20" p="113.0000563642463" q="32.000026602598552">
+            <iidm:load id="_044afb44-c766-11e1-8775-005056c00008" name="Torrey LD" loadType="UNDEFINED" p0="113" q0="32" node="20" p="113.00000197223284" q="32.000000930847371">
                 <iidm:alias>_04522737-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -332,9 +332,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="123.87514365157477" angle="-3.7246511201894776" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="123.82676803045038" angle="-3.0065026728171786" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04481515-c766-11e1-8775-005056c00008" name="Darrah LD" loadType="UNDEFINED" p0="68" q0="36" node="8" p="68.010591029794995" q="36.009345511445289">
+            <iidm:load id="_04481515-c766-11e1-8775-005056c00008" name="Darrah LD" loadType="UNDEFINED" p0="68" q0="36" node="8" p="67.999757598538139" q="35.999786116611318">
                 <iidm:alias>_044e7db8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -385,9 +385,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.46784025344323" angle="10.508519079584536" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.45864793064632" angle="11.426440566241217" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044c0cb3-c766-11e1-8775-005056c00008" name="Smythe LD" loadType="UNDEFINED" p0="5" q0="3" node="8" p="5.0001148338470278" q="3.0001148347261459">
+            <iidm:load id="_044c0cb3-c766-11e1-8775-005056c00008" name="Smythe LD" loadType="UNDEFINED" p0="5" q0="3" node="8" p="4.999972885076108" q="2.9999728851251217">
                 <iidm:alias>_045163e8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -514,9 +514,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="125.90792597604587" angle="-19.625773035683189" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="125.90818443962903" angle="-18.905168856531152" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0450a093-c766-11e1-8775-005056c00008" name="Sunnysde LD" loadType="UNDEFINED" p0="84" q0="18" node="20" p="83.999963706621131" q="17.999987038080839">
+            <iidm:load id="_0450a093-c766-11e1-8775-005056c00008" name="Sunnysde LD" loadType="UNDEFINED" p0="84" q0="18" node="20" p="84.000002125496991" q="18.000000759106076">
                 <iidm:alias>_045f4695-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -568,12 +568,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="126.80626361901399" angle="-3.8161785274804121" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="126.73352853949984" angle="-3.1650307890432448" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044b2251-c766-11e1-8775-005056c00008" name="Bellefnt LD" loadType="UNDEFINED" p0="68" q0="27" node="8" p="68.015353144195984" q="27.010160933593554">
+            <iidm:load id="_044b2251-c766-11e1-8775-005056c00008" name="Bellefnt LD" loadType="UNDEFINED" p0="68" q0="27" node="8" p="67.999772590844671" q="26.999849508814961">
                 <iidm:alias>_04622cc1-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0449e9d5-c766-11e1-8775-005056c00008" name="Bellefnt SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.40300000000001" targetDeadband="1" node="9" q="-11.079001831687245">
+            <iidm:shunt id="_0449e9d5-c766-11e1-8775-005056c00008" name="Bellefnt SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.40300000000001" targetDeadband="1" node="9" q="-11.06629581943376">
                 <iidm:alias>_047bcf48-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_6cc38790-c6a6-4309-99f4-a3258e24e785"/>
                 <iidm:shuntLinearModel bPerSection="0.00013779999999999999" gPerSection="0" maximumSectionCount="10"/>
@@ -665,12 +665,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="126.06561768013582" angle="-3.8254249805384455" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="126.06590994870818" angle="-2.9195031865320051" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04682035-c766-11e1-8775-005056c00008" name="Fieldale LD" loadType="UNDEFINED" p0="39" q0="30" node="14" p="38.999989128154127" q="29.999986061737349">
+            <iidm:load id="_04682035-c766-11e1-8775-005056c00008" name="Fieldale LD" loadType="UNDEFINED" p0="39" q0="30" node="14" p="39.000005351384907" q="30.00000686075019">
                 <iidm:alias>_0478c20a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_045c6067-c766-11e1-8775-005056c00008" name="Fieldale SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.066" targetDeadband="1" node="15" q="-5.4670337466095154">
+            <iidm:shunt id="_045c6067-c766-11e1-8775-005056c00008" name="Fieldale SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.066" targetDeadband="1" node="15" q="-5.4670590960113552">
                 <iidm:alias>_0451b209-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_2d222dd9-7306-4afd-baa5-fd303b0eeb40"/>
                 <iidm:shuntLinearModel bPerSection="6.8800000000000005e-05" gPerSection="0" maximumSectionCount="10"/>
@@ -780,7 +780,7 @@
                 <iidm:internalConnection node1="51" node2="9"/>
                 <iidm:internalConnection node1="52" node2="12"/>
                 <iidm:internalConnection node1="53" node2="15"/>
-                <iidm:bus v="138.01517582243704" angle="-7.6471172903115052" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
+                <iidm:bus v="138.01483372148616" angle="-6.939942911359597" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="_047f0391-c766-11e1-8775-005056c00008" name="Muskngum SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="392" targetV="138.59999099999999" targetQ="0" node="18" p="-0" q="-0">
                 <iidm:alias>_047eb572-c766-11e1-8775-005056c00008</iidm:alias>
@@ -789,7 +789,7 @@
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
-            <iidm:load id="_047e1936-c766-11e1-8775-005056c00008" name="Muskngum LD" loadType="UNDEFINED" p0="39" q0="18" node="17" p="38.999801030837027" q="17.999846947057993">
+            <iidm:load id="_047e1936-c766-11e1-8775-005056c00008" name="Muskngum LD" loadType="UNDEFINED" p0="39" q0="18" node="17" p="38.999750136491521" q="17.999807797711632">
                 <iidm:alias>_046e88d5-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -876,9 +876,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="221.10006999226573" angle="-2.4917620988581559" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="221.10000290370317" angle="-1.7801824436703595" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0458ddf1-c766-11e1-8775-005056c00008" name="Muskngum SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="391" targetV="221.09999999999999" targetQ="0" node="14" p="-431.50600933406747" q="-158.32202649372789">
+            <iidm:generator id="_0458ddf1-c766-11e1-8775-005056c00008" name="Muskngum SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="391" targetV="221.09999999999999" targetQ="0" node="14" p="-432.88803378180808" q="-159.63004624944404">
                 <iidm:alias>_04522732-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_5036c3a5-56f9-489c-9ecb-8c15aa7c70c5"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_12b01822-ca11-4cf8-a6b4-2f8ff805ca20"/>
@@ -886,7 +886,7 @@
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045cae83-c766-11e1-8775-005056c00008" name="65-66" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="42" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="272.93269781532786" q1="97.396749748301261" p2="-272.93269781532786" q2="-70.502461043569156">
+        <iidm:twoWindingsTransformer id="_045cae83-c766-11e1-8775-005056c00008" name="65-66" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="42" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="273.1645296159914" q1="97.424264935718639" p2="-273.1645296159914" q2="-70.487698324792291">
             <iidm:alias>_044b2254-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_044b4964-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_045645e1-c766-11e1-8775-005056c00008</iidm:alias>
@@ -961,9 +961,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="125.57774163466446" angle="-4.9293514568909407" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.1179316562984" angle="-5.537417497811429" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0453d4e2-c766-11e1-8775-005056c00008" name="Adams LD" loadType="UNDEFINED" p0="18" q0="3" node="8" p="18.077647772669192" q="3.0215998251803287">
+            <iidm:load id="_0453d4e2-c766-11e1-8775-005056c00008" name="Adams LD" loadType="UNDEFINED" p0="18" q0="3" node="8" p="17.997764330894466" q="2.9993790065153632">
                 <iidm:alias>_0448ff77-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1053,16 +1053,16 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="133.32005735690669" angle="1.9236922683418012" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="133.31999604167339" angle="2.8222234050327226" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_046bf0c4-c766-11e1-8775-005056c00008" name="Claytor SM" energySource="THERMAL" minP="0" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="40" targetV="133.31999200000001" targetQ="0" node="15" p="-44.143837272027362" q="-83.146696831248192">
+            <iidm:generator id="_046bf0c4-c766-11e1-8775-005056c00008" name="Claytor SM" energySource="THERMAL" minP="0" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="40" targetV="133.31999200000001" targetQ="0" node="15" p="-44.285220847243792" q="-83.074163594263624">
                 <iidm:alias>_0460a627-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e56da2eb-bb6a-4133-953c-40073c5bc5f4"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_d41be6b4-155e-4c8f-b46b-16b50c49f0f4"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-60" maxQ="170"/>
             </iidm:generator>
-            <iidm:load id="_048433b6-c766-11e1-8775-005056c00008" name="Claytor LD" loadType="UNDEFINED" p0="23" q0="16" node="14" p="23.000016912793971" q="16.000019609041296">
+            <iidm:load id="_048433b6-c766-11e1-8775-005056c00008" name="Claytor LD" loadType="UNDEFINED" p0="23" q0="16" node="14" p="23.000001045887654" q="16.000001212623381">
                 <iidm:alias>_0480ff6b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1133,12 +1133,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="129.7592447702105" angle="-16.201640914301979" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="129.73379129486366" angle="-15.554453843392528" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0449e9d7-c766-11e1-8775-005056c00008" name="N.Newark LD" loadType="UNDEFINED" p0="53" q0="22" node="11" p="53.001942485322175" q="22.001343874187747">
+            <iidm:load id="_0449e9d7-c766-11e1-8775-005056c00008" name="N.Newark LD" loadType="UNDEFINED" p0="53" q0="22" node="11" p="52.997695675968416" q="21.998405836667075">
                 <iidm:alias>_04531191-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_04684741-c766-11e1-8775-005056c00008" name="N.Newark SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.32300000000001" targetDeadband="1" node="12" q="-9.6647029603145178">
+            <iidm:shunt id="_04684741-c766-11e1-8775-005056c00008" name="N.Newark SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.32300000000001" targetDeadband="1" node="12" q="-9.6609116905463246">
                 <iidm:alias>_04607f19-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_eae61817-d3cb-488f-a1f3-13bc8e31431b"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -1191,9 +1191,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="131.20488698654398" angle="-0.6741940524460146" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="131.02873493567927" angle="-0.36067770733500215" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0448d86a-c766-11e1-8775-005056c00008" name="Hillsbro NegG LD" loadType="UNDEFINED" p0="12" q0="0" node="8" p="12.005756503069735" q="0">
+            <iidm:load id="_0448d86a-c766-11e1-8775-005056c00008" name="Hillsbro NegG LD" loadType="UNDEFINED" p0="12" q0="0" node="8" p="11.999574604893764" q="0">
                 <iidm:alias>_044ef2e8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1244,9 +1244,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="125.33681302748006" angle="-17.611548320015409" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="125.27336693821913" angle="-17.132018340253222" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047dcb12-c766-11e1-8775-005056c00008" name="S.Kenton LD" loadType="UNDEFINED" p0="18" q0="7" node="8" p="18.000177541131524" q="7.000115073333955">
+            <iidm:load id="_047dcb12-c766-11e1-8775-005056c00008" name="S.Kenton LD" loadType="UNDEFINED" p0="18" q0="7" node="8" p="17.996419808620722" q="6.9976796594393154">
                 <iidm:alias>_0451b205-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1300,9 +1300,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="124.19456593530134" angle="9.1251049783605787" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25"/>
+                <iidm:bus v="124.17891625511598" angle="10.02935586203278" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044afb49-c766-11e1-8775-005056c00008" name="Hazard LD" loadType="UNDEFINED" p0="21" q0="10" node="8" p="20.998987672139442" q="9.9991965781002534">
+            <iidm:load id="_044afb49-c766-11e1-8775-005056c00008" name="Hazard LD" loadType="UNDEFINED" p0="21" q0="10" node="8" p="20.997900509880154" q="9.9983337935293175">
                 <iidm:alias>_045e5c31-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1335,14 +1335,14 @@
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="3"/>
-                <iidm:bus v="31.048641483825328" angle="9.1251049783605804" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13"/>
+                <iidm:bus v="31.044729063778995" angle="10.029355862032778" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13"/>
             </iidm:nodeBreakerTopology>
             <iidm:staticVarCompensator id="_047fc6e6-c766-11e1-8775-005056c00008" name="Pinevlle SVC" bMin="-10" bMax="10" voltageSetpoint="33.494999999999997" regulationMode="VOLTAGE" node="5" p="0" q="0">
                 <iidm:alias>_046ab846-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_98f667da-02d1-4a31-b826-44314a1fbbfe"/>
             </iidm:staticVarCompensator>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045e3525-c766-11e1-8775-005056c00008" name="86-87" r="0.30796918750000002" x="2.2585859312499998" g="0" b="-0.0040863184000000004" ratedU1="132" ratedU2="33" node1="22" voltageLevelId1="_0484f70a-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_04555b88-c766-11e1-8775-005056c00008" p1="-2.0383000842727483e-14" q1="3.9392850552069043" p2="7.6617565888779289e-15" q2="-4.770010142681741e-14">
+        <iidm:twoWindingsTransformer id="_045e3525-c766-11e1-8775-005056c00008" name="86-87" r="0.30796918750000002" x="2.2585859312499998" g="0" b="-0.0040863184000000004" ratedU1="132" ratedU2="33" node1="22" voltageLevelId1="_0484f70a-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_04555b88-c766-11e1-8775-005056c00008" p1="0" q1="3.938292344025645" p2="-1.7159141005507274e-14" q2="-2.2921868321401175e-14">
             <iidm:alias>_0452755a-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04682034-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_048c7110-c766-11e1-8775-005056c00008</iidm:alias>
@@ -1418,7 +1418,7 @@
                 <iidm:temporaryLimit name="_257d56c1-d70a-4a96-b85c-d928ade03ad4" acceptableDuration="60" value="12246"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_045e3525-c766-11e1-8775-005056c00008-1" name="86-87-open-ended" r="0.30796918750000002" x="2.2585859312499998" g="0" b="-0.0040863184000000004" ratedU1="132" ratedU2="33" node1="25" voltageLevelId1="_0484f70a-c766-11e1-8775-005056c00008" node2="15" voltageLevelId2="_04555b88-c766-11e1-8775-005056c00008" p1="0" q1="3.939285055206851" p2="0" q2="0">
+        <iidm:twoWindingsTransformer id="_045e3525-c766-11e1-8775-005056c00008-1" name="86-87-open-ended" r="0.30796918750000002" x="2.2585859312499998" g="0" b="-0.0040863184000000004" ratedU1="132" ratedU2="33" node1="25" voltageLevelId1="_0484f70a-c766-11e1-8775-005056c00008" node2="15" voltageLevelId2="_04555b88-c766-11e1-8775-005056c00008" p1="8.6736173798840355e-17" q1="3.9382923440256339" p2="0" q2="0">
             <iidm:alias>_0452755a-c766-11e1-8775-005056c00008-1</iidm:alias>
             <iidm:alias>_04682034-c766-11e1-8775-005056c00008-1</iidm:alias>
             <iidm:alias>_048c7110-c766-11e1-8775-005056c00008-1</iidm:alias>
@@ -1542,12 +1542,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="132.89895200873292" angle="0.10841572358231059" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="132.85732697378614" angle="0.1375078662609665" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0447ee05-c766-11e1-8775-005056c00008" name="NwCarlsl NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="8" p="9.0009599009513295" q="0">
+            <iidm:load id="_0447ee05-c766-11e1-8775-005056c00008" name="NwCarlsl NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="8" p="8.999849382309856" q="0">
                 <iidm:alias>_04731cb7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_047a48a8-c766-11e1-8775-005056c00008" name="NwCarlsl LD" loadType="UNDEFINED" p0="30" q0="12" node="9" p="30.00319966983777" q="12.002133189060483">
+            <iidm:load id="_047a48a8-c766-11e1-8775-005056c00008" name="NwCarlsl LD" loadType="UNDEFINED" p0="30" q0="12" node="9" p="29.999497941032853" q="11.999665295889042">
                 <iidm:alias>_044c0cb9-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1598,9 +1598,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.62149483698715" angle="-2.8019211753095714" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.62189246229599" angle="-1.9006090110643905" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044ecbd1-c766-11e1-8775-005056c00008" name="Blaine LD" loadType="UNDEFINED" p0="2" q0="1" node="8" p="1.9999989627506074" q="0.99999913562565557">
+            <iidm:load id="_044ecbd1-c766-11e1-8775-005056c00008" name="Blaine LD" loadType="UNDEFINED" p0="2" q0="1" node="8" p="2.0000004609325317" q="1.0000003841104728">
                 <iidm:alias>_04700f74-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1651,9 +1651,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="133.16949499792705" angle="3.2941239740545489" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="133.16027299695691" angle="4.1169178178179564" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046b7b95-c766-11e1-8775-005056c00008" name="Sundial LD" loadType="UNDEFINED" p0="15" q0="9" node="8" p="15.000311357708068" q="9.0003113598623656">
+            <iidm:load id="_046b7b95-c766-11e1-8775-005056c00008" name="Sundial LD" loadType="UNDEFINED" p0="15" q0="9" node="8" p="14.999888963729841" q="8.9998889640038193">
                 <iidm:alias>_046efe07-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1704,9 +1704,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.7639827190831" angle="-4.5216785942785247" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.74785010355859" angle="-4.5028318053737317" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045645e2-c766-11e1-8775-005056c00008" name="Riversde LD" loadType="UNDEFINED" p0="51" q0="27" node="8" p="51.002204568424567" q="27.001945235461694">
+            <iidm:load id="_045645e2-c766-11e1-8775-005056c00008" name="Riversde LD" loadType="UNDEFINED" p0="51" q0="27" node="8" p="50.999602052898481" q="26.99964887111782">
                 <iidm:alias>_0476ed4b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1757,9 +1757,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.54523580849983" angle="-0.57889245491198116" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.95300927579751" angle="-1.144413910641342" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04887973-c766-11e1-8775-005056c00008" name="Randolph LD" loadType="UNDEFINED" p0="10" q0="5" node="8" p="10.046189321006166" q="5.0385503330645145">
+            <iidm:load id="_04887973-c766-11e1-8775-005056c00008" name="Randolph LD" loadType="UNDEFINED" p0="10" q0="5" node="8" p="9.9989870015706508" q="4.999155863147136">
                 <iidm:alias>_0462f018-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1810,9 +1810,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.48264994279926" angle="-18.818579210606423" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.48448790498743" angle="-18.104981900513174" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0477627b-c766-11e1-8775-005056c00008" name="WNwPhil2 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="11.999926804255503" q="2.9999695018351358">
+            <iidm:load id="_0477627b-c766-11e1-8775-005056c00008" name="WNwPhil2 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="11.99999171081762" q="2.9999965461748035">
                 <iidm:alias>_045841b6-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1882,9 +1882,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="126.73013547423734" angle="-2.0673831748110851" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="126.73055377468442" angle="-1.1702154270321716" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0476781a-c766-11e1-8775-005056c00008" name="Cloverdl LD" loadType="UNDEFINED" p0="43" q0="16" node="11" p="42.999975806089793" q="15.999984996027495">
+            <iidm:load id="_0476781a-c766-11e1-8775-005056c00008" name="Cloverdl LD" loadType="UNDEFINED" p0="43" q0="16" node="11" p="43.000011219680246" q="16.000006957941842">
                 <iidm:alias>_0481749a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1954,9 +1954,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="128.11668253625842" angle="-0.69842948401275695" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="128.11689468097799" angle="0.19903976962112208" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046b0665-c766-11e1-8775-005056c00008" name="Hancock LD" loadType="UNDEFINED" p0="38" q0="25" node="11" p="37.999999800166151" q="24.999999780883936">
+            <iidm:load id="_046b0665-c766-11e1-8775-005056c00008" name="Hancock LD" loadType="UNDEFINED" p0="38" q0="25" node="11" p="38.000006158404034" q="25.000006752636359">
                 <iidm:alias>_0464c4d5-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2008,12 +2008,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="128.68602305991223" angle="-17.260662291872272" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="128.64792668001738" angle="-16.657537274227082" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044bbe92-c766-11e1-8775-005056c00008" name="WMVernon LD" loadType="UNDEFINED" p0="16" q0="8" node="8" p="16.000545367076924" q="8.0004544777277182">
+            <iidm:load id="_044bbe92-c766-11e1-8775-005056c00008" name="WMVernon LD" loadType="UNDEFINED" p0="16" q0="8" node="8" p="15.998600230905227" q="7.9988335597712403">
                 <iidm:alias>_04500452-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_047825c8-c766-11e1-8775-005056c00008" name="WMVernon SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.21199999999999" targetDeadband="1" node="9" q="-9.5054931127803748">
+            <iidm:shunt id="_047825c8-c766-11e1-8775-005056c00008" name="WMVernon SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.21199999999999" targetDeadband="1" node="9" q="-9.4998659084245336">
                 <iidm:alias>_047084aa-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_2a6c1dcd-201b-4911-83b2-c16acc50a0f4"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -2047,9 +2047,9 @@
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="3"/>
-                <iidm:bus v="230.99998646418615" angle="22.331569732169982" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="230.99998523197351" angle="22.43727741858066" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_045868c0-c766-11e1-8775-005056c00008" name="Breed SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="450" targetV="230.99998500000001" targetQ="0" node="5" p="-496.61816931030779" q="28.502009987292219">
+            <iidm:generator id="_045868c0-c766-11e1-8775-005056c00008" name="Breed SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="450" targetV="230.99998500000001" targetQ="0" node="5" p="-498.20873453149278" q="27.20180519913696">
                 <iidm:alias>_045b7606-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_f26d4eb3-ebdb-4025-8080-f856ce656b42"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_7566f2a7-61eb-42fe-a59a-8276257fdbc6"/>
@@ -2123,9 +2123,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="127.47047443094633" angle="-17.707724300545351" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="127.47310081701781" angle="-16.999303779907368" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044d1e22-c766-11e1-8775-005056c00008" name="Newcmrst LD" loadType="UNDEFINED" p0="17" q0="8" node="11" p="16.999848854412246" q="7.9998814547923045">
+            <iidm:load id="_044d1e22-c766-11e1-8775-005056c00008" name="Newcmrst LD" loadType="UNDEFINED" p0="17" q0="8" node="11" p="16.999981771982007" q="7.9999857035204087">
                 <iidm:alias>_048a754b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2195,9 +2195,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="138.59999143103315" angle="12.475248772064775" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="138.5999910167661" angle="12.498600329131007" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_045ab2b0-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="220" targetV="138.59999099999999" targetQ="0" node="11" p="-242.79110499615052" q="-41.74084076940126">
+            <iidm:generator id="_045ab2b0-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="220" targetV="138.59999099999999" targetQ="0" node="11" p="-243.56871465984091" q="-46.332946452801153">
                 <iidm:alias>_046ba2a5-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_56975783-9739-40fc-8ec1-e1de8cb06c9a"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b8449cd9-5a17-497e-bf04-70f728b0f9f2"/>
@@ -2250,9 +2250,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="223.300000793457" angle="14.610780978989476" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="223.30000004845704" angle="14.649905832014579" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0483224a-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="314" targetV="223.30000000000001" targetQ="0" node="8" p="-346.52912258541477" q="-17.240885598751788">
+            <iidm:generator id="_0483224a-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="314" targetV="223.30000000000001" targetQ="0" node="8" p="-347.63898365086379" q="-18.550862392363413">
                 <iidm:alias>_045cd594-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_05df66ba-3f64-40cb-8b18-c66d26c4e2c1"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_c1d29442-5f57-41d1-bb60-4b74b4994c20"/>
@@ -2260,7 +2260,7 @@
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045b7604-c766-11e1-8775-005056c00008" name="26-25" r="0" x="6.6559680000000006" g="0" b="0" ratedU1="220" ratedU2="132" node1="22" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="108.29381751186271" q1="22.200376049018583" p2="-108.29381751186271" q2="-18.024386383599126">
+        <iidm:twoWindingsTransformer id="_045b7604-c766-11e1-8775-005056c00008" name="26-25" r="0" x="6.6559680000000006" g="0" b="0" ratedU1="220" ratedU2="132" node1="22" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="109.09331334950856" q1="22.230297790315557" p2="-109.09331334950852" q2="-17.994462368739416">
             <iidm:alias>_0447c6f3-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0463b364-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04803c1c-c766-11e1-8775-005056c00008</iidm:alias>
@@ -2403,9 +2403,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="136.6200429399974" angle="2.7951505216534032" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="136.62000214665679" angle="3.5172191362652727" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_048aea70-c766-11e1-8775-005056c00008" name="Sporn SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="513.43743900000004" targetV="136.62" targetQ="-62.132553100000003" node="20" p="-566.62746891456186" q="51.627636282073432">
+            <iidm:generator id="_048aea70-c766-11e1-8775-005056c00008" name="Sporn SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="513.43743900000004" targetV="136.62" targetQ="-62.132553100000003" node="20" p="-568.44225943395679" q="50.65520373164528">
                 <iidm:alias>_04555b84-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_27799004-aa1e-4889-ba95-ee6fdae64895"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_827a9c80-183d-4e33-9e73-ef0aab3dfb13"/>
@@ -2495,9 +2495,9 @@
                 <iidm:internalConnection node1="39" node2="9"/>
                 <iidm:internalConnection node1="40" node2="12"/>
                 <iidm:internalConnection node1="41" node2="3"/>
-                <iidm:bus v="219.70986543410694" angle="-0.98397715551021436" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41"/>
+                <iidm:bus v="219.70739326864444" angle="-0.25497041659606162" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41"/>
             </iidm:nodeBreakerTopology>
-            <iidm:danglingLine id="_0482fb33-c766-11e1-8775-005056c00008" name="68-116" p0="184" q0="0" r="0.16456000000000001" x="1.9601999999999999" g="0" b="0.00033884300000000002" ucteXnodeCode="XWE_BR21" node="41" p="184.11568647210419" q="-14.980175199335873">
+            <iidm:danglingLine id="_0482fb33-c766-11e1-8775-005056c00008" name="68-116" p0="184" q0="0" r="0.16456000000000001" x="1.9601999999999999" g="0" b="0.00033884300000000002" ucteXnodeCode="XWE_BR21" node="41" p="184.11557424977286" q="-14.979777894780163">
                 <iidm:alias>_0459c855-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_04684742-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_5631ccc0-d9d2-11e2-bb49-005056c00008</iidm:alias>
@@ -2510,7 +2510,7 @@
                 </iidm:currentLimits>
             </iidm:danglingLine>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_044f6815-c766-11e1-8775-005056c00008" name="68-69" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-196.92824771186682" q1="102.0721144952773" p2="196.92824771186682" q2="-86.115841772640607">
+        <iidm:twoWindingsTransformer id="_044f6815-c766-11e1-8775-005056c00008" name="68-69" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-196.56495844731901" q1="102.01333784287097" p2="196.56495844731899" q2="-86.106959386536602">
             <iidm:alias>_047e8e67-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04840ca7-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0487dd39-c766-11e1-8775-005056c00008</iidm:alias>
@@ -2617,9 +2617,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="131.60566408168276" angle="-9.0003936578583517" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="131.60565206383643" angle="-8.2766692635676922" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04547126-c766-11e1-8775-005056c00008" name="Natrium LD" loadType="UNDEFINED" p0="77" q0="14" node="14" p="76.999937419677025" q="13.999981036270903">
+            <iidm:load id="_04547126-c766-11e1-8775-005056c00008" name="Natrium LD" loadType="UNDEFINED" p0="77" q0="14" node="14" p="76.999907511674579" q="13.999971973245945">
                 <iidm:alias>_047b3307-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2670,9 +2670,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="123.83408022094392" angle="-16.528989866483592" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="123.75264682496636" angle="-16.131741894523792" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045d4ac9-c766-11e1-8775-005056c00008" name="Sterling LD" loadType="UNDEFINED" p0="31" q0="17" node="8" p="31.000094218841845" q="17.000086114082478">
+            <iidm:load id="_045d4ac9-c766-11e1-8775-005056c00008" name="Sterling LD" loadType="UNDEFINED" p0="31" q0="17" node="8" p="30.991711208634147" q="16.992424898169936">
                 <iidm:alias>_0477b094-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2780,9 +2780,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="130.28629568274323" angle="5.7801498864101548" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="130.27255586226093" angle="6.6611101280957739" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0466246a-c766-11e1-8775-005056c00008" name="Switchbk LD" loadType="UNDEFINED" p0="30" q0="16" node="17" p="30.000975288885574" q="16.000866932848261">
+            <iidm:load id="_0466246a-c766-11e1-8775-005056c00008" name="Switchbk LD" loadType="UNDEFINED" p0="30" q0="16" node="17" p="29.999699907444814" q="15.999733251951497">
                 <iidm:alias>_04882b59-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2833,9 +2833,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="135.0884829880909" angle="3.0939646589830416" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="135.0866343068418" angle="3.927511122833208" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046adf5a-c766-11e1-8775-005056c00008" name="Bradley LD" loadType="UNDEFINED" p0="34" q0="8" node="8" p="34.000181309510616" q="8.0000711018952533">
+            <iidm:load id="_046adf5a-c766-11e1-8775-005056c00008" name="Bradley LD" loadType="UNDEFINED" p0="34" q0="8" node="8" p="33.999984084518204" q="7.9999937586355641">
                 <iidm:alias>_04555b85-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2871,7 +2871,7 @@
                     <iidm:alias>_a4edf081-2fb2-4da4-94db-98a2a596247f</iidm:alias>
                 </iidm:switch>
                 <iidm:switch id="_312f25f3-55bc-4417-848c-236d31d823f4-1" name="DISCONNECTOR524-1" kind="DISCONNECTOR" retained="false" open="false" node1="24" node2="25"/>
-                <iidm:switch id="_686e884a-a0b1-454e-b7d1-33c7ad46f89f-1" name="BREAKER262-1" kind="BREAKER" retained="false" open="false" node1="23" node2="24"/>
+                <iidm:switch id="_686e884a-a0b1-454e-b7d1-33c7ad46f89f-1" name="BREAKER262-1" kind="BREAKER" retained="false" open="true" node1="23" node2="24"/>
                 <iidm:switch id="_346a5319-3ec2-40a2-aefd-38dfacbbe97c-1" name="DISCONNECTOR523-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="23"/>
                 <iidm:internalConnection node1="7" node2="0"/>
                 <iidm:internalConnection node1="8" node2="0"/>
@@ -2889,9 +2889,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.22155443479527" angle="-2.2945094818701235" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25"/>
+                <iidm:bus v="126.95589300873901" angle="-2.3054815617371887" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047a48a2-c766-11e1-8775-005056c00008" name="Mullin LD" loadType="UNDEFINED" p0="17" q0="7" node="8" p="17.002887338519567" q="7.0019816190070179">
+            <iidm:load id="_047a48a2-c766-11e1-8775-005056c00008" name="Mullin LD" loadType="UNDEFINED" p0="17" q0="7" node="8" p="16.989335540971318" q="6.9926827841158543">
                 <iidm:alias>_0474553a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3057,16 +3057,16 @@
                 <iidm:internalConnection node1="81" node2="18"/>
                 <iidm:internalConnection node1="82" node2="21"/>
                 <iidm:internalConnection node1="83" node2="24"/>
-                <iidm:bus v="134.24405275832822" angle="5.4709418522786244" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
+                <iidm:bus v="134.24399197530664" angle="6.3630856777938964" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_044cd00a-c766-11e1-8775-005056c00008" name="Glen Lyn SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="252" targetV="134.243988" targetQ="0" node="27" p="-278.10617481377233" q="-84.220548557188451">
+            <iidm:generator id="_044cd00a-c766-11e1-8775-005056c00008" name="Glen Lyn SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="252" targetV="134.243988" targetQ="0" node="27" p="-278.99689133763593" q="-84.32253484396017">
                 <iidm:alias>_045e5c30-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e54b499b-436c-4b89-9803-b1d75e2fa364"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_32c8ab65-80f7-4c17-b3f5-ff075cce0ba5"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
-            <iidm:load id="_04566cf5-c766-11e1-8775-005056c00008" name="Glen Lyn LD" loadType="UNDEFINED" p0="37" q0="18" node="26" p="37.000026772801547" q="18.000021707682162">
+            <iidm:load id="_04566cf5-c766-11e1-8775-005056c00008" name="Glen Lyn LD" loadType="UNDEFINED" p0="37" q0="18" node="26" p="37.000001643496461" q="18.000001332564718">
                 <iidm:alias>_04577e64-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3117,9 +3117,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.65833703178512" angle="-2.1149669950380527" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.63585035678935" angle="-2.0935344894240719" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044ea4c0-c766-11e1-8775-005056c00008" name="Kankakee LD" loadType="UNDEFINED" p0="52" q0="22" node="8" p="52.003045166288416" q="22.002147274553622">
+            <iidm:load id="_044ea4c0-c766-11e1-8775-005056c00008" name="Kankakee LD" loadType="UNDEFINED" p0="52" q0="22" node="8" p="51.999506271909624" q="21.999651859499654">
                 <iidm:alias>_047e6758-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3228,12 +3228,12 @@
                 <iidm:internalConnection node1="51" node2="9"/>
                 <iidm:internalConnection node1="52" node2="12"/>
                 <iidm:internalConnection node1="53" node2="15"/>
-                <iidm:bus v="127.42262394859442" angle="-1.8014750209015951" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
+                <iidm:bus v="127.42280030311397" angle="-0.9032197008922489" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0484cffb-c766-11e1-8775-005056c00008" name="Roanoke LD" loadType="UNDEFINED" p0="31" q0="26" node="17" p="31.000001602332155" q="26.000002239819175">
+            <iidm:load id="_0484cffb-c766-11e1-8775-005056c00008" name="Roanoke LD" loadType="UNDEFINED" p0="31" q0="26" node="17" p="31.000003628040986" q="26.000005071455341">
                 <iidm:alias>_0454983a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0489d903-c766-11e1-8775-005056c00008" name="Roanoke SC" sectionCount="5" voltageRegulatorOn="true" targetV="127.423" targetDeadband="1" node="18" q="-18.639530807848754">
+            <iidm:shunt id="_0489d903-c766-11e1-8775-005056c00008" name="Roanoke SC" sectionCount="5" voltageRegulatorOn="true" targetV="127.423" targetDeadband="1" node="18" q="-18.639582402576181">
                 <iidm:alias>_0476c638-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_5be38d1a-9d01-42d8-b8bb-e9a26cfbcf1a"/>
                 <iidm:shuntLinearModel bPerSection="0.0002296" gPerSection="0" maximumSectionCount="10"/>
@@ -3325,12 +3325,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="120.61298212356724" angle="-22.004925084917712" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="120.56658498826116" angle="-21.44257159162202" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047a219a-c766-11e1-8775-005056c00008" name="Howard LD" loadType="UNDEFINED" p0="37" q0="23" node="14" p="36.997706614682699" q="22.997624019258563">
+            <iidm:load id="_047a219a-c766-11e1-8775-005056c00008" name="Howard LD" loadType="UNDEFINED" p0="37" q0="23" node="14" p="36.991661550678764" q="22.99136171500157">
                 <iidm:alias>_04882b51-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_04488a49-c766-11e1-8775-005056c00008" name="Howard NegG LD" loadType="UNDEFINED" p0="59" q0="0" node="15" p="58.996342980169715" q="0">
+            <iidm:load id="_04488a49-c766-11e1-8775-005056c00008" name="Howard NegG LD" loadType="UNDEFINED" p0="59" q0="0" node="15" p="58.986703553785048" q="0">
                 <iidm:alias>_046d9e74-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3380,7 +3380,7 @@
                 <iidm:internalConnection node1="19" node2="6"/>
                 <iidm:internalConnection node1="20" node2="3"/>
                 <iidm:internalConnection node1="21" node2="6"/>
-                <iidm:bus v="218.7745998265824" angle="0.7756748972747558" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
+                <iidm:bus v="218.77338636449886" angle="1.5312201801111434" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_046efe09-c766-11e1-8775-005056c00008" name="CRI132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -3543,20 +3543,20 @@
                 <iidm:internalConnection node1="81" node2="18"/>
                 <iidm:internalConnection node1="82" node2="21"/>
                 <iidm:internalConnection node1="83" node2="24"/>
-                <iidm:bus v="137.28005266633096" angle="3.618052304529392" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
+                <iidm:bus v="137.28000291452958" angle="4.4170815622766986" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_045868c1-c766-11e1-8775-005056c00008" name="CabinCrk SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="477" targetV="137.28" targetQ="0" node="27" p="-526.41525946892625" q="-139.97770042459163">
+            <iidm:generator id="_045868c1-c766-11e1-8775-005056c00008" name="CabinCrk SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="477" targetV="137.28" targetQ="0" node="27" p="-528.10125860338223" q="-140.83879146998092">
                 <iidm:alias>_0487dd36-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_a6ec9760-88da-48df-a23f-7877e7c85ccd"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_e6131af8-c298-413b-84e3-4e21c3b6b06f"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-225" maxQ="640"/>
             </iidm:generator>
-            <iidm:load id="_04747c44-c766-11e1-8775-005056c00008" name="CabinCrk LD" loadType="UNDEFINED" p0="130" q0="26" node="26" p="130.0000748101364" q="26.000024936716908">
+            <iidm:load id="_04747c44-c766-11e1-8775-005056c00008" name="CabinCrk LD" loadType="UNDEFINED" p0="130" q0="26" node="26" p="130.00000413995681" q="26.000001379985626">
                 <iidm:alias>_046a9138-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_0488c79b-c766-11e1-8775-005056c00008" name="81-80" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="21" voltageLevelId1="_048a272b-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-148.24339345515386" q1="71.403997675019724" p2="148.24339345515386" q2="-62.547966940119274">
+        <iidm:twoWindingsTransformer id="_0488c79b-c766-11e1-8775-005056c00008" name="81-80" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="21" voltageLevelId1="_048a272b-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-150.5084948846945" q1="71.50109348129638" p2="150.50849488469453" q2="-62.419075764889364">
             <iidm:alias>_044974a0-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_045a3d83-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_046adf57-c766-11e1-8775-005056c00008</iidm:alias>
@@ -3636,12 +3636,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="134.74792733744391" angle="-12.980705710713785" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="134.74747338960407" angle="-12.289767698190461" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04524e4a-c766-11e1-8775-005056c00008" name="Zanesvll LD" loadType="UNDEFINED" p0="20" q0="11" node="8" p="20.000036695403281" q="11.000033637473578">
+            <iidm:load id="_04524e4a-c766-11e1-8775-005056c00008" name="Zanesvll LD" loadType="UNDEFINED" p0="20" q0="11" node="8" p="20.000003625062568" q="11.000003322974221">
                 <iidm:alias>_045c1240-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_048b5fa9-c766-11e1-8775-005056c00008" name="Zanesvll SC" sectionCount="5" voltageRegulatorOn="true" targetV="134.72300000000001" targetDeadband="1" node="9" q="-15.633180376615611">
+            <iidm:shunt id="_048b5fa9-c766-11e1-8775-005056c00008" name="Zanesvll SC" sectionCount="5" voltageRegulatorOn="true" targetV="134.72300000000001" targetDeadband="1" node="9" q="-15.633075044583459">
                 <iidm:alias>_04736ad5-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_99c6c4ad-5247-4058-96d4-ee8495103e85"/>
                 <iidm:shuntLinearModel bPerSection="0.00017220000000000001" gPerSection="0" maximumSectionCount="10"/>
@@ -3694,9 +3694,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.77395053237214" angle="8.5151765190353768" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.75943053883361" angle="9.4161975058815433" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044ca8f2-c766-11e1-8775-005056c00008" name="Tazewell LD" loadType="UNDEFINED" p0="12" q0="7" node="8" p="12.000424094833242" q="7.0004123192784249">
+            <iidm:load id="_044ca8f2-c766-11e1-8775-005056c00008" name="Tazewell LD" loadType="UNDEFINED" p0="12" q0="7" node="8" p="11.99988518574834" q="6.999888375389113">
                 <iidm:alias>_04542305-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3747,9 +3747,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="119.8276787853918" angle="-20.084281808582503" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="119.76858015086206" angle="-19.634102902624313" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04778989-c766-11e1-8775-005056c00008" name="NwLibrty LD" loadType="UNDEFINED" p0="27" q0="11" node="8" p="26.997560218048118" q="10.998343407833731">
+            <iidm:load id="_04778989-c766-11e1-8775-005056c00008" name="NwLibrty LD" loadType="UNDEFINED" p0="27" q0="11" node="8" p="26.991927121639726" q="10.994518962269341">
                 <iidm:alias>_0483e592-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3782,12 +3782,12 @@
                 <iidm:internalConnection node1="11" node2="2"/>
                 <iidm:internalConnection node1="12" node2="3"/>
                 <iidm:internalConnection node1="13" node2="3"/>
-                <iidm:bus v="122.60498159135881" angle="-6.4725949582195685" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13"/>
+                <iidm:bus v="122.60528227570248" angle="-5.5666612150070716" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0463da70-c766-11e1-8775-005056c00008" name="Danville LD" loadType="UNDEFINED" p0="25" q0="13" node="5" p="24.999991589170907" q="12.999992710615608">
+            <iidm:load id="_0463da70-c766-11e1-8775-005056c00008" name="Danville LD" loadType="UNDEFINED" p0="25" q0="13" node="5" p="25.000003662054578" q="13.000003173780787">
                 <iidm:alias>_0488eeab-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_0448b150-c766-11e1-8775-005056c00008" name="Danville NegG LD" loadType="UNDEFINED" p0="43" q0="0" node="6" p="42.999985533373966" q="0">
+            <iidm:load id="_0448b150-c766-11e1-8775-005056c00008" name="Danville NegG LD" loadType="UNDEFINED" p0="43" q0="0" node="6" p="43.000006298733872" q="0">
                 <iidm:alias>_0457cc88-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3838,9 +3838,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.46624585322255" angle="14.282214510987078" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.45613535947788" angle="15.21360827882725" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045cae82-c766-11e1-8775-005056c00008" name="Fremont LD" loadType="UNDEFINED" p0="48" q0="10" node="8" p="48.00059278192753" q="10.000205827905464">
+            <iidm:load id="_045cae82-c766-11e1-8775-005056c00008" name="Fremont LD" loadType="UNDEFINED" p0="48" q0="10" node="8" p="47.999066276223914" q="9.9996757924577704">
                 <iidm:alias>_045f4693-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3986,9 +3986,9 @@
                 <iidm:internalConnection node1="70" node2="15"/>
                 <iidm:internalConnection node1="71" node2="18"/>
                 <iidm:internalConnection node1="72" node2="21"/>
-                <iidm:bus v="132.34939545548423" angle="1.3249585304774061" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
+                <iidm:bus v="132.33269489047404" angle="2.1043869273573668" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0448d863-c766-11e1-8775-005056c00008" name="Turner LD" loadType="UNDEFINED" p0="61" q0="28" node="23" p="61.002833584906092" q="28.002167803439242">
+            <iidm:load id="_0448d863-c766-11e1-8775-005056c00008" name="Turner LD" loadType="UNDEFINED" p0="61" q0="28" node="23" p="60.999715377601596" q="27.999782256427309">
                 <iidm:alias>_046e3ab3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4042,9 +4042,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.22099623193147" angle="-3.2435943229995261" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="127.15168164861748" angle="-3.2801315300283145" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047d7cf6-c766-11e1-8775-005056c00008" name="Grant LD" loadType="UNDEFINED" p0="24" q0="4" node="8" p="24.001058991736908" q="4.0002941686979767">
+            <iidm:load id="_047d7cf6-c766-11e1-8775-005056c00008" name="Grant LD" loadType="UNDEFINED" p0="24" q0="4" node="8" p="23.996064304347215" q="3.9989068109682955">
                 <iidm:alias>_0481e9c0-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4114,9 +4114,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="221.60904710000011" angle="5.8276057247881123" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="221.48752582403947" angle="5.8722137599465105" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04867dab-c766-11e1-8775-005056c00008" name="Olive NegG LD" loadType="UNDEFINED" p0="28" q0="0" node="11" p="28.005275362278027" q="0">
+            <iidm:load id="_04867dab-c766-11e1-8775-005056c00008" name="Olive NegG LD" loadType="UNDEFINED" p0="28" q0="0" node="11" p="27.999250670103908" q="0">
                 <iidm:alias>_048433b8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4222,15 +4222,15 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="133.36335965585442" angle="0.57565070857297151" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="133.31993948787999" angle="0.60607587655787021" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:shunt id="_0447c6f6-c766-11e1-8775-005056c00008" name="Olive SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.67599999999999" targetDeadband="1" node="17" q="-40.83616396420782">
+            <iidm:shunt id="_0447c6f6-c766-11e1-8775-005056c00008" name="Olive SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.67599999999999" targetDeadband="1" node="17" q="-40.809577584559356">
                 <iidm:alias>_045e8340-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_c701959a-91c1-4a35-9a37-71fb790426ca"/>
                 <iidm:shuntLinearModel bPerSection="0.00045919999999999999" gPerSection="0" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_04575750-c766-11e1-8775-005056c00008" name="8-5" r="0" x="4.6522079999999999" g="0" b="0" ratedU1="220" ratedU2="132" node1="32" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="354.21742670053584" q1="63.453241140798475" p2="-354.21742670053578" q2="-30.392584336121782">
+        <iidm:twoWindingsTransformer id="_04575750-c766-11e1-8775-005056c00008" name="8-5" r="0" x="4.6522079999999999" g="0" b="0" ratedU1="220" ratedU2="132" node1="32" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="354.86096303820261" q1="62.613383120877032" p2="-354.86096303820261" q2="-29.426872140975174">
             <iidm:alias>_045eaa55-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_046b2d74-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04745533-c766-11e1-8775-005056c00008</iidm:alias>
@@ -4301,9 +4301,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.78017694943702" angle="7.439662247888104" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.77393095308426" angle="8.3451426333023875" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047b0bf0-c766-11e1-8775-005056c00008" name="Wythe LD" loadType="UNDEFINED" p0="22" q0="15" node="8" p="22.000345627599248" q="15.000392760692296">
+            <iidm:load id="_047b0bf0-c766-11e1-8775-005056c00008" name="Wythe LD" loadType="UNDEFINED" p0="22" q0="15" node="8" p="21.999917713770309" q="14.999906493037388">
                 <iidm:alias>_0479d376-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4354,9 +4354,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="123.90262772712643" angle="-16.561424020848236" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="123.82157402558023" angle="-16.162665107513295" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0458ddf5-c766-11e1-8775-005056c00008" name="WestLima LD" loadType="UNDEFINED" p0="33" q0="9" node="8" p="33.000066925733286" q="9.0000304208084199">
+            <iidm:load id="_0458ddf5-c766-11e1-8775-005056c00008" name="WestLima LD" loadType="UNDEFINED" p0="33" q0="9" node="8" p="32.9911879378839" q="8.9959948737614734">
                 <iidm:alias>_04492686-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4464,9 +4464,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="128.13066784473045" angle="10.379863870456695" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="128.11502909315104" angle="11.284397244970675" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044b2257-c766-11e1-8775-005056c00008" name="BeaverCk LD" loadType="UNDEFINED" p0="24" q0="15" node="17" p="24.000224735269228" q="15.000234099969475">
+            <iidm:load id="_044b2257-c766-11e1-8775-005056c00008" name="BeaverCk LD" loadType="UNDEFINED" p0="24" q0="15" node="17" p="23.999032026684965" q="14.998991708019297">
                 <iidm:alias>_045868c4-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4557,7 +4557,7 @@
                 <iidm:internalConnection node1="39" node2="9"/>
                 <iidm:internalConnection node1="40" node2="12"/>
                 <iidm:internalConnection node1="41" node2="3"/>
-                <iidm:bus v="215.846798692297" angle="2.9343943009065652" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="215.61510442675927" angle="2.9511111001125943" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_047bcf46-c766-11e1-8775-005056c00008" name="STN132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -4684,9 +4684,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="129.51005828811179" angle="-1.6000391124252757" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65"/>
+                <iidm:bus v="129.31597371547764" angle="-1.6106419809044064" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045dbff4-c766-11e1-8775-005056c00008" name="Sorenson LD" loadType="UNDEFINED" p0="11" q0="3" node="20" p="11.005645150132171" q="3.0025664162570909">
+            <iidm:load id="_045dbff4-c766-11e1-8775-005056c00008" name="Sorenson LD" loadType="UNDEFINED" p0="11" q0="3" node="20" p="10.999195086221453" q="2.9996341390247849">
                 <iidm:alias>_044d4536-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4719,13 +4719,13 @@
                 <iidm:internalConnection node1="10" node2="3"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="0"/>
-                <iidm:bus v="389.72480943846506" angle="0" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15"/>
+                <iidm:bus v="389.19651735044994" angle="0" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15"/>
             </iidm:nodeBreakerTopology>
             <iidm:lccConverterStation id="_7393a68e-c4e6-48dd-9347-543858363fdb" name="Conv1" lossFactor="0" powerFactor="0.80000000000000004" node="12" p="10" q="6">
                 <iidm:alias>_739658a7-e08b-4395-8d79-93e87b7855e3</iidm:alias>
             </iidm:lccConverterStation>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_047120e9-c766-11e1-8775-005056c00008" name="30-17" r="0" x="6.7605125399999997" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_047b8123-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="204.3132188104068" q1="115.7286959721221" p2="-204.31321881040674" q2="-95.246729280507509">
+        <iidm:twoWindingsTransformer id="_047120e9-c766-11e1-8775-005056c00008" name="30-17" r="0" x="6.7605125399999997" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_047b8123-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="205.01327068075989" q1="116.67205049572482" p2="-205.01327068075992" q2="-95.957751044430623">
             <iidm:alias>_044f6811-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0463b36a-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_047d2ed8-c766-11e1-8775-005056c00008</iidm:alias>
@@ -4744,7 +4744,7 @@
                 <iidm:temporaryLimit name="_f62f2fc6-4b6c-4571-a8c5-40d6a89ac703" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_b08e9e50-4e0c-4ac0-9f21-4a27429caeb2" name="PowTrans1" r="0.4840000000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_3bbfa58a-a1ad-4b23-a526-3d76b096c1f4" node2="41" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="-131.57604436580453" q1="21.425420451515041" p2="131.75860090030025" q2="-14.579550407926668">
+        <iidm:twoWindingsTransformer id="_b08e9e50-4e0c-4ac0-9f21-4a27429caeb2" name="PowTrans1" r="0.4840000000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_3bbfa58a-a1ad-4b23-a526-3d76b096c1f4" node2="41" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="-132.02490416645787" q1="20.701071288944551" p2="132.20886107593455" q2="-13.802687183568525">
             <iidm:alias>_046ba2aa-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_a5bf9702-545a-437d-9663-773550202828</iidm:alias>
             <iidm:alias>_ee9505e1-96d7-49b3-9d1a-924397ffb27e</iidm:alias>
@@ -4764,7 +4764,7 @@
                 <iidm:temporaryLimit name="_611bb05e-9b9a-469c-b1d1-80a944c3ce2f" acceptableDuration="60" value="1400"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:threeWindingsTransformer id="_86d83c7d-7826-4c16-b161-4ce17174e77f-1" name="T422" r1="-1.5199999809265099" x1="23.199999999999999" g1="0" b1="0" ratedU1="400" r2="2.0000000630528461" x2="19.999999999999996" g2="0" b2="0" ratedU2="220" r3="1.2000000564689806" x3="12" g3="0" b3="0" ratedU3="132" ratedU0="400" node1="15" voltageLevelId1="_3bbfa58a-a1ad-4b23-a526-3d76b096c1f4" node2="44" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" node3="65" voltageLevelId3="_047bcf46-c766-11e1-8775-005056c00008" p1="121.57604446886674" q1="-27.425420389679061" p2="0" q2="0" p3="-121.60876994601699" q3="31.025223725996483">
+        <iidm:threeWindingsTransformer id="_86d83c7d-7826-4c16-b161-4ce17174e77f-1" name="T422" r1="-1.5199999809265099" x1="23.199999999999999" g1="0" b1="0" ratedU1="400" r2="2.0000000630528461" x2="19.999999999999996" g2="0" b2="0" ratedU2="220" r3="1.2000000564689806" x3="12" g3="0" b3="0" ratedU3="132" ratedU0="400" node1="15" voltageLevelId1="_3bbfa58a-a1ad-4b23-a526-3d76b096c1f4" node2="44" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" node3="65" voltageLevelId3="_047bcf46-c766-11e1-8775-005056c00008" p1="122.02490417278584" q1="-26.701071285146309" p2="0" q2="0" p3="-122.05786672068533" q3="30.326952410061676">
             <iidm:alias>_1b2d419c-ac88-4dae-8dfe-2eb92d18c40a-1</iidm:alias>
             <iidm:alias>_206474da-93c8-46b1-863f-9a308bfc2117-1</iidm:alias>
             <iidm:alias>_9ac069ea-557b-4b8c-b12e-f9f2aecc3bf5-1</iidm:alias>
@@ -5028,16 +5028,16 @@
                 <iidm:internalConnection node1="121" node2="30"/>
                 <iidm:internalConnection node1="122" node2="33"/>
                 <iidm:internalConnection node1="123" node2="36"/>
-                <iidm:bus v="135.3000418094442" angle="-12.167339923097924" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123"/>
+                <iidm:bus v="135.30000126258997" angle="-11.47271572293975" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04859346-c766-11e1-8775-005056c00008" name="Philo SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="204" targetV="135.30000000000001" targetQ="0" node="39" p="-225.13357008733954" q="-174.75074628083078">
+            <iidm:generator id="_04859346-c766-11e1-8775-005056c00008" name="Philo SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="204" targetV="135.30000000000001" targetQ="0" node="39" p="-225.85462632094337" q="-175.18302363217694">
                 <iidm:alias>_048719e2-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e3753d6d-b894-4cce-b6fa-307c50dc107f"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_dff93c01-9c84-4c1f-8529-66c054ed9e37"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
-            <iidm:load id="_045163e2-c766-11e1-8775-005056c00008" name="Philo LD" loadType="UNDEFINED" p0="87" q0="30" node="38" p="87.000040326185399" q="30.000023175972203">
+            <iidm:load id="_045163e2-c766-11e1-8775-005056c00008" name="Philo LD" loadType="UNDEFINED" p0="87" q0="30" node="38" p="87.000001217797418" q="30.000000699883572">
                 <iidm:alias>_04513cd3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5088,9 +5088,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.53403308608084" angle="8.3828392799385494" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.51289385785211" angle="9.271987015931817" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04524e46-c766-11e1-8775-005056c00008" name="BetsyLne LD" loadType="UNDEFINED" p0="11" q0="7" node="8" p="11.000300666642723" q="7.0003188917689183">
+            <iidm:load id="_04524e46-c766-11e1-8775-005056c00008" name="BetsyLne LD" loadType="UNDEFINED" p0="11" q0="7" node="8" p="10.999563018236834" q="6.9995365406307908">
                 <iidm:alias>_04549830-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5143,15 +5143,15 @@
                 <iidm:internalConnection node1="22" node2="6"/>
                 <iidm:internalConnection node1="23" node2="3"/>
                 <iidm:internalConnection node1="24" node2="6"/>
-                <iidm:bus v="124.75883271835093" angle="-4.7755817334349624" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24"/>
+                <iidm:bus v="124.75913733186627" angle="-3.8778566484519259" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04566cf3-c766-11e1-8775-005056c00008" name="Reusens NegG LD" loadType="UNDEFINED" p0="22" q0="0" node="8" p="21.999991320443076" q="0">
+            <iidm:load id="_04566cf3-c766-11e1-8775-005056c00008" name="Reusens NegG LD" loadType="UNDEFINED" p0="22" q0="0" node="8" p="22.00000227161814" q="0">
                 <iidm:alias>_0483be81-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_0482fb36-c766-11e1-8775-005056c00008" name="Reusens LD" loadType="UNDEFINED" p0="28" q0="12" node="9" p="27.999988953291194" q="11.999992109494745">
+            <iidm:load id="_0482fb36-c766-11e1-8775-005056c00008" name="Reusens LD" loadType="UNDEFINED" p0="28" q0="12" node="9" p="28.000002891150366" q="12.00000206510747">
                 <iidm:alias>_0486cbc1-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_04558293-c766-11e1-8775-005056c00008" name="Reusens SC" sectionCount="5" voltageRegulatorOn="true" targetV="124.76300000000001" targetDeadband="1" node="10" q="-5.3542796213884438">
+            <iidm:shunt id="_04558293-c766-11e1-8775-005056c00008" name="Reusens SC" sectionCount="5" voltageRegulatorOn="true" targetV="124.76300000000001" targetDeadband="1" node="10" q="-5.354305767640267">
                 <iidm:alias>_04893ccc-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_99303cd3-6b53-4ee2-a5ce-fe8d5feeb304"/>
                 <iidm:shuntLinearModel bPerSection="6.8800000000000005e-05" gPerSection="0" maximumSectionCount="10"/>
@@ -5224,12 +5224,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="126.42567550768095" angle="12.518433314444202" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="126.42255734935276" angle="13.461802847464288" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045c8777-c766-11e1-8775-005056c00008" name="Holston NegG LD" loadType="UNDEFINED" p0="85" q0="0" node="11" p="85.000688467057486" q="0">
+            <iidm:load id="_045c8777-c766-11e1-8775-005056c00008" name="Holston NegG LD" loadType="UNDEFINED" p0="85" q0="0" node="11" p="84.99979651131278" q="0">
                 <iidm:alias>_0487dd31-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_0451d918-c766-11e1-8775-005056c00008" name="Holston LD" loadType="UNDEFINED" p0="78" q0="42" node="12" p="78.000631769770408" q="42.000566974401629">
+            <iidm:load id="_0451d918-c766-11e1-8775-005056c00008" name="Holston LD" loadType="UNDEFINED" p0="78" q0="42" node="12" p="77.999813269204665" q="41.999832421214833">
                 <iidm:alias>_0485ba54-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5337,9 +5337,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="127.78850064428582" angle="-2.7354164054360042" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="127.7276789488666" angle="-2.0592914528846924" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04742e27-c766-11e1-8775-005056c00008" name="SthPoint LD" loadType="UNDEFINED" p0="47" q0="11" node="17" p="47.008823724393181" q="11.003442093696291">
+            <iidm:load id="_04742e27-c766-11e1-8775-005056c00008" name="SthPoint LD" loadType="UNDEFINED" p0="47" q0="11" node="17" p="46.999881519657954" q="10.999953784302578">
                 <iidm:alias>_047b3303-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5391,12 +5391,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="132.92085244873445" angle="1.3358914770338133" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="132.90957478212647" angle="2.1221756850368898" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04716f06-c766-11e1-8775-005056c00008" name="CapitlHl LD" loadType="UNDEFINED" p0="39" q0="32" node="8" p="39.001224733558274" q="32.0016748668424">
+            <iidm:load id="_04716f06-c766-11e1-8775-005056c00008" name="CapitlHl LD" loadType="UNDEFINED" p0="39" q0="32" node="8" p="38.999871074731971" q="31.999823692135433">
                 <iidm:alias>_04700f70-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0466c0a0-c766-11e1-8775-005056c00008" name="CapitlHl SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.00200000000001" targetDeadband="1" node="9" q="-20.282810062021579">
+            <iidm:shunt id="_0466c0a0-c766-11e1-8775-005056c00008" name="CapitlHl SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.00200000000001" targetDeadband="1" node="9" q="-20.27936841894299">
                 <iidm:alias>_045e8346-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_99931a87-ee15-4fd0-b251-9556df7fe598"/>
                 <iidm:shuntLinearModel bPerSection="0.0002296" gPerSection="0" maximumSectionCount="10"/>
@@ -5449,9 +5449,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="132.05821466379913" angle="1.0236051971696025" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="132.04360281243163" angle="1.8052859710542395" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046efe03-c766-11e1-8775-005056c00008" name="Chemical LD" loadType="UNDEFINED" p0="71" q0="26" node="8" p="71.002896250730515" q="26.001767688800676">
+            <iidm:load id="_046efe03-c766-11e1-8775-005056c00008" name="Chemical LD" loadType="UNDEFINED" p0="71" q0="26" node="8" p="70.999698727365242" q="25.999816124943091">
                 <iidm:alias>_045d71d5-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5502,9 +5502,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.5786422673259" angle="-2.5965811357712076" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.56471204738793" angle="-2.578327925979425" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046a4319-c766-11e1-8775-005056c00008" name="JacksnRd LD" loadType="UNDEFINED" p0="19" q0="2" node="8" p="19.000689813326908" q="2.0001210213464891">
+            <iidm:load id="_046a4319-c766-11e1-8775-005056c00008" name="JacksnRd LD" loadType="UNDEFINED" p0="19" q0="2" node="8" p="18.999888012838134" q="1.9999803531680971">
                 <iidm:alias>_046c8d06-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5650,9 +5650,9 @@
                 <iidm:internalConnection node1="70" node2="15"/>
                 <iidm:internalConnection node1="71" node2="18"/>
                 <iidm:internalConnection node1="72" node2="21"/>
-                <iidm:bus v="130.60925273521102" angle="12.199494421129051" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
+                <iidm:bus v="130.59978902295978" angle="13.123682597558069" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0458ddf4-c766-11e1-8775-005056c00008" name="Saltvlle LD" loadType="UNDEFINED" p0="65" q0="10" node="23" p="65.001531863694424" q="10.000392788648272">
+            <iidm:load id="_0458ddf4-c766-11e1-8775-005056c00008" name="Saltvlle LD" loadType="UNDEFINED" p0="65" q0="10" node="23" p="64.999635108689915" q="9.9999064383006928">
                 <iidm:alias>_045645e4-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5722,9 +5722,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="132.00363202787977" angle="2.2797082359095242" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="131.72815288049532" angle="2.3637642364665847" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0476ed42-c766-11e1-8775-005056c00008" name="Trenton NegG LD" loadType="UNDEFINED" p0="13" q0="0" node="11" p="13.009564869561229" q="0">
+            <iidm:load id="_0476ed42-c766-11e1-8775-005056c00008" name="Trenton NegG LD" loadType="UNDEFINED" p0="13" q0="0" node="11" p="12.999226731518373" q="0">
                 <iidm:alias>_0471e432-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5794,9 +5794,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="128.42780206515133" angle="-3.6219953920205135" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="128.40758620551298" angle="-3.6013530188637031" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044a5f08-c766-11e1-8775-005056c00008" name="HickryCk LD" loadType="UNDEFINED" p0="39" q0="10" node="11" p="39.00208764791207" q="10.000892173146175">
+            <iidm:load id="_044a5f08-c766-11e1-8775-005056c00008" name="HickryCk LD" loadType="UNDEFINED" p0="39" q0="10" node="11" p="38.999643678741805" q="9.9998477264217858">
                 <iidm:alias>_047d7cf3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5925,9 +5925,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="125.34039727161067" angle="-15.722224390227712" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="125.26182819318707" angle="-15.315170845910366" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:shunt id="_0450eeb7-c766-11e1-8775-005056c00008" name="EastLima SC" sectionCount="5" voltageRegulatorOn="true" targetV="131.565" targetDeadband="1" node="20" q="-22.544158795074445">
+            <iidm:shunt id="_0450eeb7-c766-11e1-8775-005056c00008" name="EastLima SC" sectionCount="5" voltageRegulatorOn="true" targetV="131.565" targetDeadband="1" node="20" q="-22.515904239299804">
                 <iidm:alias>_044aad27-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_6c36f421-303e-4932-93a9-5b0ff86cb7d4"/>
                 <iidm:shuntLinearModel bPerSection="0.00028699999999999998" gPerSection="0" maximumSectionCount="10"/>
@@ -6015,16 +6015,16 @@
                 <iidm:internalConnection node1="41" node2="7"/>
                 <iidm:internalConnection node1="42" node2="12"/>
                 <iidm:internalConnection node1="43" node2="11"/>
-                <iidm:bus v="218.90473505433636" angle="-5.2015393175667182" nodes="0,1,2,3,8,9,10,13,17,18,21,22,23,24,25,26,31,32,33,34,35,39,40"/>
-                <iidm:bus v="237.9377651463725" angle="-16.961599306812289" nodes="11,15,37,43"/>
-                <iidm:bus v="226.19474576907345" angle="-5.2015392762801618" nodes="12,16,38,42"/>
-                <iidm:bus v="214.7003229083077" angle="-16.961599306812285" nodes="4,5,6,7,14,19,20,27,28,29,30,36,41"/>
+                <iidm:bus v="218.90706400143554" angle="-4.48156085190708" nodes="0,1,2,3,8,9,10,13,17,18,21,22,23,24,25,26,31,32,33,34,35,39,40"/>
+                <iidm:bus v="237.93768616171107" angle="-16.22638129462181" nodes="11,15,37,43"/>
+                <iidm:bus v="226.1946750157918" angle="-4.4815608510494815" nodes="12,16,38,42"/>
+                <iidm:bus v="214.70025163743443" angle="-16.226381294621813" nodes="4,5,6,7,14,19,20,27,28,29,30,36,41"/>
             </iidm:nodeBreakerTopology>
-            <iidm:vscConverterStation id="_b46bfb8e-7af6-459e-acf3-53a42c943a7c" name="VSC2" voltageRegulatorOn="true" lossFactor="0.32362458" voltageSetpoint="218.47" reactivePowerSetpoint="0" node="42" p="-0" q="-27.482684079051793">
+            <iidm:vscConverterStation id="_b46bfb8e-7af6-459e-acf3-53a42c943a7c" name="VSC2" voltageRegulatorOn="true" lossFactor="0.32362458" voltageSetpoint="218.47" reactivePowerSetpoint="0" node="42" p="-0" q="-27.473646017966203">
                 <iidm:alias>_a168e701-bd48-4f66-8f0b-0f69b2545530</iidm:alias>
                 <iidm:minMaxReactiveLimits minQ="-1.7976931348623157e+308" maxQ="1.7976931348623157e+308"/>
             </iidm:vscConverterStation>
-            <iidm:vscConverterStation id="_b48ce7cf-abf5-413f-bc51-9e1d3103c9bd" name="VSC1" voltageRegulatorOn="true" lossFactor="0.32467531999999999" voltageSetpoint="213.53999999999999" reactivePowerSetpoint="0" node="43" p="-0" q="-92.151020935015353">
+            <iidm:vscConverterStation id="_b48ce7cf-abf5-413f-bc51-9e1d3103c9bd" name="VSC1" voltageRegulatorOn="true" lossFactor="0.32467531999999999" voltageSetpoint="213.53999999999999" reactivePowerSetpoint="0" node="43" p="-0" q="-92.151020935008972">
                 <iidm:alias>_071bb138-ff00-4874-8acc-a884aa5cf4a9</iidm:alias>
                 <iidm:minMaxReactiveLimits minQ="-1.7976931348623157e+308" maxQ="1.7976931348623157e+308"/>
             </iidm:vscConverterStation>
@@ -6092,7 +6092,7 @@
                 <iidm:internalConnection node1="29" node2="6"/>
                 <iidm:internalConnection node1="30" node2="9"/>
                 <iidm:internalConnection node1="31" node2="3"/>
-                <iidm:bus v="201.92328378368711" angle="-11.863111626447182" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
+                <iidm:bus v="201.7604674805512" angle="-11.3718843508018" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_0448d867-c766-11e1-8775-005056c00008" name="EDO132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -6178,9 +6178,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="131.34004395247288" angle="-7.6143615097689539" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="131.34000177431253" angle="-6.8870103987930404" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0472a789-c766-11e1-8775-005056c00008" name="W.Kammer SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="160" targetV="131.34" targetQ="0" node="14" p="-176.57534908810945" q="93.992680593075789">
+            <iidm:generator id="_0472a789-c766-11e1-8775-005056c00008" name="W.Kammer SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="160" targetV="131.34" targetQ="0" node="14" p="-177.1408833889752" q="94.093245575977122">
                 <iidm:alias>_04697fc0-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_17852426-f663-4add-9a2b-0a635d51f101"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b512ea0a-96d0-4a48-9de1-a5cf499bf0dd"/>
@@ -6329,16 +6329,16 @@
                 <iidm:internalConnection node1="71" node2="15"/>
                 <iidm:internalConnection node1="72" node2="18"/>
                 <iidm:internalConnection node1="73" node2="21"/>
-                <iidm:bus v="130.02004488852387" angle="-16.961599306812285" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
+                <iidm:bus v="130.02000172770315" angle="-16.22638129462181" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04839777-c766-11e1-8775-005056c00008" name="Tidd SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="155" targetV="130.02000000000001" targetQ="0" node="24" p="-171.05736942910602" q="-95.019216188652223">
+            <iidm:generator id="_04839777-c766-11e1-8775-005056c00008" name="Tidd SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="155" targetV="130.02000000000001" targetQ="0" node="24" p="-171.60523078306971" q="-94.866667289342715">
                 <iidm:alias>_045fe2d8-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_d2a96d8d-65be-4fd6-a012-ceeeabd2bee6"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_29df1e0b-36ca-4536-97b4-6f98b84d49d8"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-90" maxQ="255"/>
             </iidm:generator>
-            <iidm:load id="_04798556-c766-11e1-8775-005056c00008" name="Tidd LD" loadType="UNDEFINED" p0="277" q0="113" node="23" p="277.00014344857158" q="113.00009753123577">
+            <iidm:load id="_04798556-c766-11e1-8775-005056c00008" name="Tidd LD" loadType="UNDEFINED" p0="277" q0="113" node="23" p="277.00000552115569" q="113.00000375385433">
                 <iidm:alias>_04502b62-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6368,13 +6368,13 @@
                 <iidm:internalConnection node1="10" node2="3"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="0"/>
-                <iidm:bus v="361.17890731901053" angle="-11.602314054031041" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="360.88546229202854" angle="-11.110664175402862" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
             </iidm:nodeBreakerTopology>
             <iidm:lccConverterStation id="_9793118d-5ba1-4a9c-b2e0-db1d15be5913" name="Conv2" lossFactor="0" powerFactor="-0.75741000000000003" node="12" p="-10" q="8.6206896551724146">
                 <iidm:alias>_453bdc57-5855-4eb5-8712-d6a0255e0da8</iidm:alias>
             </iidm:lccConverterStation>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045c1248-c766-11e1-8775-005056c00008" name="38-37" r="0" x="6.5340005399999992" g="0" b="0" ratedU1="220" ratedU2="132" node1="30" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="167.29168599769037" q1="89.641408096700133" p2="-167.29168599769037" q2="-75.623087232900374">
+        <iidm:twoWindingsTransformer id="_045c1248-c766-11e1-8775-005056c00008" name="38-37" r="0" x="6.5340005399999992" g="0" b="0" ratedU1="220" ratedU2="132" node1="30" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="170.69000436684254" q1="89.300238967491637" p2="-170.6900043668424" q2="-74.835382472946421">
             <iidm:alias>_0453d4e8-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0477d7aa-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_047df228-c766-11e1-8775-005056c00008</iidm:alias>
@@ -6398,7 +6398,7 @@
                 <iidm:temporaryLimit name="_c97df399-5a91-4c8b-b72c-496cade334b5" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_0485ba57-c766-11e1-8775-005056c00008" name="64-61" r="0" x="4.669632" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="157.89158635775999" q1="60.519703259203169" p2="-157.89158635775996" q2="-53.010519444912063">
+        <iidm:twoWindingsTransformer id="_0485ba57-c766-11e1-8775-005056c00008" name="64-61" r="0" x="4.669632" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="157.41103920119789" q1="60.541774721027195" p2="-157.41103920119787" q2="-53.071841038626054">
             <iidm:alias>_04549831-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0472ce92-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0489d905-c766-11e1-8775-005056c00008</iidm:alias>
@@ -6424,7 +6424,7 @@
                 <iidm:temporaryLimit name="_f6b1a81c-eda7-4a08-b290-bd29a5ed9fa4" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_044cd007-c766-11e1-8775-005056c00008" name="63-59" r="0" x="6.7256646120000001" g="0" b="0" ratedU1="220" ratedU2="132" node1="41" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="73" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-1.4155343563970746e-13" q1="83.151439201261084" p2="-4.4408920985006262e-14" q2="-80.568885865152623">
+        <iidm:twoWindingsTransformer id="_044cd007-c766-11e1-8775-005056c00008" name="63-59" r="0" x="6.7256646120000001" g="0" b="0" ratedU1="220" ratedU2="132" node1="41" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="73" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-5.8286708792820718e-14" q1="83.151383996176719" p2="2.4147350785597155e-13" q2="-80.568832374651336">
             <iidm:alias>_044e7db4-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_046eafe5-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0488797a-c766-11e1-8775-005056c00008</iidm:alias>
@@ -6470,7 +6470,7 @@
                 <iidm:temporaryLimit name="_f2daef4d-6f1a-44d1-9c9b-228acff12575" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_ffd940c8-03c8-4dcf-ad46-62018a0d813d" name="PowTrans2" r="0.3932500000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_04f97116-552a-4a34-afd9-4862f62ac7aa" node2="31" voltageLevelId2="_04742e21-c766-11e1-8775-005056c00008" p1="10.000003534423998" q1="-8.6206919901176509" p2="-9.99830954360508" q2="8.6988761817665274">
+        <iidm:twoWindingsTransformer id="_ffd940c8-03c8-4dcf-ad46-62018a0d813d" name="PowTrans2" r="0.3932500000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_04f97116-552a-4a34-afd9-4862f62ac7aa" node2="31" voltageLevelId2="_04742e21-c766-11e1-8775-005056c00008" p1="10.000000074940694" q1="-8.6206895196594129" p2="-9.998303329236844" q2="8.6990008598404689">
             <iidm:alias>_04479fea-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_c089eb25-9f67-4d82-88a8-635dd4808bae</iidm:alias>
             <iidm:alias>_ea8cd467-31f0-40dc-95d7-4064463724c4</iidm:alias>
@@ -6537,9 +6537,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="124.78661210135063" angle="-20.110735263632094" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.78799268470506" angle="-19.394482508276759" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0481c2b3-c766-11e1-8775-005056c00008" name="Wooster LD" loadType="UNDEFINED" p0="23" q0="11" node="8" p="22.999891122723419" q="10.999913213901987">
+            <iidm:load id="_0481c2b3-c766-11e1-8775-005056c00008" name="Wooster LD" loadType="UNDEFINED" p0="23" q0="11" node="8" p="22.999984421382642" q="10.99998758226433">
                 <iidm:alias>_04614268-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6609,9 +6609,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="125.569240580746" angle="-19.879044716207179" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="125.56949268250294" angle="-19.157625413373108" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044974a8-c766-11e1-8775-005056c00008" name="Wagenhls LD" loadType="UNDEFINED" p0="63" q0="22" node="11" p="62.999973180441316" q="21.999984390735257">
+            <iidm:load id="_044974a8-c766-11e1-8775-005056c00008" name="Wagenhls LD" loadType="UNDEFINED" p0="63" q0="22" node="11" p="63.00000086603805" q="22.000000504043317">
                 <iidm:alias>_048481d4-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6662,9 +6662,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.41115729229784" angle="-4.2975169699729667" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.32732117484409" angle="-4.2876181754266254" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047fedf2-c766-11e1-8775-005056c00008" name="Concord LD" loadType="UNDEFINED" p0="34" q0="16" node="8" p="34.007579313294151" q="16.005945001157791">
+            <iidm:load id="_047fedf2-c766-11e1-8775-005056c00008" name="Concord LD" loadType="UNDEFINED" p0="34" q0="16" node="8" p="33.998746004106003" q="15.999016485900228">
                 <iidm:alias>_046d9e75-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6772,9 +6772,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="127.70028465049954" angle="-1.3339863888821777" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="127.51757885845768" angle="-1.3608115151656688" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045f94ba-c766-11e1-8775-005056c00008" name="Delaware LD" loadType="UNDEFINED" p0="59" q0="23" node="17" p="59.023657936663376" q="23.015373030201474">
+            <iidm:load id="_045f94ba-c766-11e1-8775-005056c00008" name="Delaware LD" loadType="UNDEFINED" p0="59" q0="23" node="17" p="58.990935954945471" q="22.994111232759465">
                 <iidm:alias>_0463654a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6882,9 +6882,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="125.47558498741709" angle="-5.7960315876172537" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="125.20515834667219" angle="-5.8134214934338928" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04697fc9-c766-11e1-8775-005056c00008" name="FtWayne LD" loadType="UNDEFINED" p0="90" q0="30" node="17" p="90.065886076477369" q="30.036612307141869">
+            <iidm:load id="_04697fc9-c766-11e1-8775-005056c00008" name="FtWayne LD" loadType="UNDEFINED" p0="90" q0="30" node="17" p="89.989993906691808" q="29.994441265287914">
                 <iidm:alias>_044d1e25-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6935,9 +6935,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.01280773058832" angle="-17.866480547623347" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.01454967772952" angle="-17.154448366324083" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0474f170-c766-11e1-8775-005056c00008" name="WNwPhil1 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="11.999933747771195" q="2.9999723949554675">
+            <iidm:load id="_0474f170-c766-11e1-8775-005056c00008" name="WNwPhil1 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="11.999993922473386" q="2.9999974676976722">
                 <iidm:alias>_0466c0a7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7008,12 +7008,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="129.53159473851238" angle="3.2495317719974453" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="129.50956173811537" angle="4.0873001607366293" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044a5f05-c766-11e1-8775-005056c00008" name="Logan LD" loadType="UNDEFINED" p0="54" q0="27" node="11" p="54.002565378434596" q="27.002137849215718">
+            <iidm:load id="_044a5f05-c766-11e1-8775-005056c00008" name="Logan LD" loadType="UNDEFINED" p0="54" q0="27" node="11" p="53.998853906614762" q="26.999044928935824">
                 <iidm:alias>_04767811-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0475dbd6-c766-11e1-8775-005056c00008" name="Logan SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.41900000000001" targetDeadband="1" node="12" q="-19.261642272756532">
+            <iidm:shunt id="_0475dbd6-c766-11e1-8775-005056c00008" name="Logan SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.41900000000001" targetDeadband="1" node="12" q="-19.255090115675326">
                 <iidm:alias>_04577e67-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_a7768441-642e-48a2-b4a8-0ae06bebf676"/>
                 <iidm:shuntLinearModel bPerSection="0.0002296" gPerSection="0" maximumSectionCount="10"/>
@@ -7087,19 +7087,19 @@
                 <iidm:internalConnection node1="32" node2="3"/>
                 <iidm:internalConnection node1="33" node2="6"/>
                 <iidm:internalConnection node1="34" node2="9"/>
-                <iidm:bus v="132.66003880086433" angle="-13.706712494333804" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34"/>
+                <iidm:bus v="132.66000107743142" angle="-13.029696555414992" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04633e31-c766-11e1-8775-005056c00008" name="W.Lancst SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="19" targetV="132.66" targetQ="0" node="13" p="-20.968322704212994" q="1.6590815259004281">
+            <iidm:generator id="_04633e31-c766-11e1-8775-005056c00008" name="W.Lancst SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="19" targetV="132.66" targetQ="0" node="13" p="-21.035479902440805" q="1.4873639650989727">
                 <iidm:alias>_047bcf42-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_83fae784-1da1-4055-8108-ba978276d1b6"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_5f711f63-f631-45d3-b26c-33821ab2ee56"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-15" maxQ="45"/>
             </iidm:generator>
-            <iidm:load id="_048a9c51-c766-11e1-8775-005056c00008" name="W.Lancst LD" loadType="UNDEFINED" p0="28" q0="10" node="11" p="28.00001228430893" q="10.000007312089716">
+            <iidm:load id="_048a9c51-c766-11e1-8775-005056c00008" name="W.Lancst LD" loadType="UNDEFINED" p0="28" q0="10" node="11" p="28.00000034111352" q="10.000000203043763">
                 <iidm:alias>_044e7db6-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_045b00d9-c766-11e1-8775-005056c00008" name="W.Lancst SC" sectionCount="5" voltageRegulatorOn="true" targetV="132.66" targetDeadband="1" node="12" q="-10.101645703527282">
+            <iidm:shunt id="_045b00d9-c766-11e1-8775-005056c00008" name="W.Lancst SC" sectionCount="5" voltageRegulatorOn="true" targetV="132.66" targetDeadband="1" node="12" q="-10.101639958485995">
                 <iidm:alias>_04758db6-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_be267a3c-f7a7-4bdf-bb17-71b773247fbf"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -7209,9 +7209,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="130.00688298897975" angle="-2.1657711656431569" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="129.89747040216201" angle="-1.5900596913317735" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045dbff2-c766-11e1-8775-005056c00008" name="Portsmth LD" loadType="UNDEFINED" p0="66" q0="20" node="17" p="66.021217822329774" q="20.010717220184677">
+            <iidm:load id="_045dbff2-c766-11e1-8775-005056c00008" name="Portsmth LD" loadType="UNDEFINED" p0="66" q0="20" node="17" p="65.999499065071888" q="19.999747003201637">
                 <iidm:alias>_0454bf45-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7282,16 +7282,16 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="127.64400014027794" angle="-3.1099511625260816" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="127.64400013551636" angle="-3.1569022828279967" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04856c34-c766-11e1-8775-005056c00008" name="DeerCrk SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="7" targetV="127.64400000000001" targetQ="0" node="12" p="-7.7251715226047883" q="-34.922503849408848">
+            <iidm:generator id="_04856c34-c766-11e1-8775-005056c00008" name="DeerCrk SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="7" targetV="127.64400000000001" targetQ="0" node="12" p="-7.7499136482676647" q="-38.736507154769754">
                 <iidm:alias>_0477d7a5-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e5a479a8-ab8d-4a54-bb52-376874ae2784"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b55d80d5-720f-46f9-897f-ff8c5eaf8b44"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-15" maxQ="45"/>
             </iidm:generator>
-            <iidm:load id="_04791028-c766-11e1-8775-005056c00008" name="DeerCrk LD" loadType="UNDEFINED" p0="43" q0="27" node="11" p="43.000000070884063" q="27.000000074181003">
+            <iidm:load id="_04791028-c766-11e1-8775-005056c00008" name="DeerCrk LD" loadType="UNDEFINED" p0="43" q0="27" node="11" p="43.000000068477988" q="27.000000071663017">
                 <iidm:alias>_04486337-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7342,9 +7342,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.13369949908704" angle="-1.5720836991082232" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.9503252989261" angle="-1.5935600896245332" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0462c904-c766-11e1-8775-005056c00008" name="Medford LD" loadType="UNDEFINED" p0="22" q0="7" node="8" p="22.007550494992845" q="7.0040045084266538">
+            <iidm:load id="_0462c904-c766-11e1-8775-005056c00008" name="Medford LD" loadType="UNDEFINED" p0="22" q0="7" node="8" p="21.995218387130247" q="6.9974644799182641">
                 <iidm:alias>_0489b1f7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7433,9 +7433,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="132.53653541190019" angle="3.9463977935578356" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="132.15493427259665" angle="3.9228025694116146" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046205b5-c766-11e1-8775-005056c00008" name="CollCrnr LD" loadType="UNDEFINED" p0="7" q0="3" node="14" p="7.0072164769755769" q="3.005156397553189">
+            <iidm:load id="_046205b5-c766-11e1-8775-005056c00008" name="CollCrnr LD" loadType="UNDEFINED" p0="7" q0="3" node="14" p="6.999533734715353" q="2.9996669607628337">
                 <iidm:alias>_04486334-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7486,9 +7486,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.90976274684002" angle="4.3749151008138565" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.89358082086426" angle="5.2405980058125641" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0483be82-c766-11e1-8775-005056c00008" name="Caldwell LD" loadType="UNDEFINED" p0="42" q0="31" node="8" p="42.001575859288366" q="31.001938581306167">
+            <iidm:load id="_0483be82-c766-11e1-8775-005056c00008" name="Caldwell LD" loadType="UNDEFINED" p0="42" q0="31" node="8" p="41.999443194976649" q="30.999315044466424">
                 <iidm:alias>_045841b9-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7539,9 +7539,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.3310726837484" angle="-3.1780055230897664" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.33147747663945" angle="-2.2754324659232523" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045f94b4-c766-11e1-8775-005056c00008" name="Franklin LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="7.9999956446859688" q="2.9999972779292245">
+            <iidm:load id="_045f94b4-c766-11e1-8775-005056c00008" name="Franklin LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="8.0000018205383299" q="3.0000011378365428">
                 <iidm:alias>_047da403-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7592,9 +7592,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="125.17244773251397" angle="-4.8284337372772992" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.83939051268011" angle="-4.8784537376246506" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045f6da2-c766-11e1-8775-005056c00008" name="McKinley LD" loadType="UNDEFINED" p0="60" q0="34" node="8" p="60.055911262466353" q="34.052821481735783">
+            <iidm:load id="_045f6da2-c766-11e1-8775-005056c00008" name="McKinley LD" loadType="UNDEFINED" p0="60" q0="34" node="8" p="59.9934438289322" q="33.993808286191005">
                 <iidm:alias>_0465d641-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7741,19 +7741,19 @@
                 <iidm:internalConnection node1="71" node2="18"/>
                 <iidm:internalConnection node1="72" node2="21"/>
                 <iidm:internalConnection node1="73" node2="12"/>
-                <iidm:bus v="130.68000801247155" angle="-3.0160753681959518" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
+                <iidm:bus v="130.68000800126094" angle="-3.0030866516365586" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_044ca8f0-c766-11e1-8775-005056c00008" name="TwinBrch SM" energySource="THERMAL" minP="50" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="85" targetV="130.68000799999999" targetQ="0" node="24" p="-93.805654203058126" q="-84.26243040869366">
+            <iidm:generator id="_044ca8f0-c766-11e1-8775-005056c00008" name="TwinBrch SM" energySource="THERMAL" minP="50" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="85" targetV="130.68000799999999" targetQ="0" node="24" p="-94.106094300393067" q="-86.982477982697773">
                 <iidm:alias>_04633e38-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_0f6ab5a4-6b72-42f4-92bc-1993e1ae58a3"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_668eb671-5c36-4351-a95d-53ca850581db"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-60" maxQ="170"/>
             </iidm:generator>
-            <iidm:load id="_048740f1-c766-11e1-8775-005056c00008" name="TwinBrch LD" loadType="UNDEFINED" p0="47" q0="10" node="23" p="47.000000006728229" q="10.000000002385899">
+            <iidm:load id="_048740f1-c766-11e1-8775-005056c00008" name="TwinBrch LD" loadType="UNDEFINED" p0="47" q0="10" node="23" p="47.000000000680288" q="10.000000000241236">
                 <iidm:alias>_044ecbda-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:danglingLine id="_045338a1-c766-11e1-8775-005056c00008" name="12-117" p0="20" q0="8" r="5.7324960000000003" x="24.393599999999999" g="0" b="0.00020546369999999999" ucteXnodeCode="XMO_TE32" node="73" p="20.1617936197859" q="5.1797255248887408">
+            <iidm:danglingLine id="_045338a1-c766-11e1-8775-005056c00008" name="12-117" p0="20" q0="8" r="5.7324960000000003" x="24.393599999999999" g="0" b="0.00020546369999999999" ucteXnodeCode="XMO_TE32" node="73" p="20.161793616326701" q="5.1797255240000037">
                 <iidm:alias>_044afb42-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_0457f391-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_5631f3d0-d9d2-11e2-bb49-005056c00008</iidm:alias>
@@ -7851,9 +7851,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="124.51304530616135" angle="-6.4613884588492398" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="124.05679860968456" angle="-6.5505142196425359" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0479fa87-c766-11e1-8775-005056c00008" name="Lincoln LD" loadType="UNDEFINED" p0="45" q0="25" node="14" p="45.058187463280703" q="25.053900499571618">
+            <iidm:load id="_0479fa87-c766-11e1-8775-005056c00008" name="Lincoln LD" loadType="UNDEFINED" p0="45" q0="25" node="14" p="44.994232871463652" q="24.994660294292444">
                 <iidm:alias>_047fc6e2-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7904,9 +7904,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="134.64774364240952" angle="3.5659031072079936" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="134.64614226318827" angle="4.4312488088452842" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044c81e4-c766-11e1-8775-005056c00008" name="Hinton NegG LD" loadType="UNDEFINED" p0="42" q0="0" node="8" p="42.00019913586334" q="0">
+            <iidm:load id="_044c81e4-c766-11e1-8775-005056c00008" name="Hinton NegG LD" loadType="UNDEFINED" p0="42" q0="0" node="8" p="41.999984059610853" q="0">
                 <iidm:alias>_04494d96-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7957,9 +7957,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.28520142870607" angle="-3.3572194918721174" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.22361917984514" angle="-3.3526542537612691" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_048bfbe0-c766-11e1-8775-005056c00008" name="N. E. LD" loadType="UNDEFINED" p0="25" q0="10" node="8" p="25.004079731558228" q="10.002719968984666">
+            <iidm:load id="_048bfbe0-c766-11e1-8775-005056c00008" name="N. E. LD" loadType="UNDEFINED" p0="25" q0="10" node="8" p="24.999400257934404" q="9.9996001751535282">
                 <iidm:alias>_0480b140-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8010,9 +8010,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.13562503202759" angle="-18.788749574985587" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.13836884582015" angle="-18.078225654361987" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04854525-c766-11e1-8775-005056c00008" name="SCoshoct LD" loadType="UNDEFINED" p0="18" q0="5" node="8" p="17.99982935168698" q="4.9999209964010447">
+            <iidm:load id="_04854525-c766-11e1-8775-005056c00008" name="SCoshoct LD" loadType="UNDEFINED" p0="18" q0="5" node="8" p="17.999978462207515" q="4.9999900288037535">
                 <iidm:alias>_04747c42-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8063,9 +8063,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="125.09674678981388" angle="-3.6582960067001782" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="125.04196473481721" angle="-2.9631250126461777" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044aad24-c766-11e1-8775-005056c00008" name="WHuntngd LD" loadType="UNDEFINED" p0="33" q0="15" node="8" p="33.005750828395165" q="15.004356941249677">
+            <iidm:load id="_044aad24-c766-11e1-8775-005056c00008" name="WHuntngd LD" loadType="UNDEFINED" p0="33" q0="15" node="8" p="32.999906243404276" q="14.999928972343232">
                 <iidm:alias>_04784cd2-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8097,9 +8097,9 @@
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="3"/>
-                <iidm:bus v="129.36006562212361" angle="-2.2754720753438944" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="129.36000412107904" angle="-1.3631756208305104" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0452ea80-c766-11e1-8775-005056c00008" name="DanRiver SM" energySource="THERMAL" minP="20" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="36" targetV="129.36000000000001" targetQ="0" node="5" p="-39.729453544824622" q="-20.31207879692678">
+            <iidm:generator id="_0452ea80-c766-11e1-8775-005056c00008" name="DanRiver SM" energySource="THERMAL" minP="20" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="36" targetV="129.36000000000001" targetQ="0" node="5" p="-39.856698762519414" q="-20.275285757605449">
                 <iidm:alias>_046a4316-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_fec62959-21c5-4921-90b2-7c85e9f3bfab"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_9db08c95-4586-4a2b-87e3-5a17c944b43a"/>
@@ -8172,9 +8172,9 @@
                 <iidm:internalConnection node1="29" node2="3"/>
                 <iidm:internalConnection node1="30" node2="9"/>
                 <iidm:internalConnection node1="31" node2="6"/>
-                <iidm:bus v="130.28668380762028" angle="-2.0390955070488674" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
+                <iidm:bus v="130.16799549230493" angle="-1.5071810921033759" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
             </iidm:nodeBreakerTopology>
-            <iidm:danglingLine id="_044ef2e7-c766-11e1-8775-005056c00008" name="71-73" p0="6" q0="0" r="1.508918" x="7.9104960000000002" g="0" b="6.76079e-05" ucteXnodeCode="XMO_TE31" node="31" p="6.0032055067465704" q="-1.1308231993979825">
+            <iidm:danglingLine id="_044ef2e7-c766-11e1-8775-005056c00008" name="71-73" p0="6" q0="0" r="1.508918" x="7.9104960000000002" g="0" b="6.76079e-05" ucteXnodeCode="XMO_TE31" node="31" p="6.0032095413288804" q="-1.1287030305750168">
                 <iidm:alias>_04670ec2-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_046b2d7a-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_26a070b9-db0c-47cd-9991-0a461576aec2</iidm:alias>
@@ -8234,9 +8234,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="134.29653376002443" angle="-9.0710441588305173" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="134.29657412101696" angle="-8.3563771533081734" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0453add4-c766-11e1-8775-005056c00008" name="Summerfl LD" loadType="UNDEFINED" p0="28" q0="7" node="8" p="27.999911305670494" q="6.9999630440683909">
+            <iidm:load id="_0453add4-c766-11e1-8775-005056c00008" name="Summerfl LD" loadType="UNDEFINED" p0="28" q0="7" node="8" p="27.99990505502582" q="6.9999604396388069">
                 <iidm:alias>_04851e16-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8363,9 +8363,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="132.66007299148242" angle="18.839953986362428" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="132.66000465860472" angle="19.789238527120588" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0489b1fa-c766-11e1-8775-005056c00008" name="ClinchRv SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="607" targetV="132.66" targetQ="0" node="20" p="-669.88273060301515" q="-48.801286803473225">
+            <iidm:generator id="_0489b1fa-c766-11e1-8775-005056c00008" name="ClinchRv SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="607" targetV="132.66" targetQ="0" node="20" p="-672.02822635692462" q="-49.027774907930443">
                 <iidm:alias>_04840caa-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_2621b09a-22e3-4630-b3bd-32c102e36741"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b0d662e5-64c9-4d59-b8e0-9b1ed175769b"/>
@@ -8420,9 +8420,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.49434997634478" angle="-3.9888233676622185" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.48825777082001" angle="-3.9736276443812559" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0485e168-c766-11e1-8775-005056c00008" name="Pokagon LD" loadType="UNDEFINED" p0="20" q0="9" node="8" p="20.000322074596038" q="9.000241557243676">
+            <iidm:load id="_0485e168-c766-11e1-8775-005056c00008" name="Pokagon LD" loadType="UNDEFINED" p0="20" q0="9" node="8" p="19.999940705180951" q="8.9999555289296609">
                 <iidm:alias>_0462c902-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8473,9 +8473,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.12389236324981" angle="-4.1901246378669557" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.05111757265894" angle="-4.1842231951291629" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04812679-c766-11e1-8775-005056c00008" name="GoshenJt LD" loadType="UNDEFINED" p0="14" q0="1" node="8" p="14.002675200810973" q="1.0003184965720189">
+            <iidm:load id="_04812679-c766-11e1-8775-005056c00008" name="GoshenJt LD" loadType="UNDEFINED" p0="14" q0="1" node="8" p="13.99958713396609" q="0.9999508497648375">
                 <iidm:alias>_045b9d17-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8526,9 +8526,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="118.00350663049247" angle="-22.649882898976649" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="117.9517607021927" angle="-22.150301219119676" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0489b1f2-c766-11e1-8775-005056c00008" name="S.Tiffin LD" loadType="UNDEFINED" p0="37" q0="10" node="8" p="36.996074846568419" q="9.9982319753920361">
+            <iidm:load id="_0489b1f2-c766-11e1-8775-005056c00008" name="S.Tiffin LD" loadType="UNDEFINED" p0="37" q0="10" node="8" p="36.98913048064383" q="9.9951042995770365">
                 <iidm:alias>_046476b8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8579,9 +8579,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="123.65928362730065" angle="-11.345711170390333" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="123.52013475240145" angle="-11.170227765038884" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045cfca7-c766-11e1-8775-005056c00008" name="Haviland LD" loadType="UNDEFINED" p0="23" q0="9" node="8" p="23.00576602874423" q="9.003760767764776">
+            <iidm:load id="_045cfca7-c766-11e1-8775-005056c00008" name="Haviland LD" loadType="UNDEFINED" p0="23" q0="9" node="8" p="22.995430259350588" q="8.9970199317408426">
                 <iidm:alias>_0482ad17-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8651,9 +8651,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="131.00711594429839" angle="-8.9658054263066482" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="131.00725437651028" angle="-8.2385695820522429" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04555b82-c766-11e1-8775-005056c00008" name="SWKammer LD" loadType="UNDEFINED" p0="78" q0="3" node="11" p="77.999918499038245" q="2.999994775581194">
+            <iidm:load id="_04555b82-c766-11e1-8775-005056c00008" name="SWKammer LD" loadType="UNDEFINED" p0="78" q0="3" node="11" p="77.9999228019838" q="2.9999950514108504">
                 <iidm:alias>_0474ca6b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8761,9 +8761,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="130.37072823252646" angle="3.6690455773781601" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="130.35292113747093" angle="4.5156291775393544" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04817492-c766-11e1-8775-005056c00008" name="Baileysv LD" loadType="UNDEFINED" p0="38" q0="15" node="17" p="38.001540555737691" q="15.001013537207974">
+            <iidm:load id="_04817492-c766-11e1-8775-005056c00008" name="Baileysv LD" loadType="UNDEFINED" p0="38" q0="15" node="17" p="37.999449489880533" q="14.999637824038798">
                 <iidm:alias>_0474f17b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8814,9 +8814,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.04814330991073" angle="12.058815665738399" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.04244016064365" angle="12.994410802922671" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0461b790-c766-11e1-8775-005056c00008" name="HolstonT NegG LD" loadType="UNDEFINED" p0="10" q0="0" node="8" p="10.000145325044603" q="0">
+            <iidm:load id="_0461b790-c766-11e1-8775-005056c00008" name="HolstonT NegG LD" loadType="UNDEFINED" p0="10" q0="0" node="8" p="9.9999625871100317" q="0">
                 <iidm:alias>_0464ebe7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8867,9 +8867,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.16852341325355" angle="-1.5787128932882759" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.98519843715657" angle="-1.6010639875012476" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044c81e5-c766-11e1-8775-005056c00008" name="WMedford LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="8.0028152925999656" q="3.0017597642698366">
+            <iidm:load id="_044c81e5-c766-11e1-8775-005056c00008" name="WMedford LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="7.9983339794280166" q="2.998958809426072">
                 <iidm:alias>_04570939-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8959,12 +8959,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="124.68118222276054" angle="-15.990586133907891" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="124.59806337504854" angle="-15.596834819893697" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04854520-c766-11e1-8775-005056c00008" name="Rockhill LD" loadType="UNDEFINED" p0="59" q0="26" node="14" p="59.001010777133921" q="26.000742382925356">
+            <iidm:load id="_04854520-c766-11e1-8775-005056c00008" name="Rockhill LD" loadType="UNDEFINED" p0="59" q0="26" node="14" p="58.984908635023189" q="25.988916891702061">
                 <iidm:alias>_0461b799-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0460cd38-c766-11e1-8775-005056c00008" name="Rockhill SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.81399999999999" targetDeadband="1" node="15" q="-12.482953951973574">
+            <iidm:shunt id="_0460cd38-c766-11e1-8775-005056c00008" name="Rockhill SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.81399999999999" targetDeadband="1" node="15" q="-12.46631594964053">
                 <iidm:alias>_048b86b4-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_069d84c6-bd26-4c26-ac6c-e801a0202a00"/>
                 <iidm:shuntLinearModel bPerSection="0.0001606" gPerSection="0" maximumSectionCount="10"/>
@@ -9037,12 +9037,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="128.55634146392575" angle="4.9655247645164584" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="128.53062719858622" angle="5.8229118500908594" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047a48a5-c766-11e1-8775-005056c00008" name="Sprigg LD" loadType="UNDEFINED" p0="20" q0="10" node="11" p="20.001000898176489" q="10.000834095727514">
+            <iidm:load id="_047a48a5-c766-11e1-8775-005056c00008" name="Sprigg LD" loadType="UNDEFINED" p0="20" q0="10" node="11" p="19.999390333308277" q="9.9994919495859893">
                 <iidm:alias>_0472ce97-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_04553478-c766-11e1-8775-005056c00008" name="Sprigg SC" sectionCount="5" voltageRegulatorOn="true" targetV="129.935" targetDeadband="1" node="12" q="-9.4863447021583589">
+            <iidm:shunt id="_04553478-c766-11e1-8775-005056c00008" name="Sprigg SC" sectionCount="5" voltageRegulatorOn="true" targetV="129.935" targetDeadband="1" node="12" q="-9.4825501015075595">
                 <iidm:alias>_045bc428-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_f4cdc674-4a66-4ab8-8d4f-552cb066e259"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -9134,12 +9134,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="118.46299631682518" angle="-21.686345942072137" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="118.40972124556941" angle="-21.208962411004151" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04819ba4-c766-11e1-8775-005056c00008" name="West End NegG LD" loadType="UNDEFINED" p0="46" q0="0" node="14" p="45.994990283087709" q="0">
+            <iidm:load id="_04819ba4-c766-11e1-8775-005056c00008" name="West End NegG LD" loadType="UNDEFINED" p0="46" q0="0" node="14" p="45.986150157780578" q="0">
                 <iidm:alias>_04627ae0-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_04555b89-c766-11e1-8775-005056c00008" name="West End LD" loadType="UNDEFINED" p0="20" q0="23" node="15" p="19.997821862212049" q="22.995825387461778">
+            <iidm:load id="_04555b89-c766-11e1-8775-005056c00008" name="West End LD" loadType="UNDEFINED" p0="20" q0="23" node="15" p="19.993978329469819" q="22.988459623177942">
                 <iidm:alias>_04592c18-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9190,9 +9190,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.31248925083676" angle="-1.6735918971456067" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.11968178603334" angle="-1.6864883258390659" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046d0232-c766-11e1-8775-005056c00008" name="Deer Crk NegG LD" loadType="UNDEFINED" p0="6" q0="0" node="8" p="6.0029955674491795" q="0">
+            <iidm:load id="_046d0232-c766-11e1-8775-005056c00008" name="Deer Crk NegG LD" loadType="UNDEFINED" p0="6" q0="0" node="8" p="5.9994985699626993" q="0">
                 <iidm:alias>_0480150a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9262,9 +9262,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="133.92747668312646" angle="-11.353944414454475" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="133.92475426069626" angle="-10.6607692360299" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046c3ee3-c766-11e1-8775-005056c00008" name="Crooksvl LD" loadType="UNDEFINED" p0="34" q0="0" node="11" p="34.000086884542377" q="0">
+            <iidm:load id="_046c3ee3-c766-11e1-8775-005056c00008" name="Crooksvl LD" loadType="UNDEFINED" p0="34" q0="0" node="11" p="33.999804194352571" q="0">
                 <iidm:alias>_047e4047-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9315,9 +9315,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="132.05135837777328" angle="-14.596394308482802" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="132.05288069912791" angle="-13.895747065403127" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046dc585-c766-11e1-8775-005056c00008" name="WCambrdg LD" loadType="UNDEFINED" p0="17" q0="4" node="8" p="16.999920271434359" q="3.9999687339447054">
+            <iidm:load id="_046dc585-c766-11e1-8775-005056c00008" name="WCambrdg LD" loadType="UNDEFINED" p0="17" q0="4" node="8" p="16.999991752455688" q="3.9999967656694198">
                 <iidm:alias>_045dbff8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9406,9 +9406,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="130.32016072358471" angle="-2.5344425813765787" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="130.294132043497" angle="-2.5167624188394013" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_048b5fa5-c766-11e1-8775-005056c00008" name="SouthBnd LD" loadType="UNDEFINED" p0="70" q0="23" node="14" p="70.004742145095534" q="23.002596947622468">
+            <iidm:load id="_048b5fa5-c766-11e1-8775-005056c00008" name="SouthBnd LD" loadType="UNDEFINED" p0="70" q0="23" node="14" p="69.999218773317068" q="22.999572186979442">
                 <iidm:alias>_04522734-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9458,11 +9458,11 @@
                 <iidm:internalConnection node1="19" node2="6"/>
                 <iidm:internalConnection node1="20" node2="3"/>
                 <iidm:internalConnection node1="21" node2="6"/>
-                <iidm:bus v="228.10650946395356" angle="13.939127893842091" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
+                <iidm:bus v="228.02588628242768" angle="14.016375292255491" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:line id="_044cd006-c766-11e1-8775-005056c00008" name="31-32" r="5.1923519999999996" x="17.16264" g1="0" b1="7.20271e-05" g2="0" b2="7.20271e-05" node1="31" voltageLevelId1="_04636548-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="-26.9554789049877" q1="7.019128095377436" p2="27.208425784881239" q2="-8.5311542072121398">
+    <iidm:line id="_044cd006-c766-11e1-8775-005056c00008" name="31-32" r="5.1923519999999996" x="17.16264" g1="0" b1="7.20271e-05" g2="0" b2="7.20271e-05" node1="31" voltageLevelId1="_04636548-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="-26.842624818854006" q1="8.3535564815685746" p2="27.101172422298003" q2="-9.8437115266365343">
         <iidm:alias>_04682030-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0471bd25-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9470,7 +9470,7 @@
             <iidm:temporaryLimit name="_de6da3cb-8cb5-4900-9c33-8ad45632b535" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045a3d89-c766-11e1-8775-005056c00008" name="2-12" r="3.2582879999999999" x="10.7331839" g1="0" b1="4.5110200000000001e-05" g2="0" b2="4.5110200000000001e-05" node1="21" voltageLevelId1="_045d4ac5-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-31.528847131816327" q1="-17.114103271026764" p2="31.777898178091629" q2="16.419342494303738">
+    <iidm:line id="_045a3d89-c766-11e1-8775-005056c00008" name="2-12" r="3.2582879999999999" x="10.7331839" g1="0" b1="4.5110200000000001e-05" g2="0" b2="4.5110200000000001e-05" node1="21" voltageLevelId1="_045d4ac5-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-31.492740930047152" q1="-17.197715816249353" p2="31.741908591335736" q2="16.503409807345037">
         <iidm:alias>_046adf51-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046fe868-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9478,7 +9478,7 @@
             <iidm:temporaryLimit name="_6bd63dd1-1344-4183-b7bd-af326919f4eb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04513cd7-c766-11e1-8775-005056c00008" name="32-114" r="2.3522400000000001" x="10.6634884" g1="0" b1="4.6717149999999997e-05" g2="0" b2="4.6717149999999997e-05" node1="49" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04791027-c766-11e1-8775-005056c00008" p1="7.5453684581076024" q1="3.9557295376696944" p2="-7.5339460624538539" q2="-5.4212834823674294">
+    <iidm:line id="_04513cd7-c766-11e1-8775-005056c00008" name="32-114" r="2.3522400000000001" x="10.6634884" g1="0" b1="4.6717149999999997e-05" g2="0" b2="4.6717149999999997e-05" node1="49" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04791027-c766-11e1-8775-005056c00008" p1="7.4140176963468978" q1="3.9846339966428661" p2="-7.4028102065021972" q2="-5.4468070912077131">
         <iidm:alias>_046d0237-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0470d2c7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9486,7 +9486,7 @@
             <iidm:temporaryLimit name="_5f05650a-c63d-46e5-a426-2db4f036929f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045d71d4-c766-11e1-8775-005056c00008" name="24-72" r="8.5029120000000002" x="34.151040000000002" g1="0" b1="0.00014003675" g2="0" b2="0.00014003675" node1="30" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="25.490706095664901" q1="-5.0255862166601375" p2="-25.170370923435598" q2="1.4613499202793121">
+    <iidm:line id="_045d71d4-c766-11e1-8775-005056c00008" name="24-72" r="8.5029120000000002" x="34.151040000000002" g1="0" b1="0.00014003675" g2="0" b2="0.00014003675" node1="30" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="23.387417225173184" q1="-4.9838725435298281" p2="-23.116196294373374" q2="1.2390168811653506">
         <iidm:alias>_04667281-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d0234-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9494,7 +9494,7 @@
             <iidm:temporaryLimit name="_d2074163-ab09-4251-a1d7-6983091dc4f1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045f94b8-c766-11e1-8775-005056c00008" name="17-18" r="2.1431520000000002" x="8.7991200000000003" g1="0" b1="3.7247499999999999e-05" g2="0" b2="3.7247499999999999e-05" node1="57" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04689563-c766-11e1-8775-005056c00008" p1="113.29553395743046" q1="38.547580617768872" p2="-111.45936221484236" q2="-32.2171727461564">
+    <iidm:line id="_045f94b8-c766-11e1-8775-005056c00008" name="17-18" r="2.1431520000000002" x="8.7991200000000003" g1="0" b1="3.7247499999999999e-05" g2="0" b2="3.7247499999999999e-05" node1="57" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04689563-c766-11e1-8775-005056c00008" p1="114.53938451200713" q1="40.252590985677969" p2="-112.64390548377155" q2="-33.673713091591665">
         <iidm:alias>_045e0e17-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0485ba59-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9502,7 +9502,7 @@
             <iidm:temporaryLimit name="_2b6693c7-4e29-4c2c-91d0-3485bbe8fe87" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048963d8-c766-11e1-8775-005056c00008" name="17-113" r="1.590811" x="5.244624" g1="0" b1="2.2038549999999999e-05" g2="0" b2="2.2038549999999999e-05" node1="58" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="5.109772974426023" q1="2.9618180320082503" p2="-5.1062439616816766" q2="-3.6883553653375971">
+    <iidm:line id="_048963d8-c766-11e1-8775-005056c00008" name="17-113" r="1.590811" x="5.244624" g1="0" b1="2.2038549999999999e-05" g2="0" b2="2.2038549999999999e-05" node1="58" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="5.2045310034066663" q1="2.8955404101129343" p2="-5.2009406929691862" q2="-3.6196704389359908">
         <iidm:alias>_045841b5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046958b4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9510,7 +9510,7 @@
             <iidm:temporaryLimit name="_786432da-fa4d-4751-a275-87d0e20529f1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0458ddf0-c766-11e1-8775-005056c00008" name="49-50" r="4.6522079999999999" x="13.102848099999999" g1="0" b1="5.3776400000000002e-05" g2="0" b2="5.3776400000000002e-05" node1="112" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044d1e26-c766-11e1-8775-005056c00008" p1="62.28473038277739" q1="11.672291194180168" p2="-61.258134502252538" q2="-10.703070517177077">
+    <iidm:line id="_0458ddf0-c766-11e1-8775-005056c00008" name="49-50" r="4.6522079999999999" x="13.102848099999999" g1="0" b1="5.3776400000000002e-05" g2="0" b2="5.3776400000000002e-05" node1="112" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044d1e26-c766-11e1-8775-005056c00008" p1="62.151125496542612" q1="11.697526519486752" p2="-61.128591548937742" q2="-10.739767223817257">
         <iidm:alias>_0464ebe8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f9fd8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9518,7 +9518,7 @@
             <iidm:temporaryLimit name="_1f0844a5-ea5c-42b2-abcb-6fac2c426092" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04535fb7-c766-11e1-8775-005056c00008" name="1-3" r="2.2476959999999999" x="7.3877759999999997" g1="0" b1="3.1049149999999997e-05" g2="0" b2="3.1049149999999997e-05" node1="21" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_047eb579-c766-11e1-8775-005056c00008" p1="-39.543936275908621" q1="-16.745040215734885" p2="39.799583436209907" q2="16.574259351746406">
+    <iidm:line id="_04535fb7-c766-11e1-8775-005056c00008" name="1-3" r="2.2476959999999999" x="7.3877759999999997" g1="0" b1="3.1049149999999997e-05" g2="0" b2="3.1049149999999997e-05" node1="21" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_047eb579-c766-11e1-8775-005056c00008" p1="-39.577304060399136" q1="-16.660066286223667" p2="39.833000973370631" q2="16.489737147270013">
         <iidm:alias>_044ef2e9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047c4474-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9526,7 +9526,7 @@
             <iidm:temporaryLimit name="_4ea43e34-67a3-42b8-9601-2189db7790d4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0478e912-c766-11e1-8775-005056c00008" name="92-102" r="2.1431520000000002" x="9.7400160000000007" g1="0" b1="4.2011000000000001e-05" g2="0" b2="4.2011000000000001e-05" node1="66" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="49.799893324445968" q1="-9.0162583648579471" p2="-49.479664768040109" q2="9.0398445066998772">
+    <iidm:line id="_0478e912-c766-11e1-8775-005056c00008" name="92-102" r="2.1431520000000002" x="9.7400160000000007" g1="0" b1="4.2011000000000001e-05" g2="0" b2="4.2011000000000001e-05" node1="66" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="49.975637510777567" q1="-9.0530535262742298" p2="-49.653082114020258" q2="9.0874191111445448">
         <iidm:alias>_045a1673-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0468bc79-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9534,7 +9534,7 @@
             <iidm:temporaryLimit name="_23cc194e-9273-46e9-a793-84a9c2911737" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04547127-c766-11e1-8775-005056c00008" name="93-94" r="3.8855520000000001" x="12.7543688" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="21" voltageLevelId1="_04789af0-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="56.851535438925069" q1="-21.929140878593696" p2="-56.003874999988156" q2="22.891163090030211">
+    <iidm:line id="_04547127-c766-11e1-8775-005056c00008" name="93-94" r="3.8855520000000001" x="12.7543688" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="21" voltageLevelId1="_04789af0-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="57.267154446050505" q1="-22.041012475049747" p2="-56.40726869145972" q2="23.043560019941808">
         <iidm:alias>_04500450-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047b0bfb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9542,7 +9542,7 @@
             <iidm:temporaryLimit name="_1a9fe09e-3f63-4904-8e36-aa38c5e16c59" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04791021-c766-11e1-8775-005056c00008" name="46-48" r="10.4718237" x="32.931359999999998" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044778d3-c766-11e1-8775-005056c00008" p1="-8.6626927831010416" q1="-7.9962479185796518" p2="8.7260897649444775" q2="3.3526742150723514">
+    <iidm:line id="_04791021-c766-11e1-8775-005056c00008" name="46-48" r="10.4718237" x="32.931359999999998" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044778d3-c766-11e1-8775-005056c00008" p1="-8.7814720068922298" q1="-7.955109822963669" p2="8.8458281788333348" q2="3.3145704665826066">
         <iidm:alias>_0459ef69-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04640186-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9550,7 +9550,7 @@
             <iidm:temporaryLimit name="_467ba04d-dbad-4fe1-81c8-3bc87b41fcd1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046958b6-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="113" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-92.154562716893992" q1="-2.5673526451535702" p2="93.609820606518738" q2="7.3388894454456581">
+    <iidm:line id="_046958b6-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="113" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-92.395268630945409" q1="-2.4975018892486793" p2="93.858108672021231" q2="7.3077572843802212">
         <iidm:alias>_04776270-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a96c8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9558,7 +9558,7 @@
             <iidm:temporaryLimit name="_d0737ab4-5a3a-46c8-8aeb-789313f0f332" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046f4c26-c766-11e1-8775-005056c00008" name="75-118" r="2.5264799999999998" x="8.3809430000000003" g1="0" b1="3.4377849999999998e-05" g2="0" b2="3.4377849999999998e-05" node1="48" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="39.572821711103416" q1="28.799143751993405" p2="-39.197166205347798" q2="-28.652376510852882">
+    <iidm:line id="_046f4c26-c766-11e1-8775-005056c00008" name="75-118" r="2.5264799999999998" x="8.3809430000000003" g1="0" b1="3.4377849999999998e-05" g2="0" b2="3.4377849999999998e-05" node1="48" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="38.932772892048021" q1="28.870720141707721" p2="-38.563894155967418" q2="-28.745427731451912">
         <iidm:alias>_04619088-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04814d8a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9566,7 +9566,7 @@
             <iidm:temporaryLimit name="_173dc7ff-ae18-4410-b2e1-a4c2abac8ff6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c3954-c766-11e1-8775-005056c00008" name="94-96" r="4.6870560000000001" x="15.1414566" g1="0" b1="6.60009e-05" g2="0" b2="6.60009e-05" node1="49" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="37.720151080699956" q1="-12.761772144133857" p2="-37.289859442193304" q2="11.909702554191687">
+    <iidm:line id="_045c3954-c766-11e1-8775-005056c00008" name="94-96" r="4.6870560000000001" x="15.1414566" g1="0" b1="6.60009e-05" g2="0" b2="6.60009e-05" node1="49" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="38.341568566791494" q1="-12.894021045437706" p2="-37.897275383143665" q2="12.087725924375592">
         <iidm:alias>_046ba2a0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0472ce94-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9574,7 +9574,7 @@
             <iidm:temporaryLimit name="_efde58bf-c92e-496d-b558-d0095a271083" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04518af7-c766-11e1-8775-005056c00008" name="62-67" r="4.4953919999999998" x="20.38608" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="39" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="-2.6333597532592505" q1="-18.330752095706764" p2="2.7083273744425616" q2="15.525566043070004">
+    <iidm:line id="_04518af7-c766-11e1-8775-005056c00008" name="62-67" r="4.4953919999999998" x="20.38608" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="39" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="-2.5026956316005773" q1="-18.359721652441742" p2="2.5777417924034278" q2="15.554891084878181">
         <iidm:alias>_04544a10-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04814d86-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9582,7 +9582,7 @@
             <iidm:temporaryLimit name="_8a81d4ae-2bc8-4038-8650-27a6150946b1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0452c375-c766-11e1-8775-005056c00008" name="47-49" r="3.3279839999999998" x="10.890000000000001" g1="0" b1="4.6028449999999998e-05" g2="0" b2="4.6028449999999998e-05" node1="30" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="114" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="16.932648633718809" q1="-22.712628177092789" p2="-16.790568686203571" q2="21.509355532427207">
+    <iidm:line id="_0452c375-c766-11e1-8775-005056c00008" name="47-49" r="3.3279839999999998" x="10.890000000000001" g1="0" b1="4.6028449999999998e-05" g2="0" b2="4.6028449999999998e-05" node1="30" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="114" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="16.884430322492339" q1="-22.731097858862739" p2="-16.742496804239202" q2="21.527380130140262">
         <iidm:alias>_0465fd54-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0471e431-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9590,7 +9590,7 @@
             <iidm:temporaryLimit name="_8d6a074c-900d-4a37-830c-5da4c1de1ab5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046c17d9-c766-11e1-8775-005056c00008" name="100-106" r="10.54152" x="39.900959999999998" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="76" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="59.439459369581385" q1="10.055342100706916" p2="-57.269954427820544" q2="-7.9072117638625814">
+    <iidm:line id="_046c17d9-c766-11e1-8775-005056c00008" name="100-106" r="10.54152" x="39.900959999999998" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="76" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="59.403353854339137" q1="10.058367936830162" p2="-57.236309963654328" q2="-7.9195689429880565">
         <iidm:alias>_045d98e5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0480d851-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9598,7 +9598,7 @@
             <iidm:temporaryLimit name="_3154dc30-b0e5-4570-8e52-9333bae20ef2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046b2d77-c766-11e1-8775-005056c00008" name="77-78" r="0.655142" x="2.1605759999999998" g1="0" b1="3.6271800000000001e-05" g2="0" b2="3.6271800000000001e-05" node1="66" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044fb634-c766-11e1-8775-005056c00008" p1="43.948615933627252" q1="3.9869200539332379" p2="-43.875576135449187" q2="-5.0139513887048945">
+    <iidm:line id="_046b2d77-c766-11e1-8775-005056c00008" name="77-78" r="0.655142" x="2.1605759999999998" g1="0" b1="3.6271800000000001e-05" g2="0" b2="3.6271800000000001e-05" node1="66" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044fb634-c766-11e1-8775-005056c00008" p1="43.611611422170903" q1="3.9573944081625916" p2="-43.539667356844781" q2="-4.9877390250276088">
         <iidm:alias>_046ed6fb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04893cc3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9606,7 +9606,7 @@
             <iidm:temporaryLimit name="_cce754c5-b9d5-4105-a431-32da96e4a6cf" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c8776-c766-11e1-8775-005056c00008" name="6-7" r="0.79976199999999997" x="3.6241919999999999" g1="0" b1="1.5782850000000001e-05" g2="0" b2="1.5782850000000001e-05" node1="21" voltageLevelId1="_044f6818-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047eb571-c766-11e1-8775-005056c00008" p1="38.372434220643811" q1="-5.6977628117137646" p2="-38.302073457589749" q2="5.4780603614160679">
+    <iidm:line id="_045c8776-c766-11e1-8775-005056c00008" name="6-7" r="0.79976199999999997" x="3.6241919999999999" g1="0" b1="1.5782850000000001e-05" g2="0" b2="1.5782850000000001e-05" node1="21" voltageLevelId1="_044f6818-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047eb571-c766-11e1-8775-005056c00008" p1="38.546377061383545" q1="-6.0428148663241226" p2="-38.475183876428595" q2="5.827034758155917">
         <iidm:alias>_046efe08-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04720b4a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9614,7 +9614,7 @@
             <iidm:temporaryLimit name="_361a9cc3-fb33-4037-9b9a-c20adb90b66b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047ba839-c766-11e1-8775-005056c00008" name="77-80" r="5.1226560000000001" x="18.295200000000001" g1="0" b1="6.5426999999999995e-05" g2="0" b2="6.5426999999999995e-05" node1="67" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="76" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-45.901174550184159" q1="-23.167357431284831" p2="46.659162247785382" q2="23.495388305482273">
+    <iidm:line id="_047ba839-c766-11e1-8775-005056c00008" name="77-80" r="5.1226560000000001" x="18.295200000000001" g1="0" b1="6.5426999999999995e-05" g2="0" b2="6.5426999999999995e-05" node1="67" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="76" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-46.237841401756029" q1="-23.175190040844988" p2="47.005199212410261" q2="23.536975707856183">
         <iidm:alias>_047c6b85-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0480b148-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9622,7 +9622,7 @@
             <iidm:temporaryLimit name="_da00c66f-a882-4938-923b-f2455f7f9a81" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04592c16-c766-11e1-8775-005056c00008" name="78-79" r="0.95135000000000003" x="4.2514560000000001" g1="0" b1="1.8595050000000001e-05" g2="0" b2="1.8595050000000001e-05" node1="22" voltageLevelId1="_044fb634-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04481510-c766-11e1-8775-005056c00008" p1="-27.12732965776723" q1="-20.987816914420613" p2="27.190766559257863" q2="20.618485483549769">
+    <iidm:line id="_04592c16-c766-11e1-8775-005056c00008" name="78-79" r="0.95135000000000003" x="4.2514560000000001" g1="0" b1="1.8595050000000001e-05" g2="0" b2="1.8595050000000001e-05" node1="22" voltageLevelId1="_044fb634-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04481510-c766-11e1-8775-005056c00008" p1="-27.460032008542012" q1="-21.012076977927023" p2="27.524528804485627" q2="20.647609579287714">
         <iidm:alias>_0453add6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045b7605-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9630,7 +9630,7 @@
             <iidm:temporaryLimit name="_ba4abe9d-8490-4c19-b19b-c9d2c3597fc9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047b3301-c766-11e1-8775-005056c00008" name="103-104" r="8.1195839999999997" x="27.599615100000001" g1="0" b1="0.00011679295" g2="0" b2="0.00011679295" node1="40" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="33.038111559518377" q1="13.987439502531293" p2="-32.421614385008091" q2="-15.884809987403123">
+    <iidm:line id="_047b3301-c766-11e1-8775-005056c00008" name="103-104" r="8.1195839999999997" x="27.599615100000001" g1="0" b1="0.00011679295" g2="0" b2="0.00011679295" node1="40" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="33.048469289462872" q1="13.983587348402637" p2="-32.431715408440247" q2="-15.880089690751884">
         <iidm:alias>_0459a142-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045d98e6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9638,7 +9638,7 @@
             <iidm:temporaryLimit name="_2320da74-eda7-4f7f-ade9-1ed0e994f3af" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045e5c32-c766-11e1-8775-005056c00008" name="95-96" r="2.9795039999999999" x="9.5309279999999994" g1="0" b1="4.2298000000000001e-05" g2="0" b2="4.2298000000000001e-05" node1="21" voltageLevelId1="_044f4108-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="14.199886653737162" q1="-24.768335954945933" p2="-14.059894971745479" q2="23.794329900876644">
+    <iidm:line id="_045e5c32-c766-11e1-8775-005056c00008" name="95-96" r="2.9795039999999999" x="9.5309279999999994" g1="0" b1="4.2298000000000001e-05" g2="0" b2="4.2298000000000001e-05" node1="21" voltageLevelId1="_044f4108-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="14.739027776962418" q1="-24.904941633042167" p2="-14.595018782106012" q2="23.944159116632939">
         <iidm:alias>_04597a34-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04801509-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9646,7 +9646,7 @@
             <iidm:temporaryLimit name="_3bc03415-e95f-47a7-8e92-01089d304a9c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045ed169-c766-11e1-8775-005056c00008" name="77-80" r="2.9620799999999998" x="8.4506409999999992" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="68" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="77" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-100.18020278525397" q1="-42.757434855003936" p2="102.15313708724334" q2="43.461013464335068">
+    <iidm:line id="_045ed169-c766-11e1-8775-005056c00008" name="77-80" r="2.9620799999999998" x="8.4506409999999992" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="68" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="77" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-100.89412929102832" q1="-42.728259769627869" p2="102.89145266623663" q2="43.502019543159399">
         <iidm:alias>_0464289a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04828605-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9654,7 +9654,7 @@
             <iidm:temporaryLimit name="_f93b6d4c-39fa-4f6f-a42d-c63a4cf21a67" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047f78c2-c766-11e1-8775-005056c00008" name="5-11" r="3.5370720000000002" x="11.8831682" g1="0" b1="4.987375e-05" g2="0" b2="4.987375e-05" node1="48" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="82.820561520627606" q1="10.768716380126552" p2="-81.429440521274671" q2="-7.8291648654903803">
+    <iidm:line id="_047f78c2-c766-11e1-8775-005056c00008" name="5-11" r="3.5370720000000002" x="11.8831682" g1="0" b1="4.987375e-05" g2="0" b2="4.987375e-05" node1="48" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="83.028667679144036" q1="10.517658077806709" p2="-81.63092679351206" q2="-7.5549505280495861">
         <iidm:alias>_045bc426-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0476c633-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9662,7 +9662,7 @@
             <iidm:temporaryLimit name="_3bc4ab96-7a0d-4e18-b9f5-d89f63a82f0a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04845ac7-c766-11e1-8775-005056c00008" name="71-72" r="7.7711040000000002" x="31.363201100000001" g1="0" b1="0.00012752525" g2="0" b2="0.00012752525" node1="29" voltageLevelId1="_04664b78-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="-13.086146831962262" q1="-2.5819227281348622" p2="13.164624754063423" q2="-1.4613546509897515">
+    <iidm:line id="_04845ac7-c766-11e1-8775-005056c00008" name="71-72" r="7.7711040000000002" x="31.363201100000001" g1="0" b1="0.00012752525" g2="0" b2="0.00012752525" node1="29" voltageLevelId1="_04664b78-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="-11.060276372201795" q1="-2.8837517412951414" p2="11.116621723200245" q2="-1.2390169675614444">
         <iidm:alias>_04642891-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046b0661-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9670,7 +9670,7 @@
             <iidm:temporaryLimit name="_bcb69c6e-125e-449c-acb3-a4deb151668d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047343c2-c766-11e1-8775-005056c00008" name="66-67" r="3.9029759999999998" x="17.685359999999999" g1="0" b1="7.6962800000000001e-05" g2="0" b2="7.6962800000000001e-05" node1="50" voltageLevelId1="_047147f4-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="31.008999740499355" q1="21.034261438850084" p2="-30.708243275842456" q2="-22.525527768726295">
+    <iidm:line id="_047343c2-c766-11e1-8775-005056c00008" name="66-67" r="3.9029759999999998" x="17.685359999999999" g1="0" b1="7.6962800000000001e-05" g2="0" b2="7.6962800000000001e-05" node1="50" voltageLevelId1="_047147f4-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="30.87693969681774" q1="21.056958899886258" p2="-30.577647004371567" q2="-22.554851514314542">
         <iidm:alias>_0465af34-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04860874-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9678,7 +9678,7 @@
             <iidm:temporaryLimit name="_b4b8a31d-dc3c-4b51-88ad-a22e070eb96c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04569409-c766-11e1-8775-005056c00008" name="34-43" r="7.1961120000000003" x="29.289743399999999" g1="0" b1="0.0001212695" g2="0" b2="0.0001212695" node1="40" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_045e8349-c766-11e1-8775-005056c00008" p1="13.635998686072584" q1="-7.8127703991237691" p2="-13.533660155244917" q2="4.4390669850957121">
+    <iidm:line id="_04569409-c766-11e1-8775-005056c00008" name="34-43" r="7.1961120000000003" x="29.289743399999999" g1="0" b1="0.0001212695" g2="0" b2="0.0001212695" node1="40" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_045e8349-c766-11e1-8775-005056c00008" p1="12.84307313113929" q1="-7.7194950407946976" p2="-12.750825144221716" q2="4.3091618088662731">
         <iidm:alias>_04500454-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04505274-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9686,7 +9686,7 @@
             <iidm:temporaryLimit name="_5585c67a-0839-48e6-8847-4393e1e9b9c7" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04817498-c766-11e1-8775-005056c00008" name="52-53" r="7.0567200000000003" x="28.488240000000001" g1="0" b1="0.00011644859999999999" g2="0" b2="0.00011644859999999999" node1="21" voltageLevelId1="_04806326-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04876804-c766-11e1-8775-005056c00008" p1="13.438341583667802" q1="0.93851943063347421" p2="-13.354788545086516" q2="-4.2672352547660779">
+    <iidm:line id="_04817498-c766-11e1-8775-005056c00008" name="52-53" r="7.0567200000000003" x="28.488240000000001" g1="0" b1="0.00011644859999999999" g2="0" b2="0.00011644859999999999" node1="21" voltageLevelId1="_04806326-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04876804-c766-11e1-8775-005056c00008" p1="13.387841034016715" q1="0.95584710505679171" p2="-13.304849240923037" q2="-4.2869494262598629">
         <iidm:alias>_045115c7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0472a784-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9694,7 +9694,7 @@
             <iidm:temporaryLimit name="_e7c9dfab-fb45-4470-964f-4ba9e391f60b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044b7078-c766-11e1-8775-005056c00008" name="105-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="49" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="23" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="26.889711053786076" q1="1.3296797944122811" p2="-26.471381253948977" q2="-4.1925950816020414">
+    <iidm:line id="_044b7078-c766-11e1-8775-005056c00008" name="105-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="49" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="23" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="26.893985085632842" q1="1.3281800357170077" p2="-26.47553169544754" q2="-4.1906849684944421">
         <iidm:alias>_0452c378-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0481c2b7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9702,7 +9702,7 @@
             <iidm:temporaryLimit name="_fff133bf-25fd-46b2-b144-a227c31ee882" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048ac367-c766-11e1-8775-005056c00008" name="100-101" r="4.8264480000000001" x="21.9890881" g1="0" b1="9.4123049999999997e-05" g2="0" b2="9.4123049999999997e-05" node1="77" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046ed6f7-c766-11e1-8775-005056c00008" p1="-21.641053333542903" q1="24.672169784343399" p2="21.952692243244137" q2="-26.558421043430773">
+    <iidm:line id="_048ac367-c766-11e1-8775-005056c00008" name="100-101" r="4.8264480000000001" x="21.9890881" g1="0" b1="9.4123049999999997e-05" g2="0" b2="9.4123049999999997e-05" node1="77" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046ed6f7-c766-11e1-8775-005056c00008" p1="-21.807738940622219" q1="24.75289203206853" p2="22.122459568252502" q2="-26.624947816041967">
         <iidm:alias>_044afb45-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b5fa2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9710,7 +9710,7 @@
             <iidm:temporaryLimit name="_217e3c95-24b5-438f-a721-d2257e1a43b4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0481c2b1-c766-11e1-8775-005056c00008" name="56-57" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="57" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="-30.929734166232315" q1="-5.4126817551286646" p2="31.297394986829907" q2="4.2092397792371354">
+    <iidm:line id="_0481c2b1-c766-11e1-8775-005056c00008" name="56-57" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="57" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="-30.807866154235175" q1="-5.4714683466400658" p2="31.172881431150952" q2="4.2605401644177254">
         <iidm:alias>_045e0e12-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0487dd35-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9718,7 +9718,7 @@
             <iidm:temporaryLimit name="_f5547027-3d48-4a53-937b-bd5ba63ef70d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047a6fb7-c766-11e1-8775-005056c00008" name="47-69" r="14.705855400000001" x="48.403869999999998" g1="0" b1="0.00020351240000000001" g2="0" b2="0.00020351240000000001" node1="31" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="57" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-83.477242331490814" q1="25.72912826991141" p2="89.89822513015946" q2="-12.043541708482417">
+    <iidm:line id="_047a6fb7-c766-11e1-8775-005056c00008" name="47-69" r="14.705855400000001" x="48.403869999999998" g1="0" b1="0.00020351240000000001" g2="0" b2="0.00020351240000000001" node1="31" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="57" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-83.633819532878732" q1="25.815985840032173" p2="90.080700665313373" q2="-12.045005039796537">
         <iidm:alias>_04758db9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0485ba56-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9726,7 +9726,7 @@
             <iidm:temporaryLimit name="_e9fec217-cf6f-4d39-9495-26ed10c05100" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0453fbf0-c766-11e1-8775-005056c00008" name="110-111" r="3.8332799999999998" x="13.1551189" g1="0" b1="5.7392100000000002e-05" g2="0" b2="5.7392100000000002e-05" node1="40" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_046a1c00-c766-11e1-8775-005056c00008" p1="-39.264264319166593" q1="-20.588022960459917" p2="39.729496626932274" q2="20.312108350062548">
+    <iidm:line id="_0453fbf0-c766-11e1-8775-005056c00008" name="110-111" r="3.8332799999999998" x="13.1551189" g1="0" b1="5.7392100000000002e-05" g2="0" b2="5.7392100000000002e-05" node1="40" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_046a1c00-c766-11e1-8775-005056c00008" p1="-39.389508276468284" q1="-20.54447614765051" p2="39.856701542767439" q2="20.275287873806398">
         <iidm:alias>_0447c6f5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04812675-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9734,7 +9734,7 @@
             <iidm:temporaryLimit name="_ea48fee0-31b6-4990-a332-25d08b7d731f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04778984-c766-11e1-8775-005056c00008" name="41-42" r="7.14384" x="23.522401800000001" g1="0" b1="9.8714400000000005e-05" g2="0" b2="9.8714400000000005e-05" node1="21" voltageLevelId1="_048c4a08-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="-9.8651035935645872" q1="-11.430986757877283" p2="9.9669149966285708" q2="8.9555915621222582">
+    <iidm:line id="_04778984-c766-11e1-8775-005056c00008" name="41-42" r="7.14384" x="23.522401800000001" g1="0" b1="9.8714400000000005e-05" g2="0" b2="9.8714400000000005e-05" node1="21" voltageLevelId1="_048c4a08-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="-10.47004806149101" q1="-11.259351363892362" p2="10.576520245297901" q2="8.801612536286644">
         <iidm:alias>_044d1e2a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046512f1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9742,7 +9742,7 @@
             <iidm:temporaryLimit name="_063af52c-fe10-4c1e-85d4-dd80dcc1d2f9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04653a08-c766-11e1-8775-005056c00008" name="80-99" r="7.9104960000000002" x="35.893439999999998" g1="0" b1="0.00015668044999999999" g2="0" b2="0.00015668044999999999" node1="78" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04644fa4-c766-11e1-8775-005056c00008" p1="2.5630773124582484" q1="6.5502464082000724" p2="-2.5224134944437466" q2="-12.159125900711729">
+    <iidm:line id="_04653a08-c766-11e1-8775-005056c00008" name="80-99" r="7.9104960000000002" x="35.893439999999998" g1="0" b1="0.00015668044999999999" g2="0" b2="0.00015668044999999999" node1="78" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04644fa4-c766-11e1-8775-005056c00008" p1="1.995833990544537" q1="6.6809955906119463" p2="-1.9552053744424023" q2="-12.289965102496769">
         <iidm:alias>_04773b69-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0477b092-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9750,7 +9750,7 @@
             <iidm:temporaryLimit name="_c05229ce-6abb-4209-ad4f-0dcd4a070f28" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04581aa5-c766-11e1-8775-005056c00008" name="54-59" r="8.7642720000000001" x="39.953229999999998" g1="0" b1="0.0001716024" g2="0" b2="0.0001716024" node1="58" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-19.549275234181998" q1="-10.545290561610541" p2="19.793764152810382" q2="6.0318977267028648">
+    <iidm:line id="_04581aa5-c766-11e1-8775-005056c00008" name="54-59" r="8.7642720000000001" x="39.953229999999998" g1="0" b1="0.0001716024" g2="0" b2="0.0001716024" node1="58" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-19.649100460035239" q1="-10.518767416566559" p2="19.895519294998376" q2="6.014176066801995">
         <iidm:alias>_0457cc82-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045cae81-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9758,7 +9758,7 @@
             <iidm:temporaryLimit name="_ac528cbe-6fc1-41dd-ba9d-d8b7a4c77576" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04690a93-c766-11e1-8775-005056c00008" name="92-94" r="8.3809430000000003" x="27.529920000000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="67" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="64.752849213002079" q1="-16.292560650360553" p2="-62.592332990140441" q2="19.424394041102751">
+    <iidm:line id="_04690a93-c766-11e1-8775-005056c00008" name="92-94" r="8.3809430000000003" x="27.529920000000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="67" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="65.185622339016788" q1="-16.35223166517482" p2="-62.996316710246013" q2="19.579338276647015">
         <iidm:alias>_044c33c1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0483706b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9766,7 +9766,7 @@
             <iidm:temporaryLimit name="_6ac84228-6b04-4b10-b560-29655c8e93b4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046009e3-c766-11e1-8775-005056c00008" name="37-39" r="5.5931040000000003" x="18.469439999999999" g1="0" b1="7.7479350000000006e-05" g2="0" b2="7.7479350000000006e-05" node1="57" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046bf0c7-c766-11e1-8775-005056c00008" p1="67.685952172017068" q1="18.05231295548688" p2="-65.922705637226215" q2="-14.559472186068239">
+    <iidm:line id="_046009e3-c766-11e1-8775-005056c00008" name="37-39" r="5.5931040000000003" x="18.469439999999999" g1="0" b1="7.7479350000000006e-05" g2="0" b2="7.7479350000000006e-05" node1="57" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046bf0c7-c766-11e1-8775-005056c00008" p1="67.007386627559384" q1="18.05491706491965" p2="-65.274492796595212" q2="-14.659683778498472">
         <iidm:alias>_044c33c9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04789afa-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9774,7 +9774,7 @@
             <iidm:temporaryLimit name="_2ccdc288-c132-40d1-a928-3887bec4ff67" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0458b6e8-c766-11e1-8775-005056c00008" name="46-47" r="6.6211200000000003" x="22.12848" g1="0" b1="9.0679499999999998e-05" g2="0" b2="9.0679499999999998e-05" node1="33" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_0457f396-c766-11e1-8775-005056c00008" p1="-32.15281487804225" q1="1.103239425896295" p2="32.544501630054604" q2="-3.0165002176769122">
+    <iidm:line id="_0458b6e8-c766-11e1-8775-005056c00008" name="46-47" r="6.6211200000000003" x="22.12848" g1="0" b1="9.0679499999999998e-05" g2="0" b2="9.0679499999999998e-05" node1="33" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_0457f396-c766-11e1-8775-005056c00008" p1="-32.35286693378724" q1="1.1885089823099062" p2="32.749584855546367" q2="-3.0848880434895856">
         <iidm:alias>_04507980-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0464c4da-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9782,7 +9782,7 @@
             <iidm:temporaryLimit name="_06ca3245-2668-448f-a5c6-961924217a5c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044f8f22-c766-11e1-8775-005056c00008" name="82-83" r="1.9514879999999999" x="6.3858959999999998" g1="0" b1="0.0001089302" g2="0" b2="0.0001089302" node1="31" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728074-c766-11e1-8775-005056c00008" p1="-65.561169866400206" q1="39.158856111103439" p2="66.256485848010243" q2="-40.511497223502381">
+    <iidm:line id="_044f8f22-c766-11e1-8775-005056c00008" name="82-83" r="1.9514879999999999" x="6.3858959999999998" g1="0" b1="0.0001089302" g2="0" b2="0.0001089302" node1="31" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728074-c766-11e1-8775-005056c00008" p1="-66.32337062086215" q1="39.490142315314728" p2="67.033785311762429" q2="-40.792033767622868">
         <iidm:alias>_047a48a6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b3891-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9790,7 +9790,7 @@
             <iidm:temporaryLimit name="_dfbd2f07-76ab-41e3-910f-dc706979ea4b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045cfca6-c766-11e1-8775-005056c00008" name="108-109" r="1.82952" x="5.0181120000000004" g1="0" b1="2.1809000000000001e-05" g2="0" b2="2.1809000000000001e-05" node1="21" voltageLevelId1="_046c65f4-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b7b99-c766-11e1-8775-005056c00008" p1="20.849106321009572" q1="-0.5540380276309721" p2="-20.799499784468249" q2="-0.0076236969579897632">
+    <iidm:line id="_045cfca6-c766-11e1-8775-005056c00008" name="108-109" r="1.82952" x="5.0181120000000004" g1="0" b1="2.1809000000000001e-05" g2="0" b2="2.1809000000000001e-05" node1="21" voltageLevelId1="_046c65f4-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b7b99-c766-11e1-8775-005056c00008" p1="20.787105520545836" q1="-0.53205286797386109" p2="-20.737794835620889" q2="-0.030424761950086608">
         <iidm:alias>_04481514-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04716f00-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9798,7 +9798,7 @@
             <iidm:temporaryLimit name="_11451cec-81c7-4f83-a7db-df7dcaffa94e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04784cd5-c766-11e1-8775-005056c00008" name="70-74" r="6.9870239999999999" x="23.051952400000001" g1="0" b1="9.6648299999999994e-05" g2="0" b2="9.6648299999999994e-05" node1="48" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047dcb11-c766-11e1-8775-005056c00008" p1="23.957300868651409" q1="9.4523507343044226" p2="-23.669230741602515" q2="-11.689552134670203">
+    <iidm:line id="_04784cd5-c766-11e1-8775-005056c00008" name="70-74" r="6.9870239999999999" x="23.051952400000001" g1="0" b1="9.6648299999999994e-05" g2="0" b2="9.6648299999999994e-05" node1="48" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047dcb11-c766-11e1-8775-005056c00008" p1="23.000767345281901" q1="9.4962738143656793" p2="-22.730432503023788" q2="-11.787457703948197">
         <iidm:alias>_045e5c33-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046ab84b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9806,7 +9806,7 @@
             <iidm:temporaryLimit name="_37a5cc00-bd7f-4ec7-a77c-e140e23450d2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04747c40-c766-11e1-8775-005056c00008" name="77-82" r="5.1923519999999996" x="14.8626719" g1="0" b1="0.0002345615" g2="0" b2="0.0002345615" node1="69" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_046512f8-c766-11e1-8775-005056c00008" p1="-26.508739796607237" q1="30.894965454339957" p2="27.080244598877425" q2="-37.303319826150528">
+    <iidm:line id="_04747c40-c766-11e1-8775-005056c00008" name="77-82" r="5.1923519999999996" x="14.8626719" g1="0" b1="0.0002345615" g2="0" b2="0.0002345615" node1="69" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_046512f8-c766-11e1-8775-005056c00008" p1="-27.518118386659363" q1="31.332782503831591" p2="28.115059822742243" q2="-37.665951055152021">
         <iidm:alias>_0451b202-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0452ea84-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9814,7 +9814,7 @@
             <iidm:temporaryLimit name="_e9798d58-b518-4fab-984c-c72076dfc2ae" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045e3524-c766-11e1-8775-005056c00008" name="23-24" r="2.3522400000000001" x="8.5726080000000007" g1="0" b1="0.00014290635" g2="0" b2="0.00014290635" node1="39" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_048c22fa-c766-11e1-8775-005056c00008" p1="57.52458007824616" q1="-9.1921309525794381" p2="-57.07548553917222" q2="5.8284103790633619">
+    <iidm:line id="_045e3524-c766-11e1-8775-005056c00008" name="23-24" r="2.3522400000000001" x="8.5726080000000007" g1="0" b1="0.00014290635" g2="0" b2="0.00014290635" node1="39" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_048c22fa-c766-11e1-8775-005056c00008" p1="53.251870250751288" q1="-9.7766724008521813" p2="-52.862799894910552" q2="6.2190140248688577">
         <iidm:alias>_046cb413-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f9fd3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9822,7 +9822,7 @@
             <iidm:temporaryLimit name="_e8ec73b8-1ecf-4d18-9ef9-80eabf3a4969" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0474f177-c766-11e1-8775-005056c00008" name="15-17" r="2.2999679999999998" x="7.6142880000000002" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="48" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-159.91868496764286" q1="-14.464459299606144" p2="163.67731531516463" q2="22.764800955756183">
+    <iidm:line id="_0474f177-c766-11e1-8775-005056c00008" name="15-17" r="2.2999679999999998" x="7.6142880000000002" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="48" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-159.93498579276954" q1="-15.565376321858265" p2="163.71487176889093" q2="23.951124595361804">
         <iidm:alias>_044c5ad2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046931a7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9830,7 +9830,7 @@
             <iidm:temporaryLimit name="_2ceac3d1-f73d-43db-8d37-9e329f1787bb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0483be84-c766-11e1-8775-005056c00008" name="8-30" r="2.0860400000000001" x="24.393599999999999" g1="0" b1="0.00053099175999999997" g2="0" b2="0.00053099175999999997" node1="30" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="38" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="102.91382030696595" q1="19.969827239127746" p2="-102.37387764854675" q2="-64.47200988492402">
+    <iidm:line id="_0483be84-c766-11e1-8775-005056c00008" name="8-30" r="2.0860400000000001" x="24.393599999999999" g1="0" b1="0.00053099175999999997" g2="0" b2="0.00053099175999999997" node1="30" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="38" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="103.78564681237188" q1="20.939782488602795" p2="-103.23372441415874" q2="-65.220203838290274">
         <iidm:alias>_0454e651-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04801506-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9838,7 +9838,7 @@
             <iidm:temporaryLimit name="_ca795ad3-97e5-4416-aaba-53cce27f6434" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0488eea6-c766-11e1-8775-005056c00008" name="49-69" r="17.16264" x="56.453762099999999" g1="0" b1="0.00023760329999999999" g2="0" b2="0.00023760329999999999" node1="115" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-75.176899132016715" q1="26.443050833125785" p2="81.364409029983079" q2="-14.874689902136391">
+    <iidm:line id="_0488eea6-c766-11e1-8775-005056c00008" name="49-69" r="17.16264" x="56.453762099999999" g1="0" b1="0.00023760329999999999" g2="0" b2="0.00023760329999999999" node1="115" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-75.304267223963279" q1="26.522299499494391" p2="81.514331571126917" q2="-14.879744056138854">
         <iidm:alias>_04492681-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046735d6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9846,7 +9846,7 @@
             <iidm:temporaryLimit name="_c42dc3ef-3a2e-4070-8efb-78e5c0cd5554" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047566a0-c766-11e1-8775-005056c00008" name="13-15" r="12.9634562" x="42.584255200000001" g1="0" b1="0.00017986685000000001" g2="0" b2="0.00017986685000000001" node1="21" voltageLevelId1="_04851e1b-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="10.634179774122545" q1="-0.23755101266677267" p2="-10.538128782618038" q2="-5.1986593984165017">
+    <iidm:line id="_047566a0-c766-11e1-8775-005056c00008" name="13-15" r="12.9634562" x="42.584255200000001" g1="0" b1="0.00017986685000000001" g2="0" b2="0.00017986685000000001" node1="21" voltageLevelId1="_04851e1b-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="10.927620672655568" q1="0.23540231796543437" p2="-10.824195649014401" q2="-5.6313548341522051">
         <iidm:alias>_04662461-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04865694-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9854,7 +9854,7 @@
             <iidm:temporaryLimit name="_ad988fd9-9270-4230-95a2-1858f32259df" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0476c63a-c766-11e1-8775-005056c00008" name="69-70" r="5.2271999999999998" x="22.12848" g1="0" b1="0.00035009184999999998" g2="0" b2="0.00035009184999999998" node1="59" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="75.549946676144558" q1="19.455191274468344" p2="-73.762296101670103" q2="-24.339126337241765">
+    <iidm:line id="_0476c63a-c766-11e1-8775-005056c00008" name="69-70" r="5.2271999999999998" x="22.12848" g1="0" b1="0.00035009184999999998" g2="0" b2="0.00035009184999999998" node1="59" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="77.618161060415119" q1="19.819113108417053" p2="-75.73645827451206" q2="-24.294934412630123">
         <iidm:alias>_047e193a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b1184-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9862,7 +9862,7 @@
             <iidm:temporaryLimit name="_519e3ecb-3561-4d11-ac6b-172a0b4b09b2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04520028-c766-11e1-8775-005056c00008" name="19-20" r="4.3908480000000001" x="20.38608" g1="0" b1="8.5514249999999999e-05" g2="0" b2="8.5514249999999999e-05" node1="39" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b2d70-c766-11e1-8775-005056c00008" p1="-20.879331476211561" q1="-3.0574033492840118" p2="21.003647993737943" q2="0.96027715290440829">
+    <iidm:line id="_04520028-c766-11e1-8775-005056c00008" name="19-20" r="4.3908480000000001" x="20.38608" g1="0" b1="8.5514249999999999e-05" g2="0" b2="8.5514249999999999e-05" node1="39" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b2d70-c766-11e1-8775-005056c00008" p1="-12.814697086414476" q1="1.190068775861411" p2="12.863340553509959" q2="-3.5976653864579324">
         <iidm:alias>_0472f5a9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04745537-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9870,7 +9870,7 @@
             <iidm:temporaryLimit name="_b88528bf-cb1c-4c00-ad79-d5937197d40c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04862f83-c766-11e1-8775-005056c00008" name="94-95" r="2.2999679999999998" x="7.5620159999999998" g1="0" b1="3.1852600000000001e-05" g2="0" b2="3.1852600000000001e-05" node1="51" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f4108-c766-11e1-8775-005056c00008" p1="56.643136787981831" q1="6.6157512948779225" p2="-56.201468155784731" q2="-6.2335987355525004">
+    <iidm:line id="_04862f83-c766-11e1-8775-005056c00008" name="94-95" r="2.2999679999999998" x="7.5620159999999998" g1="0" b1="3.1852600000000001e-05" g2="0" b2="3.1852600000000001e-05" node1="51" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f4108-c766-11e1-8775-005056c00008" p1="57.188429938150477" q1="6.504029626922728" p2="-56.738471189908012" q2="-6.0943732563490869">
         <iidm:alias>_044ca8f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04837060-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9878,7 +9878,7 @@
             <iidm:temporaryLimit name="_b70e76a1-6e79-4fb6-b487-dffa9bfeab7b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047b0bf6-c766-11e1-8775-005056c00008" name="12-16" r="3.6938879999999998" x="14.5316162" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="68" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046f7338-c766-11e1-8775-005056c00008" p1="9.50209823886515" q1="9.0997250587540588" p2="-9.4602907999364252" q2="-11.010403249374143">
+    <iidm:line id="_047b0bf6-c766-11e1-8775-005056c00008" name="12-16" r="3.6938879999999998" x="14.5316162" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="68" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046f7338-c766-11e1-8775-005056c00008" p1="9.7919479813185504" q1="9.5808633258855593" p2="-9.7467684716805714" q2="-11.477298304541337">
         <iidm:alias>_0450798a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045c8772-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9886,7 +9886,7 @@
             <iidm:temporaryLimit name="_af73f526-c58b-40e7-8e1c-14f05a39f6a2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04524e47-c766-11e1-8775-005056c00008" name="100-103" r="2.7878400000000001" x="9.1476000000000006" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="78" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0475b4c0-c766-11e1-8775-005056c00008" p1="115.59165790191206" q1="-20.691432888435575" p2="-113.47503009054788" q2="22.130850328998186">
+    <iidm:line id="_04524e47-c766-11e1-8775-005056c00008" name="100-103" r="2.7878400000000001" x="9.1476000000000006" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="78" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0475b4c0-c766-11e1-8775-005056c00008" p1="115.38860322334213" q1="-20.643031576164656" p2="-113.27949694050041" q2="22.057774026050257">
         <iidm:alias>_04684744-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048aea71-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9894,7 +9894,7 @@
             <iidm:temporaryLimit name="_1631e50b-21a3-470b-803b-f9665b6fcd60" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04682038-c766-11e1-8775-005056c00008" name="27-32" r="3.9900959999999999" x="13.1551189" g1="0" b1="5.5268600000000001e-05" g2="0" b2="5.5268600000000001e-05" node1="40" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="15.733223883372061" q1="-2.6096284189358689" p2="-15.672237606005568" q2="1.0038248192521544">
+    <iidm:line id="_04682038-c766-11e1-8775-005056c00008" name="27-32" r="3.9900959999999999" x="13.1551189" g1="0" b1="5.5268600000000001e-05" g2="0" b2="5.5268600000000001e-05" node1="40" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="15.962837673592386" q1="-2.6750371639424411" p2="-15.899842079379944" q2="1.0810153448391817">
         <iidm:alias>_0455347a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479ac63-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9902,7 +9902,7 @@
             <iidm:temporaryLimit name="_52eb4b09-42bb-4106-ac26-fe1059639d3a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0482fb31-c766-11e1-8775-005056c00008" name="59-61" r="5.7150720000000002" x="26.1360016" g1="0" b1="0.0001113407" g2="0" b2="0.0001113407" node1="68" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-100.83815123386731" q1="22.27657294925514" p2="104.47302695792446" q2="-9.4565529415317897">
+    <iidm:line id="_0482fb31-c766-11e1-8775-005056c00008" name="59-61" r="5.7150720000000002" x="26.1360016" g1="0" b1="0.0001113407" g2="0" b2="0.0001113407" node1="68" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-100.75664430276572" q1="22.244178313441825" p2="104.38543873594976" q2="-9.451966605632256">
         <iidm:alias>_044a10e9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0473b8f5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9910,7 +9910,7 @@
             <iidm:temporaryLimit name="_b5a7dea0-bfce-4548-a04d-7bb7b6d9f80a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047d55e3-c766-11e1-8775-005056c00008" name="100-104" r="7.8582239999999999" x="35.544960000000003" g1="0" b1="0.00015524565000000001" g2="0" b2="0.00015524565000000001" node1="79" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="55.04501506016031" q1="10.976728854244636" p2="-53.641075660188122" q2="-9.9722539045417182">
+    <iidm:line id="_047d55e3-c766-11e1-8775-005056c00008" name="100-104" r="7.8582239999999999" x="35.544960000000003" g1="0" b1="0.00015524565000000001" g2="0" b2="0.00015524565000000001" node1="79" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="55.001208104437872" q1="10.980547165615398" p2="-53.599323686769985" q2="-9.9853733849530926">
         <iidm:alias>_04636547-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048aea76-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9918,7 +9918,7 @@
             <iidm:temporaryLimit name="_17a10cd0-b653-4dcf-bdc3-4d5005ea9591" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04653a02-c766-11e1-8775-005056c00008" name="75-77" r="10.4718237" x="34.830577900000002" g1="0" b1="0.00014284895" g2="0" b2="0.00014284895" node1="49" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-35.809721687529922" q1="-7.081000018001343" p2="36.646499502319443" q2="5.0293231079805132">
+    <iidm:line id="_04653a02-c766-11e1-8775-005056c00008" name="75-77" r="10.4718237" x="34.830577900000002" g1="0" b1="0.00014284895" g2="0" b2="0.00014284895" node1="49" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-36.616409956005654" q1="-6.9280757083360083" p2="37.490582720503596" q2="5.0036304618960239">
         <iidm:alias>_04642894-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04720b47-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9926,7 +9926,7 @@
             <iidm:temporaryLimit name="_6f81df11-7e71-4b6e-a6ee-a8c5f72f4ba5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04483c2a-c766-11e1-8775-005056c00008" name="23-32" r="5.5234079999999999" x="20.089872400000001" g1="0" b1="0.00033660465000000001" g2="0" b2="0.00033660465000000001" node1="40" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="81.152192430230173" q1="7.2564620045780499" p2="-79.02686803367294" q2="-10.928089918453384">
+    <iidm:line id="_04483c2a-c766-11e1-8775-005056c00008" name="23-32" r="5.5234079999999999" x="20.089872400000001" g1="0" b1="0.00033660465000000001" g2="0" b2="0.00033660465000000001" node1="40" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="80.524852291684624" q1="6.051664101249548" p2="-78.429146674013595" q2="-9.781327068594015">
         <iidm:alias>_044b978a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0461dea6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9934,7 +9934,7 @@
             <iidm:temporaryLimit name="_a8f6a7d2-e58d-4671-a776-97be7291355e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048719e5-c766-11e1-8775-005056c00008" name="96-97" r="3.0143520000000001" x="15.42024" g1="0" b1="6.8870549999999994e-05" g2="0" b2="6.8870549999999994e-05" node1="50" voltageLevelId1="_045a1672-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="2.6454270333590788" q1="-25.325814067246395" p2="-2.5407057427961059" q2="23.46960866786727">
+    <iidm:line id="_048719e5-c766-11e1-8775-005056c00008" name="96-97" r="3.0143520000000001" x="15.42024" g1="0" b1="6.8870549999999994e-05" g2="0" b2="6.8870549999999994e-05" node1="50" voltageLevelId1="_045a1672-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="3.0816726573279221" q1="-25.476962257544283" p2="-2.9751773449388899" q2="23.630320956450017">
         <iidm:alias>_0451b207-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04828601-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9942,7 +9942,7 @@
             <iidm:temporaryLimit name="_ea6d39aa-df95-4d3e-b7b6-a800e552e72a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048481d0-c766-11e1-8775-005056c00008" name="25-27" r="5.5408330000000001" x="28.401121100000001" g1="0" b1="0.000506198385" g2="0" b2="0.000506198385" node1="30" voltageLevelId1="_04728079-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0476c639-c766-11e1-8775-005056c00008" p1="148.73615959814802" q1="29.12246746077583" p2="-141.91999783067914" q2="-12.202493351669114">
+    <iidm:line id="_048481d0-c766-11e1-8775-005056c00008" name="25-27" r="5.5408330000000001" x="28.401121100000001" g1="0" b1="0.000506198385" g2="0" b2="0.000506198385" node1="30" voltageLevelId1="_04728079-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0476c639-c766-11e1-8775-005056c00008" p1="149.09468466792791" q1="30.009787447251867" p2="-142.22761234528323" q2="-12.80522665600731">
         <iidm:alias>_046d2947-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04725960-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9950,7 +9950,7 @@
             <iidm:temporaryLimit name="_d9d53af2-5ffa-4f2a-a4e6-ed22371332d6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04885268-c766-11e1-8775-005056c00008" name="110-112" r="4.3037280000000004" x="11.1513615" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="41" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="13" voltageLevelId2="_04784cd1-c766-11e1-8775-005056c00008" p1="69.35439222764451" q1="11.007409586584336" p2="-67.999994151833818" q2="-12.999989282032251">
+    <iidm:line id="_04885268-c766-11e1-8775-005056c00008" name="110-112" r="4.3037280000000004" x="11.1513615" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="41" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="13" voltageLevelId2="_04784cd1-c766-11e1-8775-005056c00008" p1="69.354403113392067" q1="11.007381541100486" p2="-68.000011020602699" q2="-13.000002967598398">
         <iidm:alias>_04611b55-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0481c2ba-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9958,7 +9958,7 @@
             <iidm:temporaryLimit name="_d50299b9-a055-408a-aa1e-2e93a715120f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0484a8e4-c766-11e1-8775-005056c00008" name="89-92" r="1.7249760000000001" x="8.7991200000000003" g1="0" b1="0.00015725434999999999" g2="0" b2="0.00015725434999999999" node1="57" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="68" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="227.6113771184356" q1="-3.2588800250804573" p2="-222.53337882814685" q2="23.711762385800402">
+    <iidm:line id="_0484a8e4-c766-11e1-8775-005056c00008" name="89-92" r="1.7249760000000001" x="8.7991200000000003" g1="0" b1="0.00015725434999999999" g2="0" b2="0.00015725434999999999" node1="57" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="68" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="228.46572881947526" q1="-3.1857748060866387" p2="-223.34953932380702" q2="23.833862476138744">
         <iidm:alias>_04481517-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04808a3c-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9966,7 +9966,7 @@
             <iidm:temporaryLimit name="_eee9ca2b-764f-4ab8-a745-405338044743" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04689568-c766-11e1-8775-005056c00008" name="49-54" r="15.1414566" x="50.703842199999997" g1="0" b1="0.00020948120000000001" g2="0" b2="0.00020948120000000001" node1="116" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="46.672066269105848" q1="9.6001474234145867" p2="-44.721058155554637" q2="-10.230530030397823">
+    <iidm:line id="_04689568-c766-11e1-8775-005056c00008" name="49-54" r="15.1414566" x="50.703842199999997" g1="0" b1="0.00020948120000000001" g2="0" b2="0.00020948120000000001" node1="116" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="46.528700456000685" q1="9.6237598548016674" p2="-44.588217886934714" q2="-10.289384671971177">
         <iidm:alias>_046030f0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04605808-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9974,7 +9974,7 @@
             <iidm:temporaryLimit name="_690202a4-aad2-4ad3-8842-961b39e37709" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046c8d04-c766-11e1-8775-005056c00008" name="40-41" r="2.5264799999999998" x="8.4854880000000001" g1="0" b1="3.5066600000000001e-05" g2="0" b2="3.5066600000000001e-05" node1="40" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048c4a08-c766-11e1-8775-005056c00008" p1="27.265198917840312" q1="-1.9623588476822578" p2="-27.130975345345103" q2="1.4327620743490921">
+    <iidm:line id="_046c8d04-c766-11e1-8775-005056c00008" name="40-41" r="2.5264799999999998" x="8.4854880000000001" g1="0" b1="3.5066600000000001e-05" g2="0" b2="3.5066600000000001e-05" node1="40" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048c4a08-c766-11e1-8775-005056c00008" p1="26.647339906551899" q1="-1.8129840841182383" p2="-26.519072779673547" q2="1.2642525426536237">
         <iidm:alias>_045cae80-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a2194-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9982,7 +9982,7 @@
             <iidm:temporaryLimit name="_34f2ef7c-32da-4444-b989-d02f5f931c50" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046735d5-c766-11e1-8775-005056c00008" name="39-40" r="3.206016" x="10.54152" g1="0" b1="4.4536249999999999e-05" g2="0" b2="4.4536249999999999e-05" node1="22" voltageLevelId1="_046bf0c7-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="38.925142354446201" q1="3.5611334044162097" p2="-38.582894883283657" q2="-3.7002889119208433">
+    <iidm:line id="_046735d5-c766-11e1-8775-005056c00008" name="39-40" r="3.206016" x="10.54152" g1="0" b1="4.4536249999999999e-05" g2="0" b2="4.4536249999999999e-05" node1="22" voltageLevelId1="_046bf0c7-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="38.282573185698816" q1="3.6651709856550143" p2="-37.95087950343985" q2="-3.8378351637804329">
         <iidm:alias>_045115c1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048badc2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9990,7 +9990,7 @@
             <iidm:temporaryLimit name="_38d58455-5205-46bb-8e44-c66873f62938" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0470d2c4-c766-11e1-8775-005056c00008" name="89-92" r="6.8476319999999999" x="27.5473423" g1="0" b1="0.00011880164999999999" g2="0" b2="0.00011880164999999999" node1="58" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="71.801212392058588" q1="-5.843133435978304" p2="-69.789768037561288" q2="9.8176091232481753">
+    <iidm:line id="_0470d2c4-c766-11e1-8775-005056c00008" name="89-92" r="6.8476319999999999" x="27.5473423" g1="0" b1="0.00011880164999999999" g2="0" b2="0.00011880164999999999" node1="58" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="72.071906671865094" q1="-5.8335710903224784" p2="-70.045334410649289" q2="9.8692006737417071">
         <iidm:alias>_04690a97-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04690a98-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9998,7 +9998,7 @@
             <iidm:temporaryLimit name="_0cce41c7-b99f-4fec-93d2-73ea24433fa1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0479ac60-c766-11e1-8775-005056c00008" name="33-37" r="7.2309599999999996" x="24.742080000000001" g1="0" b1="0.00010502754999999999" g2="0" b2="0.00010502754999999999" node1="21" voltageLevelId1="_0456bb11-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="42.271832805341717" q1="-20.535593845609036" p2="-41.257413408441046" q2="20.750572621736048">
+    <iidm:line id="_0479ac60-c766-11e1-8775-005056c00008" name="33-37" r="7.2309599999999996" x="24.742080000000001" g1="0" b1="0.00010502754999999999" g2="0" b2="0.00010502754999999999" node1="21" voltageLevelId1="_0456bb11-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="39.742276729456151" q1="-20.276663829853408" p2="-38.828443320942682" q2="20.153149206612849">
         <iidm:alias>_04716f08-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0483be89-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10006,7 +10006,7 @@
             <iidm:temporaryLimit name="_343677c6-7477-4bf6-a12c-2c7e4a684d6f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048c4a00-c766-11e1-8775-005056c00008" name="105-108" r="4.5476640000000002" x="12.249072099999999" g1="0" b1="5.2915499999999998e-05" g2="0" b2="5.2915499999999998e-05" node1="50" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_046c65f4-c766-11e1-8775-005056c00008" p1="22.997237006271778" q1="-0.86260788588862336" p2="-22.849105781575826" q2="-0.44596085503065541">
+    <iidm:line id="_048c4a00-c766-11e1-8775-005056c00008" name="105-108" r="4.5476640000000002" x="12.249072099999999" g1="0" b1="5.2915499999999998e-05" g2="0" b2="5.2915499999999998e-05" node1="50" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_046c65f4-c766-11e1-8775-005056c00008" p1="22.934428878534309" q1="-0.84280624942940885" p2="-22.78710601225109" q2="-0.46794750061901091">
         <iidm:alias>_046adf53-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04795e46-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10014,7 +10014,7 @@
             <iidm:temporaryLimit name="_74cf84b9-e14f-4f81-9e8b-3a791cd474a0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04631724-c766-11e1-8775-005056c00008" name="34-37" r="0.44605400000000001" x="1.637856" g1="0" b1="2.8236900000000001e-05" g2="0" b2="2.8236900000000001e-05" node1="41" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-54.300985135197379" q1="-35.72845529995282" p2="54.421324700714159" q2="35.287765936876362">
+    <iidm:line id="_04631724-c766-11e1-8775-005056c00008" name="34-37" r="0.44605400000000001" x="1.637856" g1="0" b1="2.8236900000000001e-05" g2="0" b2="2.8236900000000001e-05" node1="41" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-56.383379897628984" q1="-35.462931163347697" p2="56.509967208673984" q2="35.046323797347334">
         <iidm:alias>_04592c19-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04719611-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10022,7 +10022,7 @@
             <iidm:temporaryLimit name="_8e90bf2e-3be4-41be-a84e-c1d4e709f8a1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04814d85-c766-11e1-8775-005056c00008" name="61-62" r="1.435738" x="6.5514239999999999" g1="0" b1="2.812215e-05" g2="0" b2="2.812215e-05" node1="40" voltageLevelId1="_0448d867-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="59.941592561283194" q1="-18.17434269406774" p2="-59.616503485889979" q2="18.685568470057074">
+    <iidm:line id="_04814d85-c766-11e1-8775-005056c00008" name="61-62" r="1.435738" x="6.5514239999999999" g1="0" b1="2.812215e-05" g2="0" b2="2.812215e-05" node1="40" voltageLevelId1="_0448d867-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="60.101591318343793" q1="-18.205964344201359" p2="-59.774810254927026" q2="18.724911240621378">
         <iidm:alias>_045a3d85-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047abdd8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10030,7 +10030,7 @@
             <iidm:temporaryLimit name="_39a23399-348e-44d9-8032-8fc62e6c7d63" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046a4318-c766-11e1-8775-005056c00008" name="101-102" r="4.2863040000000003" x="19.5148811" g1="0" b1="8.4366399999999999e-05" g2="0" b2="8.4366399999999999e-05" node1="22" voltageLevelId1="_046ed6f7-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="-43.953042552277857" q1="11.55803128559697" p2="44.479548896566463" q2="-12.039958819465857">
+    <iidm:line id="_046a4318-c766-11e1-8775-005056c00008" name="101-102" r="4.2863040000000003" x="19.5148811" g1="0" b1="8.4366399999999999e-05" g2="0" b2="8.4366399999999999e-05" node1="22" voltageLevelId1="_046ed6f7-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="-44.122377572471869" q1="11.625041507651879" p2="44.653109163490271" q2="-12.087391963696453">
         <iidm:alias>_04878f1b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04885261-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10038,7 +10038,7 @@
             <iidm:temporaryLimit name="_0501dacc-29fc-44a2-8cad-31a20b011d25" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c81e3-c766-11e1-8775-005056c00008" name="26-30" r="3.8671600000000002" x="41.624000000000002" g1="0" b1="0.00093801650000000002" g2="0" b2="0.00093801650000000002" node1="21" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="238.23529894586537" q1="-4.9594837957776079" p2="-233.69794206216042" q2="-36.677135679271935">
+    <iidm:line id="_044c81e3-c766-11e1-8775-005056c00008" name="26-30" r="3.8671600000000002" x="41.624000000000002" g1="0" b1="0.00093801650000000002" g2="0" b2="0.00093801650000000002" node1="21" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="238.54566991428308" q1="-3.6794347963925667" p2="-233.98840734253579" q2="-37.649159473865325">
         <iidm:alias>_0463654b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04747c4a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10046,7 +10046,7 @@
             <iidm:temporaryLimit name="_c95a66fd-913c-48c7-b8ef-cf3007c60af6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048915b9-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="41" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="117" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-52.969956729242064" q1="-19.076899676789218" p2="55.578191893760376" q2="22.751748443656979">
+    <iidm:line id="_048915b9-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="41" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="117" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-53.574611835434318" q1="-18.914045503850303" p2="56.23583974798305" q2="22.83105234533242">
         <iidm:alias>_044bbe98-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0456e224-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10054,7 +10054,7 @@
             <iidm:temporaryLimit name="_6cd83bc2-204f-44d5-afd4-fbfef8d2146f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c5ad6-c766-11e1-8775-005056c00008" name="105-106" r="2.4393600000000002" x="9.5309279999999994" g1="0" b1="4.1150150000000001e-05" g2="0" b2="4.1150150000000001e-05" node1="51" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="9.6080188245320812" q1="6.1491637029425199" p2="-9.5871672087740052" q2="-7.3967220093629464">
+    <iidm:line id="_044c5ad6-c766-11e1-8775-005056c00008" name="105-106" r="2.4393600000000002" x="9.5309279999999994" g1="0" b1="4.1150150000000001e-05" g2="0" b2="4.1150150000000001e-05" node1="51" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="9.6374988311548311" q1="6.1385444858842275" p2="-9.6165837661687767" q2="-7.3858610993743108">
         <iidm:alias>_04505270-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04531190-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10062,7 +10062,7 @@
             <iidm:temporaryLimit name="_487e1317-48f9-4747-b931-f3f79e95f55a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048badc5-c766-11e1-8775-005056c00008" name="60-61" r="0.45999400000000001" x="2.3522400000000001" g1="0" b1="4.1781450000000003e-05" g2="0" b2="4.1781450000000003e-05" node1="30" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-169.27706333569105" q1="15.878460330038251" p2="170.05244026871424" q2="-13.351296126967634">
+    <iidm:line id="_048badc5-c766-11e1-8775-005056c00008" name="60-61" r="0.45999400000000001" x="2.3522400000000001" g1="0" b1="4.1781450000000003e-05" g2="0" b2="4.1781450000000003e-05" node1="30" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-169.28939903389528" q1="15.891259164173166" p2="170.06489765538808" q2="-13.36347374361187">
         <iidm:alias>_04793734-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048a4e31-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10070,7 +10070,7 @@
             <iidm:temporaryLimit name="_3c55a929-a755-409b-af5f-bae188892af1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044cd003-c766-11e1-8775-005056c00008" name="23-25" r="2.7181440000000001" x="13.9391994" g1="0" b1="0.00024793390000000002" g2="0" b2="0.00024793390000000002" node1="41" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="-196.3777974040307" q1="-9.1404731016745711" p2="202.34875249014976" q2="30.642764233725156">
+    <iidm:line id="_044cd003-c766-11e1-8775-005056c00008" name="23-25" r="2.7181440000000001" x="13.9391994" g1="0" b1="0.00024793390000000002" g2="0" b2="0.00024793390000000002" node1="41" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="-197.48766577230242" q1="-12.232739393594271" p2="203.56734276022289" q2="34.317621696415124">
         <iidm:alias>_045ed161-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0473b8f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10078,7 +10078,7 @@
             <iidm:temporaryLimit name="_9658628a-596f-41a9-96a7-c5a8aaf5400c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0457a574-c766-11e1-8775-005056c00008" name="19-34" r="13.102848099999999" x="43.037277199999998" g1="0" b1="0.00018135905000000001" g2="0" b2="0.00018135905000000001" node1="40" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0483be8b-c766-11e1-8775-005056c00008" p1="55.902923080441106" q1="-15.340530679031311" p2="-53.129035101361467" q2="18.820573431172491">
+    <iidm:line id="_0457a574-c766-11e1-8775-005056c00008" name="19-34" r="13.102848099999999" x="43.037277199999998" g1="0" b1="0.00018135905000000001" g2="0" b2="0.00018135905000000001" node1="40" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0483be8b-c766-11e1-8775-005056c00008" p1="52.491239017893079" q1="-15.865105437252486" p2="-49.999874224709487" q2="18.44150531707588">
         <iidm:alias>_04502b61-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04686e5b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10086,7 +10086,7 @@
             <iidm:temporaryLimit name="_b69ab61b-751d-487a-a538-2d47eea7572e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04595326-c766-11e1-8775-005056c00008" name="59-60" r="5.5234079999999999" x="25.264800000000001" g1="0" b1="0.00010789715" g2="0" b2="0.00010789715" node1="69" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_045cfca4-c766-11e1-8775-005056c00008" p1="-89.196104957655947" q1="19.150724157591352" p2="91.939276668688692" q2="-10.278941663133999">
+    <iidm:line id="_04595326-c766-11e1-8775-005056c00008" name="59-60" r="5.5234079999999999" x="25.264800000000001" g1="0" b1="0.00010789715" g2="0" b2="0.00010789715" node1="69" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_045cfca4-c766-11e1-8775-005056c00008" p1="-89.110316752987657" q1="19.117983470879061" p2="91.84804404359501" q2="-10.271107179364405">
         <iidm:alias>_04611b57-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0463b366-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10094,7 +10094,7 @@
             <iidm:temporaryLimit name="_a38d4859-b54a-482f-a2ad-0b4ce4c4da2a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045a8ba1-c766-11e1-8775-005056c00008" name="15-19" r="2.0908799999999998" x="6.865056" g1="0" b1="2.8983e-05" g2="0" b2="2.8983e-05" node1="50" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="29.130040419157865" q1="8.417794113274887" p2="-29.006890216493765" q2="-8.9191007438074141">
+    <iidm:line id="_045a8ba1-c766-11e1-8775-005056c00008" name="15-19" r="2.0908799999999998" x="6.865056" g1="0" b1="2.8983e-05" g2="0" b2="2.8983e-05" node1="50" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="32.525016407230837" q1="10.770610141599612" p2="-32.367113177690939" q2="-11.15255928323316">
         <iidm:alias>_047629f1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0481e9c1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10102,7 +10102,7 @@
             <iidm:temporaryLimit name="_15d16bd2-d87c-4584-93d2-b294dc1be116" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04513cd6-c766-11e1-8775-005056c00008" name="90-91" r="4.4256960000000003" x="14.566463499999999" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="31" voltageLevelId1="_047d07c3-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044f8f29-c766-11e1-8775-005056c00008" p1="4.2547238029305472" q1="-16.320251956488125" p2="-4.1845651245677322" q2="14.562740290916048">
+    <iidm:line id="_04513cd6-c766-11e1-8775-005056c00008" name="90-91" r="4.4256960000000003" x="14.566463499999999" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="31" voltageLevelId1="_047d07c3-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044f8f29-c766-11e1-8775-005056c00008" p1="4.3988754790109965" q1="-16.340000988944531" p2="-4.3281996353697467" q2="14.584329595965336">
         <iidm:alias>_045f94b9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04627ae1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10110,7 +10110,7 @@
             <iidm:temporaryLimit name="_7d2a67fb-9d8c-4745-a67e-ce6ade5e520e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0487b623-c766-11e1-8775-005056c00008" name="22-23" r="5.9590079999999999" x="27.704158799999998" g1="0" b1="0.00011593205" g2="0" b2="0.00011593205" node1="21" voltageLevelId1="_04773b6a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_047f9fdb-c766-11e1-8775-005056c00008" p1="-49.787389838520923" q1="-7.8089218073316538" p2="50.693839012558172" q2="8.0710134951678736">
+    <iidm:line id="_0487b623-c766-11e1-8775-005056c00008" name="22-23" r="5.9590079999999999" x="27.704158799999998" g1="0" b1="0.00011593205" g2="0" b2="0.00011593205" node1="21" voltageLevelId1="_04773b6a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_047f9fdb-c766-11e1-8775-005056c00008" p1="-55.537458264020913" q1="-11.393466344876085" p2="56.711409621673823" q2="12.958080822957264">
         <iidm:alias>_045e0e18-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0477b095-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10118,7 +10118,7 @@
             <iidm:temporaryLimit name="_6477d99a-dd64-4083-8f56-1396610879f0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048b1189-c766-11e1-8775-005056c00008" name="83-85" r="7.4923200000000003" x="25.787520000000001" g1="0" b1="9.9862250000000004e-05" g2="0" b2="9.9862250000000004e-05" node1="32" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-54.247849981284055" q1="19.082776499086439" p2="55.776845492272031" q2="-17.110069332085107">
+    <iidm:line id="_048b1189-c766-11e1-8775-005056c00008" name="83-85" r="7.4923200000000003" x="25.787520000000001" g1="0" b1="9.9862250000000004e-05" g2="0" b2="9.9862250000000004e-05" node1="32" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-54.712779992014561" q1="19.216751114394327" p2="56.267877792070628" q2="-17.153143156720507">
         <iidm:alias>_0455d0b1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0462c906-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10126,7 +10126,7 @@
             <iidm:temporaryLimit name="_38cb3e5b-af1a-4684-aa2f-242826ed460c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045868c5-c766-11e1-8775-005056c00008" name="17-31" r="8.2589760000000005" x="27.233711199999998" g1="0" b1="0.00011449725" g2="0" b2="0.00011449725" node1="60" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="17.170622802839421" q1="1.9571553863936311" p2="-17.018044337563698" q2="-5.2399811728016585">
+    <iidm:line id="_045868c5-c766-11e1-8775-005056c00008" name="17-31" r="8.2589760000000005" x="27.233711199999998" g1="0" b1="0.00011449725" g2="0" b2="0.00011449725" node1="60" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="17.243793593641161" q1="1.0157691758662466" p2="-17.09269776108933" q2="-4.2977322256156674">
         <iidm:alias>_04544a16-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0467f924-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10134,7 +10134,7 @@
             <iidm:temporaryLimit name="_9066b19a-f404-42c3-88ce-51d375f6fdb5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0488c796-c766-11e1-8775-005056c00008" name="89-90" r="9.0256319999999999" x="32.75712" g1="0" b1="0.00015151515000000001" g2="0" b2="0.00015151515000000001" node1="59" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="59.660243932132275" q1="9.2564763011569333" p2="-57.761899259255912" q2="-7.4549351045146235">
+    <iidm:line id="_0488c796-c766-11e1-8775-005056c00008" name="89-90" r="9.0256319999999999" x="32.75712" g1="0" b1="0.00015151515000000001" g2="0" b2="0.00015151515000000001" node1="59" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="59.712382463349535" q1="9.2601955560152636" p2="-57.810798389186445" q2="-7.4467752542687782">
         <iidm:alias>_0459ef61-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04837069-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10142,7 +10142,7 @@
             <iidm:temporaryLimit name="_924b4a0b-bef5-432a-ad87-ab5c10d9c019" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0462c907-c766-11e1-8775-005056c00008" name="70-75" r="7.4574720000000001" x="24.56784" g1="0" b1="0.0001033058" g2="0" b2="0.0001033058" node1="50" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="9.4278670391285608" q1="7.1647021638913415" p2="-9.3536151465089112" q2="-10.353113658667775">
+    <iidm:line id="_0462c907-c766-11e1-8775-005056c00008" name="70-75" r="7.4574720000000001" x="24.56784" g1="0" b1="0.0001033058" g2="0" b2="0.0001033058" node1="50" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="8.2589556132718425" q1="7.244890463809794" p2="-8.1931048589035473" q2="-10.456435450545259">
         <iidm:alias>_04649dc9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04784cdb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10150,7 +10150,7 @@
             <iidm:temporaryLimit name="_d432d118-553c-4f4c-a734-e98e0762ec40" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045fbbc3-c766-11e1-8775-005056c00008" name="50-57" r="8.2589760000000005" x="23.34816" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="22" voltageLevelId1="_044d1e26-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="44.258211501604976" q1="6.7031025723908968" p2="-43.297330733156784" q2="-7.2092115531327829">
+    <iidm:line id="_045fbbc3-c766-11e1-8775-005056c00008" name="50-57" r="8.2589760000000005" x="23.34816" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="22" voltageLevelId1="_044d1e26-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="44.128599714079868" q1="6.7397704753385312" p2="-43.172875417720618" q2="-7.2605376177428225">
         <iidm:alias>_04500455-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0468e383-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10158,7 +10158,7 @@
             <iidm:temporaryLimit name="_2f32bda4-7275-4485-9901-12f8cff9e4a1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044b9789-c766-11e1-8775-005056c00008" name="5-6" r="2.0734560000000002" x="9.4089600000000004" g1="0" b1="4.0920549999999999e-05" g2="0" b2="4.0920549999999999e-05" node1="49" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f6818-c766-11e1-8775-005056c00008" p1="91.39708152675216" q1="19.513844892838332" p2="-90.375478767578414" q2="-16.304383876187686">
+    <iidm:line id="_044b9789-c766-11e1-8775-005056c00008" name="5-6" r="2.0734560000000002" x="9.4089600000000004" g1="0" b1="4.0920549999999999e-05" g2="0" b2="4.0920549999999999e-05" node1="49" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f6818-c766-11e1-8775-005056c00008" p1="91.570281190196496" q1="19.179696001844153" p2="-90.545883313800076" q2="-15.956836988870959">
         <iidm:alias>_044a5f01-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0455d0b2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10166,7 +10166,7 @@
             <iidm:temporaryLimit name="_b3b0e81b-a434-4e9c-ad94-1161ff47b077" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04720b41-c766-11e1-8775-005056c00008" name="55-59" r="8.2572340000000004" x="37.600994100000001" g1="0" b1="0.00016201790000000001" g2="0" b2="0.00016201790000000001" node1="30" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-24.078982370758791" q1="-11.567635484027596" p2="24.42515299460154" q2="7.8504078754296325">
+    <iidm:line id="_04720b41-c766-11e1-8775-005056c00008" name="55-59" r="8.2572340000000004" x="37.600994100000001" g1="0" b1="0.00016201790000000001" g2="0" b2="0.00016201790000000001" node1="30" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-24.17732959796923" q1="-11.539756482782741" p2="24.52572128987741" q2="7.8326345199215037">
         <iidm:alias>_04656113-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04675ce4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10174,7 +10174,7 @@
             <iidm:temporaryLimit name="_6db0d250-4a2e-4169-abf0-f842aeca485d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048963d9-c766-11e1-8775-005056c00008" name="1-2" r="5.2794720000000002" x="17.4065762" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="22" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_045d4ac5-c766-11e1-8775-005056c00008" p1="-11.458268006758127" q1="-10.256904626532309" p2="11.52852506791878" q2="8.1138617388545278">
+    <iidm:line id="_048963d9-c766-11e1-8775-005056c00008" name="1-2" r="5.2794720000000002" x="17.4065762" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="22" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_045d4ac5-c766-11e1-8775-005056c00008" p1="-11.42229797899404" q1="-10.339582580228448" p2="11.492800225725111" q2="8.1977602871657762">
         <iidm:alias>_044b9786-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04845acb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10182,7 +10182,7 @@
             <iidm:temporaryLimit name="_9f39cb45-314c-445e-b177-909854a9ce45" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0484f709-c766-11e1-8775-005056c00008" name="11-12" r="1.0367280000000001" x="3.4151039999999999" g1="0" b1="1.4405399999999999e-05" g2="0" b2="1.4405399999999999e-05" node1="40" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="34.613527952049175" q1="-24.307894754130356" p2="-34.505044805618915" q2="24.17459430740114">
+    <iidm:line id="_0484f709-c766-11e1-8775-005056c00008" name="11-12" r="1.0367280000000001" x="3.4151039999999999" g1="0" b1="1.4405399999999999e-05" g2="0" b2="1.4405399999999999e-05" node1="40" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="34.705325948118137" q1="-25.322562528850838" p2="-34.593365578590173" q2="25.200814182386043">
         <iidm:alias>_0456e227-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04880440-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10190,7 +10190,7 @@
             <iidm:temporaryLimit name="_70fad3e1-4529-4a7f-9e6c-8ab249d65460" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044bbe91-c766-11e1-8775-005056c00008" name="8-9" r="1.18096" x="14.762" g1="0" b1="0.001200413215" g2="0" b2="0.001200413215" node1="31" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_045c8779-c766-11e1-8775-005056c00008" p1="-485.13651874939569" q1="-83.423068826996442" p2="490.81054915630989" q2="32.934875747259355">
+    <iidm:line id="_044bbe91-c766-11e1-8775-005056c00008" name="8-9" r="1.18096" x="14.762" g1="0" b1="0.001200413215" g2="0" b2="0.001200413215" node1="31" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_045c8779-c766-11e1-8775-005056c00008" p1="-486.64586045922863" q1="-83.553165640584794" p2="492.36165877290364" q2="33.695853448139701">
         <iidm:alias>_04745535-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048a7548-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="2000">
@@ -10198,7 +10198,7 @@
             <iidm:temporaryLimit name="_205e5d8a-f05a-479d-adaa-3514f48f6857" acceptableDuration="60" value="2400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04566cf8-c766-11e1-8775-005056c00008" name="64-65" r="1.30196" x="14.6168" g1="0" b1="0.000392562" g2="0" b2="0.000392562" node1="35" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-157.89158576309489" q1="-33.92273885832288" p2="158.57512794492001" q2="3.5949293050304711">
+    <iidm:line id="_04566cf8-c766-11e1-8775-005056c00008" name="64-65" r="1.30196" x="14.6168" g1="0" b1="0.000392562" g2="0" b2="0.000392562" node1="35" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-157.41103918884559" q1="-33.953282542073424" p2="158.09047497923038" q2="3.5789828676456517">
         <iidm:alias>_044a10e2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04793738-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10206,7 +10206,7 @@
             <iidm:temporaryLimit name="_8cee2b62-2953-439b-ba4b-4a48d55116c0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046783f3-c766-11e1-8775-005056c00008" name="54-56" r="0.47915999999999997" x="1.6639919999999999" g1="0" b1="2.1005500000000001e-05" g2="0" b2="2.1005500000000001e-05" node1="60" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="29.60613101447586" q1="2.7080802106002415" p2="-29.579422508900262" q2="-3.2821261863811664">
+    <iidm:line id="_046783f3-c766-11e1-8775-005056c00008" name="54-56" r="0.47915999999999997" x="1.6639919999999999" g1="0" b1="2.1005500000000001e-05" g2="0" b2="2.1005500000000001e-05" node1="60" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="29.576081335056859" q1="2.6940062934020834" p2="-29.549429011876178" q2="-3.2682485282359495">
         <iidm:alias>_0460f444-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d2949-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10214,7 +10214,7 @@
             <iidm:temporaryLimit name="_640627c7-0672-413e-8dc8-c9965709a5cb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04670ec6-c766-11e1-8775-005056c00008" name="84-85" r="5.2620480000000001" x="11.1687832" g1="0" b1="3.541095e-05" g2="0" b2="3.541095e-05" node1="21" voltageLevelId1="_047b0bf4-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-44.008026632797211" q1="14.233716314203631" p2="44.705548753814483" q2="-13.910528918633732">
+    <iidm:line id="_04670ec6-c766-11e1-8775-005056c00008" name="84-85" r="5.2620480000000001" x="11.1687832" g1="0" b1="3.541095e-05" g2="0" b2="3.541095e-05" node1="21" voltageLevelId1="_047b0bf4-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-44.335825617394967" q1="14.340161084791141" p2="45.043973159101114" q2="-13.994088237016545">
         <iidm:alias>_0453fbf5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046512f7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10222,7 +10222,7 @@
             <iidm:temporaryLimit name="_8b888209-5038-4b98-80fc-062b5ea55747" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0460cd36-c766-11e1-8775-005056c00008" name="34-36" r="1.51763" x="4.669632" g1="0" b1="1.6299349999999998e-05" g2="0" b2="1.6299349999999998e-05" node1="43" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="34.793008078238955" q1="11.202864089027237" p2="-34.662014042244707" q2="-11.303133847305229">
+    <iidm:line id="_0460cd36-c766-11e1-8775-005056c00008" name="34-36" r="1.51763" x="4.669632" g1="0" b1="1.6299349999999998e-05" g2="0" b2="1.6299349999999998e-05" node1="43" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="34.555285265556336" q1="11.218330388452774" p2="-34.425694065159753" q2="-11.322250221069503">
         <iidm:alias>_046a6a26-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0487b620-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10230,7 +10230,7 @@
             <iidm:temporaryLimit name="_c0a08025-3a61-4d24-9944-f3ef0b079f64" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04549836-c766-11e1-8775-005056c00008" name="24-70" r="0.38507000000000002" x="71.699759999999998" g1="0" b1="0.00029264234999999998" g2="0" b2="0.00029264234999999998" node1="32" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="18.575242535702884" q1="-0.8028277135123042" p2="-18.567209654996855" q2="-7.746915961761272">
+    <iidm:line id="_04549836-c766-11e1-8775-005056c00008" name="24-70" r="0.38507000000000002" x="71.699759999999998" g1="0" b1="0.00029264234999999998" g2="0" b2="0.00029264234999999998" node1="32" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="16.476156111943439" q1="-1.2351415516382935" p2="-16.469804268213103" q2="-7.5980269684247066">
         <iidm:alias>_04549834-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04854522-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10238,7 +10238,7 @@
             <iidm:temporaryLimit name="_32793450-bbfd-4dcd-a911-89e199600780" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0452273a-c766-11e1-8775-005056c00008" name="85-86" r="6.0983999999999998" x="21.431519999999999" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="50" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0484f70a-c766-11e1-8775-005056c00008" p1="21.283026953872" q1="16.354030319297546" p2="-20.99899457227048" q2="-17.877761657590145">
+    <iidm:line id="_0452273a-c766-11e1-8775-005056c00008" name="85-86" r="6.0983999999999998" x="21.431519999999999" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="50" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0484f70a-c766-11e1-8775-005056c00008" p1="21.281951544175577" q1="16.351882833530851" p2="-20.99789915745194" q2="-17.874918628618776">
         <iidm:alias>_044afb43-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479fa85-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10246,7 +10246,7 @@
             <iidm:temporaryLimit name="_2ec4bef5-7abb-4f52-bb62-49ee474d672b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0450eeb5-c766-11e1-8775-005056c00008" name="16-17" r="7.9104960000000002" x="31.380622899999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="22" voltageLevelId1="_046f7338-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-15.543786632852536" q1="1.0076855276918202" p2="15.663109156063515" q2="-5.0124093552778248">
+    <iidm:line id="_0450eeb5-c766-11e1-8775-005056c00008" name="16-17" r="7.9104960000000002" x="31.380622899999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="22" voltageLevelId1="_046f7338-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-15.25263173837495" q1="1.4776981666351028" p2="15.369361628819425" q2="-5.4838605550943793">
         <iidm:alias>_044ef2ea-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04837066-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10254,7 +10254,7 @@
             <iidm:temporaryLimit name="_9280074c-8555-49ff-9e62-8ed8f7d95060" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048a4e33-c766-11e1-8775-005056c00008" name="62-66" r="8.3983679999999996" x="37.984317799999999" g1="0" b1="0.00016586315" g2="0" b2="0.00016586315" node1="41" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-15.420033600304794" q1="-21.537270612223995" p2="15.70424937630669" q2="16.790577005953171">
+    <iidm:line id="_048a4e33-c766-11e1-8775-005056c00008" name="62-66" r="8.3983679999999996" x="37.984317799999999" g1="0" b1="0.00016586315" g2="0" b2="0.00016586315" node1="41" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-15.288796994712406" q1="-21.568383428397052" p2="15.571622283649303" q2="16.815417084733063">
         <iidm:alias>_046e13a9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a96c7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10262,7 +10262,7 @@
             <iidm:temporaryLimit name="_ace48562-0a49-4b76-ae82-c896a00b04f9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0478e913-c766-11e1-8775-005056c00008" name="76-77" r="7.736256" x="25.787520000000001" g1="0" b1="0.00010560145" g2="0" b2="0.00010560145" node1="21" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-61.863276089836759" q1="-21.301627723547028" p2="63.987985858534749" q2="24.913780684268112">
+    <iidm:line id="_0478e913-c766-11e1-8775-005056c00008" name="76-77" r="7.736256" x="25.787520000000001" g1="0" b1="0.00010560145" g2="0" b2="0.00010560145" node1="21" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-62.479083091177991" q1="-21.192914321324118" p2="64.641958830356316" q2="24.93401937207565">
         <iidm:alias>_044b9785-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04725965-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10270,7 +10270,7 @@
             <iidm:temporaryLimit name="_3f744dba-88dc-4d89-90d4-a6f196054b28" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048badc1-c766-11e1-8775-005056c00008" name="60-62" r="2.1431520000000002" x="9.7748640000000009" g1="0" b1="4.2125800000000002e-05" g2="0" b2="4.2125800000000002e-05" node1="32" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="-0.66214490180276364" q1="-8.5995127107044897" p2="0.66994660835297171" q2="7.1824757129068066">
+    <iidm:line id="_048badc1-c766-11e1-8775-005056c00008" name="60-62" r="2.1431520000000002" x="9.7748640000000009" g1="0" b1="4.2125800000000002e-05" g2="0" b2="4.2125800000000002e-05" node1="32" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="-0.55856833300779118" q1="-8.6201470450963331" p2="0.56639487463337845" q2="7.2032219247715172">
         <iidm:alias>_045b7600-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04720b44-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10278,7 +10278,7 @@
             <iidm:temporaryLimit name="_43f91aaf-c5f4-4995-85a2-37afac616331" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0472a780-c766-11e1-8775-005056c00008" name="27-28" r="3.3332109999999999" x="14.89752" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="42" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04819ba0-c766-11e1-8775-005056c00008" p1="32.599300772070769" q1="-1.0939757955529756" p2="-32.383113421203689" q2="0.041373131563141215">
+    <iidm:line id="_0472a780-c766-11e1-8775-005056c00008" name="27-28" r="3.3332109999999999" x="14.89752" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="42" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04819ba0-c766-11e1-8775-005056c00008" p1="32.601024470359832" q1="-0.39021076982801906" p2="-32.384118710660971" q2="-0.65210210300223559">
         <iidm:alias>_04531198-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0475188b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10286,7 +10286,7 @@
             <iidm:temporaryLimit name="_2c20e8bd-84e6-4a1e-b88e-071f631327cb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c81e1-c766-11e1-8775-005056c00008" name="45-46" r="6.9695999999999998" x="23.626943600000001" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="31" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="34" voltageLevelId2="_048a7544-c766-11e1-8775-005056c00008" p1="-33.312338209177916" q1="-7.0180145831912952" p2="33.783818342333319" q2="5.3355694428633678">
+    <iidm:line id="_044c81e1-c766-11e1-8775-005056c00008" name="45-46" r="6.9695999999999998" x="23.626943600000001" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="31" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="34" voltageLevelId2="_048a7544-c766-11e1-8775-005056c00008" p1="-33.687695714466273" q1="-7.0266202652669767" p2="34.169816415347441" q2="5.3808768667204649">
         <iidm:alias>_04561ed6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045c877a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10294,7 +10294,7 @@
             <iidm:temporaryLimit name="_6ad31f7e-233f-4801-898f-9ffc883ec724" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c1249-c766-11e1-8775-005056c00008" name="18-19" r="1.949746" x="8.5900320000000008" g1="0" b1="3.2770900000000002e-05" g2="0" b2="3.2770900000000002e-05" node1="22" voltageLevelId1="_04689563-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="51.403637116534384" q1="-1.8354043336665029" p2="-51.074607207624524" q2="2.2634947853077869">
+    <iidm:line id="_045c1249-c766-11e1-8775-005056c00008" name="18-19" r="1.949746" x="8.5900320000000008" g1="0" b1="3.2770900000000002e-05" g2="0" b2="3.2770900000000002e-05" node1="22" voltageLevelId1="_04689563-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="52.650463887637422" q1="-0.32009239495778136" p2="-52.30365928204079" q2="0.83293845241304698">
         <iidm:alias>_046b066b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047ae4e0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10302,7 +10302,7 @@
             <iidm:temporaryLimit name="_a025c9d8-58f9-4320-a1fe-73ecc68d4147" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044a5f09-c766-11e1-8775-005056c00008" name="9-10" r="1.2487200000000001" x="15.584800700000001" g1="0" b1="0.0012706611300000001" g2="0" b2="0.0012706611300000001" node1="21" voltageLevelId1="_045c8779-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_044f4102-c766-11e1-8775-005056c00008" p1="-490.81054915631012" q1="-32.934875747258886" p2="496.61816442941495" q2="-28.50199784608747">
+    <iidm:line id="_044a5f09-c766-11e1-8775-005056c00008" name="9-10" r="1.2487200000000001" x="15.584800700000001" g1="0" b1="0.0012706611300000001" g2="0" b2="0.0012706611300000001" node1="21" voltageLevelId1="_045c8779-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_044f4102-c766-11e1-8775-005056c00008" p1="-492.36165877290352" q1="-33.695853448140575" p2="498.20873423332176" q2="-27.201803424583424">
         <iidm:alias>_04614262-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04834957-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="2000">
@@ -10310,7 +10310,7 @@
             <iidm:temporaryLimit name="_b7fac0a3-c5af-48b9-af49-261fd8d46e00" acceptableDuration="60" value="2400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0480b14b-c766-11e1-8775-005056c00008" name="85-88" r="3.4847999999999999" x="17.772480000000002" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="51" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0470f9d2-c766-11e1-8775-005056c00008" p1="-62.580440343980662" q1="3.5056140795532307" p2="63.416625891752822" q2="-1.8688792499167495">
+    <iidm:line id="_0480b14b-c766-11e1-8775-005056c00008" name="85-88" r="3.4847999999999999" x="17.772480000000002" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="51" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0470f9d2-c766-11e1-8775-005056c00008" p1="-62.990246689166419" q1="3.5770526413190491" p2="63.837708188024635" q2="-1.882285738339462">
         <iidm:alias>_047602e2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04765105-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10318,7 +10318,7 @@
             <iidm:temporaryLimit name="_51646744-d343-42b5-8ba7-fcedc7cc3a98" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04486330-c766-11e1-8775-005056c00008" name="69-77" r="5.3840159999999999" x="17.598240000000001" g1="0" b1="0.00029786500000000002" g2="0" b2="0.00029786500000000002" node1="60" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="33.47500242122824" q1="17.69143696708424" p2="-32.995824672031588" q2="-26.902364841218358">
+    <iidm:line id="_04486330-c766-11e1-8775-005056c00008" name="69-77" r="5.3840159999999999" x="17.598240000000001" g1="0" b1="0.00029786500000000002" g2="0" b2="0.00029786500000000002" node1="60" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="32.560723831828135" q1="18.074563948161174" p2="-32.093779791927581" q2="-27.324159042612923">
         <iidm:alias>_046205b9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479d379-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10326,7 +10326,7 @@
             <iidm:temporaryLimit name="_76311a15-b79a-4439-a7ce-47afa8fa6fe2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04553477-c766-11e1-8775-005056c00008" name="11-13" r="3.8768400000000001" x="12.7369442" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="41" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04851e1b-c766-11e1-8775-005056c00008" p1="45.170666016450987" q1="15.717879495875744" p2="-44.641753285103086" q2="-15.768387643936755">
+    <iidm:line id="_04553477-c766-11e1-8775-005056c00008" name="11-13" r="3.8768400000000001" x="12.7369442" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="41" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04851e1b-c766-11e1-8775-005056c00008" p1="45.465452088212253" q1="16.218847152699343" p2="-44.926366522204617" q2="-16.234418669171664">
         <iidm:alias>_0479fa89-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0485452a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10334,7 +10334,7 @@
             <iidm:temporaryLimit name="_efbf8de7-4b84-4834-bb7c-6250b6072211" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04488a45-c766-11e1-8775-005056c00008" name="103-105" r="9.3218399999999999" x="28.314" g1="0" b1="0.0001170799" g2="0" b2="0.0001170799" node1="42" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="43.794170222232637" q1="12.537082176292468" p2="-42.67622632785924" q2="-13.123434904150718">
+    <iidm:line id="_04488a45-c766-11e1-8775-005056c00008" name="103-105" r="9.3218399999999999" x="28.314" g1="0" b1="0.0001170799" g2="0" b2="0.0001170799" node1="42" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="43.796522927564418" q1="12.53536647036656" p2="-42.678496262061103" q2="-13.121471138375135">
         <iidm:alias>_044f8f24-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04611b58-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10342,7 +10342,7 @@
             <iidm:temporaryLimit name="_22b6919a-a7a0-49fc-9e90-329069c55055" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046009e6-c766-11e1-8775-005056c00008" name="45-49" r="11.918016400000001" x="32.408639999999998" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="32" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="118" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-40.323472693920223" q1="-8.1588173433326965" p2="41.499984596173597" q2="6.8804468218429946">
+    <iidm:line id="_046009e6-c766-11e1-8775-005056c00008" name="45-49" r="11.918016400000001" x="32.408639999999998" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="32" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="118" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-40.73223989461642" q1="-8.073563266854201" p2="41.931961239880273" q2="6.8591490848220946">
         <iidm:alias>_044ca8f9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047dcb1b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10350,7 +10350,7 @@
             <iidm:temporaryLimit name="_8b91f4fd-4038-45b7-870c-fbc08592b95a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046a6a27-c766-11e1-8775-005056c00008" name="88-89" r="2.4219360000000001" x="12.4058876" g1="0" b1="5.549815e-05" g2="0" b2="5.549815e-05" node1="22" voltageLevelId1="_0470f9d2-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-111.41723095302207" q1="-8.1313252534394564" p2="113.21844223721193" q2="15.450745660976573">
+    <iidm:line id="_046a6a27-c766-11e1-8775-005056c00008" name="88-89" r="2.4219360000000001" x="12.4058876" g1="0" b1="5.549815e-05" g2="0" b2="5.549815e-05" node1="22" voltageLevelId1="_0470f9d2-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-111.83677501038936" q1="-8.1173904075627661" p2="113.65177510124474" q2="15.507587538046158">
         <iidm:alias>_045ef879-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04649dc1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10358,7 +10358,7 @@
             <iidm:temporaryLimit name="_970bc323-73bf-440d-a3c5-00aebc3a1992" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048a7540-c766-11e1-8775-005056c00008" name="80-98" r="4.1469120000000004" x="18.817920000000001" g1="0" b1="8.20707e-05" g2="0" b2="8.20707e-05" node1="79" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04773b62-c766-11e1-8775-005056c00008" p1="11.965505461485652" q1="11.845583448817177" p2="-11.894535420223622" q2="-14.567923428036419">
+    <iidm:line id="_048a7540-c766-11e1-8775-005056c00008" name="80-98" r="4.1469120000000004" x="18.817920000000001" g1="0" b1="8.20707e-05" g2="0" b2="8.20707e-05" node1="79" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04773b62-c766-11e1-8775-005056c00008" p1="11.40086432421462" q1="11.97788024525858" p2="-11.332013837944078" q2="-14.709796260443063">
         <iidm:alias>_045338a2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04887972-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10366,7 +10366,7 @@
             <iidm:temporaryLimit name="_cb084dc7-1b26-415f-9495-4695df661912" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04640183-c766-11e1-8775-005056c00008" name="91-92" r="6.7430880000000002" x="22.163329999999998" g1="0" b1="9.3778700000000004e-05" g2="0" b2="9.3778700000000004e-05" node1="22" voltageLevelId1="_044f8f29-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="-5.8155828550810282" q1="-14.562740614256317" p2="5.8992630104811079" q2="11.700406237566794">
+    <iidm:line id="_04640183-c766-11e1-8775-005056c00008" name="91-92" r="6.7430880000000002" x="22.163329999999998" g1="0" b1="9.3778700000000004e-05" g2="0" b2="9.3778700000000004e-05" node1="22" voltageLevelId1="_044f8f29-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="-5.6717631193663687" q1="-14.584329618651509" p2="5.7550042018540069" q2="11.72092087500697">
         <iidm:alias>_04492680-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_044c5ad5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10374,7 +10374,7 @@
             <iidm:temporaryLimit name="_3a165a76-f6ba-461b-84d6-159a5e0b5077" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0474a358-c766-11e1-8775-005056c00008" name="7-12" r="1.501949" x="5.9241599999999996" g1="0" b1="2.5080350000000001e-05" g2="0" b2="2.5080350000000001e-05" node1="22" voltageLevelId1="_047eb571-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="19.301383730833361" q1="-7.4781813517982787" p2="-19.264188761775884" q2="6.7689466806371179">
+    <iidm:line id="_0474a358-c766-11e1-8775-005056c00008" name="7-12" r="1.501949" x="5.9241599999999996" g1="0" b1="2.5080350000000001e-05" g2="0" b2="2.5080350000000001e-05" node1="22" voltageLevelId1="_047eb571-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="19.47529586575466" q1="-7.82701511251563" p2="-19.437054572803824" q2="7.1219987093810593">
         <iidm:alias>_046ab848-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0477feb7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10382,7 +10382,7 @@
             <iidm:temporaryLimit name="_b19bc945-cc51-4d77-8eaa-3f6afe2d9316" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04765108-c766-11e1-8775-005056c00008" name="99-100" r="3.13632" x="14.165711399999999" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_04644fa4-c766-11e1-8775-005056c00008" node2="80" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-39.477795144575111" q1="12.159125537711084" p2="39.77792176352029" q2="-13.044348995405342">
+    <iidm:line id="_04765108-c766-11e1-8775-005056c00008" name="99-100" r="3.13632" x="14.165711399999999" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_04644fa4-c766-11e1-8775-005056c00008" node2="80" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-40.044779253293839" q1="12.289965092712244" p2="40.353317139239039" q2="-13.137169921325714">
         <iidm:alias>_0471e436-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047e4040-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10390,7 +10390,7 @@
             <iidm:temporaryLimit name="_a9e283ed-fcad-4f4c-ab57-8531875bb098" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047b8128-c766-11e1-8775-005056c00008" name="114-115" r="0.400752" x="1.8120959999999999" g1="0" b1="7.9201000000000006e-06" g2="0" b2="7.9201000000000006e-06" node1="22" voltageLevelId1="_04791027-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="-0.46886568114174171" q1="2.4195268709542472" p2="0.46903196442333783" q2="-2.6748699171045458">
+    <iidm:line id="_047b8128-c766-11e1-8775-005056c00008" name="114-115" r="0.400752" x="1.8120959999999999" g1="0" b1="7.9201000000000006e-06" g2="0" b2="7.9201000000000006e-06" node1="22" voltageLevelId1="_04791027-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="-0.59552256210814258" q1="2.4478495273100935" p2="0.59569623542049555" q2="-2.7024211217269807">
         <iidm:alias>_046c17d3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d0233-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10398,7 +10398,7 @@
             <iidm:temporaryLimit name="_c59e4022-b1c0-4811-a32e-f54656bff32d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046931a5-c766-11e1-8775-005056c00008" name="83-84" r="10.890000000000001" x="22.999680000000001" g1="0" b1="7.4035799999999993e-05" g2="0" b2="7.4035799999999993e-05" node1="33" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b0bf4-c766-11e1-8775-005056c00008" p1="-32.009639485404229" q1="20.914231556112803" p2="33.00772393152733" q2="-21.234034174327803">
+    <iidm:line id="_046931a5-c766-11e1-8775-005056c00008" name="83-84" r="10.890000000000001" x="22.999680000000001" g1="0" b1="7.4035799999999993e-05" g2="0" b2="7.4035799999999993e-05" node1="33" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b0bf4-c766-11e1-8775-005056c00008" p1="-32.320395607000464" q1="21.058340686028416" p2="33.336262736013573" q2="-21.339697678265786">
         <iidm:alias>_0465d645-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479102b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10406,7 +10406,7 @@
             <iidm:temporaryLimit name="_1268eb09-e233-44ce-b8af-22dc30eb16ad" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047ae4ea-c766-11e1-8775-005056c00008" name="14-15" r="10.367279999999999" x="33.976799999999997" g1="0" b1="0.0001440542" g2="0" b2="0.0001440542" node1="21" voltageLevelId1="_047b8129-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="16.147910199215143" q1="6.7231590949304785" p2="-15.933998052451843" q2="-10.691922175420357">
+    <iidm:line id="_047ae4ea-c766-11e1-8775-005056c00008" name="14-15" r="10.367279999999999" x="33.976799999999997" g1="0" b1="0.0001440542" g2="0" b2="0.0001440542" node1="21" voltageLevelId1="_047b8129-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="16.500225414709931" q1="7.3662218463727145" p2="-16.271381525450607" q2="-11.273576840218972">
         <iidm:alias>_0449e9d9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046ed6fa-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10414,7 +10414,7 @@
             <iidm:temporaryLimit name="_9c0c454b-ecc3-40f6-b505-f32fec412522" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046e3ab2-c766-11e1-8775-005056c00008" name="80-96" r="6.2029439999999996" x="31.711680000000001" g1="0" b1="0.0001417585" g2="0" b2="0.0001417585" node1="80" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="5.15128216089128" q1="26.231562784576688" p2="-4.867586361310031" q2="-29.862164157983241">
+    <iidm:line id="_046e3ab2-c766-11e1-8775-005056c00008" name="80-96" r="6.2029439999999996" x="31.711680000000001" g1="0" b1="0.0001417585" g2="0" b2="0.0001417585" node1="80" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="4.71484740367739" q1="26.3944052250955" p2="-4.4294616520969026" q2="-30.015706873302602">
         <iidm:alias>_045338a4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04865695-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10422,7 +10422,7 @@
             <iidm:temporaryLimit name="_1432f4d6-9299-4b0d-bd7f-16e059f9de66" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04893cc4-c766-11e1-8775-005056c00008" name="56-59" r="13.9914722" x="41.643360000000001" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="59" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-20.044411080590368" q1="-7.7117595879629661" p2="20.423559148210259" q2="3.8016940728431572">
+    <iidm:line id="_04893cc4-c766-11e1-8775-005056c00008" name="56-59" r="13.9914722" x="41.643360000000001" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="59" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-20.132759534549589" q1="-7.6765254412041433" p2="20.51471188073771" q2="3.7747981243547302">
         <iidm:alias>_046b5484-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04798557-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10430,7 +10430,7 @@
             <iidm:temporaryLimit name="_193f6952-4267-4cc8-a541-726c095028ba" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c1243-c766-11e1-8775-005056c00008" name="92-100" r="11.290752400000001" x="51.400799999999997" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="71" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="36.684057695022318" q1="-17.255144206460727" p2="-35.64553745072665" q2="17.231519660847379">
+    <iidm:line id="_045c1243-c766-11e1-8775-005056c00008" name="92-100" r="11.290752400000001" x="51.400799999999997" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="71" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="36.861794209970547" q1="-17.294840365293883" p2="-35.813677225816583" q2="17.315241712425834">
         <iidm:alias>_045e8348-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045ed164-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10438,7 +10438,7 @@
             <iidm:temporaryLimit name="_579249ce-1c81-4d29-8d3f-5fc627a18f99" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0474a356-c766-11e1-8775-005056c00008" name="43-44" r="10.593792000000001" x="42.7584953" g1="0" b1="0.00017412765" g2="0" b2="0.00017412765" node1="22" voltageLevelId1="_045e8349-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04544a15-c766-11e1-8775-005056c00008" p1="-4.4665187138473383" q1="-11.439181769785371" p2="4.5310587851670414" q2="6.0806809860693196">
+    <iidm:line id="_0474a356-c766-11e1-8775-005056c00008" name="43-44" r="10.593792000000001" x="42.7584953" g1="0" b1="0.00017412765" g2="0" b2="0.00017412765" node1="22" voltageLevelId1="_045e8349-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04544a15-c766-11e1-8775-005056c00008" p1="-5.2455922120480736" q1="-11.30684004800418" p2="5.3137941166824048" q2="5.9675948275628645">
         <iidm:alias>_04642899-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047b0bf2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10446,7 +10446,7 @@
             <iidm:temporaryLimit name="_3d2cb4b5-ee82-4866-9855-4a5f4803cd3b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04627ae6-c766-11e1-8775-005056c00008" name="109-110" r="4.8438720000000002" x="13.2770882" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="22" voltageLevelId1="_046b7b99-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="12.799502146039815" q1="-2.9923728131255816" p2="-12.748481947645313" q2="1.285881883382423">
+    <iidm:line id="_04627ae6-c766-11e1-8775-005056c00008" name="109-110" r="4.8438720000000002" x="13.2770882" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="22" voltageLevelId1="_046b7b99-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="12.737792891585292" q1="-2.969576328927646" p2="-12.687279769906176" q2="1.2616852981863773">
         <iidm:alias>_0466e7b5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a6fbb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10454,7 +10454,7 @@
             <iidm:temporaryLimit name="_6fc48d8d-05f8-4104-a6a2-3686d430a091" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0478c207-c766-11e1-8775-005056c00008" name="68-81" r="0.84699999999999998" x="9.7767990000000005" g1="0" b1="0.00083471078000000004" g2="0" b2="0.00083471078000000004" node1="38" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_048a272b-c766-11e1-8775-005056c00008" p1="-147.83698447805969" q1="-4.149594614215486" p2="148.24339345515389" q2="-71.40399767501934">
+    <iidm:line id="_0478c207-c766-11e1-8775-005056c00008" name="68-81" r="0.84699999999999998" x="9.7767990000000005" g1="0" b1="0.00083471078000000004" g2="0" b2="0.00083471078000000004" node1="38" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_048a272b-c766-11e1-8775-005056c00008" p1="-150.08999717285084" q1="-3.9116103395539032" p2="150.50849488469441" q2="-71.501093481296323">
         <iidm:alias>_044a37f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045b4ef6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10462,7 +10462,7 @@
             <iidm:temporaryLimit name="_191836a1-39cd-402b-8dcf-4f3867c45bd0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0467d215-c766-11e1-8775-005056c00008" name="85-89" r="4.1643359999999996" x="30.143518400000001" g1="0" b1="0.00013487144999999999" g2="0" b2="0.00013487144999999999" node1="52" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-83.18521122517906" q1="-3.8392770256338498" p2="84.941102151863618" q2="11.961472575179616">
+    <iidm:line id="_0467d215-c766-11e1-8775-005056c00008" name="85-89" r="4.1643359999999996" x="30.143518400000001" g1="0" b1="0.00013487144999999999" g2="0" b2="0.00013487144999999999" node1="52" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-83.602587529081035" q1="-3.7806959096592099" p2="85.376522063497688" q2="12.034042917658727">
         <iidm:alias>_047629f9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0478e915-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10470,7 +10470,7 @@
             <iidm:temporaryLimit name="_66cbdeeb-a4e4-4bfc-aec1-9fb7a2d2b6bc" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044a37f2-c766-11e1-8775-005056c00008" name="89-90" r="4.1469120000000004" x="17.371727" g1="0" b1="0.00030417815" g2="0" b2="0.00030417815" node1="62" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="112.65106593855879" q1="21.234816569794216" p2="-109.4941878317871" q2="-18.225371349358969">
+    <iidm:line id="_044a37f2-c766-11e1-8775-005056c00008" name="89-90" r="4.1469120000000004" x="17.371727" g1="0" b1="0.00030417815" g2="0" b2="0.00030417815" node1="62" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="112.74995469489811" q1="21.245312827368434" p2="-109.58768958167443" q2="-18.213055695621566">
         <iidm:alias>_045386c2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048719e9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10478,7 +10478,7 @@
             <iidm:temporaryLimit name="_8489e809-6588-4ed2-a9a4-43c44a0d47da" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04658820-c766-11e1-8775-005056c00008" name="98-100" r="6.9173280000000004" x="31.188960999999999" g1="0" b1="0.0001365932" g2="0" b2="0.0001365932" node1="22" voltageLevelId1="_04773b62-c766-11e1-8775-005056c00008" node2="82" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-22.105652883755262" q1="6.5678536737422579" p2="22.321999437229724" q2="-10.546671889778041">
+    <iidm:line id="_04658820-c766-11e1-8775-005056c00008" name="98-100" r="6.9173280000000004" x="31.188960999999999" g1="0" b1="0.0001365932" g2="0" b2="0.0001365932" node1="22" voltageLevelId1="_04773b62-c766-11e1-8775-005056c00008" node2="82" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-22.667970654788448" q1="6.7098025895583904" p2="22.894849066380623" q2="-10.641064139384788">
         <iidm:alias>_046f4c22-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046fe865-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10486,7 +10486,7 @@
             <iidm:temporaryLimit name="_620beaaf-63c8-4020-bea5-c3609c0eaadf" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c5ada-c766-11e1-8775-005056c00008" name="28-29" r="4.1294880000000003" x="16.430831900000001" g1="0" b1="6.8296599999999999e-05" g2="0" b2="6.8296599999999999e-05" node1="22" voltageLevelId1="_04819ba0-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04588fd5-c766-11e1-8775-005056c00008" p1="15.37991525140621" q1="-4.8313060139859569" p2="-15.316022583851263" q2="2.8747332500035592">
+    <iidm:line id="_044c5ada-c766-11e1-8775-005056c00008" name="28-29" r="4.1294880000000003" x="16.430831900000001" g1="0" b1="6.8296599999999999e-05" g2="0" b2="6.8296599999999999e-05" node1="22" voltageLevelId1="_04819ba0-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04588fd5-c766-11e1-8775-005056c00008" p1="15.39480920196524" q1="-6.3405538750721284" p2="-15.327053991302122" q2="4.4051657205027848">
         <iidm:alias>_0461697a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04697fc1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10494,13 +10494,13 @@
             <iidm:temporaryLimit name="_6748d0d0-aec8-4b7b-a9ab-be6aecda7c5d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c5ada-c766-11e1-8775-005056c00008-1" name="28-29-open-ended" r="4.1294880000000003" x="16.430831900000001" g1="0" b1="6.8296599999999999e-05" g2="0" b2="6.8296599999999999e-05" node1="25" voltageLevelId1="_04819ba0-c766-11e1-8775-005056c00008" node2="25" voltageLevelId2="_04588fd5-c766-11e1-8775-005056c00008" p1="0.00031245752501864264" q1="-2.2120469412013315" p2="0" q2="0">
+    <iidm:line id="_044c5ada-c766-11e1-8775-005056c00008-1" name="28-29-open-ended" r="4.1294880000000003" x="16.430831900000001" g1="0" b1="6.8296599999999999e-05" g2="0" b2="6.8296599999999999e-05" node1="25" voltageLevelId1="_04819ba0-c766-11e1-8775-005056c00008" node2="25" voltageLevelId2="_04588fd5-c766-11e1-8775-005056c00008" p1="0" q1="-0" p2="0" q2="0">
         <iidm:currentLimits1 permanentLimit="1000">
             <iidm:temporaryLimit name="_accb8136-1faf-4399-9787-3cd567284fd2-1" acceptableDuration="900" value="1150"/>
             <iidm:temporaryLimit name="_6748d0d0-aec8-4b7b-a9ab-be6aecda7c5d-1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0468e382-c766-11e1-8775-005056c00008" name="3-5" r="4.1991839999999998" x="18.817920000000001" g1="0" b1="8.1496799999999995e-05" g2="0" b2="8.1496799999999995e-05" node1="31" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-70.1030452023832" q1="-16.943266309004244" p2="71.416177959857166" q2="20.034176223186318">
+    <iidm:line id="_0468e382-c766-11e1-8775-005056c00008" name="3-5" r="4.1991839999999998" x="18.817920000000001" g1="0" b1="8.1496799999999995e-05" g2="0" b2="8.1496799999999995e-05" node1="31" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-70.18300802076655" q1="-16.751154665672878" p2="71.497897445695159" q2="19.85130361280461">
         <iidm:alias>_046b0668-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04742e24-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10508,7 +10508,7 @@
             <iidm:temporaryLimit name="_828ca44c-560b-4f94-b825-21e237285fae" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0447c6f1-c766-11e1-8775-005056c00008" name="82-96" r="2.8226879999999999" x="9.2347199999999994" g1="0" b1="0.00015610649999999999" g2="0" b2="0.00015610649999999999" node1="33" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="-15.521647217953809" q1="-9.5960311548428407" p2="15.570367085091972" q2="4.4829323922376876">
+    <iidm:line id="_0447c6f1-c766-11e1-8775-005056c00008" name="82-96" r="2.8226879999999999" x="9.2347199999999994" g1="0" b1="0.00015610649999999999" g2="0" b2="0.00015610649999999999" node1="33" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="-15.790543248195437" q1="-9.5681462391762224" p2="15.840633385908024" q2="4.4611461916586279">
         <iidm:alias>_0478e91a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0480d856-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10516,7 +10516,7 @@
             <iidm:temporaryLimit name="_233b7735-85f4-4a6f-9d87-15129fe42ef5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0483e594-c766-11e1-8775-005056c00008" name="38-65" r="4.3608399999999996" x="47.7224" g1="0" b1="0.0010805785" g2="0" b2="0.0010805785" node1="29" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-157.29337645408546" q1="-98.340284278466868" p2="160.25469155891702" q2="33.86434775892743">
+    <iidm:line id="_0483e594-c766-11e1-8775-005056c00008" name="38-65" r="4.3608399999999996" x="47.7224" g1="0" b1="0.0010805785" g2="0" b2="0.0010805785" node1="29" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-160.69170103760567" q1="-97.999239827331593" p2="163.77042789184125" q2="34.879241082572889">
         <iidm:alias>_04638c56-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d5054-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10524,7 +10524,7 @@
             <iidm:temporaryLimit name="_990ce3c5-c90c-41b9-abee-fb803d9df3a5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04784cd4-c766-11e1-8775-005056c00008" name="106-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_04479fe8-c766-11e1-8775-005056c00008" node2="24" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="23.857135257742858" q1="-0.69604717950810624" p2="-23.528611298150093" q2="-2.4531143327069325">
+    <iidm:line id="_04784cd4-c766-11e1-8775-005056c00008" name="106-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_04479fe8-c766-11e1-8775-005056c00008" node2="24" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="23.852881858788667" q1="-0.69457666910630234" p2="-23.524474223449861" q2="-2.4550111460222013">
         <iidm:alias>_04483c21-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f0395-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10532,7 +10532,7 @@
             <iidm:temporaryLimit name="_1372c3b0-62d7-47d7-a8c0-ed8e10bc1f1a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046f9a43-c766-11e1-8775-005056c00008" name="27-115" r="2.8575360000000001" x="12.9111843" g1="0" b1="5.6588600000000002e-05" g2="0" b2="5.6588600000000002e-05" node1="43" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="22.567950642045581" q1="2.9001421857855068" p2="-22.476573174594776" q2="-4.329127533037858">
+    <iidm:line id="_046f9a43-c766-11e1-8775-005056c00008" name="27-115" r="2.8575360000000001" x="12.9111843" g1="0" b1="5.6588600000000002e-05" g2="0" b2="5.6588600000000002e-05" node1="43" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="22.683428318384397" q1="2.8764834561961927" p2="-22.590910940468945" q2="-4.2950401182047386">
         <iidm:alias>_046d0238-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048c22f4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10540,7 +10540,7 @@
             <iidm:temporaryLimit name="_64cfd0fb-1d8e-45d2-a52f-469238dfc0c6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04529c61-c766-11e1-8775-005056c00008" name="12-14" r="3.7461600000000002" x="12.3187675" g1="0" b1="5.2112050000000002e-05" g2="0" b2="5.2112050000000002e-05" node1="71" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b8129-c766-11e1-8775-005056c00008" p1="30.365391666202363" q1="6.6710518265456713" p2="-30.150583532760646" q2="-7.7234771905054895">
+    <iidm:line id="_04529c61-c766-11e1-8775-005056c00008" name="12-14" r="3.7461600000000002" x="12.3187675" g1="0" b1="5.2112050000000002e-05" g2="0" b2="5.2112050000000002e-05" node1="71" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b8129-c766-11e1-8775-005056c00008" p1="30.721705475538474" q1="7.3380240102976249" p2="-30.499812508542945" q2="-8.3661726919633974">
         <iidm:alias>_045fbbc1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047bf65b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10548,7 +10548,7 @@
             <iidm:temporaryLimit name="_efe2501d-bcee-42ff-a037-3d8a280487b0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0463da77-c766-11e1-8775-005056c00008" name="76-118" r="2.8575360000000001" x="9.4786560000000009" g1="0" b1="3.8911849999999999e-05" g2="0" b2="3.8911849999999999e-05" node1="22" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="-6.1473055581771305" q1="-14.707725624954589" p2="6.1914205896825196" q2="13.648014911672174">
+    <iidm:line id="_0463da77-c766-11e1-8775-005056c00008" name="76-118" r="2.8575360000000001" x="9.4786560000000009" g1="0" b1="3.8911849999999999e-05" g2="0" b2="3.8911849999999999e-05" node1="22" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="-5.5206750167436915" q1="-14.806871603532079" p2="5.5639876722246937" q2="13.745498834072151">
         <iidm:alias>_046931a0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04806320-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10556,7 +10556,7 @@
             <iidm:temporaryLimit name="_2ae204bf-78cc-49cb-b886-a933b33057e4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046931a3-c766-11e1-8775-005056c00008" name="74-75" r="2.1431520000000002" x="7.0741440000000004" g1="0" b1="2.9671699999999999e-05" g2="0" b2="2.9671699999999999e-05" node1="23" voltageLevelId1="_047dcb11-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="-44.346104389081511" q1="-4.2416180718888388" p2="44.610102540998859" q2="4.1513748383208373">
+    <iidm:line id="_046931a3-c766-11e1-8775-005056c00008" name="74-75" r="2.1431520000000002" x="7.0741440000000004" g1="0" b1="2.9671699999999999e-05" g2="0" b2="2.9671699999999999e-05" node1="23" voltageLevelId1="_047dcb11-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="-45.269340517713971" q1="-4.146095895053441" p2="45.544587484659232" q2="4.0939912050369154">
         <iidm:alias>_044f4103-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04638c58-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10564,7 +10564,7 @@
             <iidm:temporaryLimit name="_e822432e-79af-4bba-8f40-5250468f81a0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045ed162-c766-11e1-8775-005056c00008" name="3-12" r="8.4332159999999998" x="27.878398900000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="32" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-8.6986255056748938" q1="-9.6318849828020436" p2="8.7677093719801569" q2="5.9490442405282895">
+    <iidm:line id="_045ed162-c766-11e1-8775-005056c00008" name="3-12" r="8.4332159999999998" x="27.878398900000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="32" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-8.6496366194274845" q1="-9.7384302084752044" p2="8.7191585287831366" q2="6.0576424588390081">
         <iidm:alias>_047a48a1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047b5a14-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10572,7 +10572,7 @@
             <iidm:temporaryLimit name="_c437e52c-43d7-4ae9-87ad-dc19396dc6ff" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04499bb6-c766-11e1-8775-005056c00008" name="49-51" r="8.468064" x="23.8708782" g1="0" b1="9.81405e-05" g2="0" b2="9.81405e-05" node1="119" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04542300-c766-11e1-8775-005056c00008" p1="77.005214918751903" q1="18.639450523185541" p2="-74.069009283886118" q2="-13.753720499044467">
+    <iidm:line id="_04499bb6-c766-11e1-8775-005056c00008" name="49-51" r="8.468064" x="23.8708782" g1="0" b1="9.81405e-05" g2="0" b2="9.81405e-05" node1="119" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04542300-c766-11e1-8775-005056c00008" p1="76.842632283386592" q1="18.665289935771352" p2="-73.91750661608107" q2="-13.810858198831106">
         <iidm:alias>_0487dd38-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b1180-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10580,7 +10580,7 @@
             <iidm:temporaryLimit name="_90dcdbe1-437b-443f-b0b5-c2353f7c6954" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04839779-c766-11e1-8775-005056c00008" name="40-42" r="9.6703209999999995" x="31.885919999999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="42" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="0.065173997515429599" q1="-9.8771027131922828" p2="-0.021063901323111617" q2="6.2005962043192362">
+    <iidm:line id="_04839779-c766-11e1-8775-005056c00008" name="40-42" r="9.6703209999999995" x="31.885919999999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="42" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="-0.55176559139645631" q1="-9.7134652021014904" p2="0.59435324168533532" q2="6.0351226226089558">
         <iidm:alias>_044974a9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04616975-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10588,7 +10588,7 @@
             <iidm:temporaryLimit name="_9b8510fa-bd0e-4e63-8f4c-0e5443a3eb63" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0484a8e1-c766-11e1-8775-005056c00008" name="32-113" r="10.71576" x="35.370719999999999" g1="0" b1="0.00014864555000000001" g2="0" b2="0.00014864555000000001" node1="52" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="0.92168842393959027" q1="-8.5156516364878065" p2="-0.89674608851548676" q2="3.6883554761939483">
+    <iidm:line id="_0484a8e1-c766-11e1-8775-005056c00008" name="32-113" r="10.71576" x="35.370719999999999" g1="0" b1="0.00014864555000000001" g2="0" b2="0.00014864555000000001" node1="52" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="0.82286744023527292" q1="-8.4347168325269397" p2="-0.7985577343683613" q2="3.6196704486329376">
         <iidm:alias>_04723258-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0482860a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10596,7 +10596,7 @@
             <iidm:temporaryLimit name="_336bfd86-a922-4154-9e06-cd87382cdc5f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04898ae4-c766-11e1-8775-005056c00008" name="51-58" r="4.4431200000000004" x="12.5278568" g1="0" b1="5.1308550000000002e-05" g2="0" b2="5.1308550000000002e-05" node1="31" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="25.405009349971188" q1="0.44913213187575546" p2="-25.228074453903883" q2="-1.6047704743979221">
+    <iidm:line id="_04898ae4-c766-11e1-8775-005056c00008" name="51-58" r="4.4431200000000004" x="12.5278568" g1="0" b1="5.1308550000000002e-05" g2="0" b2="5.1308550000000002e-05" node1="31" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="25.304403116350322" q1="0.49076753035802723" p2="-25.128840772053064" q2="-1.6503341416594957">
         <iidm:alias>_044778d4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04789af1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10604,7 +10604,7 @@
             <iidm:temporaryLimit name="_2be10dec-f0ac-470d-83f7-a2a4e70f3491" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046efe04-c766-11e1-8775-005056c00008" name="29-31" r="1.8817919999999999" x="5.7673439999999996" g1="0" b1="2.3817700000000001e-05" g2="0" b2="2.3817700000000001e-05" node1="22" voltageLevelId1="_04588fd5-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="-8.6850362781336088" q1="-6.8750272512135" p2="8.6987026781348362" q2="6.1433568635796947">
+    <iidm:line id="_046efe04-c766-11e1-8775-005056c00008" name="29-31" r="1.8817919999999999" x="5.7673439999999996" g1="0" b1="2.3817700000000001e-05" g2="0" b2="2.3817700000000001e-05" node1="22" voltageLevelId1="_04588fd5-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="-8.6690078567004676" q1="-8.4040710919183237" p2="8.685239580667508" q2="7.6806828946119339">
         <iidm:alias>_04492688-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047cb9a5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10612,7 +10612,7 @@
             <iidm:temporaryLimit name="_f0e21213-6535-44a7-89b6-3063f8738d6b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044a10e4-c766-11e1-8775-005056c00008" name="65-68" r="0.66791999999999996" x="7.7439999999999998" g1="0" b1="0.00065909092999999995" g2="0" b2="0.00065909092999999995" node1="41" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0449e9d2-c766-11e1-8775-005056c00008" p1="-160.25628294124982" q1="23.466176718134513" p2="160.6495457178217" q2="-82.942344681730091">
+    <iidm:line id="_044a10e4-c766-11e1-8775-005056c00008" name="65-68" r="0.66791999999999996" x="7.7439999999999998" g1="0" b1="0.00065909092999999995" g2="0" b2="0.00065909092999999995" node1="41" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0449e9d2-c766-11e1-8775-005056c00008" p1="-162.13740302047387" q1="23.747567302222958" p2="162.53938137039742" q2="-83.121949608537165">
         <iidm:alias>_0461dea7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047629f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10620,7 +10620,7 @@
             <iidm:temporaryLimit name="_ab31cd46-6d0c-4d9c-95f1-396a45a237e1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046b7b92-c766-11e1-8775-005056c00008" name="49-54" r="12.719519999999999" x="50.355361899999998" g1="0" b1="0.00021177684999999999" g2="0" b2="0.00021177684999999999" node1="120" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="46.923351100987695" q1="11.832406587502639" p2="-45.222018535872579" q2="-12.339176658693821">
+    <iidm:line id="_046b7b92-c766-11e1-8775-005056c00008" name="49-54" r="12.719519999999999" x="50.355361899999998" g1="0" b1="0.00021177684999999999" g2="0" b2="0.00021177684999999999" node1="120" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="46.776386683175971" q1="11.850195975627042" p2="-45.084232681427103" q2="-12.393298616933865">
         <iidm:alias>_0462f017-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047120e1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10628,7 +10628,7 @@
             <iidm:temporaryLimit name="_1bf78539-b6fa-4d8b-ba8e-9b5970019be6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04607f15-c766-11e1-8775-005056c00008" name="70-71" r="1.536797" x="6.1855200000000004" g1="0" b1="2.5195149999999999e-05" g2="0" b2="2.5195149999999999e-05" node1="52" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04664b78-c766-11e1-8775-005056c00008" p1="-7.0768473094091515" q1="-4.5417390839546616" p2="7.0829413252158666" q2="3.7127459275323473">
+    <iidm:line id="_04607f15-c766-11e1-8775-005056c00008" name="70-71" r="1.536797" x="6.1855200000000004" g1="0" b1="2.5195149999999999e-05" g2="0" b2="2.5195149999999999e-05" node1="52" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04664b78-c766-11e1-8775-005056c00008" p1="-5.0529597652083247" q1="-4.847949963464651" p2="5.0570668308730999" q2="4.0124547718700203">
         <iidm:alias>_04486336-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f51b4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10636,7 +10636,7 @@
             <iidm:temporaryLimit name="_08ff3ae4-d1dd-49f7-9eda-32ffc8eb0010" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c5ad7-c766-11e1-8775-005056c00008" name="55-56" r="0.85029100000000002" x="2.631024" g1="0" b1="1.0732300000000001e-05" g2="0" b2="1.0732300000000001e-05" node1="31" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="-28.763579080484586" q1="-6.9789629152809747" p2="28.810695399677826" q2="6.7853931512846968">
+    <iidm:line id="_044c5ad7-c766-11e1-8775-005056c00008" name="55-56" r="0.85029100000000002" x="2.631024" g1="0" b1="1.0732300000000001e-05" g2="0" b2="1.0732300000000001e-05" node1="31" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="-28.686480941941596" q1="-7.0045932067748691" p2="28.733377076293714" q2="6.8103407549630308">
         <iidm:alias>_04558294-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045868c2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10644,7 +10644,7 @@
             <iidm:temporaryLimit name="_94316214-afd8-4c0d-bca4-916acb92af85" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048a2725-c766-11e1-8775-005056c00008" name="35-37" r="1.9166399999999999" x="8.6597279999999994" g1="0" b1="3.7821399999999997e-05" g2="0" b2="3.7821399999999997e-05" node1="21" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-29.339284293694579" q1="-14.466145041828321" p2="29.470823662778734" q2="13.885652613290722">
+    <iidm:line id="_048a2725-c766-11e1-8775-005056c00008" name="35-37" r="1.9166399999999999" x="8.6597279999999994" g1="0" b1="3.7821399999999997e-05" g2="0" b2="3.7821399999999997e-05" node1="21" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-29.558276232140202" q1="-14.435415745748575" p2="29.691496337579139" q2="13.864021291865569">
         <iidm:alias>_0471bd29-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04808a30-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10652,7 +10652,7 @@
             <iidm:temporaryLimit name="_4ea6b532-d914-4b0c-97ee-9f02a14a40b3" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04614263-c766-11e1-8775-005056c00008" name="4-5" r="0.30666199999999999" x="1.3904350000000001" g1="0" b1="6.0261499999999999e-06" g2="0" b2="6.0261499999999999e-06" node1="22" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-108.37269835648262" q1="-20.169351121773115" p2="108.58360569329906" q2="20.912010804178934">
+    <iidm:line id="_04614263-c766-11e1-8775-005056c00008" name="4-5" r="0.30666199999999999" x="1.3904350000000001" g1="0" b1="6.0261499999999999e-06" g2="0" b2="6.0261499999999999e-06" node1="22" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-108.55255688718206" q1="-19.942037415329423" p2="108.76411672316679" q2="20.687792033081077">
         <iidm:alias>_04529c66-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04753f92-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10660,7 +10660,7 @@
             <iidm:temporaryLimit name="_2a95fb2b-6661-46e7-a9f6-fe63c1b7433c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0451b208-c766-11e1-8775-005056c00008" name="20-21" r="3.1885919999999999" x="14.7929754" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_046b2d70-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0460f448-c766-11e1-8775-005056c00008" p1="-39.079938411873677" q1="-3.9813154247976295" p2="39.390565744100073" q2="3.4451526394896841">
+    <iidm:line id="_0451b208-c766-11e1-8775-005056c00008" name="20-21" r="3.1885919999999999" x="14.7929754" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_046b2d70-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0460f448-c766-11e1-8775-005056c00008" p1="-30.861103980174747" q1="0.59828672547103212" p2="31.058733319395927" q2="-1.6013905007596023">
         <iidm:alias>_046c65f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048c22f6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10668,7 +10668,7 @@
             <iidm:temporaryLimit name="_4b67f5f5-f0e1-4bfb-9d57-4d3474720a45" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047d55e4-c766-11e1-8775-005056c00008" name="104-105" r="1.731946" x="6.5862720000000001" g1="0" b1="2.8294300000000001e-05" g2="0" b2="2.8294300000000001e-05" node1="32" voltageLevelId1="_0483977a-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="48.062680897376815" q1="0.85707029374534205" p2="-47.818749807348496" q2="-0.85326571580869226">
+    <iidm:line id="_047d55e4-c766-11e1-8775-005056c00008" name="104-105" r="1.731946" x="6.5862720000000001" g1="0" b1="2.8294300000000001e-05" g2="0" b2="2.8294300000000001e-05" node1="32" voltageLevelId1="_0483977a-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="48.03103236066768" q1="0.86545670295970367" p2="-47.787420632151097" q2="-0.86286940777010079">
         <iidm:alias>_0451d910-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046c65f2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10676,7 +10676,7 @@
             <iidm:temporaryLimit name="_1ca40dc7-6736-4fa8-b4cb-ca696949e421" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046dc589-c766-11e1-8775-005056c00008" name="44-45" r="3.9029759999999998" x="15.699023199999999" g1="0" b1="6.4279149999999996e-05" g2="0" b2="6.4279149999999996e-05" node1="23" voltageLevelId1="_04544a15-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_045d23b4-c766-11e1-8775-005056c00008" p1="-20.531605375804702" q1="-4.5756422161839483" p2="20.633863520152264" q2="2.840190928646591">
+    <iidm:line id="_046dc589-c766-11e1-8775-005056c00008" name="44-45" r="3.9029759999999998" x="15.699023199999999" g1="0" b1="6.4279149999999996e-05" g2="0" b2="6.4279149999999996e-05" node1="23" voltageLevelId1="_04544a15-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_045d23b4-c766-11e1-8775-005056c00008" p1="-21.312393794318496" q1="-4.466562394602394" p2="21.422240406479087" q2="2.7626890860906932">
         <iidm:alias>_04518afa-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04667287-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10684,7 +10684,7 @@
             <iidm:temporaryLimit name="_ba738481-ddba-4ebe-a218-8aad0b537f5b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04642896-c766-11e1-8775-005056c00008" name="4-11" r="3.641616" x="11.9877129" g1="0" b1="5.0160700000000002e-05" g2="0" b2="5.0160700000000002e-05" node1="23" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="69.368540421300111" q1="8.1672188918170132" p2="-68.359494492712784" q2="-6.5834159434684274">
+    <iidm:line id="_04642896-c766-11e1-8775-005056c00008" name="4-11" r="3.641616" x="11.9877129" g1="0" b1="5.0160700000000002e-05" g2="0" b2="5.0160700000000002e-05" node1="23" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="69.553209605016292" q1="7.9423721250827057" p2="-68.539069983518004" q2="-6.3409062750165415">
         <iidm:alias>_0455f7c5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04803c17-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10692,7 +10692,7 @@
             <iidm:temporaryLimit name="_b1d87c24-e527-4174-aa04-cd0b9de271ea" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047d07c0-c766-11e1-8775-005056c00008" name="92-93" r="4.4953919999999998" x="14.775551800000001" g1="0" b1="6.2557400000000005e-05" g2="0" b2="6.2557400000000005e-05" node1="72" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04789af0-c766-11e1-8775-005056c00008" p1="70.185535815653026" q1="-12.666208121764596" p2="-68.851961610011131" q2="14.928729398117957">
+    <iidm:line id="_047d07c0-c766-11e1-8775-005056c00008" name="92-93" r="4.4953919999999998" x="14.775551800000001" g1="0" b1="6.2557400000000005e-05" g2="0" b2="6.2557400000000005e-05" node1="72" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04789af0-c766-11e1-8775-005056c00008" p1="70.617179362593831" q1="-12.72376495792976" p2="-69.267039754035679" q2="15.041124144499927">
         <iidm:alias>_044a5f07-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047602e5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10700,7 +10700,7 @@
             <iidm:temporaryLimit name="_4e1daf8e-7708-4b96-8d3f-67f58f2505f9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044f4109-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="43" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="121" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-52.969956729242064" q1="-19.076899676789218" p2="55.578191893760376" q2="22.751748443656979">
+    <iidm:line id="_044f4109-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="43" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="121" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-53.574611835434318" q1="-18.914045503850303" p2="56.23583974798305" q2="22.83105234533242">
         <iidm:alias>_046958b0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04758db0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10708,7 +10708,7 @@
             <iidm:temporaryLimit name="_c58940cb-bd36-4dfc-9615-11716dd652a7" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046e61c8-c766-11e1-8775-005056c00008" name="69-75" r="7.0567200000000003" x="21.257280000000002" g1="0" b1="0.00035583104999999999" g2="0" b2="0.00035583104999999999" node1="61" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="89.411917523337507" q1="24.259876901992154" p2="-86.028406518592007" q2="-26.519857334968666">
+    <iidm:line id="_046e61c8-c766-11e1-8775-005056c00008" name="69-75" r="7.0567200000000003" x="21.257280000000002" g1="0" b1="0.00035583104999999999" g2="0" b2="0.00035583104999999999" node1="61" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="90.103399411886613" q1="24.482834358750804" p2="-86.667727415570539" q2="-26.580153943469341">
         <iidm:alias>_046d294a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048ac362-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10716,7 +10716,7 @@
             <iidm:temporaryLimit name="_3c9a454c-10ee-4c72-a059-77f723f5b7c7" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0463da71-c766-11e1-8775-005056c00008" name="79-80" r="2.7181440000000001" x="12.2664957" g1="0" b1="5.3661600000000001e-05" g2="0" b2="5.3661600000000001e-05" node1="23" voltageLevelId1="_04481510-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-66.191995544586774" q1="-32.337346580955071" p2="67.017635620731497" q2="34.103924862743263">
+    <iidm:line id="_0463da71-c766-11e1-8775-005056c00008" name="79-80" r="2.7181440000000001" x="12.2664957" g1="0" b1="5.3661600000000001e-05" g2="0" b2="5.3661600000000001e-05" node1="23" voltageLevelId1="_04481510-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-66.52440020690058" q1="-32.368064585762269" p2="67.357266988938633" q2="34.167417300987445">
         <iidm:alias>_0464ebe9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04662468-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10724,7 +10724,7 @@
             <iidm:temporaryLimit name="_270a7d04-9ff9-4178-8b72-b610735a72ac" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044fdd41-c766-11e1-8775-005056c00008" name="51-52" r="3.5370720000000002" x="10.2453117" g1="0" b1="4.0059699999999999e-05" g2="0" b2="4.0059699999999999e-05" node1="32" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04806326-c766-11e1-8775-005056c00008" p1="31.664148139112125" q1="5.3047084973888881" p2="-31.438173983284141" q2="-5.9384392834258755">
+    <iidm:line id="_044fdd41-c766-11e1-8775-005056c00008" name="51-52" r="3.5370720000000002" x="10.2453117" g1="0" b1="4.0059699999999999e-05" g2="0" b2="4.0059699999999999e-05" node1="32" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04806326-c766-11e1-8775-005056c00008" p1="31.613121643869626" q1="5.3201050014437259" p2="-31.387819588661202" q2="-5.9558371138542014">
         <iidm:alias>_045115c2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0464ebe5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10732,7 +10732,7 @@
             <iidm:temporaryLimit name="_9d1eb182-ceb5-426e-9440-5f4d426a31cb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c3958-c766-11e1-8775-005056c00008" name="53-54" r="4.5825120000000004" x="21.257280000000002" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="22" voltageLevelId1="_04876804-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="-9.6451065201296231" q1="-6.7326759231088582" p2="9.6808984002278464" q2="4.0998438895674854">
+    <iidm:line id="_045c3958-c766-11e1-8775-005056c00008" name="53-54" r="4.5825120000000004" x="21.257280000000002" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="22" voltageLevelId1="_04876804-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="-9.6951353048039888" q1="-6.7130380993458445" p2="9.731149339000698" q2="4.0812068466314351">
         <iidm:alias>_044f6817-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0455f7c6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10740,7 +10740,7 @@
             <iidm:temporaryLimit name="_735ac8df-6a6a-43f0-86f2-49d3280c9a3b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044ef2e1-c766-11e1-8775-005056c00008" name="54-55" r="2.9446560000000002" x="12.3187675" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="63" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04767817-c766-11e1-8775-005056c00008" p1="10.177894498268206" q1="1.7038941507760106" p2="-10.157422285305161" q2="-3.4533822104988849">
+    <iidm:line id="_044ef2e1-c766-11e1-8775-005056c00008" name="54-55" r="2.9446560000000002" x="12.3187675" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="63" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04767817-c766-11e1-8775-005056c00008" p1="10.156584510675312" q1="1.7058315726244468" p2="-10.13619069605568" q2="-3.4556506852569453">
         <iidm:alias>_04640181-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047dcb17-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10748,7 +10748,7 @@
             <iidm:temporaryLimit name="_52aadf8d-53f2-4827-8c70-421bdf1ba822" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0456e226-c766-11e1-8775-005056c00008" name="80-97" r="3.1885919999999999" x="16.2740154" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="82" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="12.662290559111794" q1="30.838138714231139" p2="-12.459608093856964" q2="-32.469918800441896">
+    <iidm:line id="_0456e226-c766-11e1-8775-005056c00008" name="80-97" r="3.1885919999999999" x="16.2740154" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="82" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="12.22731144771458" q1="30.998187413441393" p2="-12.024711740777514" q2="-32.630209868368595">
         <iidm:alias>_04479fe9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047df222-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10756,7 +10756,7 @@
             <iidm:temporaryLimit name="_fece5807-6af8-4161-8de8-8f8473d92f11" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0487b624-c766-11e1-8775-005056c00008" name="103-110" r="6.8058139999999998" x="31.5897121" g1="0" b1="0.00013228879999999999" g2="0" b2="0.00013228879999999999" node1="43" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="57.786611650762453" q1="18.491400429894611" p2="-56.341644927594423" q2="-16.238213234218776">
+    <iidm:line id="_0487b624-c766-11e1-8775-005056c00008" name="103-110" r="6.8058139999999998" x="31.5897121" g1="0" b1="0.00013228879999999999" g2="0" b2="0.00013228879999999999" node1="43" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="57.719727324995006" q1="18.497440709700992" p2="-56.277621027654888" q2="-16.257537987330092">
         <iidm:alias>_046a9139-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b3895-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10764,7 +10764,7 @@
             <iidm:temporaryLimit name="_3eacc034-737e-41de-a7b6-b610d3bd0921" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045338a8-c766-11e1-8775-005056c00008" name="56-58" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="61" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="-13.162745528116332" q1="-0.63246555859964237" p2="13.228145637285893" q2="-1.3951983903947789">
+    <iidm:line id="_045338a8-c766-11e1-8775-005056c00008" name="56-58" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="61" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="-13.064437372004845" q1="-0.68082226127904466" p2="13.128848996638318" q2="-1.3496623906834333">
         <iidm:alias>_0451d915-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04817494-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10772,7 +10772,7 @@
             <iidm:temporaryLimit name="_0d0c3ec5-798a-48a4-9bc8-d19c57128a13" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04854529-c766-11e1-8775-005056c00008" name="15-33" r="6.6211200000000003" x="21.675455100000001" g1="0" b1="9.1655200000000003e-05" g2="0" b2="9.1655200000000003e-05" node1="52" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456bb11-c766-11e1-8775-005056c00008" p1="67.195061955707857" q1="-8.0992325870253676" p2="-65.277592534383587" q2="11.53183465991534">
+    <iidm:line id="_04854529-c766-11e1-8775-005056c00008" name="15-33" r="6.6211200000000003" x="21.675455100000001" g1="0" b1="9.1655200000000003e-05" g2="0" b2="9.1655200000000003e-05" node1="52" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456bb11-c766-11e1-8775-005056c00008" p1="64.515556239880283" q1="-8.2947408075035653" p2="-62.737703979785131" q2="11.279646234594853">
         <iidm:alias>_0448d862-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047d2ed5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10780,7 +10780,7 @@
             <iidm:temporaryLimit name="_5b0395f4-534d-4975-a1af-e0b6ef439193" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04649dc2-c766-11e1-8775-005056c00008" name="35-36" r="0.39029799999999998" x="1.7772479999999999" g1="0" b1="7.6905500000000004e-06" g2="0" b2="7.6905500000000004e-06" node1="22" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="-3.6607845268845036" q1="5.4661149967765503" p2="3.6619180182879503" q2="-5.696951480778381">
+    <iidm:line id="_04649dc2-c766-11e1-8775-005056c00008" name="35-36" r="0.39029799999999998" x="1.7772479999999999" g1="0" b1="7.6905500000000004e-06" g2="0" b2="7.6905500000000004e-06" node1="22" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="-3.4329040060705864" q1="5.4394247533243085" p2="3.433990216805177" q2="-5.6701670591915461">
         <iidm:alias>_044c0cb5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0456e225-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10788,7 +10788,7 @@
             <iidm:temporaryLimit name="_74c4b341-7b99-4a81-b88a-2ed3b0c4b1de" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0470d2c9-c766-11e1-8775-005056c00008" name="37-40" r="10.3324327" x="29.272320000000001" g1="0" b1="0.0001205234" g2="0" b2="0.0001205234" node1="61" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="56.97099887062209" q1="10.190941900585671" p2="-54.740297848316445" q2="-7.4560611721563506">
+    <iidm:line id="_0470d2c9-c766-11e1-8775-005056c00008" name="37-40" r="10.3324327" x="29.272320000000001" g1="0" b1="0.0001205234" g2="0" b2="0.0001205234" node1="61" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="56.309597513973145" q1="10.232875351502871" p2="-54.124805068883106" q2="-7.6241620233100358">
         <iidm:alias>_045b9d10-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046a4317-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10796,7 +10796,7 @@
             <iidm:temporaryLimit name="_e98d56fe-a54b-45e4-acff-0ac310beb3dd" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044e56a2-c766-11e1-8775-005056c00008" name="48-49" r="3.1188959999999999" x="8.7991200000000003" g1="0" b1="3.6099649999999999e-05" g2="0" b2="3.6099649999999999e-05" node1="23" voltageLevelId1="_044778d3-c766-11e1-8775-005056c00008" node2="122" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-28.726129472415508" q1="1.2804741572286351" p2="28.868519293467266" q2="-2.1950651945235378">
+    <iidm:line id="_044e56a2-c766-11e1-8775-005056c00008" name="48-49" r="3.1188959999999999" x="8.7991200000000003" g1="0" b1="3.6099649999999999e-05" g2="0" b2="3.6099649999999999e-05" node1="23" voltageLevelId1="_044778d3-c766-11e1-8775-005056c00008" node2="122" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-28.845831895683503" q1="1.3185013058748321" p2="28.989432000102227" q2="-2.229673044173734">
         <iidm:alias>_0454bf49-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0460a623-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10804,7 +10804,7 @@
             <iidm:temporaryLimit name="_f2e58700-2366-46e0-8408-9472d85acd23" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047eb573-c766-11e1-8775-005056c00008" name="56-59" r="14.3748007" x="43.734237700000001" g1="0" b1="0.0001632805" g2="0" b2="0.0001632805" node1="62" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-19.094359838382385" q1="-7.7463439548334154" p2="19.449085631405435" q2="3.4768246564949679">
+    <iidm:line id="_047eb573-c766-11e1-8775-005056c00008" name="56-59" r="14.3748007" x="43.734237700000001" g1="0" b1="0.0001632805" g2="0" b2="0.0001632805" node1="62" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-19.178887619068533" q1="-7.7132768314314166" p2="19.536237057110302" q2="3.4517309789191444">
         <iidm:alias>_0468bc78-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048915b0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10812,7 +10812,7 @@
             <iidm:temporaryLimit name="_89654167-95a6-4c76-aad7-63a881116e17" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046f9a4b-c766-11e1-8775-005056c00008" name="94-100" r="3.1014719999999998" x="10.105919999999999" g1="0" b1="0.00017332415000000001" g2="0" b2="0.00017332415000000001" node1="52" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-5.7680604186933184" q1="-52.170401470900984" p2="6.216931831369763" q2="47.567366911911442">
+    <iidm:line id="_046f9a4b-c766-11e1-8775-005056c00008" name="94-100" r="3.1014719999999998" x="10.105919999999999" g1="0" b1="0.00017332415000000001" g2="0" b2="0.00017332415000000001" node1="52" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-6.1261132969240197" q1="-52.232640057683987" p2="6.5769894473175299" q2="47.636761124674486">
         <iidm:alias>_04812676-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048a2722-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10820,7 +10820,7 @@
             <iidm:temporaryLimit name="_216c0f3b-03e8-4b7d-96fc-a5f891331f7f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046735d0-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="123" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-92.154562716893992" q1="-2.5673526451535702" p2="93.609820606518738" q2="7.3388894454456581">
+    <iidm:line id="_046735d0-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="123" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-92.395268630945409" q1="-2.4975018892486793" p2="93.858108672021231" q2="7.3077572843802212">
         <iidm:alias>_04570934-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b3894-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10828,7 +10828,7 @@
             <iidm:temporaryLimit name="_32655e4f-e7da-46b0-a908-b601224ddb73" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046d294b-c766-11e1-8775-005056c00008" name="21-22" r="3.641616" x="16.901281399999998" g1="0" b1="7.0592299999999998e-05" g2="0" b2="7.0592299999999998e-05" node1="22" voltageLevelId1="_0460f448-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04773b6a-c766-11e1-8775-005056c00008" p1="-39.39056574410003" q1="-3.4451526394896592" p2="39.742066390710924" q2="2.7713951100007073">
+    <iidm:line id="_046d294b-c766-11e1-8775-005056c00008" name="21-22" r="3.641616" x="16.901281399999998" g1="0" b1="7.0592299999999998e-05" g2="0" b2="7.0592299999999998e-05" node1="22" voltageLevelId1="_0460f448-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04773b6a-c766-11e1-8775-005056c00008" p1="-45.057093366824468" q1="-6.3970475425978304" p2="45.538471619929993" q2="6.3943108349866149">
         <iidm:alias>_044a37f0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_044be5a2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10836,7 +10836,7 @@
             <iidm:temporaryLimit name="_bafaeace-e459-4dc2-87a0-467a9ea25f8d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_6a131803-f462-47e2-bc21-bda919364fe9" name="reactor1" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="36" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="37" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="5.8286708792820718e-14" q1="-83.151439201261041" p2="-6.106226635438361e-14" q2="92.151084564051018">
+    <iidm:line id="_6a131803-f462-47e2-bc21-bda919364fe9" name="reactor1" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="36" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="37" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="-2.4980018054066022e-14" q1="-83.151383996176691" p2="2.4980018054066022e-14" q2="92.15102338401077">
         <iidm:alias>_04531196-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_ca0adad2-ffe3-4efa-b56b-7d333b8ae18f</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10844,7 +10844,7 @@
             <iidm:temporaryLimit name="_ae4eadea-f3fc-4ac6-8899-c1698ece7a89" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_9803b364-2a93-4f21-94b7-8bdbe27a16f2" name="reactor2" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="38" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="5.9466509529093603e-07" q1="27.482702004563027" p2="-5.9466509529093603e-07" q2="-26.596964400879997">
+    <iidm:line id="_9803b364-2a93-4f21-94b7-8bdbe27a16f2" name="reactor2" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="38" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="1.2352424291761643e-08" q1="27.473646750563546" p2="-1.2352424638706339e-08" q2="-26.588492178954105">
         <iidm:alias>_0461b792-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_afe0e60b-3870-44fb-ba93-a056228f9636</iidm:alias>
     </iidm:line>

--- a/tests/main_sa/reference/launch/shunt_compensator_contingency/outputIIDM.xml
+++ b/tests/main_sa/reference/launch/shunt_compensator_contingency/outputIIDM.xml
@@ -31,8 +31,8 @@
                     <iidm:alias>_bea273f1-1e21-476d-b0d0-92dd6cb9a2d4</iidm:alias>
                     <iidm:alias>_c94e6b68-da6c-43d1-94fd-09ad60c74134</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_047abdd7-c766-11e1-8775-005056c00008-BREAKER" name="BREAKER-Jay LD" kind="BREAKER" retained="true" open="false" node1="0" node2="8"/>
                 <iidm:internalConnection node1="7" node2="0"/>
-                <iidm:internalConnection node1="8" node2="0"/>
                 <iidm:internalConnection node1="9" node2="1"/>
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="4"/>
@@ -47,9 +47,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="124.64726657750028" angle="7.3367940213233602" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.74835478599108" angle="-3.8271007442482352" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047abdd7-c766-11e1-8775-005056c00008" name="Jay LD" loadType="UNDEFINED" p0="14" q0="8" node="8" p="13.996767166364741" q="7.9969213478186054">
+            <iidm:load id="_047abdd7-c766-11e1-8775-005056c00008" name="Jay LD" loadType="UNDEFINED" p0="14" q0="8" node="8" p="13.996836122793876" q="7.9969870106057401">
                 <iidm:alias>_04590500-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -139,12 +139,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="127.70193952287953" angle="10.75198219520828" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="127.89425793467699" angle="-0.60398570578658728" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045b00d5-c766-11e1-8775-005056c00008" name="Madison LD" loadType="UNDEFINED" p0="62" q0="13" node="14" p="61.995708787604087" q="12.998500417362854">
+            <iidm:load id="_045b00d5-c766-11e1-8775-005056c00008" name="Madison LD" loadType="UNDEFINED" p0="62" q0="13" node="14" p="61.995982698023724" q="12.998596134470194">
                 <iidm:alias>_045b27e3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_04689566-c766-11e1-8775-005056c00008" name="Madison NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="15" p="8.9993770820715611" q="0">
+            <iidm:load id="_04689566-c766-11e1-8775-005056c00008" name="Madison NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="15" p="8.9994168432615069" q="0">
                 <iidm:alias>_04765100-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -272,16 +272,16 @@
                 <iidm:internalConnection node1="61" node2="12"/>
                 <iidm:internalConnection node1="62" node2="15"/>
                 <iidm:internalConnection node1="63" node2="18"/>
-                <iidm:bus v="126.06000013975378" angle="-7.5441768352912062" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63"/>
+                <iidm:bus v="126.0600018236976" angle="-18.738958148956844" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_046c3ee7-c766-11e1-8775-005056c00008" name="Torrey SM" energySource="THERMAL" minP="20" maxP="80" ratedS="100" voltageRegulatorOn="true" targetP="48" targetV="126.06" targetQ="0" node="21" p="-53.147204257111532" q="-7.2712243517990673">
+            <iidm:generator id="_046c3ee7-c766-11e1-8775-005056c00008" name="Torrey SM" energySource="THERMAL" minP="20" maxP="80" ratedS="100" voltageRegulatorOn="true" targetP="48" targetV="126.06" targetQ="0" node="21" p="-53.13803863727815" q="-7.2820912844449888">
                 <iidm:alias>_047147f3-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_b97aee41-3115-4cfd-9071-b52fb44d0b66"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_5005c073-28d1-4a7d-b257-649dec43ec73"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-30" maxQ="85"/>
             </iidm:generator>
-            <iidm:load id="_044afb44-c766-11e1-8775-005056c00008" name="Torrey LD" loadType="UNDEFINED" p0="113" q0="32" node="20" p="113.0000001879126" q="32.000000088690321">
+            <iidm:load id="_044afb44-c766-11e1-8775-005056c00008" name="Torrey LD" loadType="UNDEFINED" p0="113" q0="32" node="20" p="113.0000024521398" q="32.000001157352131">
                 <iidm:alias>_04522737-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -332,9 +332,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="123.42114374980243" angle="8.270026350030955" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="123.41083815157756" angle="-2.9792373063200888" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04481515-c766-11e1-8775-005056c00008" name="Darrah LD" loadType="UNDEFINED" p0="68" q0="36" node="8" p="67.907936526840331" q="35.918804188728778">
+            <iidm:load id="_04481515-c766-11e1-8775-005056c00008" name="Darrah LD" loadType="UNDEFINED" p0="68" q0="36" node="8" p="67.907933392903374" q="35.918801425986757">
                 <iidm:alias>_044e7db8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -385,9 +385,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.46291810852327" angle="22.646113791188764" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.45709374473356" angle="11.419088027979717" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044c0cb3-c766-11e1-8775-005056c00008" name="Smythe LD" loadType="UNDEFINED" p0="5" q0="3" node="8" p="4.9999439789543354" q="2.9999439791635591">
+            <iidm:load id="_044c0cb3-c766-11e1-8775-005056c00008" name="Smythe LD" loadType="UNDEFINED" p0="5" q0="3" node="8" p="4.999943560349239" q="2.9999435605616012">
                 <iidm:alias>_045163e8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -514,9 +514,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="125.90820948952478" angle="-7.7165316301640052" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="125.90817882014159" angle="-18.91137715407578" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0450a093-c766-11e1-8775-005056c00008" name="Sunnysde LD" loadType="UNDEFINED" p0="84" q0="18" node="20" p="84.000001228896522" q="18.000000438891615">
+            <iidm:load id="_0450a093-c766-11e1-8775-005056c00008" name="Sunnysde LD" loadType="UNDEFINED" p0="84" q0="18" node="20" p="84.000002916984641" q="18.000001041780241">
                 <iidm:alias>_045f4695-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -568,12 +568,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="125.65518935627016" angle="8.2095250524627943" nodes="0,1,4,7,8,9,10,12,14,15,18,19"/>
+                <iidm:bus v="125.65760822396126" angle="-3.0568799167990872" nodes="0,1,4,7,8,9,10,12,14,15,18,19"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044b2251-c766-11e1-8775-005056c00008" name="Bellefnt LD" loadType="UNDEFINED" p0="68" q0="27" node="8" p="67.775083367275855" q="26.851322274095796">
+            <iidm:load id="_044b2251-c766-11e1-8775-005056c00008" name="Bellefnt LD" loadType="UNDEFINED" p0="68" q0="27" node="8" p="67.775112394983438" q="26.851341441229298">
                 <iidm:alias>_04622cc1-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0449e9d5-c766-11e1-8775-005056c00008" name="Bellefnt SC" sectionCount="0" voltageRegulatorOn="true" targetV="126.40300000000001" targetDeadband="1" node="9" q="0">
+            <iidm:shunt id="_0449e9d5-c766-11e1-8775-005056c00008" name="Bellefnt SC" sectionCount="0" voltageRegulatorOn="true" targetV="126.40300000000001" targetDeadband="1" node="9" q="-0">
                 <iidm:alias>_047bcf48-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_6cc38790-c6a6-4309-99f4-a3258e24e785"/>
                 <iidm:shuntLinearModel bPerSection="0.00013779999999999999" gPerSection="0" maximumSectionCount="10"/>
@@ -665,12 +665,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="126.06591777568038" angle="8.3061360805831992" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="126.06589727302713" angle="-2.9274733082122184" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04682035-c766-11e1-8775-005056c00008" name="Fieldale LD" loadType="UNDEFINED" p0="39" q0="30" node="14" p="39.000004524116669" q="30.000005800149797">
+            <iidm:load id="_04682035-c766-11e1-8775-005056c00008" name="Fieldale LD" loadType="UNDEFINED" p0="39" q0="30" node="14" p="39.000004079875175" q="30.000005230609382">
                 <iidm:alias>_0478c20a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_045c6067-c766-11e1-8775-005056c00008" name="Fieldale SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.066" targetDeadband="1" node="15" q="-5.4670597748708643">
+            <iidm:shunt id="_045c6067-c766-11e1-8775-005056c00008" name="Fieldale SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.066" targetDeadband="1" node="15" q="-5.4670579966071804">
                 <iidm:alias>_0451b209-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_2d222dd9-7306-4afd-baa5-fd303b0eeb40"/>
                 <iidm:shuntLinearModel bPerSection="6.8800000000000005e-05" gPerSection="0" maximumSectionCount="10"/>
@@ -780,7 +780,7 @@
                 <iidm:internalConnection node1="51" node2="9"/>
                 <iidm:internalConnection node1="52" node2="12"/>
                 <iidm:internalConnection node1="53" node2="15"/>
-                <iidm:bus v="138.01488828724257" angle="4.2508229372215096" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
+                <iidm:bus v="138.01484837358376" angle="-6.945596845540515" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="_047f0391-c766-11e1-8775-005056c00008" name="Muskngum SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="392" targetV="138.59999099999999" targetQ="0" node="18" p="-0" q="-0">
                 <iidm:alias>_047eb572-c766-11e1-8775-005056c00008</iidm:alias>
@@ -789,7 +789,7 @@
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
-            <iidm:load id="_047e1936-c766-11e1-8775-005056c00008" name="Muskngum LD" loadType="UNDEFINED" p0="39" q0="18" node="17" p="38.999748251633811" q="17.999806347827306">
+            <iidm:load id="_047e1936-c766-11e1-8775-005056c00008" name="Muskngum LD" loadType="UNDEFINED" p0="39" q0="18" node="17" p="38.999749528649907" q="17.999807330143163">
                 <iidm:alias>_046e88d5-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -876,9 +876,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="221.09999999908916" angle="9.4138452537190638" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="221.10000516855186" angle="-1.7856733080354565" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0458ddf1-c766-11e1-8775-005056c00008" name="Muskngum SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="391" targetV="221.09999999999999" targetQ="0" node="14" p="-432.92826801105429" q="-159.72825656685526">
+            <iidm:generator id="_0458ddf1-c766-11e1-8775-005056c00008" name="Muskngum SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="391" targetV="221.09999999999999" targetQ="0" node="14" p="-432.85360639949494" q="-159.64594051613631">
                 <iidm:alias>_04522732-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_5036c3a5-56f9-489c-9ecb-8c15aa7c70c5"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_12b01822-ca11-4cf8-a6b4-2f8ff805ca20"/>
@@ -886,7 +886,7 @@
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045cae83-c766-11e1-8775-005056c00008" name="65-66" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="42" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="273.3368531560829" q1="97.438582787959902" p2="-273.3368531560829" q2="-70.470962142091793">
+        <iidm:twoWindingsTransformer id="_045cae83-c766-11e1-8775-005056c00008" name="65-66" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="42" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="273.17317119489206" q1="97.424754231479909" p2="-273.17317119489206" q2="-70.486645656326459">
             <iidm:alias>_044b2254-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_044b4964-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_045645e1-c766-11e1-8775-005056c00008</iidm:alias>
@@ -961,9 +961,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="124.05260765034865" angle="5.5055631194418613" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.09629092653297" angle="-5.536197114694577" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0453d4e2-c766-11e1-8775-005056c00008" name="Adams LD" loadType="UNDEFINED" p0="18" q0="3" node="8" p="17.996353373324776" q="2.9989871165520747">
+            <iidm:load id="_0453d4e2-c766-11e1-8775-005056c00008" name="Adams LD" loadType="UNDEFINED" p0="18" q0="3" node="8" p="17.996429947410189" q="2.9990083842886142">
                 <iidm:alias>_0448ff77-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1053,16 +1053,16 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="133.31999311769951" angle="14.047647301928144" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="133.31999252569182" angle="2.8144377094336233" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_046bf0c4-c766-11e1-8775-005056c00008" name="Claytor SM" energySource="THERMAL" minP="0" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="40" targetV="133.31999200000001" targetQ="0" node="15" p="-44.289336880926285" q="-83.072047922467036">
+            <iidm:generator id="_046bf0c4-c766-11e1-8775-005056c00008" name="Claytor SM" energySource="THERMAL" minP="0" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="40" targetV="133.31999200000001" targetQ="0" node="15" p="-44.281698864398464" q="-83.075976386128119">
                 <iidm:alias>_0460a627-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e56da2eb-bb6a-4133-953c-40073c5bc5f4"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_d41be6b4-155e-4c8f-b46b-16b50c49f0f4"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-60" maxQ="170"/>
             </iidm:generator>
-            <iidm:load id="_048433b6-c766-11e1-8775-005056c00008" name="Claytor LD" loadType="UNDEFINED" p0="23" q0="16" node="14" p="23.000000289233689" q="16.000000335343408">
+            <iidm:load id="_048433b6-c766-11e1-8775-005056c00008" name="Claytor LD" loadType="UNDEFINED" p0="23" q0="16" node="14" p="23.000000136036366" q="16.000000157723321">
                 <iidm:alias>_0480ff6b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1133,12 +1133,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="129.73850952106872" angle="-4.3846174155545432" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="129.73348908215777" angle="-15.559856641430629" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0449e9d7-c766-11e1-8775-005056c00008" name="N.Newark LD" loadType="UNDEFINED" p0="53" q0="22" node="11" p="52.997632908170154" q="21.998362413679942">
+            <iidm:load id="_0449e9d7-c766-11e1-8775-005056c00008" name="N.Newark LD" loadType="UNDEFINED" p0="53" q0="22" node="11" p="52.997628876826766" q="21.998359624783351">
                 <iidm:alias>_04531191-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_04684741-c766-11e1-8775-005056c00008" name="N.Newark SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.32300000000001" targetDeadband="1" node="12" q="-9.6616144094776057">
+            <iidm:shunt id="_04684741-c766-11e1-8775-005056c00008" name="N.Newark SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.32300000000001" targetDeadband="1" node="12" q="-9.6608666807330241">
                 <iidm:alias>_04607f19-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_eae61817-d3cb-488f-a1f3-13bc8e31431b"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -1191,9 +1191,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.63275284664888" angle="11.056178546816735" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.71882126280471" angle="-0.33126405839497725" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0448d86a-c766-11e1-8775-005056c00008" name="Hillsbro NegG LD" loadType="UNDEFINED" p0="12" q0="0" node="8" p="11.988328466010653" q="0">
+            <iidm:load id="_0448d86a-c766-11e1-8775-005056c00008" name="Hillsbro NegG LD" loadType="UNDEFINED" p0="12" q0="0" node="8" p="11.988354584013026" q="0">
                 <iidm:alias>_044ef2e8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1244,9 +1244,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="125.31882810355492" angle="-6.0213606708278276" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="125.27143145518509" angle="-17.136428668110522" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047dcb12-c766-11e1-8775-005056c00008" name="S.Kenton LD" loadType="UNDEFINED" p0="18" q0="7" node="8" p="17.996265187542814" q="6.9975794556502127">
+            <iidm:load id="_047dcb12-c766-11e1-8775-005056c00008" name="S.Kenton LD" loadType="UNDEFINED" p0="18" q0="7" node="8" p="17.996250728266634" q="6.997570085196049">
                 <iidm:alias>_0451b205-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1281,6 +1281,9 @@
                     <iidm:alias>_8ef85f09-3622-4a12-87bf-fefcecc01e4a</iidm:alias>
                     <iidm:alias>_a0244ab3-80e5-4c20-b201-a142d50e6ec1</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_dffdb415-95a8-496a-ad1a-93cdeb444fae-1" name="DISCONNECTOR723-1" kind="DISCONNECTOR" retained="false" open="false" node1="24" node2="25"/>
+                <iidm:switch id="_aa063f2e-1205-4d1a-a549-3ccc5b31e65d-1" name="BREAKER362-1" kind="BREAKER" retained="false" open="false" node1="23" node2="24"/>
+                <iidm:switch id="_28b3e895-483c-478d-a5a3-7b9d7c9e11f3-1" name="DISCONNECTOR724-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="23"/>
                 <iidm:internalConnection node1="7" node2="0"/>
                 <iidm:internalConnection node1="8" node2="0"/>
                 <iidm:internalConnection node1="9" node2="1"/>
@@ -1297,9 +1300,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="125.19320341608433" angle="21.154367733348863" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.16345071534509" angle="10.023697638622892" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044afb49-c766-11e1-8775-005056c00008" name="Hazard LD" loadType="UNDEFINED" p0="21" q0="10" node="8" p="20.997160760033498" q="9.9977467365018278">
+            <iidm:load id="_044afb49-c766-11e1-8775-005056c00008" name="Hazard LD" loadType="UNDEFINED" p0="21" q0="10" node="8" p="20.996782492145453" q="9.9974465527550613">
                 <iidm:alias>_045e5c31-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1320,6 +1323,9 @@
                     <iidm:alias>_2a61ce12-8d9c-4aae-8bc7-c8f820ecae6c</iidm:alias>
                     <iidm:alias>_a3d5e8cc-be34-4d4a-a586-ce582737826b</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_83a05cd7-017e-4e7a-bc5e-a01ee9681f9f-1" name="DISCONNECTOR725-1" kind="DISCONNECTOR" retained="false" open="false" node1="14" node2="15"/>
+                <iidm:switch id="_cf4393c0-21c2-4e35-b330-c1acda2647ba-1" name="BREAKER363-1" kind="BREAKER" retained="false" open="true" node1="13" node2="14"/>
+                <iidm:switch id="_b9ab29b9-3d90-4536-8d1a-7757d8c22ae4-1" name="DISCONNECTOR726-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="13"/>
                 <iidm:internalConnection node1="4" node2="0"/>
                 <iidm:internalConnection node1="5" node2="0"/>
                 <iidm:internalConnection node1="6" node2="1"/>
@@ -1329,14 +1335,14 @@
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="3"/>
-                <iidm:bus v="31.29830085402109" angle="21.15436773334886" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="31.040862678836273" angle="10.02369763862289" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13"/>
             </iidm:nodeBreakerTopology>
             <iidm:staticVarCompensator id="_047fc6e6-c766-11e1-8775-005056c00008" name="Pinevlle SVC" bMin="-10" bMax="10" voltageSetpoint="33.494999999999997" regulationMode="VOLTAGE" node="5" p="0" q="0">
                 <iidm:alias>_046ab846-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_98f667da-02d1-4a31-b826-44314a1fbbfe"/>
             </iidm:staticVarCompensator>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045e3525-c766-11e1-8775-005056c00008" name="86-87" r="0.30796918750000002" x="2.2585859312499998" g="0" b="-0.0040863184000000004" ratedU1="132" ratedU2="33" node1="22" voltageLevelId1="_0484f70a-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_04555b88-c766-11e1-8775-005056c00008" p1="3.0704605524789486e-14" q1="4.0028906375509976" p2="-1.6790295872364988e-14" q2="-1.4965082627591698e-14">
+        <iidm:twoWindingsTransformer id="_045e3525-c766-11e1-8775-005056c00008" name="86-87" r="0.30796918750000002" x="2.2585859312499998" g="0" b="-0.0040863184000000004" ratedU1="132" ratedU2="33" node1="22" voltageLevelId1="_0484f70a-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_04555b88-c766-11e1-8775-005056c00008" p1="7.0256300777060687e-15" q1="3.9373114363818775" p2="-1.761368760383037e-14" q2="-2.034639163558064e-14">
             <iidm:alias>_0452755a-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04682034-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_048c7110-c766-11e1-8775-005056c00008</iidm:alias>
@@ -1412,6 +1418,82 @@
                 <iidm:temporaryLimit name="_257d56c1-d70a-4a96-b85c-d928ade03ad4" acceptableDuration="60" value="12246"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
+        <iidm:twoWindingsTransformer id="_045e3525-c766-11e1-8775-005056c00008-1" name="86-87-open-ended" r="0.30796918750000002" x="2.2585859312499998" g="0" b="-0.0040863184000000004" ratedU1="132" ratedU2="33" node1="25" voltageLevelId1="_0484f70a-c766-11e1-8775-005056c00008" node2="15" voltageLevelId2="_04555b88-c766-11e1-8775-005056c00008" p1="8.6736173798840355e-17" q1="3.9373114363818913" p2="0" q2="0">
+            <iidm:alias>_0452755a-c766-11e1-8775-005056c00008-1</iidm:alias>
+            <iidm:alias>_04682034-c766-11e1-8775-005056c00008-1</iidm:alias>
+            <iidm:alias>_048c7110-c766-11e1-8775-005056c00008-1</iidm:alias>
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="31" loadTapChangingCapabilities="false">
+                <iidm:step r="-78.460970487743992" x="-78.460970487743992" g="364.27347129590328" b="364.27347129590328" rho="0.4641016"/>
+                <iidm:step r="-76.770985444658564" x="-76.770985444658564" g="330.49609255595948" b="330.49609255595948" rho="0.48196488000000004"/>
+                <iidm:step r="-75.017181047101431" x="-75.017181047101431" g="300.27508580410921" b="300.27508580410921" rho="0.49982816000000002"/>
+                <iidm:step r="-73.199557295072623" x="-73.199557295072623" g="273.1281647135425" b="273.1281647135425" rho="0.51769144000000011"/>
+                <iidm:step r="-71.318114188572153" x="-71.318114188572153" g="248.65210975826625" b="248.65210975826625" rho="0.53555472000000004"/>
+                <iidm:step r="-69.372851727600008" x="-69.372851727600008" g="226.50770848984379" b="226.50770848984379" rho="0.55341799999999997"/>
+                <iidm:step r="-67.363769912156158" x="-67.363769912156158" g="206.40793906293555" b="206.40793906293555" rho="0.57128128"/>
+                <iidm:step r="-65.290868742240633" x="-65.290868742240633" g="188.10862264852744" b="188.10862264852744" rho="0.58914456000000004"/>
+                <iidm:step r="-63.154148217853432" x="-63.154148217853432" g="171.40097232995538" b="171.40097232995538" rho="0.60700784000000008"/>
+                <iidm:step r="-60.953608338994556" x="-60.953608338994556" g="156.10561116167679" b="156.10561116167679" rho="0.62487112"/>
+                <iidm:step r="-58.689249105663997" x="-58.689249105663997" g="142.06773741726079" b="142.06773741726079" rho="0.64273440000000004"/>
+                <iidm:step r="-56.361070517861769" x="-56.361070517861769" g="129.15319231405709" b="129.15319231405709" rho="0.66059767999999996"/>
+                <iidm:step r="-53.969072575587838" x="-53.969072575587838" g="117.24524269951107" b="117.24524269951107" rho="0.67846096"/>
+                <iidm:step r="-51.51325527884223" x="-51.51325527884223" g="106.24193390397649" b="106.24193390397649" rho="0.69632424000000004"/>
+                <iidm:step r="-48.993618627624947" x="-48.993618627624947" g="96.053900138385018" b="96.053900138385018" rho="0.71418752000000008"/>
+                <iidm:step r="-46.410162621936003" x="-46.410162621936003" g="86.602544237115268" b="86.602544237115268" rho="0.7320508"/>
+                <iidm:step r="-43.762887261775354" x="-43.762887261775354" g="77.81851722275475" b="77.81851722275475" rho="0.74991407999999993"/>
+                <iidm:step r="-41.051792547143037" x="-41.051792547143037" g="69.640442552852292" b="69.640442552852292" rho="0.76777735999999996"/>
+                <iidm:step r="-38.276878478039045" x="-38.276878478039045" g="62.013841060226049" b="62.013841060226049" rho="0.78564064"/>
+                <iidm:step r="-35.438145054463355" x="-35.438145054463355" g="54.890221299184191" b="54.890221299184191" rho="0.80350392000000004"/>
+                <iidm:step r="-32.53559227641599" x="-32.53559227641599" g="48.2263068397802" b="48.2263068397802" rho="0.82136720000000008"/>
+                <iidm:step r="-29.569220143896956" x="-29.569220143896956" g="41.983377444222199" b="41.983377444222199" rho="0.83923048"/>
+                <iidm:step r="-26.53902865690624" x="-26.53902865690624" g="36.126705339843348" b="36.126705339843348" rho="0.85709376000000004"/>
+                <iidm:step r="-23.445017815443848" x="-23.445017815443848" g="30.625071218648301" b="30.625071218648301" rho="0.87495704000000007"/>
+                <iidm:step r="-20.287187619509762" x="-20.287187619509762" g="25.450347332714429" b="25.450347332714429" rho="0.89282032000000011"/>
+                <iidm:step r="-17.06553806910399" x="-17.06553806910399" g="20.577137262099331" b="20.577137262099331" rho="0.91068360000000004"/>
+                <iidm:step r="-13.780069164226571" x="-13.780069164226571" g="15.982463718828566" b="15.982463718828566" rho="0.92854687999999996"/>
+                <iidm:step r="-10.430780904877434" x="-10.430780904877434" g="11.645497203453271" b="11.645497203453271" rho="0.94641016"/>
+                <iidm:step r="-7.0176732910566368" x="-7.0176732910566368" g="7.5473195169912355" b="7.5473195169912355" rho="0.96427344000000004"/>
+                <iidm:step r="-3.5407463227641656" x="-3.5407463227641656" g="3.6707171036300279" b="3.6707171036300279" rho="0.98213671999999985"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1"/>
+                <iidm:step r="3.6045656772358381" x="3.6045656772358381" g="-3.4791571719583358" b="-3.4791571719583358" rho="1.01786328"/>
+                <iidm:step r="7.272950708943382" x="7.272950708943382" g="-6.7798551833225922" b="-6.7798551833225922" rho="1.0357265600000001"/>
+                <iidm:step r="11.005155095122543" x="11.005155095122543" g="-9.9140937064517427" b="-9.9140937064517427" rho="1.0535898399999999"/>
+                <iidm:step r="14.801178835773431" x="14.801178835773431" g="-12.892880531259154" b="-12.892880531259154" rho="1.0714531199999999"/>
+                <iidm:step r="18.661021930895984" x="18.661021930895984" g="-15.726328348801433" b="-15.726328348801433" rho="1.0893164"/>
+                <iidm:step r="22.584684380490238" x="22.584684380490238" g="-18.423740693731116" b="-18.423740693731116" rho="1.10717968"/>
+                <iidm:step r="26.572166184556178" x="26.572166184556178" g="-20.993688411566747" b="-20.993688411566747" rho="1.12504296"/>
+                <iidm:step r="30.623467343093779" x="30.623467343093779" g="-23.444077826121855" b="-23.444077826121855" rho="1.1429062400000001"/>
+                <iidm:step r="34.738587856103067" x="34.738587856103067" g="-25.782211620922489" b="-25.782211620922489" rho="1.1607695200000001"/>
+                <iidm:step r="38.917527723583987" x="38.917527723583987" g="-28.014843311220961" b="-28.014843311220961" rho="1.1786327999999999"/>
+                <iidm:step r="43.16028694553664" x="43.16028694553664" g="-30.148226066322692" b="-30.148226066322692" rho="1.19649608"/>
+                <iidm:step r="47.466865521960955" x="47.466865521960955" g="-32.188156542116317" b="-32.188156542116317" rho="1.21435936"/>
+                <iidm:step r="51.837263452856973" x="51.837263452856973" g="-34.140014298236885" b="-34.140014298236885" rho="1.23222264"/>
+                <iidm:step r="56.271480738224653" x="56.271480738224653" g="-36.0087973009527" b="-36.0087973009527" rho="1.2500859200000001"/>
+                <iidm:step r="60.769517378063973" x="60.769517378063973" g="-37.799153949786998" b="-37.799153949786998" rho="1.2679491999999999"/>
+                <iidm:step r="65.331373372375026" x="65.331373372375026" g="-39.515412011505823" b="-39.515412011505823" rho="1.2858124799999999"/>
+                <iidm:step r="69.957048721157761" x="69.957048721157761" g="-41.161604798123854" b="-41.161604798123854" rho="1.30367576"/>
+                <iidm:step r="74.646543424412172" x="74.646543424412172" g="-42.741494884907091" b="-42.741494884907091" rho="1.32153904"/>
+                <iidm:step r="79.399857482138245" x="79.399857482138245" g="-44.258595629064871" b="-44.258595629064871" rho="1.33940232"/>
+                <iidm:step r="84.216990894335964" x="84.216990894335964" g="-45.716190719151165" b="-45.716190719151165" rho="1.3572655999999998"/>
+                <iidm:step r="89.097943661005473" x="89.097943661005473" g="-47.11735195848069" b="-47.11735195848069" rho="1.3751288800000001"/>
+                <iidm:step r="94.04271578214653" x="94.04271578214653" g="-48.464955462553469" b="-48.464955462553469" rho="1.3929921599999999"/>
+                <iidm:step r="99.051307257759348" x="99.051307257759348" g="-49.761696430103783" b="-49.761696430103783" rho="1.41085544"/>
+                <iidm:step r="104.12371808784383" x="104.12371808784383" g="-51.010102629540867" b="-51.010102629540867" rho="1.42871872"/>
+                <iidm:step r="109.25994827240002" x="109.25994827240002" g="-52.212546726893493" b="-52.212546726893493" rho="1.446582"/>
+                <iidm:step r="114.45999781142788" x="114.45999781142788" g="-53.371257567609966" b="-53.371257567609966" rho="1.4644452800000001"/>
+                <iidm:step r="119.72386670492732" x="119.72386670492732" g="-54.488330512455207" b="-54.488330512455207" rho="1.4823085599999999"/>
+                <iidm:step r="125.05155495289854" x="125.05155495289854" g="-55.565736917068101" b="-55.565736917068101" rho="1.5001718399999999"/>
+                <iidm:step r="130.44306255534144" x="130.44306255534144" g="-56.605332835313817" b="-56.605332835313817" rho="1.51803512"/>
+                <iidm:step r="135.89838951225599" x="135.89838951225599" g="-57.608867018227542" b="-57.608867018227542" rho="1.5358984"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="2186">
+                <iidm:temporaryLimit name="_580d3b53-5508-4d8d-97cc-4ea463e0cdb9-1" acceptableDuration="900" value="2514"/>
+                <iidm:temporaryLimit name="_a867e68a-58d1-49cb-955f-bb8e59cf2a11-1" acceptableDuration="60" value="3061"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="8747">
+                <iidm:temporaryLimit name="_1a7f23f9-e2c0-46a6-a93c-687f2209e33d-1" acceptableDuration="900" value="10059"/>
+                <iidm:temporaryLimit name="_257d56c1-d70a-4a96-b85c-d928ade03ad4-1" acceptableDuration="60" value="12246"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
     </iidm:substation>
     <iidm:substation id="_045beb3a-c766-11e1-8775-005056c00008" name="Minas Tirith" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
         <iidm:voltageLevel id="_048a9c58-c766-11e1-8775-005056c00008" name="MNT132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -1460,12 +1542,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="132.7386535432824" angle="12.131162782069673" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="132.85734250243954" angle="0.13637835692911107" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0447ee05-c766-11e1-8775-005056c00008" name="NwCarlsl NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="8" p="8.9998273337102237" q="0">
+            <iidm:load id="_0447ee05-c766-11e1-8775-005056c00008" name="NwCarlsl NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="8" p="8.9998363574985127" q="0">
                 <iidm:alias>_04731cb7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_047a48a8-c766-11e1-8775-005056c00008" name="NwCarlsl LD" loadType="UNDEFINED" p0="30" q0="12" node="9" p="29.999424445700747" q="11.999616299587634">
+            <iidm:load id="_047a48a8-c766-11e1-8775-005056c00008" name="NwCarlsl LD" loadType="UNDEFINED" p0="30" q0="12" node="9" p="29.999454524995038" q="11.999636352200721">
                 <iidm:alias>_044c0cb9-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1516,9 +1598,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.62190330519591" angle="9.3248959879023179" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.62187722797486" angle="-1.9084641951803787" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044ecbd1-c766-11e1-8775-005056c00008" name="Blaine LD" loadType="UNDEFINED" p0="2" q0="1" node="8" p="2.0000004230158206" q="1.0000003525132086">
+            <iidm:load id="_044ecbd1-c766-11e1-8775-005056c00008" name="Blaine LD" loadType="UNDEFINED" p0="2" q0="1" node="8" p="2.000000405850153" q="1.0000003382084839">
                 <iidm:alias>_04700f74-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1569,9 +1651,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="133.17621270122214" angle="15.343348177779015" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="133.15144156508509" angle="4.1114980279282864" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046b7b95-c766-11e1-8775-005056c00008" name="Sundial LD" loadType="UNDEFINED" p0="15" q0="9" node="8" p="14.999477561216521" q="8.9994775672819269">
+            <iidm:load id="_046b7b95-c766-11e1-8775-005056c00008" name="Sundial LD" loadType="UNDEFINED" p0="15" q0="9" node="8" p="14.999470372062238" q="8.9994703782957224">
                 <iidm:alias>_046efe07-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1622,9 +1704,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.69952510606981" angle="7.3243463405944551" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.74786558872584" angle="-4.503947254974018" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045645e2-c766-11e1-8775-005056c00008" name="Riversde LD" loadType="UNDEFINED" p0="51" q0="27" node="8" p="50.999542702583675" q="26.999596503485719">
+            <iidm:load id="_045645e2-c766-11e1-8775-005056c00008" name="Riversde LD" loadType="UNDEFINED" p0="51" q0="27" node="8" p="50.999574474127151" q="26.999624537038791">
                 <iidm:alias>_0476ed4b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1675,9 +1757,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.76697445020817" angle="10.164397779406491" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.9082355220426" angle="-1.1390479426794697" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04887973-c766-11e1-8775-005056c00008" name="Randolph LD" loadType="UNDEFINED" p0="10" q0="5" node="8" p="9.9974929264014527" q="4.997910946601019">
+            <iidm:load id="_04887973-c766-11e1-8775-005056c00008" name="Randolph LD" loadType="UNDEFINED" p0="10" q0="5" node="8" p="9.9975418556914732" q="4.9979517142606307">
                 <iidm:alias>_0462f018-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1728,9 +1810,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.48468288979716" angle="-6.917093814949868" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.48445351441167" angle="-18.111063206918402" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0477627b-c766-11e1-8775-005056c00008" name="WNwPhil2 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="11.999991792226302" q="2.9999965800950719">
+            <iidm:load id="_0477627b-c766-11e1-8775-005056c00008" name="WNwPhil2 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="11.999992068412713" q="2.9999966951726922">
                 <iidm:alias>_045841b6-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1800,9 +1882,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="126.73056520671027" angle="10.055168869973931" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="126.73053806851252" angle="-1.1779672972265118" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0476781a-c766-11e1-8775-005056c00008" name="Cloverdl LD" loadType="UNDEFINED" p0="43" q0="16" node="11" p="43.00001036344981" q="16.000006426946133">
+            <iidm:load id="_0476781a-c766-11e1-8775-005056c00008" name="Cloverdl LD" loadType="UNDEFINED" p0="43" q0="16" node="11" p="43.000010099174851" q="16.000006263054662">
                 <iidm:alias>_0481749a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1872,9 +1954,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="128.11689999787527" angle="11.424432800515826" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="128.11688421066603" angle="0.19128045503951827" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046b0665-c766-11e1-8775-005056c00008" name="Hancock LD" loadType="UNDEFINED" p0="38" q0="25" node="11" p="38.000005156438291" q="25.000005653989604">
+            <iidm:load id="_046b0665-c766-11e1-8775-005056c00008" name="Hancock LD" loadType="UNDEFINED" p0="38" q0="25" node="11" p="38.000004917735339" q="25.000005392253893">
                 <iidm:alias>_0464c4d5-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1926,12 +2008,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="128.66312018141062" angle="-5.50316453444138" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="128.64719026446764" angle="-16.662680896639348" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044bbe92-c766-11e1-8775-005056c00008" name="WMVernon LD" loadType="UNDEFINED" p0="16" q0="8" node="8" p="15.998550953360166" q="7.9987924975875906">
+            <iidm:load id="_044bbe92-c766-11e1-8775-005056c00008" name="WMVernon LD" loadType="UNDEFINED" p0="16" q0="8" node="8" p="15.998546853706404" q="7.9987890814160245">
                 <iidm:alias>_04500452-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_047825c8-c766-11e1-8775-005056c00008" name="WMVernon SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.21199999999999" targetDeadband="1" node="9" q="-9.5021099360244516">
+            <iidm:shunt id="_047825c8-c766-11e1-8775-005056c00008" name="WMVernon SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.21199999999999" targetDeadband="1" node="9" q="-9.4997571491287864">
                 <iidm:alias>_047084aa-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_2a6c1dcd-201b-4911-83b2-c16acc50a0f4"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -1965,9 +2047,9 @@
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="3"/>
-                <iidm:bus v="231.00000439616576" angle="34.736010467642963" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="230.99998900363664" angle="22.434740902865354" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_045868c0-c766-11e1-8775-005056c00008" name="Breed SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="450" targetV="230.99998500000001" targetQ="0" node="5" p="-498.25503991042063" q="23.566168255978738">
+            <iidm:generator id="_045868c0-c766-11e1-8775-005056c00008" name="Breed SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="450" targetV="230.99998500000001" targetQ="0" node="5" p="-498.16911222448255" q="27.212155722450426">
                 <iidm:alias>_045b7606-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_f26d4eb3-ebdb-4025-8080-f856ce656b42"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_7566f2a7-61eb-42fe-a59a-8276257fdbc6"/>
@@ -2041,9 +2123,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="127.47338050725898" angle="-5.8119694100766246" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="127.47305213524726" angle="-17.005291197771214" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044d1e22-c766-11e1-8775-005056c00008" name="Newcmrst LD" loadType="UNDEFINED" p0="17" q0="8" node="11" p="16.999982038346211" q="7.9999859124333588">
+            <iidm:load id="_044d1e22-c766-11e1-8775-005056c00008" name="Newcmrst LD" loadType="UNDEFINED" p0="17" q0="8" node="11" p="16.999982467119494" q="7.9999862487258984">
                 <iidm:alias>_048a754b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2113,9 +2195,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="138.59999464903683" angle="24.362615219400112" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="138.5999910054565" angle="12.50064437713047" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_045ab2b0-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="220" targetV="138.59999099999999" targetQ="0" node="11" p="-243.59135284509455" q="-49.287218044171752">
+            <iidm:generator id="_045ab2b0-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="220" targetV="138.59999099999999" targetQ="0" node="11" p="-243.54934375419148" q="-46.611083799427298">
                 <iidm:alias>_046ba2a5-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_56975783-9739-40fc-8ec1-e1de8cb06c9a"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b8449cd9-5a17-497e-bf04-70f728b0f9f2"/>
@@ -2168,9 +2250,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="223.30000788466296" angle="26.76933602587636" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="223.3000002098446" angle="14.650959571502076" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0483224a-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="314" targetV="223.30000000000001" targetQ="0" node="8" p="-347.67129451527131" q="-23.122936208749714">
+            <iidm:generator id="_0483224a-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="314" targetV="223.30000000000001" targetQ="0" node="8" p="-347.61133608552785" q="-18.555443789412042">
                 <iidm:alias>_045cd594-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_05df66ba-3f64-40cb-8b18-c66d26c4e2c1"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_c1d29442-5f57-41d1-bb60-4b74b4994c20"/>
@@ -2178,7 +2260,7 @@
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045b7604-c766-11e1-8775-005056c00008" name="26-25" r="0" x="6.6559680000000006" g="0" b="0" ratedU1="220" ratedU2="132" node1="22" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="122.03828935330787" q1="22.745499645878109" p2="-122.03828935330776" q2="-17.479314627814968">
+        <iidm:twoWindingsTransformer id="_045b7604-c766-11e1-8775-005056c00008" name="26-25" r="0" x="6.6559680000000006" g="0" b="0" ratedU1="220" ratedU2="132" node1="22" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="109.04311817888241" q1="22.228415007578132" p2="-109.04311817888248" q2="-17.996349852458646">
             <iidm:alias>_0447c6f3-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0463b364-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04803c1c-c766-11e1-8775-005056c00008</iidm:alias>
@@ -2321,9 +2403,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="136.6200010376009" angle="14.744536262091165" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="136.62000792713292" angle="3.5132890865844884" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_048aea70-c766-11e1-8775-005056c00008" name="Sporn SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="513.43743900000004" targetV="136.62" targetQ="-62.132553100000003" node="20" p="-568.49509257877594" q="42.821398117943197">
+            <iidm:generator id="_048aea70-c766-11e1-8775-005056c00008" name="Sporn SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="513.43743900000004" targetV="136.62" targetQ="-62.132553100000003" node="20" p="-568.39705148764881" q="43.051611204006257">
                 <iidm:alias>_04555b84-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_27799004-aa1e-4889-ba95-ee6fdae64895"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_827a9c80-183d-4e33-9e73-ef0aab3dfb13"/>
@@ -2413,9 +2495,9 @@
                 <iidm:internalConnection node1="39" node2="9"/>
                 <iidm:internalConnection node1="40" node2="12"/>
                 <iidm:internalConnection node1="41" node2="3"/>
-                <iidm:bus v="219.70663631312388" angle="10.953319994154127" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41"/>
+                <iidm:bus v="219.70741469497057" angle="-0.26009908486267092" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41"/>
             </iidm:nodeBreakerTopology>
-            <iidm:danglingLine id="_0482fb33-c766-11e1-8775-005056c00008" name="68-116" p0="184" q0="0" r="0.16456000000000001" x="1.9601999999999999" g="0" b="0.00033884300000000002" ucteXnodeCode="XWE_BR21" node="41" p="184.11556977543418" q="-14.979655788868218">
+            <iidm:danglingLine id="_0482fb33-c766-11e1-8775-005056c00008" name="68-116" p0="184" q0="0" r="0.16456000000000001" x="1.9601999999999999" g="0" b="0.00033884300000000002" ucteXnodeCode="XWE_BR21" node="41" p="184.11558076814018" q="-14.979781267934314">
                 <iidm:alias>_0459c855-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_04684742-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_5631ccc0-d9d2-11e2-bb49-005056c00008</iidm:alias>
@@ -2428,7 +2510,7 @@
                 </iidm:currentLimits>
             </iidm:danglingLine>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_044f6815-c766-11e1-8775-005056c00008" name="68-69" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-197.55429518965178" q1="102.06782689275049" p2="197.5542951896519" q2="-86.031271498886312">
+        <iidm:twoWindingsTransformer id="_044f6815-c766-11e1-8775-005056c00008" name="68-69" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-196.62735442463989" q1="102.01763510311883" p2="196.62735442463992" q2="-86.103018514977677">
             <iidm:alias>_047e8e67-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04840ca7-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0487dd39-c766-11e1-8775-005056c00008</iidm:alias>
@@ -2535,9 +2617,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="131.60564713705989" angle="2.9154835398459729" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="131.60565147604217" angle="-8.2826567866530407" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04547126-c766-11e1-8775-005056c00008" name="Natrium LD" loadType="UNDEFINED" p0="77" q0="14" node="14" p="76.999906229971501" q="13.999971584851384">
+            <iidm:load id="_04547126-c766-11e1-8775-005056c00008" name="Natrium LD" loadType="UNDEFINED" p0="77" q0="14" node="14" p="76.999908101350584" q="13.999972151935502">
                 <iidm:alias>_047b3307-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2588,9 +2670,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="123.81649587662071" angle="-5.0512818393707111" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="123.74996651374425" angle="-16.135629255834949" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045d4ac9-c766-11e1-8775-005056c00008" name="Sterling LD" loadType="UNDEFINED" p0="31" q0="17" node="8" p="30.991335989202938" q="16.992082018196264">
+            <iidm:load id="_045d4ac9-c766-11e1-8775-005056c00008" name="Sterling LD" loadType="UNDEFINED" p0="31" q0="17" node="8" p="30.991300384137112" q="16.992049482007904">
                 <iidm:alias>_0477b094-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2698,9 +2780,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="130.28742280518122" angle="17.885300901758697" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="130.26494060056922" angle="6.6547628169904298" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0466246a-c766-11e1-8775-005056c00008" name="Switchbk LD" loadType="UNDEFINED" p0="30" q0="16" node="17" p="29.998953570880015" q="15.99906985159723">
+            <iidm:load id="_0466246a-c766-11e1-8775-005056c00008" name="Switchbk LD" loadType="UNDEFINED" p0="30" q0="16" node="17" p="29.998939649036281" q="15.999057476914707">
                 <iidm:alias>_04882b59-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2751,9 +2833,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="135.08664149025267" angle="15.153063519783991" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="135.08666959243786" angle="3.9210090731753873" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046adf5a-c766-11e1-8775-005056c00008" name="Bradley LD" loadType="UNDEFINED" p0="34" q0="8" node="8" p="33.999980209488292" q="7.999992239016521">
+            <iidm:load id="_046adf5a-c766-11e1-8775-005056c00008" name="Bradley LD" loadType="UNDEFINED" p0="34" q0="8" node="8" p="33.999981527264104" q="7.9999927557911565">
                 <iidm:alias>_04555b85-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2788,6 +2870,9 @@
                     <iidm:alias>_7f359893-b7c5-41b0-ada8-8df06cf7a8e6</iidm:alias>
                     <iidm:alias>_a4edf081-2fb2-4da4-94db-98a2a596247f</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_312f25f3-55bc-4417-848c-236d31d823f4-1" name="DISCONNECTOR524-1" kind="DISCONNECTOR" retained="false" open="false" node1="24" node2="25"/>
+                <iidm:switch id="_686e884a-a0b1-454e-b7d1-33c7ad46f89f-1" name="BREAKER262-1" kind="BREAKER" retained="false" open="false" node1="23" node2="24"/>
+                <iidm:switch id="_346a5319-3ec2-40a2-aefd-38dfacbbe97c-1" name="DISCONNECTOR523-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="23"/>
                 <iidm:internalConnection node1="7" node2="0"/>
                 <iidm:internalConnection node1="8" node2="0"/>
                 <iidm:internalConnection node1="9" node2="1"/>
@@ -2804,9 +2889,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.88099097333006" angle="8.9316170039179692" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.15474046713881" angle="-2.323855342647009" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047a48a2-c766-11e1-8775-005056c00008" name="Mullin LD" loadType="UNDEFINED" p0="17" q0="7" node="8" p="16.999277389551811" q="6.9995040978953744">
+            <iidm:load id="_047a48a2-c766-11e1-8775-005056c00008" name="Mullin LD" loadType="UNDEFINED" p0="17" q0="7" node="8" p="16.999357688608711" q="6.9995592036164345">
                 <iidm:alias>_0474553a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2972,16 +3057,16 @@
                 <iidm:internalConnection node1="81" node2="18"/>
                 <iidm:internalConnection node1="82" node2="21"/>
                 <iidm:internalConnection node1="83" node2="24"/>
-                <iidm:bus v="134.24398892724696" angle="17.588323497145971" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
+                <iidm:bus v="134.24398868157959" angle="6.3554592854607899" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_044cd00a-c766-11e1-8775-005056c00008" name="Glen Lyn SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="252" targetV="134.243988" targetQ="0" node="27" p="-279.02282234983551" q="-84.086396719344705">
+            <iidm:generator id="_044cd00a-c766-11e1-8775-005056c00008" name="Glen Lyn SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="252" targetV="134.243988" targetQ="0" node="27" p="-278.97470284571023" q="-84.43851590757248">
                 <iidm:alias>_045e5c30-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e54b499b-436c-4b89-9803-b1d75e2fa364"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_32c8ab65-80f7-4c17-b3f5-ff075cce0ba5"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
-            <iidm:load id="_04566cf5-c766-11e1-8775-005056c00008" name="Glen Lyn LD" loadType="UNDEFINED" p0="37" q0="18" node="26" p="37.000000383348301" q="18.000000310822948">
+            <iidm:load id="_04566cf5-c766-11e1-8775-005056c00008" name="Glen Lyn LD" loadType="UNDEFINED" p0="37" q0="18" node="26" p="37.000000281782945" q="18.000000228472661">
                 <iidm:alias>_04577e64-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3032,9 +3117,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.56294297840665" angle="9.7761809022072903" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.63586758790319" angle="-2.0946546157440253" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044ea4c0-c766-11e1-8775-005056c00008" name="Kankakee LD" loadType="UNDEFINED" p0="52" q0="22" node="8" p="51.999428605322947" q="21.999597094972714">
+            <iidm:load id="_044ea4c0-c766-11e1-8775-005056c00008" name="Kankakee LD" loadType="UNDEFINED" p0="52" q0="22" node="8" p="51.999465515153041" q="21.999623120950456">
                 <iidm:alias>_047e6758-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3143,12 +3228,12 @@
                 <iidm:internalConnection node1="51" node2="9"/>
                 <iidm:internalConnection node1="52" node2="12"/>
                 <iidm:internalConnection node1="53" node2="15"/>
-                <iidm:bus v="127.4228046506128" angle="10.322196251139303" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
+                <iidm:bus v="127.42279064704927" angle="-0.91099865187255114" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0484cffb-c766-11e1-8775-005056c00008" name="Roanoke LD" loadType="UNDEFINED" p0="31" q0="26" node="17" p="31.000002750937881" q="26.000003845397156">
+            <iidm:load id="_0484cffb-c766-11e1-8775-005056c00008" name="Roanoke LD" loadType="UNDEFINED" p0="31" q0="26" node="17" p="31.000002537754607" q="26.000003547399007">
                 <iidm:alias>_0454983a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0489d903-c766-11e1-8775-005056c00008" name="Roanoke SC" sectionCount="5" voltageRegulatorOn="true" targetV="127.423" targetDeadband="1" node="18" q="-18.639583674492414">
+            <iidm:shunt id="_0489d903-c766-11e1-8775-005056c00008" name="Roanoke SC" sectionCount="5" voltageRegulatorOn="true" targetV="127.423" targetDeadband="1" node="18" q="-18.639579577571453">
                 <iidm:alias>_0476c638-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_5be38d1a-9d01-42d8-b8bb-e9a26cfbcf1a"/>
                 <iidm:shuntLinearModel bPerSection="0.0002296" gPerSection="0" maximumSectionCount="10"/>
@@ -3240,12 +3325,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="120.59924251470763" angle="-10.297822764194006" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="120.56532659216569" angle="-21.447619040351334" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047a219a-c766-11e1-8775-005056c00008" name="Howard LD" loadType="UNDEFINED" p0="37" q0="23" node="14" p="36.991477631404912" q="22.991171196951193">
+            <iidm:load id="_047a219a-c766-11e1-8775-005056c00008" name="Howard LD" loadType="UNDEFINED" p0="37" q0="23" node="14" p="36.991427301197213" q="22.991119061073292">
                 <iidm:alias>_04882b51-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_04488a49-c766-11e1-8775-005056c00008" name="Howard NegG LD" loadType="UNDEFINED" p0="59" q0="0" node="15" p="58.986410277105129" q="0">
+            <iidm:load id="_04488a49-c766-11e1-8775-005056c00008" name="Howard NegG LD" loadType="UNDEFINED" p0="59" q0="0" node="15" p="58.986330020827992" q="0">
                 <iidm:alias>_046d9e74-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3295,7 +3380,7 @@
                 <iidm:internalConnection node1="19" node2="6"/>
                 <iidm:internalConnection node1="20" node2="3"/>
                 <iidm:internalConnection node1="21" node2="6"/>
-                <iidm:bus v="218.77299065139553" angle="12.746123052920119" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
+                <iidm:bus v="218.77339741798301" angle="1.5258218896608686" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_046efe09-c766-11e1-8775-005056c00008" name="CRI132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -3458,20 +3543,20 @@
                 <iidm:internalConnection node1="81" node2="18"/>
                 <iidm:internalConnection node1="82" node2="21"/>
                 <iidm:internalConnection node1="83" node2="24"/>
-                <iidm:bus v="137.28000009090005" angle="15.642819054313609" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
+                <iidm:bus v="137.28000444660518" angle="4.411241499405179" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_045868c1-c766-11e1-8775-005056c00008" name="CabinCrk SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="477" targetV="137.28" targetQ="0" node="27" p="-528.1503423050458" q="-142.82765424058857">
+            <iidm:generator id="_045868c1-c766-11e1-8775-005056c00008" name="CabinCrk SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="477" targetV="137.28" targetQ="0" node="27" p="-528.05925895795156" q="-143.66722459387893">
                 <iidm:alias>_0487dd36-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_a6ec9760-88da-48df-a23f-7877e7c85ccd"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_e6131af8-c298-413b-84e3-4e21c3b6b06f"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-225" maxQ="640"/>
             </iidm:generator>
-            <iidm:load id="_04747c44-c766-11e1-8775-005056c00008" name="CabinCrk LD" loadType="UNDEFINED" p0="130" q0="26" node="26" p="130.0000001291194" q="26.000000043039801">
+            <iidm:load id="_04747c44-c766-11e1-8775-005056c00008" name="CabinCrk LD" loadType="UNDEFINED" p0="130" q0="26" node="26" p="130.00000631620057" q="26.00000210540022">
                 <iidm:alias>_046a9138-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_0488c79b-c766-11e1-8775-005056c00008" name="81-80" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="21" voltageLevelId1="_048a272b-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-151.07280393227038" q1="71.524010285417589" p2="151.07280393227046" q2="-62.385219746141075">
+        <iidm:twoWindingsTransformer id="_0488c79b-c766-11e1-8775-005056c00008" name="81-80" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="21" voltageLevelId1="_048a272b-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-150.48548356109609" q1="71.500057846325177" p2="150.48548356109609" q2="-62.420355076991129">
             <iidm:alias>_044974a0-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_045a3d83-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_046adf57-c766-11e1-8775-005056c00008</iidm:alias>
@@ -3551,12 +3636,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="134.7473695323248" angle="-1.1047999460258504" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="134.74747905806734" angle="-12.295468240544675" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04524e4a-c766-11e1-8775-005056c00008" name="Zanesvll LD" loadType="UNDEFINED" p0="20" q0="11" node="8" p="20.000003494465393" q="11.00000320326013">
+            <iidm:load id="_04524e4a-c766-11e1-8775-005056c00008" name="Zanesvll LD" loadType="UNDEFINED" p0="20" q0="11" node="8" p="20.000004191397768" q="11.000003842114889">
                 <iidm:alias>_045c1240-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_048b5fa9-c766-11e1-8775-005056c00008" name="Zanesvll SC" sectionCount="5" voltageRegulatorOn="true" targetV="134.72300000000001" targetDeadband="1" node="9" q="-15.633050946053448">
+            <iidm:shunt id="_048b5fa9-c766-11e1-8775-005056c00008" name="Zanesvll SC" sectionCount="5" voltageRegulatorOn="true" targetV="134.72300000000001" targetDeadband="1" node="9" q="-15.633076359866205">
                 <iidm:alias>_04736ad5-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_99c6c4ad-5247-4058-96d4-ee8495103e85"/>
                 <iidm:shuntLinearModel bPerSection="0.00017220000000000001" gPerSection="0" maximumSectionCount="10"/>
@@ -3609,9 +3694,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.77007895301608" angle="20.637561821050816" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.75452048744731" angle="9.4094829141129317" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044ca8f2-c766-11e1-8775-005056c00008" name="Tazewell LD" loadType="UNDEFINED" p0="12" q0="7" node="8" p="11.999684055991738" q="6.999692834909971">
+            <iidm:load id="_044ca8f2-c766-11e1-8775-005056c00008" name="Tazewell LD" loadType="UNDEFINED" p0="12" q0="7" node="8" p="11.999680464328147" q="6.9996893430764526">
                 <iidm:alias>_04542305-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3662,9 +3747,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="119.82789456972401" angle="-8.5304938275492734" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="119.76630267385727" angle="-19.63842377643882" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04778989-c766-11e1-8775-005056c00008" name="NwLibrty LD" loadType="UNDEFINED" p0="27" q0="11" node="8" p="26.991655602803981" q="10.994334634997152">
+            <iidm:load id="_04778989-c766-11e1-8775-005056c00008" name="NwLibrty LD" loadType="UNDEFINED" p0="27" q0="11" node="8" p="26.99160858506151" q="10.994302715966199">
                 <iidm:alias>_0483e592-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3697,12 +3782,12 @@
                 <iidm:internalConnection node1="11" node2="2"/>
                 <iidm:internalConnection node1="12" node2="3"/>
                 <iidm:internalConnection node1="13" node2="3"/>
-                <iidm:bus v="122.605290503535" angle="5.6589784755951058" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13"/>
+                <iidm:bus v="122.60526933490688" angle="-5.5746317464297039" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0463da70-c766-11e1-8775-005056c00008" name="Danville LD" loadType="UNDEFINED" p0="25" q0="13" node="5" p="25.000003100893458" q="13.000002687441109">
+            <iidm:load id="_0463da70-c766-11e1-8775-005056c00008" name="Danville LD" loadType="UNDEFINED" p0="25" q0="13" node="5" p="25.000002808452198" q="13.000002433991998">
                 <iidm:alias>_0488eeab-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_0448b150-c766-11e1-8775-005056c00008" name="Danville NegG LD" loadType="UNDEFINED" p0="43" q0="0" node="6" p="43.000005333536748" q="0">
+            <iidm:load id="_0448b150-c766-11e1-8775-005056c00008" name="Danville NegG LD" loadType="UNDEFINED" p0="43" q0="0" node="6" p="43.000004830537783" q="0">
                 <iidm:alias>_0457cc88-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3753,9 +3838,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.58688657463094" angle="26.417903080668548" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.44995142623299" angle="15.207052990217901" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045cae82-c766-11e1-8775-005056c00008" name="Fremont LD" loadType="UNDEFINED" p0="48" q0="10" node="8" p="47.998193801254075" q="9.9993728555240988">
+            <iidm:load id="_045cae82-c766-11e1-8775-005056c00008" name="Fremont LD" loadType="UNDEFINED" p0="48" q0="10" node="8" p="47.998066260106519" q="9.9993285715535905">
                 <iidm:alias>_045f4693-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3901,9 +3986,9 @@
                 <iidm:internalConnection node1="70" node2="15"/>
                 <iidm:internalConnection node1="71" node2="18"/>
                 <iidm:internalConnection node1="72" node2="21"/>
-                <iidm:bus v="132.26449566347685" angle="13.344639963642654" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
+                <iidm:bus v="132.24567483891792" angle="2.1092575342434601" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0448d863-c766-11e1-8775-005056c00008" name="Turner LD" loadType="UNDEFINED" p0="61" q0="28" node="23" p="60.983629277787323" q="27.987477070623392">
+            <iidm:load id="_0448d863-c766-11e1-8775-005056c00008" name="Turner LD" loadType="UNDEFINED" p0="61" q0="28" node="23" p="60.983611324960805" q="27.987463338679337">
                 <iidm:alias>_046e3ab3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3938,6 +4023,9 @@
                     <iidm:alias>_0b877750-4384-4ec3-bb38-08ee5ccf16d3</iidm:alias>
                     <iidm:alias>_1ed822d3-f3ab-4432-80f0-4c55ae3b4b78</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_3be2355e-0065-43df-a264-57a295042faa-1" name="DISCONNECTOR526-1" kind="DISCONNECTOR" retained="false" open="false" node1="24" node2="25"/>
+                <iidm:switch id="_2463ff2c-7690-4dd6-bf44-039f9f475bb1-1" name="BREAKER263-1" kind="BREAKER" retained="false" open="true" node1="23" node2="24"/>
+                <iidm:switch id="_ddcf7aac-e7c3-45e9-bd81-6146e951addd-1" name="DISCONNECTOR525-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="23"/>
                 <iidm:internalConnection node1="7" node2="0"/>
                 <iidm:internalConnection node1="8" node2="0"/>
                 <iidm:internalConnection node1="9" node2="1"/>
@@ -3954,9 +4042,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.13563059186053" angle="7.8334309254507222" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.20367966115899" angle="-3.2829170793933367" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047d7cf6-c766-11e1-8775-005056c00008" name="Grant LD" loadType="UNDEFINED" p0="24" q0="4" node="8" p="23.999737005490214" q="3.99992694623635">
+            <iidm:load id="_047d7cf6-c766-11e1-8775-005056c00008" name="Grant LD" loadType="UNDEFINED" p0="24" q0="4" node="8" p="23.999765640914372" q="3.9999349004658922">
                 <iidm:alias>_0481e9c0-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4026,9 +4114,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="221.02904313090852" angle="18.143933138631098" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="221.48776234580976" angle="5.8710461473860587" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04867dab-c766-11e1-8775-005056c00008" name="Olive NegG LD" loadType="UNDEFINED" p0="28" q0="0" node="11" p="27.999120818525132" q="0">
+            <iidm:load id="_04867dab-c766-11e1-8775-005056c00008" name="Olive NegG LD" loadType="UNDEFINED" p0="28" q0="0" node="11" p="27.999180832233506" q="0">
                 <iidm:alias>_048433b8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4134,15 +4222,15 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="133.19337003449712" angle="12.62249850064501" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="133.31996884894349" angle="0.60494198882424388" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:shunt id="_0447c6f6-c766-11e1-8775-005056c00008" name="Olive SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.67599999999999" targetDeadband="1" node="17" q="-40.732127893352306">
+            <iidm:shunt id="_0447c6f6-c766-11e1-8775-005056c00008" name="Olive SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.67599999999999" targetDeadband="1" node="17" q="-40.80959555955598">
                 <iidm:alias>_045e8340-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_c701959a-91c1-4a35-9a37-71fb790426ca"/>
                 <iidm:shuntLinearModel bPerSection="0.00045919999999999999" gPerSection="0" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_04575750-c766-11e1-8775-005056c00008" name="8-5" r="0" x="4.6522079999999999" g="0" b="0" ratedU1="220" ratedU2="132" node1="32" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="370.88967905353798" q1="59.663340528712084" p2="-370.88967905353786" q2="-23.446088901396422">
+        <iidm:twoWindingsTransformer id="_04575750-c766-11e1-8775-005056c00008" name="8-5" r="0" x="4.6522079999999999" g="0" b="0" ratedU1="220" ratedU2="132" node1="32" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="354.85915397575337" q1="62.616571442959888" p2="-354.85915397575337" q2="-29.430357442721533">
             <iidm:alias>_045eaa55-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_046b2d74-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04745533-c766-11e1-8775-005056c00008</iidm:alias>
@@ -4213,9 +4301,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.77651723514137" angle="19.567540069951985" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.77308881030174" angle="8.3376380173638349" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047b0bf0-c766-11e1-8775-005056c00008" name="Wythe LD" loadType="UNDEFINED" p0="22" q0="15" node="8" p="21.999845835421329" q="14.999824813387994">
+            <iidm:load id="_047b0bf0-c766-11e1-8775-005056c00008" name="Wythe LD" loadType="UNDEFINED" p0="22" q0="15" node="8" p="21.999844968856646" q="14.999823828660011">
                 <iidm:alias>_0479d376-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4266,9 +4354,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="123.88514575161275" angle="-5.0815993493681564" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="123.81890943251541" angle="-16.16656142700436" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0458ddf5-c766-11e1-8775-005056c00008" name="WestLima LD" loadType="UNDEFINED" p0="33" q0="9" node="8" p="32.990791037324065" q="8.9958144972576033">
+            <iidm:load id="_0458ddf5-c766-11e1-8775-005056c00008" name="WestLima LD" loadType="UNDEFINED" p0="33" q0="9" node="8" p="32.990753257527992" q="8.9957973278245156">
                 <iidm:alias>_04492686-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4376,9 +4464,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="128.43465943241941" angle="22.480732160950339" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="128.09956527822132" angle="11.279016580899453" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044b2257-c766-11e1-8775-005056c00008" name="BeaverCk LD" loadType="UNDEFINED" p0="24" q0="15" node="17" p="23.99795220517186" q="14.997866941057255">
+            <iidm:load id="_044b2257-c766-11e1-8775-005056c00008" name="BeaverCk LD" loadType="UNDEFINED" p0="24" q0="15" node="17" p="23.997803311876364" q="14.997711853017739">
                 <iidm:alias>_045868c4-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4437,6 +4525,9 @@
                     <iidm:alias>_2b636cdd-aa2f-4a65-92fc-12b4fc392e5f</iidm:alias>
                     <iidm:alias>_c96e50b9-ea15-4421-b6c8-bd9c9158a69a</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_e5318967-afcc-4fcc-b0de-d5f2522a95a6-1" name="DISCONNECTOR699-1" kind="DISCONNECTOR" retained="false" open="false" node1="43" node2="44"/>
+                <iidm:switch id="_e9f91b69-a29b-44ea-aa0f-cff86ee80320-1" name="BREAKER350-1" kind="BREAKER" retained="true" open="true" node1="42" node2="43"/>
+                <iidm:switch id="_ad86e83d-6334-4dd8-b642-b4c16d65329a-1" name="DISCONNECTOR700-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="42"/>
                 <iidm:internalConnection node1="13" node2="0"/>
                 <iidm:internalConnection node1="14" node2="1"/>
                 <iidm:internalConnection node1="15" node2="2"/>
@@ -4466,7 +4557,7 @@
                 <iidm:internalConnection node1="39" node2="9"/>
                 <iidm:internalConnection node1="40" node2="12"/>
                 <iidm:internalConnection node1="41" node2="3"/>
-                <iidm:bus v="214.60379387380362" angle="15.689363068606921" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41"/>
+                <iidm:bus v="215.61437096902671" angle="2.9510143901649619" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_047bcf46-c766-11e1-8775-005056c00008" name="STN132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -4546,6 +4637,9 @@
                     <iidm:alias>_4aab41d6-d1b6-4dbe-a6aa-cb7ccd941912</iidm:alias>
                     <iidm:alias>_e9315b98-af75-40bb-bf8e-05bd03d43db5</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_b8b0b9a9-af8b-41d2-a4f8-940637e63f70-1" name="DISCONNECTOR701-1" kind="DISCONNECTOR" retained="false" open="false" node1="64" node2="65"/>
+                <iidm:switch id="_0b78ffaa-9859-4658-af17-c8d355633556-1" name="BREAKER351-1" kind="BREAKER" retained="true" open="false" node1="63" node2="64"/>
+                <iidm:switch id="_9dfeeaef-5c49-4c2c-97b1-03876970bee4-1" name="DISCONNECTOR702-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="63"/>
                 <iidm:internalConnection node1="19" node2="0"/>
                 <iidm:internalConnection node1="20" node2="0"/>
                 <iidm:internalConnection node1="21" node2="1"/>
@@ -4590,9 +4684,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="129.37847545731714" angle="9.0038409815766123" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="129.31518243055709" angle="-1.6105899832082429" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045dbff4-c766-11e1-8775-005056c00008" name="Sorenson LD" loadType="UNDEFINED" p0="11" q0="3" node="20" p="10.999083790782484" q="2.999583552827398">
+            <iidm:load id="_045dbff4-c766-11e1-8775-005056c00008" name="Sorenson LD" loadType="UNDEFINED" p0="11" q0="3" node="20" p="10.999133127338631" q="2.9996059773229975">
                 <iidm:alias>_044d4536-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4613,6 +4707,9 @@
                     <iidm:alias>_340082f1-db9c-446d-97df-80e45aa0058b</iidm:alias>
                     <iidm:alias>_90c04b95-703a-4bae-82b8-7edf3075aa24</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_4d08a684-cdcb-484a-a767-03b10f4ada7f-1" name="DISCONNECTOR735-1" kind="DISCONNECTOR" retained="false" open="false" node1="14" node2="15"/>
+                <iidm:switch id="_f468d841-1bf6-470e-85d4-55d34fab8bff-1" name="BREAKER368-1" kind="BREAKER" retained="true" open="false" node1="13" node2="14"/>
+                <iidm:switch id="_f193bd8f-badf-4600-82ac-f212d1f33534-1" name="DISCONNECTOR736-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="13"/>
                 <iidm:internalConnection node1="4" node2="0"/>
                 <iidm:internalConnection node1="5" node2="1"/>
                 <iidm:internalConnection node1="6" node2="2"/>
@@ -4622,13 +4719,13 @@
                 <iidm:internalConnection node1="10" node2="3"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="0"/>
-                <iidm:bus v="384.35448560292025" angle="15.466621875946871" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="389.19455341741826" angle="0" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15"/>
             </iidm:nodeBreakerTopology>
             <iidm:lccConverterStation id="_7393a68e-c4e6-48dd-9347-543858363fdb" name="Conv1" lossFactor="0" powerFactor="0.80000000000000004" node="12" p="10" q="6">
                 <iidm:alias>_739658a7-e08b-4395-8d79-93e87b7855e3</iidm:alias>
             </iidm:lccConverterStation>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_047120e9-c766-11e1-8775-005056c00008" name="30-17" r="0" x="6.7605125399999997" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_047b8123-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="298.83163576051703" q1="111.6716062747594" p2="-298.83163576051709" q2="-73.427160690534663">
+        <iidm:twoWindingsTransformer id="_047120e9-c766-11e1-8775-005056c00008" name="30-17" r="0" x="6.7605125399999997" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_047b8123-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="205.00464981970313" q1="116.67770681867171" p2="-205.00464981970308" q2="-95.964090956456715">
             <iidm:alias>_044f6811-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0463b36a-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_047d2ed8-c766-11e1-8775-005056c00008</iidm:alias>
@@ -4647,7 +4744,7 @@
                 <iidm:temporaryLimit name="_f62f2fc6-4b6c-4571-a8c5-40d6a89ac703" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_b08e9e50-4e0c-4ac0-9f21-4a27429caeb2" name="PowTrans1" r="0.4840000000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_3bbfa58a-a1ad-4b23-a526-3d76b096c1f4" node2="41" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="-10.000000491490461" q1="-6.0000005576548832" p2="10.001436871143911" q2="6.0538647946607753">
+        <iidm:twoWindingsTransformer id="_b08e9e50-4e0c-4ac0-9f21-4a27429caeb2" name="PowTrans1" r="0.4840000000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_3bbfa58a-a1ad-4b23-a526-3d76b096c1f4" node2="41" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="-132.01957057968241" q1="20.696302955008168" p2="132.20351280610129" q2="-13.798469464299421">
             <iidm:alias>_046ba2aa-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_a5bf9702-545a-437d-9663-773550202828</iidm:alias>
             <iidm:alias>_ee9505e1-96d7-49b3-9d1a-924397ffb27e</iidm:alias>
@@ -4667,6 +4764,32 @@
                 <iidm:temporaryLimit name="_611bb05e-9b9a-469c-b1d1-80a944c3ce2f" acceptableDuration="60" value="1400"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
+        <iidm:threeWindingsTransformer id="_86d83c7d-7826-4c16-b161-4ce17174e77f-1" name="T422" r1="-1.5199999809265099" x1="23.199999999999999" g1="0" b1="0" ratedU1="400" r2="2.0000000630528461" x2="19.999999999999996" g2="0" b2="0" ratedU2="220" r3="1.2000000564689806" x3="12" g3="0" b3="0" ratedU3="132" ratedU0="400" node1="15" voltageLevelId1="_3bbfa58a-a1ad-4b23-a526-3d76b096c1f4" node2="44" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" node3="65" voltageLevelId3="_047bcf46-c766-11e1-8775-005056c00008" p1="122.01957059921756" q1="-26.696302943285446" p2="0" q2="0" p3="-122.05253019206714" q3="30.321859012618614">
+            <iidm:alias>_1b2d419c-ac88-4dae-8dfe-2eb92d18c40a-1</iidm:alias>
+            <iidm:alias>_206474da-93c8-46b1-863f-9a308bfc2117-1</iidm:alias>
+            <iidm:alias>_9ac069ea-557b-4b8c-b12e-f9f2aecc3bf5-1</iidm:alias>
+            <iidm:alias>_ae46e10e-1fbe-4139-b493-ed8e2844ee8d-1</iidm:alias>
+            <iidm:ratioTapChanger1 lowTapPosition="1" tapPosition="11" targetDeadband="0" loadTapChangingCapabilities="true" regulating="false" targetV="220">
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.95238095238095233"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.96385542168674687"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.97560975609756106"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.98765432098765438"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0126582278481011"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0256410256410258"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0389610389610389"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0526315789473684"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0666666666666667"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0810810810810809"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.095890410958904"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.1111111111111112"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.1267605633802817"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.1428571428571428"/>
+            </iidm:ratioTapChanger1>
+            <iidm:currentLimits1 permanentLimit="500">
+                <iidm:temporaryLimit name="_3fd18f6e-749a-4fa7-af1b-b0c2d3952638-1" acceptableDuration="1800" value="533"/>
+            </iidm:currentLimits1>
+        </iidm:threeWindingsTransformer>
     </iidm:substation>
     <iidm:substation id="_04642898-c766-11e1-8775-005056c00008" name="Rómenna" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
         <iidm:voltageLevel id="_0457f394-c766-11e1-8775-005056c00008" name="RÓM132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -4905,16 +5028,16 @@
                 <iidm:internalConnection node1="121" node2="30"/>
                 <iidm:internalConnection node1="122" node2="33"/>
                 <iidm:internalConnection node1="123" node2="36"/>
-                <iidm:bus v="135.30000000534255" angle="-0.28684052601710941" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123"/>
+                <iidm:bus v="135.30000293007424" angle="-11.478450977798982" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04859346-c766-11e1-8775-005056c00008" name="Philo SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="204" targetV="135.30000000000001" targetQ="0" node="39" p="-225.87561809272404" q="-175.19896149406878">
+            <iidm:generator id="_04859346-c766-11e1-8775-005056c00008" name="Philo SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="204" targetV="135.30000000000001" targetQ="0" node="39" p="-225.8366642084321" q="-175.19952792294811">
                 <iidm:alias>_048719e2-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e3753d6d-b894-4cce-b6fa-307c50dc107f"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_dff93c01-9c84-4c1f-8529-66c054ed9e37"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
-            <iidm:load id="_045163e2-c766-11e1-8775-005056c00008" name="Philo LD" loadType="UNDEFINED" p0="87" q0="30" node="38" p="87.000000005153012" q="30.000000002961496">
+            <iidm:load id="_045163e2-c766-11e1-8775-005056c00008" name="Philo LD" loadType="UNDEFINED" p0="87" q0="30" node="38" p="87.000002826124827" q="30.000001624209695">
                 <iidm:alias>_04513cd3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4965,9 +5088,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.77842406194928" angle="20.480059511125894" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.49236263210106" angle="9.2675273340804036" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04524e46-c766-11e1-8775-005056c00008" name="BetsyLne LD" loadType="UNDEFINED" p0="11" q0="7" node="8" p="10.998874466483025" q="6.9988062930461865">
+            <iidm:load id="_04524e46-c766-11e1-8775-005056c00008" name="BetsyLne LD" loadType="UNDEFINED" p0="11" q0="7" node="8" p="10.998813121427897" q="6.998741234668171">
                 <iidm:alias>_04549830-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5020,15 +5143,15 @@
                 <iidm:internalConnection node1="22" node2="6"/>
                 <iidm:internalConnection node1="23" node2="3"/>
                 <iidm:internalConnection node1="24" node2="6"/>
-                <iidm:bus v="124.759145599894" angle="7.3475439565312364" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24"/>
+                <iidm:bus v="124.75912435708352" angle="-3.8856225145612542" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04566cf3-c766-11e1-8775-005056c00008" name="Reusens NegG LD" loadType="UNDEFINED" p0="22" q0="0" node="8" p="22.000001710397918" q="0">
+            <iidm:load id="_04566cf3-c766-11e1-8775-005056c00008" name="Reusens NegG LD" loadType="UNDEFINED" p0="22" q0="0" node="8" p="22.000001560187894" q="0">
                 <iidm:alias>_0483be81-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_0482fb36-c766-11e1-8775-005056c00008" name="Reusens LD" loadType="UNDEFINED" p0="28" q0="12" node="9" p="28.00000217687008" q="12.000001554907238">
+            <iidm:load id="_0482fb36-c766-11e1-8775-005056c00008" name="Reusens LD" loadType="UNDEFINED" p0="28" q0="12" node="9" p="28.000001985693686" q="12.000001418352664">
                 <iidm:alias>_0486cbc1-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_04558293-c766-11e1-8775-005056c00008" name="Reusens SC" sectionCount="5" voltageRegulatorOn="true" targetV="124.76300000000001" targetDeadband="1" node="10" q="-5.3543064773205504">
+            <iidm:shunt id="_04558293-c766-11e1-8775-005056c00008" name="Reusens SC" sectionCount="5" voltageRegulatorOn="true" targetV="124.76300000000001" targetDeadband="1" node="10" q="-5.3543046539591046">
                 <iidm:alias>_04893ccc-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_99303cd3-6b53-4ee2-a5ce-fe8d5feeb304"/>
                 <iidm:shuntLinearModel bPerSection="6.8800000000000005e-05" gPerSection="0" maximumSectionCount="10"/>
@@ -5101,12 +5224,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="126.42390612401725" angle="24.677106916925332" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="126.42210971909667" angle="13.454256014929548" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045c8777-c766-11e1-8775-005056c00008" name="Holston NegG LD" loadType="UNDEFINED" p0="85" q0="0" node="11" p="84.999645871999604" q="0">
+            <iidm:load id="_045c8777-c766-11e1-8775-005056c00008" name="Holston NegG LD" loadType="UNDEFINED" p0="85" q0="0" node="11" p="84.999640644666755" q="0">
                 <iidm:alias>_0487dd31-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_0451d918-c766-11e1-8775-005056c00008" name="Holston LD" loadType="UNDEFINED" p0="78" q0="42" node="12" p="77.999675035481999" q="41.999708365581164">
+            <iidm:load id="_0451d918-c766-11e1-8775-005056c00008" name="Holston LD" loadType="UNDEFINED" p0="78" q0="42" node="12" p="77.999670238635375" q="41.999704060730842">
                 <iidm:alias>_0485ba54-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5214,9 +5337,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="127.09927496802828" angle="9.2602087094244325" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="127.09735677468539" angle="-1.9982046624636325" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04742e27-c766-11e1-8775-005056c00008" name="SthPoint LD" loadType="UNDEFINED" p0="47" q0="11" node="17" p="46.908909802038409" q="10.964491321939249">
+            <iidm:load id="_04742e27-c766-11e1-8775-005056c00008" name="SthPoint LD" loadType="UNDEFINED" p0="47" q0="11" node="17" p="46.908921820505171" q="10.964496003934853">
                 <iidm:alias>_047b3303-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5268,12 +5391,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="132.86461066585773" angle="13.356988418128035" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="132.85198422963282" angle="2.1228342914794722" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04716f06-c766-11e1-8775-005056c00008" name="CapitlHl LD" loadType="UNDEFINED" p0="39" q0="32" node="8" p="38.993047596225828" q="31.990493004255065">
+            <iidm:load id="_04716f06-c766-11e1-8775-005056c00008" name="CapitlHl LD" loadType="UNDEFINED" p0="39" q0="32" node="8" p="38.993040061327221" q="31.990482701345513">
                 <iidm:alias>_04700f70-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0466c0a0-c766-11e1-8775-005056c00008" name="CapitlHl SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.00200000000001" targetDeadband="1" node="9" q="-20.265649472963666">
+            <iidm:shunt id="_0466c0a0-c766-11e1-8775-005056c00008" name="CapitlHl SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.00200000000001" targetDeadband="1" node="9" q="-20.261797871385703">
                 <iidm:alias>_045e8346-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_99931a87-ee15-4fd0-b251-9556df7fe598"/>
                 <iidm:shuntLinearModel bPerSection="0.0002296" gPerSection="0" maximumSectionCount="10"/>
@@ -5326,9 +5449,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="131.98304762816775" angle="13.043299397359547" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="131.96632277143132" angle="1.8082163637262276" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046efe03-c766-11e1-8775-005056c00008" name="Chemical LD" loadType="UNDEFINED" p0="71" q0="26" node="8" p="70.9829856493607" q="25.989616484058637">
+            <iidm:load id="_046efe03-c766-11e1-8775-005056c00008" name="Chemical LD" loadType="UNDEFINED" p0="71" q0="26" node="8" p="70.982966628388183" q="25.98960487687015">
                 <iidm:alias>_045d71d5-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5379,9 +5502,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.52042144733997" angle="9.234940862425784" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.56472277875343" angle="-2.579443332883689" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046a4319-c766-11e1-8775-005056c00008" name="JacksnRd LD" loadType="UNDEFINED" p0="19" q0="2" node="8" p="18.999870929116977" q="1.9999773560367102">
+            <iidm:load id="_046a4319-c766-11e1-8775-005056c00008" name="JacksnRd LD" loadType="UNDEFINED" p0="19" q0="2" node="8" p="18.999878834590501" q="1.9999787429558009">
                 <iidm:alias>_046c8d06-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5527,9 +5650,9 @@
                 <iidm:internalConnection node1="70" node2="15"/>
                 <iidm:internalConnection node1="71" node2="18"/>
                 <iidm:internalConnection node1="72" node2="21"/>
-                <iidm:bus v="130.60462358274702" angle="24.341958229686259" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
+                <iidm:bus v="130.5978964160935" angle="13.116421494924122" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0458ddf4-c766-11e1-8775-005056c00008" name="Saltvlle LD" loadType="UNDEFINED" p0="65" q0="10" node="23" p="64.999190162607803" q="9.9997923502489936">
+            <iidm:load id="_0458ddf4-c766-11e1-8775-005056c00008" name="Saltvlle LD" loadType="UNDEFINED" p0="65" q0="10" node="23" p="64.999182807756469" q="9.999790464405411">
                 <iidm:alias>_045645e4-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5599,9 +5722,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="131.45085410109721" angle="13.862281278601483" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="131.58479789827592" angle="2.3859280580848687" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0476ed42-c766-11e1-8775-005056c00008" name="Trenton NegG LD" loadType="UNDEFINED" p0="13" q0="0" node="11" p="12.993519887280886" q="0">
+            <iidm:load id="_0476ed42-c766-11e1-8775-005056c00008" name="Trenton NegG LD" loadType="UNDEFINED" p0="13" q0="0" node="11" p="12.993556904619005" q="0">
                 <iidm:alias>_0471e432-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5671,9 +5794,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="128.34753219857049" angle="8.2551023476073304" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="128.40760338914379" angle="-3.6024713202504737" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044a5f08-c766-11e1-8775-005056c00008" name="HickryCk LD" loadType="UNDEFINED" p0="39" q0="10" node="11" p="38.999590851061654" q="9.9998251506378004">
+            <iidm:load id="_044a5f08-c766-11e1-8775-005056c00008" name="HickryCk LD" loadType="UNDEFINED" p0="39" q0="10" node="11" p="38.999616820963475" q="9.9998362488112829">
                 <iidm:alias>_047d7cf3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5802,9 +5925,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="125.32349472613807" angle="-4.2321982790886299" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="125.25924408208833" angle="-15.319080817421668" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:shunt id="_0450eeb7-c766-11e1-8775-005056c00008" name="EastLima SC" sectionCount="5" voltageRegulatorOn="true" targetV="131.565" targetDeadband="1" node="20" q="-22.53807890408433">
+            <iidm:shunt id="_0450eeb7-c766-11e1-8775-005056c00008" name="EastLima SC" sectionCount="5" voltageRegulatorOn="true" targetV="131.565" targetDeadband="1" node="20" q="-22.514975257203218">
                 <iidm:alias>_044aad27-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_6c36f421-303e-4932-93a9-5b0ff86cb7d4"/>
                 <iidm:shuntLinearModel bPerSection="0.00028699999999999998" gPerSection="0" maximumSectionCount="10"/>
@@ -5892,16 +6015,16 @@
                 <iidm:internalConnection node1="41" node2="7"/>
                 <iidm:internalConnection node1="42" node2="12"/>
                 <iidm:internalConnection node1="43" node2="11"/>
-                <iidm:bus v="218.90683385517917" angle="6.7116699414536729" nodes="0,1,2,3,8,9,10,13,17,18,21,22,23,24,25,26,31,32,33,34,35,39,40"/>
-                <iidm:bus v="237.93768351965895" angle="-5.0357163758221892" nodes="11,15,37,43"/>
-                <iidm:bus v="226.19467205404072" angle="6.7116699434394107" nodes="12,16,38,42"/>
-                <iidm:bus v="214.70024925341002" angle="-5.0357163758221892" nodes="4,5,6,7,14,19,20,27,28,29,30,36,41"/>
+                <iidm:bus v="218.90697973296855" angle="-4.4873516503835127" nodes="0,1,2,3,8,9,10,13,17,18,21,22,23,24,25,26,31,32,33,34,35,39,40"/>
+                <iidm:bus v="237.93768571651023" angle="-16.232813991906355" nodes="11,15,37,43"/>
+                <iidm:bus v="226.19467630918487" angle="-4.4873516679431278" nodes="12,16,38,42"/>
+                <iidm:bus v="214.70025123571276" angle="-16.232813991906355" nodes="4,5,6,7,14,19,20,27,28,29,30,36,41"/>
             </iidm:nodeBreakerTopology>
-            <iidm:vscConverterStation id="_b46bfb8e-7af6-459e-acf3-53a42c943a7c" name="VSC2" voltageRegulatorOn="true" lossFactor="0.32362458" voltageSetpoint="218.47" reactivePowerSetpoint="0" node="42" p="-0" q="-27.474502843110766">
+            <iidm:vscConverterStation id="_b46bfb8e-7af6-459e-acf3-53a42c943a7c" name="VSC2" voltageRegulatorOn="true" lossFactor="0.32362458" voltageSetpoint="218.47" reactivePowerSetpoint="0" node="42" p="-0" q="-27.473968421459873">
                 <iidm:alias>_a168e701-bd48-4f66-8f0b-0f69b2545530</iidm:alias>
                 <iidm:minMaxReactiveLimits minQ="-1.7976931348623157e+308" maxQ="1.7976931348623157e+308"/>
             </iidm:vscConverterStation>
-            <iidm:vscConverterStation id="_b48ce7cf-abf5-413f-bc51-9e1d3103c9bd" name="VSC1" voltageRegulatorOn="true" lossFactor="0.32467531999999999" voltageSetpoint="213.53999999999999" reactivePowerSetpoint="0" node="43" p="-0" q="-92.151020935009171">
+            <iidm:vscConverterStation id="_b48ce7cf-abf5-413f-bc51-9e1d3103c9bd" name="VSC1" voltageRegulatorOn="true" lossFactor="0.32467531999999999" voltageSetpoint="213.53999999999999" reactivePowerSetpoint="0" node="43" p="-0" q="-92.151020935009015">
                 <iidm:alias>_071bb138-ff00-4874-8acc-a884aa5cf4a9</iidm:alias>
                 <iidm:minMaxReactiveLimits minQ="-1.7976931348623157e+308" maxQ="1.7976931348623157e+308"/>
             </iidm:vscConverterStation>
@@ -5969,7 +6092,7 @@
                 <iidm:internalConnection node1="29" node2="6"/>
                 <iidm:internalConnection node1="30" node2="9"/>
                 <iidm:internalConnection node1="31" node2="3"/>
-                <iidm:bus v="201.80787208433659" angle="-0.26109699626381749" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
+                <iidm:bus v="201.75776960651481" angle="-11.376136123530868" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_0448d867-c766-11e1-8775-005056c00008" name="EDO132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -6055,9 +6178,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="131.34000010727109" angle="4.3055208493316481" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="131.34000205124789" angle="-6.8930645236643917" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0472a789-c766-11e1-8775-005056c00008" name="W.Kammer SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="160" targetV="131.34" targetQ="0" node="14" p="-177.15734752370514" q="94.093797540618098">
+            <iidm:generator id="_0472a789-c766-11e1-8775-005056c00008" name="W.Kammer SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="160" targetV="131.34" targetQ="0" node="14" p="-177.12679545759386" q="94.090538445070607">
                 <iidm:alias>_04697fc0-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_17852426-f663-4add-9a2b-0a635d51f101"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b512ea0a-96d0-4a48-9de1-a5cf499bf0dd"/>
@@ -6206,16 +6329,16 @@
                 <iidm:internalConnection node1="71" node2="15"/>
                 <iidm:internalConnection node1="72" node2="18"/>
                 <iidm:internalConnection node1="73" node2="21"/>
-                <iidm:bus v="130.0200002839654" angle="-5.0357163758221892" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
+                <iidm:bus v="130.02000148442514" angle="-16.232813991906355" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04839777-c766-11e1-8775-005056c00008" name="Tidd SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="155" targetV="130.02000000000001" targetQ="0" node="24" p="-171.62118041358931" q="-94.869129763513058">
+            <iidm:generator id="_04839777-c766-11e1-8775-005056c00008" name="Tidd SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="155" targetV="130.02000000000001" targetQ="0" node="24" p="-171.59158309954401" q="-94.871067237587781">
                 <iidm:alias>_045fe2d8-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_d2a96d8d-65be-4fd6-a012-ceeeabd2bee6"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_29df1e0b-36ca-4536-97b4-6f98b84d49d8"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-90" maxQ="255"/>
             </iidm:generator>
-            <iidm:load id="_04798556-c766-11e1-8775-005056c00008" name="Tidd LD" loadType="UNDEFINED" p0="277" q0="113" node="23" p="277.00000090745755" q="113.00000061698373">
+            <iidm:load id="_04798556-c766-11e1-8775-005056c00008" name="Tidd LD" loadType="UNDEFINED" p0="277" q0="113" node="23" p="277.00000474372126" q="113.00000322527379">
                 <iidm:alias>_04502b62-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6245,13 +6368,13 @@
                 <iidm:internalConnection node1="10" node2="3"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="0"/>
-                <iidm:bus v="360.97090025397375" angle="0" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="360.88059972939874" angle="-11.114908936262585" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
             </iidm:nodeBreakerTopology>
             <iidm:lccConverterStation id="_9793118d-5ba1-4a9c-b2e0-db1d15be5913" name="Conv2" lossFactor="0" powerFactor="-0.75741000000000003" node="12" p="-10" q="8.6206896551724146">
                 <iidm:alias>_453bdc57-5855-4eb5-8712-d6a0255e0da8</iidm:alias>
             </iidm:lccConverterStation>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045c1248-c766-11e1-8775-005056c00008" name="38-37" r="0" x="6.5340005399999992" g="0" b="0" ratedU1="220" ratedU2="132" node1="30" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="172.01710933907503" q1="88.788031600478675" p2="-172.01710933907509" q2="-74.188313606158871">
+        <iidm:twoWindingsTransformer id="_045c1248-c766-11e1-8775-005056c00008" name="38-37" r="0" x="6.5340005399999992" g="0" b="0" ratedU1="220" ratedU2="132" node1="30" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="170.66942930477188" q1="89.314804665481745" p2="-170.66942930477191" q2="-74.851284947540236">
             <iidm:alias>_0453d4e8-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0477d7aa-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_047df228-c766-11e1-8775-005056c00008</iidm:alias>
@@ -6275,7 +6398,7 @@
                 <iidm:temporaryLimit name="_c97df399-5a91-4c8b-b72c-496cade334b5" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_0485ba57-c766-11e1-8775-005056c00008" name="64-61" r="0" x="4.669632" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="157.45662253222855" q1="60.539677568247399" p2="-157.45662253222847" q2="-53.066025501765765">
+        <iidm:twoWindingsTransformer id="_0485ba57-c766-11e1-8775-005056c00008" name="64-61" r="0" x="4.669632" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="157.42820071038707" q1="60.54100120990654" p2="-157.42820071038693" q2="-53.069667388610029">
             <iidm:alias>_04549831-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0472ce92-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0489d905-c766-11e1-8775-005056c00008</iidm:alias>
@@ -6301,7 +6424,7 @@
                 <iidm:temporaryLimit name="_f6b1a81c-eda7-4a08-b290-bd29a5ed9fa4" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_044cd007-c766-11e1-8775-005056c00008" name="63-59" r="0" x="6.7256646120000001" g="0" b="0" ratedU1="220" ratedU2="132" node1="41" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="73" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="1.8041124150158794e-14" q1="83.151382149556596" p2="-5.5511151231257827e-15" q2="-80.568830585384347">
+        <iidm:twoWindingsTransformer id="_044cd007-c766-11e1-8775-005056c00008" name="63-59" r="0" x="6.7256646120000001" g="0" b="0" ratedU1="220" ratedU2="132" node1="41" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="73" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-9.7144514654701197e-14" q1="83.151383685010543" p2="2.2204460492503131e-14" q2="-80.568832073149892">
             <iidm:alias>_044e7db4-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_046eafe5-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0488797a-c766-11e1-8775-005056c00008</iidm:alias>
@@ -6347,7 +6470,7 @@
                 <iidm:temporaryLimit name="_f2daef4d-6f1a-44d1-9c9b-228acff12575" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_ffd940c8-03c8-4dcf-ad46-62018a0d813d" name="PowTrans2" r="0.3932500000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_04f97116-552a-4a34-afd9-4862f62ac7aa" node2="31" voltageLevelId2="_04742e21-c766-11e1-8775-005056c00008" p1="9.9999999082262434" q1="-8.6206895760572149" p2="-9.9983039656534967" q2="8.6989638486467449">
+        <iidm:twoWindingsTransformer id="_ffd940c8-03c8-4dcf-ad46-62018a0d813d" name="PowTrans2" r="0.3932500000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_04f97116-552a-4a34-afd9-4862f62ac7aa" node2="31" voltageLevelId2="_04742e21-c766-11e1-8775-005056c00008" p1="10.000000019172568" q1="-8.6206903932097241" p2="-9.9983032276081705" q2="8.6990038500291558">
             <iidm:alias>_04479fea-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_c089eb25-9f67-4d82-88a8-635dd4808bae</iidm:alias>
             <iidm:alias>_ea8cd467-31f0-40dc-95d7-4064463724c4</iidm:alias>
@@ -6414,9 +6537,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="124.78814141368444" angle="-8.2063417256745428" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.78796653271266" angle="-19.400614819681923" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0481c2b3-c766-11e1-8775-005056c00008" name="Wooster LD" loadType="UNDEFINED" p0="23" q0="11" node="8" p="22.999984404022634" q="10.999987568426647">
+            <iidm:load id="_0481c2b3-c766-11e1-8775-005056c00008" name="Wooster LD" loadType="UNDEFINED" p0="23" q0="11" node="8" p="22.999984899279863" q="10.999987963196727">
                 <iidm:alias>_04614268-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6486,9 +6609,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="125.56951926563275" angle="-7.9688826212463235" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="125.56948733267738" angle="-19.163846893574007" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044974a8-c766-11e1-8775-005056c00008" name="Wagenhls LD" loadType="UNDEFINED" p0="63" q0="22" node="11" p="63.000000137417722" q="22.000000079978566">
+            <iidm:load id="_044974a8-c766-11e1-8775-005056c00008" name="Wagenhls LD" loadType="UNDEFINED" p0="63" q0="22" node="11" p="63.000001379551705" q="22.000000802913693">
                 <iidm:alias>_048481d4-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6539,9 +6662,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.27260435455106" angle="7.3008651972893981" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.32650823585325" angle="-4.288567552507895" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047fedf2-c766-11e1-8775-005056c00008" name="Concord LD" loadType="UNDEFINED" p0="34" q0="16" node="8" p="33.998541131747544" q="15.998855805971216">
+            <iidm:load id="_047fedf2-c766-11e1-8775-005056c00008" name="Concord LD" loadType="UNDEFINED" p0="34" q0="16" node="8" p="33.998600363753134" q="15.998902261144254">
                 <iidm:alias>_046d9e75-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6649,9 +6772,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="127.41376280883438" angle="9.8861061552110954" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="127.53830744612557" angle="-1.360876134084513" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045f94ba-c766-11e1-8775-005056c00008" name="Delaware LD" loadType="UNDEFINED" p0="59" q0="23" node="17" p="58.994183963169824" q="22.996221343176838">
+            <iidm:load id="_045f94ba-c766-11e1-8775-005056c00008" name="Delaware LD" loadType="UNDEFINED" p0="59" q0="23" node="17" p="58.994403593614841" q="22.99636403172272">
                 <iidm:alias>_0463654a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6759,9 +6882,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="125.26215354733399" angle="5.0772088325472566" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="125.20193894881382" angle="-5.8139013088774165" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04697fc9-c766-11e1-8775-005056c00008" name="FtWayne LD" loadType="UNDEFINED" p0="90" q0="30" node="17" p="89.98843285449702" q="29.993574083364109">
+            <iidm:load id="_04697fc9-c766-11e1-8775-005056c00008" name="FtWayne LD" loadType="UNDEFINED" p0="90" q0="30" node="17" p="89.98868109619184" q="29.993711983726683">
                 <iidm:alias>_044d1e25-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6812,9 +6935,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.01473444148056" angle="-5.9667221009249873" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.0145175333131" angle="-17.160500638469546" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0474f170-c766-11e1-8775-005056c00008" name="WNwPhil1 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="11.999994015340482" q="2.9999975063922819">
+            <iidm:load id="_0474f170-c766-11e1-8775-005056c00008" name="WNwPhil1 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="11.999994304068464" q="2.9999976266955688">
                 <iidm:alias>_0466c0a7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6885,12 +7008,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="129.57571019781435" angle="15.316864763047347" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="129.47146902720172" angle="4.0851700605250141" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044a5f05-c766-11e1-8775-005056c00008" name="Logan LD" loadType="UNDEFINED" p0="54" q0="27" node="11" p="53.992428079769226" q="26.993690361406813">
+            <iidm:load id="_044a5f05-c766-11e1-8775-005056c00008" name="Logan LD" loadType="UNDEFINED" p0="54" q0="27" node="11" p="53.992311930239211" q="26.993593579249509">
                 <iidm:alias>_04767811-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0475dbd6-c766-11e1-8775-005056c00008" name="Logan SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.41900000000001" targetDeadband="1" node="12" q="-19.274764644911635">
+            <iidm:shunt id="_0475dbd6-c766-11e1-8775-005056c00008" name="Logan SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.41900000000001" targetDeadband="1" node="12" q="-19.243764763286787">
                 <iidm:alias>_04577e67-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_a7768441-642e-48a2-b4a8-0ae06bebf676"/>
                 <iidm:shuntLinearModel bPerSection="0.0002296" gPerSection="0" maximumSectionCount="10"/>
@@ -6964,19 +7087,19 @@
                 <iidm:internalConnection node1="32" node2="3"/>
                 <iidm:internalConnection node1="33" node2="6"/>
                 <iidm:internalConnection node1="34" node2="9"/>
-                <iidm:bus v="132.65999999987227" angle="-1.8481556454577004" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34"/>
+                <iidm:bus v="132.66000316261324" angle="-13.035265988872654" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04633e31-c766-11e1-8775-005056c00008" name="W.Lancst SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="19" targetV="132.66" targetQ="0" node="13" p="-21.037435018439982" q="1.4818010979960958">
+            <iidm:generator id="_04633e31-c766-11e1-8775-005056c00008" name="W.Lancst SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="19" targetV="132.66" targetQ="0" node="13" p="-21.033806960589267" q="1.4844882608844956">
                 <iidm:alias>_047bcf42-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_83fae784-1da1-4055-8108-ba978276d1b6"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_5f711f63-f631-45d3-b26c-33821ab2ee56"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-15" maxQ="45"/>
             </iidm:generator>
-            <iidm:load id="_048a9c51-c766-11e1-8775-005056c00008" name="W.Lancst LD" loadType="UNDEFINED" p0="28" q0="10" node="11" p="27.999999999959574" q="9.9999999999759339">
+            <iidm:load id="_048a9c51-c766-11e1-8775-005056c00008" name="W.Lancst LD" loadType="UNDEFINED" p0="28" q0="10" node="11" p="28.000001001279646" q="10.000000595999795">
                 <iidm:alias>_044e7db6-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_045b00d9-c766-11e1-8775-005056c00008" name="W.Lancst SC" sectionCount="5" voltageRegulatorOn="true" targetV="132.66" targetDeadband="1" node="12" q="-10.101639794380553">
+            <iidm:shunt id="_045b00d9-c766-11e1-8775-005056c00008" name="W.Lancst SC" sectionCount="5" voltageRegulatorOn="true" targetV="132.66" targetDeadband="1" node="12" q="-10.101640276046014">
                 <iidm:alias>_04758db6-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_be267a3c-f7a7-4bdf-bb17-71b773247fbf"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -7086,9 +7209,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="129.39217068407231" angle="9.7404424970864731" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="129.4080538680744" angle="-1.5517646300477324" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045dbff2-c766-11e1-8775-005056c00008" name="Portsmth LD" loadType="UNDEFINED" p0="66" q0="20" node="17" p="65.901885262427172" q="19.950471661190612">
+            <iidm:load id="_045dbff2-c766-11e1-8775-005056c00008" name="Portsmth LD" loadType="UNDEFINED" p0="66" q0="20" node="17" p="65.901934209138275" q="19.950496357252312">
                 <iidm:alias>_0454bf45-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7159,16 +7282,16 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="127.64400153070468" angle="7.9124214547574692" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="127.64400021300251" angle="-3.1531625860967254" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04856c34-c766-11e1-8775-005056c00008" name="DeerCrk SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="7" targetV="127.64400000000001" targetQ="0" node="12" p="-7.7506339541620992" q="-39.593534748102087">
+            <iidm:generator id="_04856c34-c766-11e1-8775-005056c00008" name="DeerCrk SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="7" targetV="127.64400000000001" targetQ="0" node="12" p="-7.7492973012697313" q="-37.434263999802937">
                 <iidm:alias>_0477d7a5-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e5a479a8-ab8d-4a54-bb52-376874ae2784"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b55d80d5-720f-46f9-897f-ff8c5eaf8b44"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-15" maxQ="45"/>
             </iidm:generator>
-            <iidm:load id="_04791028-c766-11e1-8775-005056c00008" name="DeerCrk LD" loadType="UNDEFINED" p0="43" q0="27" node="11" p="43.000000773482903" q="27.000000809458857">
+            <iidm:load id="_04791028-c766-11e1-8775-005056c00008" name="DeerCrk LD" loadType="UNDEFINED" p0="43" q0="27" node="11" p="43.000000107632644" q="27.000000112638816">
                 <iidm:alias>_04486337-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7219,9 +7342,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.83658837423008" angle="9.7027935339121694" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.99650016444239" angle="-1.5962163702567966" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0462c904-c766-11e1-8775-005056c00008" name="Medford LD" loadType="UNDEFINED" p0="22" q0="7" node="8" p="21.998117702541816" q="6.9990018404222445">
+            <iidm:load id="_0462c904-c766-11e1-8775-005056c00008" name="Medford LD" loadType="UNDEFINED" p0="22" q0="7" node="8" p="21.998211302788473" q="6.9990514741558085">
                 <iidm:alias>_0489b1f7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7310,9 +7433,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="131.95608002182757" angle="15.45645213976645" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="132.09202935475568" angle="3.9335883957307192" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046205b5-c766-11e1-8775-005056c00008" name="CollCrnr LD" loadType="UNDEFINED" p0="7" q0="3" node="14" p="6.9981639292319207" q="2.9986886355484503">
+            <iidm:load id="_046205b5-c766-11e1-8775-005056c00008" name="CollCrnr LD" loadType="UNDEFINED" p0="7" q0="3" node="14" p="6.9981851779716653" q="2.9987038105809125">
                 <iidm:alias>_04486334-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7363,9 +7486,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.91586427287743" angle="16.466124561143918" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.88172634856861" angle="5.2348400809567037" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0483be82-c766-11e1-8775-005056c00008" name="Caldwell LD" loadType="UNDEFINED" p0="42" q0="31" node="8" p="41.997824047184828" q="30.997323278874617">
+            <iidm:load id="_0483be82-c766-11e1-8775-005056c00008" name="Caldwell LD" loadType="UNDEFINED" p0="42" q0="31" node="8" p="41.997792445011967" q="30.997284404538267">
                 <iidm:alias>_045841b9-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7416,9 +7539,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.33148854854434" angle="8.9501092626463645" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.33146204004042" angle="-2.2833190938820835" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045f94b4-c766-11e1-8775-005056c00008" name="Franklin LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="8.0000016742422062" q="3.0000010464014517">
+            <iidm:load id="_045f94b4-c766-11e1-8775-005056c00008" name="Franklin LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="8.0000015995403757" q="3.000000999712801">
                 <iidm:alias>_047da403-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7469,9 +7592,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="124.90990945650871" angle="5.8665811636863863" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.83589380892819" angle="-4.8785551603176884" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045f6da2-c766-11e1-8775-005056c00008" name="McKinley LD" loadType="UNDEFINED" p0="60" q0="34" node="8" p="59.992309628194171" q="33.992737181388719">
+            <iidm:load id="_045f6da2-c766-11e1-8775-005056c00008" name="McKinley LD" loadType="UNDEFINED" p0="60" q0="34" node="8" p="59.992515863781136" q="33.992931943022384">
                 <iidm:alias>_0465d641-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7618,19 +7741,19 @@
                 <iidm:internalConnection node1="71" node2="18"/>
                 <iidm:internalConnection node1="72" node2="21"/>
                 <iidm:internalConnection node1="73" node2="12"/>
-                <iidm:bus v="130.68001230266412" angle="8.7172596653905572" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
+                <iidm:bus v="130.68000809467043" angle="-3.0041944547042743" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_044ca8f0-c766-11e1-8775-005056c00008" name="TwinBrch SM" energySource="THERMAL" minP="50" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="85" targetV="130.68000799999999" targetQ="0" node="24" p="-94.11484087196834" q="-90.78895296662877">
+            <iidm:generator id="_044ca8f0-c766-11e1-8775-005056c00008" name="TwinBrch SM" energySource="THERMAL" minP="50" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="85" targetV="130.68000799999999" targetQ="0" node="24" p="-94.098610086846719" q="-86.999426603187388">
                 <iidm:alias>_04633e38-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_0f6ab5a4-6b72-42f4-92bc-1993e1ae58a3"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_668eb671-5c36-4351-a95d-53ca850581db"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-60" maxQ="170"/>
             </iidm:generator>
-            <iidm:load id="_048740f1-c766-11e1-8775-005056c00008" name="TwinBrch LD" loadType="UNDEFINED" p0="47" q0="10" node="23" p="47.000002321225928" q="10.000000823129779">
+            <iidm:load id="_048740f1-c766-11e1-8775-005056c00008" name="TwinBrch LD" loadType="UNDEFINED" p0="47" q0="10" node="23" p="47.000000051073357" q="10.00000001811112">
                 <iidm:alias>_044ecbda-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:danglingLine id="_045338a1-c766-11e1-8775-005056c00008" name="12-117" p0="20" q0="8" r="5.7324960000000003" x="24.393599999999999" g="0" b="0.00020546369999999999" ucteXnodeCode="XMO_TE32" node="73" p="20.161794943471708" q="5.1797258653070095">
+            <iidm:danglingLine id="_045338a1-c766-11e1-8775-005056c00008" name="12-117" p0="20" q0="8" r="5.7324960000000003" x="24.393599999999999" g="0" b="0.00020546369999999999" ucteXnodeCode="XMO_TE32" node="73" p="20.161793645148542" q="5.1797255314080815">
                 <iidm:alias>_044afb42-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_0457f391-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_5631f3d0-d9d2-11e2-bb49-005056c00008</iidm:alias>
@@ -7728,9 +7851,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="124.10487905796739" angle="4.3247515542497483" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="124.05072326418158" angle="-6.5508284459061787" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0479fa87-c766-11e1-8775-005056c00008" name="Lincoln LD" loadType="UNDEFINED" p0="45" q0="25" node="14" p="44.993009751705408" q="24.993527883022253">
+            <iidm:load id="_0479fa87-c766-11e1-8775-005056c00008" name="Lincoln LD" loadType="UNDEFINED" p0="45" q0="25" node="14" p="44.993138158320079" q="24.993646765835937">
                 <iidm:alias>_047fc6e2-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7781,9 +7904,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="134.64614784717014" angle="15.656630565871536" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="134.64617077359625" angle="4.4241367154223568" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044c81e4-c766-11e1-8775-005056c00008" name="Hinton NegG LD" loadType="UNDEFINED" p0="42" q0="0" node="8" p="41.999979636146335" q="0">
+            <iidm:load id="_044c81e4-c766-11e1-8775-005056c00008" name="Hinton NegG LD" loadType="UNDEFINED" p0="42" q0="0" node="8" p="41.999980479401096" q="0">
                 <iidm:alias>_04494d96-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7834,9 +7957,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.25060079771407" angle="8.020404852618233" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.22335610673068" angle="-3.3534010093009186" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_048bfbe0-c766-11e1-8775-005056c00008" name="N. E. LD" loadType="UNDEFINED" p0="25" q0="10" node="8" p="24.999322711825716" q="9.9995484786279949">
+            <iidm:load id="_048bfbe0-c766-11e1-8775-005056c00008" name="N. E. LD" loadType="UNDEFINED" p0="25" q0="10" node="8" p="24.999355641190025" q="9.9995704311506781">
                 <iidm:alias>_0480b140-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7887,9 +8010,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.13866064011303" angle="-6.8906742851254172" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.13831769022744" angle="-18.084252061200424" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04854525-c766-11e1-8775-005056c00008" name="SCoshoct LD" loadType="UNDEFINED" p0="18" q0="5" node="8" p="17.999978758338923" q="4.9999901659015178">
+            <iidm:load id="_04854525-c766-11e1-8775-005056c00008" name="SCoshoct LD" loadType="UNDEFINED" p0="18" q0="5" node="8" p="17.999979191312853" q="4.9999903663522565">
                 <iidm:alias>_04747c42-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7940,9 +8063,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="124.51588977374892" angle="8.3329572462734625" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.51007808901605" angle="-2.9212562276283918" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044aad24-c766-11e1-8775-005056c00008" name="WHuntngd LD" loadType="UNDEFINED" p0="33" q0="15" node="8" p="32.944172626047433" q="14.957730389199241">
+            <iidm:load id="_044aad24-c766-11e1-8775-005056c00008" name="WHuntngd LD" loadType="UNDEFINED" p0="33" q0="15" node="8" p="32.944176458259875" q="14.957733289115382">
                 <iidm:alias>_04784cd2-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7974,9 +8097,9 @@
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="3"/>
-                <iidm:bus v="129.36000155890787" angle="9.8626492559008696" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="129.36000025663319" angle="-1.3713045816245601" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0452ea80-c766-11e1-8775-005056c00008" name="DanRiver SM" energySource="THERMAL" minP="20" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="36" targetV="129.36000000000001" targetQ="0" node="5" p="-39.860403192833651" q="-20.274212511867574">
+            <iidm:generator id="_0452ea80-c766-11e1-8775-005056c00008" name="DanRiver SM" energySource="THERMAL" minP="20" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="36" targetV="129.36000000000001" targetQ="0" node="5" p="-39.853528977958611" q="-20.276205479533683">
                 <iidm:alias>_046a4316-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_fec62959-21c5-4921-90b2-7c85e9f3bfab"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_9db08c95-4586-4a2b-87e3-5a17c944b43a"/>
@@ -8049,9 +8172,9 @@
                 <iidm:internalConnection node1="29" node2="3"/>
                 <iidm:internalConnection node1="30" node2="9"/>
                 <iidm:internalConnection node1="31" node2="6"/>
-                <iidm:bus v="129.67934539987726" angle="9.837012758572758" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
+                <iidm:bus v="129.70747663989997" angle="-1.4708746131553696" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
             </iidm:nodeBreakerTopology>
-            <iidm:danglingLine id="_044ef2e7-c766-11e1-8775-005056c00008" name="71-73" p0="6" q0="0" r="1.508918" x="7.9104960000000002" g="0" b="6.76079e-05" ucteXnodeCode="XMO_TE31" node="31" p="6.0032336130943342" q="-1.1199927788615638">
+            <iidm:danglingLine id="_044ef2e7-c766-11e1-8775-005056c00008" name="71-73" p0="6" q0="0" r="1.508918" x="7.9104960000000002" g="0" b="6.76079e-05" ucteXnodeCode="XMO_TE31" node="31" p="6.0032333630657178" q="-1.1204943660565931">
                 <iidm:alias>_04670ec2-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_046b2d7a-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_26a070b9-db0c-47cd-9991-0a461576aec2</iidm:alias>
@@ -8111,9 +8234,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="134.29662051732285" angle="2.8350173225735666" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="134.29657714726054" angle="-8.3621820443297281" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0453add4-c766-11e1-8775-005056c00008" name="Summerfl LD" loadType="UNDEFINED" p0="28" q0="7" node="8" p="27.999904228577467" q="6.9999600952861094">
+            <iidm:load id="_0453add4-c766-11e1-8775-005056c00008" name="Summerfl LD" loadType="UNDEFINED" p0="28" q0="7" node="8" p="27.999905041593177" q="6.9999604340418839">
                 <iidm:alias>_04851e16-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8240,9 +8363,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="132.66000305988609" angle="31.00354875953883" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="132.65999999921647" angle="19.781624663222015" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0489b1fa-c766-11e1-8775-005056c00008" name="ClinchRv SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="607" targetV="132.66" targetQ="0" node="20" p="-672.09068716805632" q="-46.156201454306114">
+            <iidm:generator id="_0489b1fa-c766-11e1-8775-005056c00008" name="ClinchRv SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="607" targetV="132.66" targetQ="0" node="20" p="-671.9747802672465" q="-49.205408516378938">
                 <iidm:alias>_04840caa-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_2621b09a-22e3-4630-b3bd-32c102e36741"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b0d662e5-64c9-4d59-b8e0-9b1ed175769b"/>
@@ -8297,9 +8420,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.47114924240648" angle="7.78672050794244" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.48826388459267" angle="-3.9747382460421732" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0485e168-c766-11e1-8775-005056c00008" name="Pokagon LD" loadType="UNDEFINED" p0="20" q0="9" node="8" p="19.999932778564766" q="8.9999495839800581">
+            <iidm:load id="_0485e168-c766-11e1-8775-005056c00008" name="Pokagon LD" loadType="UNDEFINED" p0="20" q0="9" node="8" p="19.999936781886003" q="8.9999525864644578">
                 <iidm:alias>_0462c902-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8350,9 +8473,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.04643448364803" angle="7.3220321096540166" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.05027239445349" angle="-4.1851595819263379" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04812679-c766-11e1-8775-005056c00008" name="GoshenJt LD" loadType="UNDEFINED" p0="14" q0="1" node="8" p="13.999518711792277" q="0.99994270444136868">
+            <iidm:load id="_04812679-c766-11e1-8775-005056c00008" name="GoshenJt LD" loadType="UNDEFINED" p0="14" q0="1" node="8" p="13.999533174127073" q="0.99994442610902567">
                 <iidm:alias>_045b9d17-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8403,9 +8526,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="118.00106781852421" angle="-11.026606659623976" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="117.94991577380534" angle="-22.154991984377656" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0489b1f2-c766-11e1-8775-005056c00008" name="S.Tiffin LD" loadType="UNDEFINED" p0="37" q0="10" node="8" p="36.988841248566764" q="9.9949740407143004">
+            <iidm:load id="_0489b1f2-c766-11e1-8775-005056c00008" name="S.Tiffin LD" loadType="UNDEFINED" p0="37" q0="10" node="8" p="36.988772712283314" q="9.9949431747410422">
                 <iidm:alias>_046476b8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8456,9 +8579,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="123.59870503578125" angle="-0.18861719237450911" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="123.51687881890874" angle="-11.172357454831475" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045cfca7-c766-11e1-8775-005056c00008" name="Haviland LD" loadType="UNDEFINED" p0="23" q0="9" node="8" p="22.995041073234301" q="8.996766149760969">
+            <iidm:load id="_045cfca7-c766-11e1-8775-005056c00008" name="Haviland LD" loadType="UNDEFINED" p0="23" q0="9" node="8" p="22.995049528375716" q="8.9967716631916801">
                 <iidm:alias>_0482ad17-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8528,9 +8651,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="131.0072148909168" angle="2.9537655951530946" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="131.00724640198464" angle="-8.2446376363539997" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04555b82-c766-11e1-8775-005056c00008" name="SWKammer LD" loadType="UNDEFINED" p0="78" q0="3" node="11" p="77.999922908431245" q="2.9999950582344006">
+            <iidm:load id="_04555b82-c766-11e1-8775-005056c00008" name="SWKammer LD" loadType="UNDEFINED" p0="78" q0="3" node="11" p="77.999924668231003" q="2.9999951710420034">
                 <iidm:alias>_0474ca6b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8638,9 +8761,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="130.38370836243627" angle="15.742564966455062" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="130.3357758473569" angle="4.5107055635239899" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04817492-c766-11e1-8775-005056c00008" name="Baileysv LD" loadType="UNDEFINED" p0="38" q0="15" node="17" p="37.997387543229458" q="14.99828131782745">
+            <iidm:load id="_04817492-c766-11e1-8775-005056c00008" name="Baileysv LD" loadType="UNDEFINED" p0="38" q0="15" node="17" p="37.997350474193794" q="14.998256931429676">
                 <iidm:alias>_0474f17b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8691,9 +8814,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.04518919393871" angle="24.210928808248067" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.04141810175335" angle="12.986976654357674" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0461b790-c766-11e1-8775-005056c00008" name="HolstonT NegG LD" loadType="UNDEFINED" p0="10" q0="0" node="8" p="9.9999242123147418" q="0">
+            <iidm:load id="_0461b790-c766-11e1-8775-005056c00008" name="HolstonT NegG LD" loadType="UNDEFINED" p0="10" q0="0" node="8" p="9.999923385247488" q="0">
                 <iidm:alias>_0464ebe7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8744,9 +8867,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.87287386145354" angle="9.6880063904051763" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.02768701080282" angle="-1.603325229225443" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044c81e5-c766-11e1-8775-005056c00008" name="WMedford LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="7.9992995350220415" q="2.9995622221662752">
+            <iidm:load id="_044c81e5-c766-11e1-8775-005056c00008" name="WMedford LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="7.9993330487010876" q="2.9995831670222457">
                 <iidm:alias>_04570939-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8836,12 +8959,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="124.66172703148504" angle="-4.5184869968951631" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="124.59534937965259" angle="-15.600681874513562" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04854520-c766-11e1-8775-005056c00008" name="Rockhill LD" loadType="UNDEFINED" p0="59" q0="26" node="14" p="58.984185225019345" q="25.988385666398152">
+            <iidm:load id="_04854520-c766-11e1-8775-005056c00008" name="Rockhill LD" loadType="UNDEFINED" p0="59" q0="26" node="14" p="58.984124284341952" q="25.988340915722596">
                 <iidm:alias>_0461b799-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0460cd38-c766-11e1-8775-005056c00008" name="Rockhill SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.81399999999999" targetDeadband="1" node="15" q="-12.479058587737409">
+            <iidm:shunt id="_0460cd38-c766-11e1-8775-005056c00008" name="Rockhill SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.81399999999999" targetDeadband="1" node="15" q="-12.46577287289127">
                 <iidm:alias>_048b86b4-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_069d84c6-bd26-4c26-ac6c-e801a0202a00"/>
                 <iidm:shuntLinearModel bPerSection="0.0001606" gPerSection="0" maximumSectionCount="10"/>
@@ -8914,12 +9037,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="128.67579700827639" angle="17.04766203796861" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="128.49941596248925" angle="5.8200758441473015" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047a48a5-c766-11e1-8775-005056c00008" name="Sprigg LD" loadType="UNDEFINED" p0="20" q0="10" node="11" p="19.997433394511983" q="9.9978612535871765">
+            <iidm:load id="_047a48a5-c766-11e1-8775-005056c00008" name="Sprigg LD" loadType="UNDEFINED" p0="20" q0="10" node="11" p="19.99736349310194" q="9.9978030074637072">
                 <iidm:alias>_0472ce97-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_04553478-c766-11e1-8775-005056c00008" name="Sprigg SC" sectionCount="5" voltageRegulatorOn="true" targetV="129.935" targetDeadband="1" node="12" q="-9.5039824623004989">
+            <iidm:shunt id="_04553478-c766-11e1-8775-005056c00008" name="Sprigg SC" sectionCount="5" voltageRegulatorOn="true" targetV="129.935" targetDeadband="1" node="12" q="-9.4779453441502852">
                 <iidm:alias>_045bc428-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_f4cdc674-4a66-4ab8-8d4f-552cb066e259"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -9011,12 +9134,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="118.46432357326326" angle="-10.093970455672792" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="118.40767124575768" angle="-21.213496299208547" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04819ba4-c766-11e1-8775-005056c00008" name="West End NegG LD" loadType="UNDEFINED" p0="46" q0="0" node="14" p="45.98574171087246" q="0">
+            <iidm:load id="_04819ba4-c766-11e1-8775-005056c00008" name="West End NegG LD" loadType="UNDEFINED" p0="46" q0="0" node="14" p="45.985655817118236" q="0">
                 <iidm:alias>_04627ae0-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_04555b89-c766-11e1-8775-005056c00008" name="West End LD" loadType="UNDEFINED" p0="20" q0="23" node="15" p="19.993800743857591" q="22.988119320085815">
+            <iidm:load id="_04555b89-c766-11e1-8775-005056c00008" name="West End LD" loadType="UNDEFINED" p0="20" q0="23" node="15" p="19.99376339874706" q="22.988047756793655">
                 <iidm:alias>_04592c18-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9067,9 +9190,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.15924361230071" angle="9.0086072947414131" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.12167207585458" angle="-1.6864442207363739" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046d0232-c766-11e1-8775-005056c00008" name="Deer Crk NegG LD" loadType="UNDEFINED" p0="6" q0="0" node="8" p="5.9994874235009101" q="0">
+            <iidm:load id="_046d0232-c766-11e1-8775-005056c00008" name="Deer Crk NegG LD" loadType="UNDEFINED" p0="6" q0="0" node="8" p="5.9995141164734491" q="0">
                 <iidm:alias>_0480150a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9139,9 +9262,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="133.92154715894858" angle="0.52922245626535847" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="133.92463054535031" angle="-10.666224886220707" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046c3ee3-c766-11e1-8775-005056c00008" name="Crooksvl LD" loadType="UNDEFINED" p0="34" q0="0" node="11" p="33.99982246541213" q="0">
+            <iidm:load id="_046c3ee3-c766-11e1-8775-005056c00008" name="Crooksvl LD" loadType="UNDEFINED" p0="34" q0="0" node="11" p="33.99982489270409" q="0">
                 <iidm:alias>_047e4047-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9192,9 +9315,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="132.05304457236403" angle="-2.7092311851433184" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="132.05285335609813" angle="-13.901592037122633" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046dc585-c766-11e1-8775-005056c00008" name="WCambrdg LD" loadType="UNDEFINED" p0="17" q0="4" node="8" p="16.999991831515967" q="3.9999967966734404">
+            <iidm:load id="_046dc585-c766-11e1-8775-005056c00008" name="WCambrdg LD" loadType="UNDEFINED" p0="17" q0="4" node="8" p="16.999992331994743" q="3.9999969929395669">
                 <iidm:alias>_045dbff8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9283,9 +9406,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="130.23718348733172" angle="9.2739684023785358" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="130.29402374494279" angle="-2.5178535853736714" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_048b5fa5-c766-11e1-8775-005056c00008" name="SouthBnd LD" loadType="UNDEFINED" p0="70" q0="23" node="14" p="69.999090094976339" q="22.999501720836516">
+            <iidm:load id="_048b5fa5-c766-11e1-8775-005056c00008" name="SouthBnd LD" loadType="UNDEFINED" p0="70" q0="23" node="14" p="69.999141041549649" q="22.999529619915478">
                 <iidm:alias>_04522734-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9335,11 +9458,11 @@
                 <iidm:internalConnection node1="19" node2="6"/>
                 <iidm:internalConnection node1="20" node2="3"/>
                 <iidm:internalConnection node1="21" node2="6"/>
-                <iidm:bus v="227.7805931467567" angle="26.310177129331038" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
+                <iidm:bus v="228.02640732112522" angle="14.014523104472374" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:line id="_044cd006-c766-11e1-8775-005056c00008" name="31-32" r="5.1923519999999996" x="17.16264" g1="0" b1="7.20271e-05" g2="0" b2="7.20271e-05" node1="31" voltageLevelId1="_04636548-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="-29.269248725757997" q1="9.9560566322965585" p2="29.581738672065345" q2="-11.266006081557755">
+    <iidm:line id="_044cd006-c766-11e1-8775-005056c00008" name="31-32" r="5.1923519999999996" x="17.16264" g1="0" b1="7.20271e-05" g2="0" b2="7.20271e-05" node1="31" voltageLevelId1="_04636548-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="-26.832635097019569" q1="8.1944735404423454" p2="27.090053884936971" q2="-9.6887405424815292">
         <iidm:alias>_04682030-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0471bd25-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9347,7 +9470,7 @@
             <iidm:temporaryLimit name="_de6da3cb-8cb5-4900-9c33-8ad45632b535" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045a3d89-c766-11e1-8775-005056c00008" name="2-12" r="3.2582879999999999" x="10.7331839" g1="0" b1="4.5110200000000001e-05" g2="0" b2="4.5110200000000001e-05" node1="21" voltageLevelId1="_045d4ac5-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-30.55075051005489" q1="-17.702964023064425" p2="30.791780660205468" q2="16.982050357993582">
+    <iidm:line id="_045a3d89-c766-11e1-8775-005056c00008" name="2-12" r="3.2582879999999999" x="10.7331839" g1="0" b1="4.5110200000000001e-05" g2="0" b2="4.5110200000000001e-05" node1="21" voltageLevelId1="_045d4ac5-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-31.492792007932067" q1="-17.19762825414773" p2="31.741959711334339" q2="16.503322311997078">
         <iidm:alias>_046adf51-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046fe868-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9355,7 +9478,7 @@
             <iidm:temporaryLimit name="_6bd63dd1-1344-4183-b7bd-af326919f4eb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04513cd7-c766-11e1-8775-005056c00008" name="32-114" r="2.3522400000000001" x="10.6634884" g1="0" b1="4.6717149999999997e-05" g2="0" b2="4.6717149999999997e-05" node1="49" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04791027-c766-11e1-8775-005056c00008" p1="6.3595673004933726" q1="4.3106626262745875" p2="-6.3499840895571396" q2="-5.7776305881993135">
+    <iidm:line id="_04513cd7-c766-11e1-8775-005056c00008" name="32-114" r="2.3522400000000001" x="10.6634884" g1="0" b1="4.6717149999999997e-05" g2="0" b2="4.6717149999999997e-05" node1="49" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04791027-c766-11e1-8775-005056c00008" p1="7.4181056367051594" q1="3.7245166080960734" p2="-7.4072398366109171" q2="-5.1889898890352049">
         <iidm:alias>_046d0237-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0470d2c7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9363,7 +9486,7 @@
             <iidm:temporaryLimit name="_5f05650a-c63d-46e5-a426-2db4f036929f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045d71d4-c766-11e1-8775-005056c00008" name="24-72" r="8.5029120000000002" x="34.151040000000002" g1="0" b1="0.00014003675" g2="0" b2="0.00014003675" node1="30" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="24.058792706706338" q1="-4.6580178537088104" p2="-23.771495583576861" q2="1.0024599417659603">
+    <iidm:line id="_045d71d4-c766-11e1-8775-005056c00008" name="24-72" r="8.5029120000000002" x="34.151040000000002" g1="0" b1="0.00014003675" g2="0" b2="0.00014003675" node1="30" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="23.398008587775706" q1="-4.3474014016902611" p2="-23.127340631686145" q2="0.61697043544852292">
         <iidm:alias>_04667281-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d0234-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9371,7 +9494,7 @@
             <iidm:temporaryLimit name="_d2074163-ab09-4251-a1d7-6983091dc4f1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045f94b8-c766-11e1-8775-005056c00008" name="17-18" r="2.1431520000000002" x="8.7991200000000003" g1="0" b1="3.7247499999999999e-05" g2="0" b2="3.7247499999999999e-05" node1="57" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04689563-c766-11e1-8775-005056c00008" p1="110.62574308086266" q1="40.888466865358232" p2="-108.83820760788363" q2="-34.75403011520519">
+    <iidm:line id="_045f94b8-c766-11e1-8775-005056c00008" name="17-18" r="2.1431520000000002" x="8.7991200000000003" g1="0" b1="3.7247499999999999e-05" g2="0" b2="3.7247499999999999e-05" node1="57" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04689563-c766-11e1-8775-005056c00008" p1="114.54973523411311" q1="40.289613053570037" p2="-112.65354112532331" q2="-33.707759118335211">
         <iidm:alias>_045e0e17-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0485ba59-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9379,7 +9502,7 @@
             <iidm:temporaryLimit name="_2b6693c7-4e29-4c2c-91d0-3485bbe8fe87" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048963d8-c766-11e1-8775-005056c00008" name="17-113" r="1.590811" x="5.244624" g1="0" b1="2.2038549999999999e-05" g2="0" b2="2.2038549999999999e-05" node1="58" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="1.2594930659001604" q1="4.6572622782339401" p2="-1.2569414433063493" q2="-5.3853982058287873">
+    <iidm:line id="_048963d8-c766-11e1-8775-005056c00008" name="17-113" r="1.590811" x="5.244624" g1="0" b1="2.2038549999999999e-05" g2="0" b2="2.2038549999999999e-05" node1="58" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="5.1859099591996145" q1="2.832579600954086" p2="-5.1823767367711397" q2="-3.5569046559566173">
         <iidm:alias>_045841b5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046958b4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9387,7 +9510,7 @@
             <iidm:temporaryLimit name="_786432da-fa4d-4751-a275-87d0e20529f1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0458ddf0-c766-11e1-8775-005056c00008" name="49-50" r="4.6522079999999999" x="13.102848099999999" g1="0" b1="5.3776400000000002e-05" g2="0" b2="5.3776400000000002e-05" node1="112" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044d1e26-c766-11e1-8775-005056c00008" p1="62.136919539862056" q1="11.700221919316604" p2="-61.114816904937307" q2="-10.7436797160767">
+    <iidm:line id="_0458ddf0-c766-11e1-8775-005056c00008" name="49-50" r="4.6522079999999999" x="13.102848099999999" g1="0" b1="5.3776400000000002e-05" g2="0" b2="5.3776400000000002e-05" node1="112" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044d1e26-c766-11e1-8775-005056c00008" p1="62.153561595970871" q1="11.69707168321305" p2="-61.130953648538586" q2="-10.739103604473616">
         <iidm:alias>_0464ebe8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f9fd8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9395,7 +9518,7 @@
             <iidm:temporaryLimit name="_1f0844a5-ea5c-42b2-abcb-6fac2c426092" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04535fb7-c766-11e1-8775-005056c00008" name="1-3" r="2.2476959999999999" x="7.3877759999999997" g1="0" b1="3.1049149999999997e-05" g2="0" b2="3.1049149999999997e-05" node1="21" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_047eb579-c766-11e1-8775-005056c00008" p1="-40.515723300463755" q1="-16.144416780986262" p2="40.779844447550509" q2="16.002635634948074">
+    <iidm:line id="_04535fb7-c766-11e1-8775-005056c00008" name="1-3" r="2.2476959999999999" x="7.3877759999999997" g1="0" b1="3.1049149999999997e-05" g2="0" b2="3.1049149999999997e-05" node1="21" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_047eb579-c766-11e1-8775-005056c00008" p1="-39.577221377176805" q1="-16.660125837896501" p2="39.83291758073905" q2="16.489794108339275">
         <iidm:alias>_044ef2e9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047c4474-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9403,7 +9526,7 @@
             <iidm:temporaryLimit name="_4ea43e34-67a3-42b8-9601-2189db7790d4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0478e912-c766-11e1-8775-005056c00008" name="92-102" r="2.1431520000000002" x="9.7400160000000007" g1="0" b1="4.2011000000000001e-05" g2="0" b2="4.2011000000000001e-05" node1="66" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="49.939749868852459" q1="-9.0387819341230546" p2="-49.617698852598302" q2="9.0707553934084864">
+    <iidm:line id="_0478e912-c766-11e1-8775-005056c00008" name="92-102" r="2.1431520000000002" x="9.7400160000000007" g1="0" b1="4.2011000000000001e-05" g2="0" b2="4.2011000000000001e-05" node1="66" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="49.976049075758496" q1="-9.0576260042581573" p2="-49.653469535313356" q2="9.0921391191746928">
         <iidm:alias>_045a1673-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0468bc79-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9411,7 +9534,7 @@
             <iidm:temporaryLimit name="_23cc194e-9273-46e9-a793-84a9c2911737" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04547127-c766-11e1-8775-005056c00008" name="93-94" r="3.8855520000000001" x="12.7543688" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="21" voltageLevelId1="_04789af0-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="57.205943584062148" q1="-22.068704860807486" p2="-56.347546862756623" q2="23.066007325427083">
+    <iidm:line id="_04547127-c766-11e1-8775-005056c00008" name="93-94" r="3.8855520000000001" x="12.7543688" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="21" voltageLevelId1="_04789af0-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="57.261348560695048" q1="-22.012012406488736" p2="-56.401833220998675" q2="23.013519466288702">
         <iidm:alias>_04500450-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047b0bfb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9419,7 +9542,7 @@
             <iidm:temporaryLimit name="_1a9fe09e-3f63-4904-8e36-aa38c5e16c59" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04791021-c766-11e1-8775-005056c00008" name="46-48" r="10.4718237" x="32.931359999999998" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044778d3-c766-11e1-8775-005056c00008" p1="-8.810707788638922" q1="-7.9449788216322457" p2="8.8753028891703885" q2="3.3051946677479545">
+    <iidm:line id="_04791021-c766-11e1-8775-005056c00008" name="46-48" r="10.4718237" x="32.931359999999998" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044778d3-c766-11e1-8775-005056c00008" p1="-8.7803532603477485" q1="-7.9554962508277303" p2="8.8447003012492384" q2="3.3149278976861298">
         <iidm:alias>_0459ef69-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04640186-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9427,7 +9550,7 @@
             <iidm:temporaryLimit name="_467ba04d-dbad-4fe1-81c8-3bc87b41fcd1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046958b6-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="113" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-92.489470649272761" q1="-2.4716501013365941" p2="93.955284161166759" q2="7.2970856685822927">
+    <iidm:line id="_046958b6-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="113" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-92.396864158787182" q1="-2.4971681711489251" p2="93.85975454129543" q2="7.3076802673118895">
         <iidm:alias>_04776270-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a96c8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9435,7 +9558,7 @@
             <iidm:temporaryLimit name="_d0737ab4-5a3a-46c8-8aeb-789313f0f332" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046f4c26-c766-11e1-8775-005056c00008" name="75-118" r="2.5264799999999998" x="8.3809430000000003" g1="0" b1="3.4377849999999998e-05" g2="0" b2="3.4377849999999998e-05" node1="48" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="38.907564242304993" q1="27.140774966010095" p2="-38.550841361308827" q2="-27.045788049258796">
+    <iidm:line id="_046f4c26-c766-11e1-8775-005056c00008" name="75-118" r="2.5264799999999998" x="8.3809430000000003" g1="0" b1="3.4377849999999998e-05" g2="0" b2="3.4377849999999998e-05" node1="48" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="38.794503195581989" q1="27.231078215601812" p2="-38.438360083181252" q2="-27.137948014713594">
         <iidm:alias>_04619088-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04814d8a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9443,7 +9566,7 @@
             <iidm:temporaryLimit name="_173dc7ff-ae18-4410-b2e1-a4c2abac8ff6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c3954-c766-11e1-8775-005056c00008" name="94-96" r="4.6870560000000001" x="15.1414566" g1="0" b1="6.60009e-05" g2="0" b2="6.60009e-05" node1="49" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="38.266766059935996" q1="-13.009924915394244" p2="-37.823400924059925" q2="12.199846268918821">
+    <iidm:line id="_045c3954-c766-11e1-8775-005056c00008" name="94-96" r="4.6870560000000001" x="15.1414566" g1="0" b1="6.60009e-05" g2="0" b2="6.60009e-05" node1="49" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="38.33171646296806" q1="-12.810003327263065" p2="-37.888123656684158" q2="12.001871595101802">
         <iidm:alias>_046ba2a0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0472ce94-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9451,7 +9574,7 @@
             <iidm:temporaryLimit name="_efde58bf-c92e-496d-b558-d0095a271083" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04518af7-c766-11e1-8775-005056c00008" name="62-67" r="4.4953919999999998" x="20.38608" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="39" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="-2.4918188776705268" q1="-18.362434635586904" p2="2.5668746334477985" q2="15.557646586907817">
+    <iidm:line id="_04518af7-c766-11e1-8775-005056c00008" name="62-67" r="4.4953919999999998" x="20.38608" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="39" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="-2.505336663399989" q1="-18.359166350798603" p2="2.5803814097997022" q2="15.554329310536719">
         <iidm:alias>_04544a10-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04814d86-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9459,7 +9582,7 @@
             <iidm:temporaryLimit name="_8a81d4ae-2bc8-4038-8650-27a6150946b1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0452c375-c766-11e1-8775-005056c00008" name="47-49" r="3.3279839999999998" x="10.890000000000001" g1="0" b1="4.6028449999999998e-05" g2="0" b2="4.6028449999999998e-05" node1="30" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="114" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="16.982803027804096" q1="-22.798446103171923" p2="-16.839695831340411" q2="21.598608499083863">
+    <iidm:line id="_0452c375-c766-11e1-8775-005056c00008" name="47-49" r="3.3279839999999998" x="10.890000000000001" g1="0" b1="4.6028449999999998e-05" g2="0" b2="4.6028449999999998e-05" node1="30" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="114" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="16.891441809267256" q1="-22.73465043948822" p2="-16.749435192926381" q2="21.531173410558424">
         <iidm:alias>_0465fd54-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0471e431-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9467,7 +9590,7 @@
             <iidm:temporaryLimit name="_8d6a074c-900d-4a37-830c-5da4c1de1ab5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046c17d9-c766-11e1-8775-005056c00008" name="100-106" r="10.54152" x="39.900959999999998" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="76" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="59.402299853269135" q1="10.058454593229836" p2="-57.235327768999376" q2="-7.9199277654933455">
+    <iidm:line id="_046c17d9-c766-11e1-8775-005056c00008" name="100-106" r="10.54152" x="39.900959999999998" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="76" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="59.404251662038156" q1="10.058293914393273" p2="-57.237146422390829" q2="-7.9192618415231255">
         <iidm:alias>_045d98e5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0480d851-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9475,7 +9598,7 @@
             <iidm:temporaryLimit name="_3154dc30-b0e5-4570-8e52-9333bae20ef2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046b2d77-c766-11e1-8775-005056c00008" name="77-78" r="0.655142" x="2.1605759999999998" g1="0" b1="3.6271800000000001e-05" g2="0" b2="3.6271800000000001e-05" node1="66" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044fb634-c766-11e1-8775-005056c00008" p1="43.73113755522342" q1="3.446280639744427" p2="-43.658894543274194" q2="-4.4744049116711304">
+    <iidm:line id="_046b2d77-c766-11e1-8775-005056c00008" name="77-78" r="0.655142" x="2.1605759999999998" g1="0" b1="3.6271800000000001e-05" g2="0" b2="3.6271800000000001e-05" node1="66" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044fb634-c766-11e1-8775-005056c00008" p1="43.645639306613539" q1="3.3413917298323632" p2="-43.573687290822086" q2="-4.3701349762227988">
         <iidm:alias>_046ed6fb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04893cc3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9483,7 +9606,7 @@
             <iidm:temporaryLimit name="_cce754c5-b9d5-4105-a431-32da96e4a6cf" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c8776-c766-11e1-8775-005056c00008" name="6-7" r="0.79976199999999997" x="3.6241919999999999" g1="0" b1="1.5782850000000001e-05" g2="0" b2="1.5782850000000001e-05" node1="21" voltageLevelId1="_044f6818-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047eb571-c766-11e1-8775-005056c00008" p1="42.720849945617964" q1="-7.9547446404858446" p2="-42.63245360174929" q2="7.8174052280379991">
+    <iidm:line id="_045c8776-c766-11e1-8775-005056c00008" name="6-7" r="0.79976199999999997" x="3.6241919999999999" g1="0" b1="1.5782850000000001e-05" g2="0" b2="1.5782850000000001e-05" node1="21" voltageLevelId1="_044f6818-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047eb571-c766-11e1-8775-005056c00008" p1="38.546064240896776" q1="-6.0425145251802999" p2="-38.474872367448796" q2="5.8267283585212644">
         <iidm:alias>_046efe08-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04720b4a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9491,7 +9614,7 @@
             <iidm:temporaryLimit name="_361a9cc3-fb33-4037-9b9a-c20adb90b66b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047ba839-c766-11e1-8775-005056c00008" name="77-80" r="5.1226560000000001" x="18.295200000000001" g1="0" b1="6.5426999999999995e-05" g2="0" b2="6.5426999999999995e-05" node1="67" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="76" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-46.111682096596901" q1="-23.694446501372049" p2="46.883213578313331" q2="24.072318838589496">
+    <iidm:line id="_047ba839-c766-11e1-8775-005056c00008" name="77-80" r="5.1226560000000001" x="18.295200000000001" g1="0" b1="6.5426999999999995e-05" g2="0" b2="6.5426999999999995e-05" node1="67" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="76" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-46.200824051485348" q1="-23.7975469257503" p2="46.97635487801309" q2="24.190028274251524">
         <iidm:alias>_047c6b85-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0480b148-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9499,7 +9622,7 @@
             <iidm:temporaryLimit name="_da00c66f-a882-4938-923b-f2455f7f9a81" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04592c16-c766-11e1-8775-005056c00008" name="78-79" r="0.95135000000000003" x="4.2514560000000001" g1="0" b1="1.8595050000000001e-05" g2="0" b2="1.8595050000000001e-05" node1="22" voltageLevelId1="_044fb634-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04481510-c766-11e1-8775-005056c00008" p1="-27.324079950646368" q1="-21.515197796438066" p2="27.389380589697907" q2="21.154842182717477">
+    <iidm:line id="_04592c16-c766-11e1-8775-005056c00008" name="78-79" r="0.95135000000000003" x="4.2514560000000001" g1="0" b1="1.8595050000000001e-05" g2="0" b2="1.8595050000000001e-05" node1="22" voltageLevelId1="_044fb634-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04481510-c766-11e1-8775-005056c00008" p1="-27.409274246052252" q1="-21.619446950226099" p2="27.475088315425566" q2="21.261530263517564">
         <iidm:alias>_0453add6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045b7605-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9507,7 +9630,7 @@
             <iidm:temporaryLimit name="_ba4abe9d-8490-4c19-b19b-c9d2c3597fc9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047b3301-c766-11e1-8775-005056c00008" name="103-104" r="8.1195839999999997" x="27.599615100000001" g1="0" b1="0.00011679295" g2="0" b2="0.00011679295" node1="40" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="33.048769521966811" q1="13.983474025948034" p2="-32.432008212605076" q2="-15.879951186379209">
+    <iidm:line id="_047b3301-c766-11e1-8775-005056c00008" name="103-104" r="8.1195839999999997" x="27.599615100000001" g1="0" b1="0.00011679295" g2="0" b2="0.00011679295" node1="40" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="33.048209860820748" q1="13.983683598415055" p2="-32.431462369866829" q2="-15.880207238680969">
         <iidm:alias>_0459a142-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045d98e6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9515,7 +9638,7 @@
             <iidm:temporaryLimit name="_2320da74-eda7-4f7f-ade9-1ed0e994f3af" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045e5c32-c766-11e1-8775-005056c00008" name="95-96" r="2.9795039999999999" x="9.5309279999999994" g1="0" b1="4.2298000000000001e-05" g2="0" b2="4.2298000000000001e-05" node1="21" voltageLevelId1="_044f4108-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="14.673960997448503" q1="-25.003768862244886" p2="-14.529487639971622" q2="24.043889224828778">
+    <iidm:line id="_045e5c32-c766-11e1-8775-005056c00008" name="95-96" r="2.9795039999999999" x="9.5309279999999994" g1="0" b1="4.2298000000000001e-05" g2="0" b2="4.2298000000000001e-05" node1="21" voltageLevelId1="_044f4108-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="14.731899584339688" q1="-24.829580016938031" p2="-14.588553970898266" q2="23.866993764137394">
         <iidm:alias>_04597a34-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04801509-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9523,7 +9646,7 @@
             <iidm:temporaryLimit name="_3bc03415-e95f-47a7-8e92-01089d304a9c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045ed169-c766-11e1-8775-005056c00008" name="77-80" r="2.9620799999999998" x="8.4506409999999992" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="68" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="77" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-100.69777083579919" q1="-43.844885727770766" p2="102.70595768389741" q2="44.652082614308632">
+    <iidm:line id="_045ed169-c766-11e1-8775-005056c00008" name="77-80" r="2.9620799999999998" x="8.4506409999999992" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="68" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="77" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-100.90057208687841" q1="-44.051075268582494" p2="102.91916866139927" q2="44.888644621321639">
         <iidm:alias>_0464289a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04828605-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9531,7 +9654,7 @@
             <iidm:temporaryLimit name="_f93b6d4c-39fa-4f6f-a42d-c63a4cf21a67" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047f78c2-c766-11e1-8775-005056c00008" name="5-11" r="3.5370720000000002" x="11.8831682" g1="0" b1="4.987375e-05" g2="0" b2="4.987375e-05" node1="48" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="88.066743006395029" q1="8.5287063092273865" p2="-86.502743974609601" q2="-5.0050145650150411">
+    <iidm:line id="_047f78c2-c766-11e1-8775-005056c00008" name="5-11" r="3.5370720000000002" x="11.8831682" g1="0" b1="4.987375e-05" g2="0" b2="4.987375e-05" node1="48" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="83.028030965836436" q1="10.519338415312813" p2="-81.630304107117894" q2="-7.5566769734075585">
         <iidm:alias>_045bc426-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0476c633-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9539,7 +9662,7 @@
             <iidm:temporaryLimit name="_3bc4ab96-7a0d-4e18-b9f5-d89f63a82f0a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04845ac7-c766-11e1-8775-005056c00008" name="71-72" r="7.7711040000000002" x="31.363201100000001" g1="0" b1="0.00012752525" g2="0" b2="0.00012752525" node1="29" voltageLevelId1="_04664b78-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="-11.719352050420937" q1="-3.0606005552570141" p2="11.783206867452447" q2="-1.002455137744426">
+    <iidm:line id="_04845ac7-c766-11e1-8775-005056c00008" name="71-72" r="7.7711040000000002" x="31.363201100000001" g1="0" b1="0.00012752525" g2="0" b2="0.00012752525" node1="29" voltageLevelId1="_04664b78-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="-11.081486706948859" q1="-3.4753864854946164" p2="11.139025282806815" q2="-0.61695986802569902">
         <iidm:alias>_04642891-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046b0661-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9547,7 +9670,7 @@
             <iidm:temporaryLimit name="_bcb69c6e-125e-449c-acb3-a4deb151668d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047343c2-c766-11e1-8775-005056c00008" name="66-67" r="3.9029759999999998" x="17.685359999999999" g1="0" b1="7.6962800000000001e-05" g2="0" b2="7.6962800000000001e-05" node1="50" voltageLevelId1="_047147f4-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="30.865952774583967" q1="21.059173732065155" p2="-30.566778861811638" q2="-22.557606685176356">
+    <iidm:line id="_047343c2-c766-11e1-8775-005056c00008" name="66-67" r="3.9029759999999998" x="17.685359999999999" g1="0" b1="7.6962800000000001e-05" g2="0" b2="7.6962800000000001e-05" node1="50" voltageLevelId1="_047147f4-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="30.879609205238616" q1="21.056531563480853" p2="-30.58028673780937" q2="-22.554289633844185">
         <iidm:alias>_0465af34-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04860874-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9555,7 +9678,7 @@
             <iidm:temporaryLimit name="_b4b8a31d-dc3c-4b51-88ad-a22e070eb96c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04569409-c766-11e1-8775-005056c00008" name="34-43" r="7.1961120000000003" x="29.289743399999999" g1="0" b1="0.0001212695" g2="0" b2="0.0001212695" node1="40" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_045e8349-c766-11e1-8775-005056c00008" p1="12.587086860240907" q1="-7.5903282193971728" p2="-12.498648105647749" q2="4.1611846539392987">
+    <iidm:line id="_04569409-c766-11e1-8775-005056c00008" name="34-43" r="7.1961120000000003" x="29.289743399999999" g1="0" b1="0.0001212695" g2="0" b2="0.0001212695" node1="40" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_045e8349-c766-11e1-8775-005056c00008" p1="12.846788713386925" q1="-7.7234417712841061" p2="-12.754470652497121" q2="4.3135345780726295">
         <iidm:alias>_04500454-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04505274-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9563,7 +9686,7 @@
             <iidm:temporaryLimit name="_5585c67a-0839-48e6-8847-4393e1e9b9c7" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04817498-c766-11e1-8775-005056c00008" name="52-53" r="7.0567200000000003" x="28.488240000000001" g1="0" b1="0.00011644859999999999" g2="0" b2="0.00011644859999999999" node1="21" voltageLevelId1="_04806326-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04876804-c766-11e1-8775-005056c00008" p1="13.382649693196644" q1="0.95764172286413529" p2="-13.299715427379343" q2="-4.2889891784222351">
+    <iidm:line id="_04817498-c766-11e1-8775-005056c00008" name="52-53" r="7.0567200000000003" x="28.488240000000001" g1="0" b1="0.00011644859999999999" g2="0" b2="0.00011644859999999999" node1="21" voltageLevelId1="_04806326-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04876804-c766-11e1-8775-005056c00008" p1="13.388774716300478" q1="0.95552756582421228" p2="-13.305772567411134" q2="-4.2865858174357108">
         <iidm:alias>_045115c7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0472a784-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9571,7 +9694,7 @@
             <iidm:temporaryLimit name="_e7c9dfab-fb45-4470-964f-4ba9e391f60b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044b7078-c766-11e1-8775-005056c00008" name="105-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="49" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="23" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="26.894108305388247" q1="1.3281358925300004" p2="-26.475651350669864" q2="-4.1906289470725691">
+    <iidm:line id="_044b7078-c766-11e1-8775-005056c00008" name="105-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="49" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="23" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="26.893877605211276" q1="1.3282179235391336" p2="-26.47542728900553" q2="-4.1907326984443678">
         <iidm:alias>_0452c378-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0481c2b7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9579,7 +9702,7 @@
             <iidm:temporaryLimit name="_fff133bf-25fd-46b2-b144-a227c31ee882" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048ac367-c766-11e1-8775-005056c00008" name="100-101" r="4.8264480000000001" x="21.9890881" g1="0" b1="9.4123049999999997e-05" g2="0" b2="9.4123049999999997e-05" node1="77" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046ed6f7-c766-11e1-8775-005056c00008" p1="-21.774116295617333" q1="24.728345260506366" p2="22.088096900580172" q2="-26.603836147581987">
+    <iidm:line id="_048ac367-c766-11e1-8775-005056c00008" name="100-101" r="4.8264480000000001" x="21.9890881" g1="0" b1="9.4123049999999997e-05" g2="0" b2="9.4123049999999997e-05" node1="77" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046ed6f7-c766-11e1-8775-005056c00008" p1="-21.808102612764092" q1="24.758148218187998" p2="22.122901974755205" q2="-26.629824477050484">
         <iidm:alias>_044afb45-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b5fa2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9587,7 +9710,7 @@
             <iidm:temporaryLimit name="_217e3c95-24b5-438f-a721-d2257e1a43b4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0481c2b1-c766-11e1-8775-005056c00008" name="56-57" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="57" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="-30.794918568267494" q1="-5.4777282802575549" p2="31.159653649177876" q2="4.2660072514304268">
+    <iidm:line id="_0481c2b1-c766-11e1-8775-005056c00008" name="56-57" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="57" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="-30.81008527946296" q1="-5.4704016359530749" p2="31.175148623866722" q2="4.2596094972702971">
         <iidm:alias>_045e0e12-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0487dd35-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9595,7 +9718,7 @@
             <iidm:temporaryLimit name="_f5547027-3d48-4a53-937b-bd5ba63ef70d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047a6fb7-c766-11e1-8775-005056c00008" name="47-69" r="14.705855400000001" x="48.403869999999998" g1="0" b1="0.00020351240000000001" g2="0" b2="0.00020351240000000001" node1="31" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="57" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-83.83603695191789" q1="25.92902173994327" p2="90.316458952915156" q2="-12.047467323212254">
+    <iidm:line id="_047a6fb7-c766-11e1-8775-005056c00008" name="47-69" r="14.705855400000001" x="48.403869999999998" g1="0" b1="0.00020351240000000001" g2="0" b2="0.00020351240000000001" node1="31" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="57" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-83.642093393415635" q1="25.820610155724399" p2="90.090344351334267" q2="-12.04511419474151">
         <iidm:alias>_04758db9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0485ba56-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9603,7 +9726,7 @@
             <iidm:temporaryLimit name="_e9fec217-cf6f-4d39-9495-26ed10c05100" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0453fbf0-c766-11e1-8775-005056c00008" name="110-111" r="3.8332799999999998" x="13.1551189" g1="0" b1="5.7392100000000002e-05" g2="0" b2="5.7392100000000002e-05" node1="40" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_046a1c00-c766-11e1-8775-005056c00008" p1="-39.393154291620938" q1="-20.543207150284243" p2="39.86040476366616" q2="20.274215120927714">
+    <iidm:line id="_0453fbf0-c766-11e1-8775-005056c00008" name="110-111" r="3.8332799999999998" x="13.1551189" g1="0" b1="5.7392100000000002e-05" g2="0" b2="5.7392100000000002e-05" node1="40" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_046a1c00-c766-11e1-8775-005056c00008" p1="-39.38638460448842" q1="-20.545560831419813" p2="39.853528887553111" q2="20.276204696837848">
         <iidm:alias>_0447c6f5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04812675-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9611,7 +9734,7 @@
             <iidm:temporaryLimit name="_ea48fee0-31b6-4990-a332-25d08b7d731f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04778984-c766-11e1-8775-005056c00008" name="41-42" r="7.14384" x="23.522401800000001" g1="0" b1="9.8714400000000005e-05" g2="0" b2="9.8714400000000005e-05" node1="21" voltageLevelId1="_048c4a08-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="-10.655798992613867" q1="-11.123225764505301" p2="10.762812658754161" q2="8.6653439454731149">
+    <iidm:line id="_04778984-c766-11e1-8775-005056c00008" name="41-42" r="7.14384" x="23.522401800000001" g1="0" b1="9.8714400000000005e-05" g2="0" b2="9.8714400000000005e-05" node1="21" voltageLevelId1="_048c4a08-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="-10.467198306683468" q1="-11.262957559566967" p2="10.573680239119351" q2="8.805323747600486">
         <iidm:alias>_044d1e2a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046512f1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9619,7 +9742,7 @@
             <iidm:temporaryLimit name="_063af52c-fe10-4c1e-85d4-dd80dcc1d2f9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04653a08-c766-11e1-8775-005056c00008" name="80-99" r="7.9104960000000002" x="35.893439999999998" g1="0" b1="0.00015668044999999999" g2="0" b2="0.00015668044999999999" node1="78" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04644fa4-c766-11e1-8775-005056c00008" p1="1.9988762661792072" q1="6.6802920859016135" p2="-1.9582482375782133" q2="-12.289264377677304">
+    <iidm:line id="_04653a08-c766-11e1-8775-005056c00008" name="80-99" r="7.9104960000000002" x="35.893439999999998" g1="0" b1="0.00015668044999999999" g2="0" b2="0.00015668044999999999" node1="78" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04644fa4-c766-11e1-8775-005056c00008" p1="2.0067151655394908" q1="6.6784916700606418" p2="-1.9660885166064199" q2="-12.287471376708913">
         <iidm:alias>_04773b69-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0477b092-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9627,7 +9750,7 @@
             <iidm:temporaryLimit name="_c05229ce-6abb-4209-ad4f-0dcd4a070f28" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04581aa5-c766-11e1-8775-005056c00008" name="54-59" r="8.7642720000000001" x="39.953229999999998" g1="0" b1="0.0001716024" g2="0" b2="0.0001716024" node1="58" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-19.663249079301178" q1="-10.51500746920096" p2="19.909942376133248" q2="6.0116674162919788">
+    <iidm:line id="_04581aa5-c766-11e1-8775-005056c00008" name="54-59" r="8.7642720000000001" x="39.953229999999998" g1="0" b1="0.0001716024" g2="0" b2="0.0001716024" node1="58" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-19.647592874355531" q1="-10.51916609835887" p2="19.893982460651223" q2="6.0144414096325001">
         <iidm:alias>_0457cc82-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045cae81-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9635,7 +9758,7 @@
             <iidm:temporaryLimit name="_ac528cbe-6fc1-41dd-ba9d-d8b7a4c77576" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04690a93-c766-11e1-8775-005056c00008" name="92-94" r="8.3809430000000003" x="27.529920000000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="67" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="65.122136583034333" q1="-16.387174358044049" p2="-62.936565904507724" q2="19.601413879203893">
+    <iidm:line id="_04690a93-c766-11e1-8775-005056c00008" name="92-94" r="8.3809430000000003" x="27.529920000000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="67" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="65.179184634419158" q1="-16.324484978838463" p2="-62.990618469032967" q2="19.549451332493121">
         <iidm:alias>_044c33c1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0483706b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9643,7 +9766,7 @@
             <iidm:temporaryLimit name="_6ac84228-6b04-4b10-b560-29655c8e93b4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046009e3-c766-11e1-8775-005056c00008" name="37-39" r="5.5931040000000003" x="18.469439999999999" g1="0" b1="7.7479350000000006e-05" g2="0" b2="7.7479350000000006e-05" node1="57" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046bf0c7-c766-11e1-8775-005056c00008" p1="66.79928435213354" q1="18.13131747976313" p2="-65.076944434637994" q2="-14.773233489650291">
+    <iidm:line id="_046009e3-c766-11e1-8775-005056c00008" name="37-39" r="5.5931040000000003" x="18.469439999999999" g1="0" b1="7.7479350000000006e-05" g2="0" b2="7.7479350000000006e-05" node1="57" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046bf0c7-c766-11e1-8775-005056c00008" p1="67.009792132691643" q1="18.051737859061003" p2="-65.276756245137776" q2="-14.655943050262451">
         <iidm:alias>_044c33c9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04789afa-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9651,7 +9774,7 @@
             <iidm:temporaryLimit name="_2ccdc288-c132-40d1-a928-3887bec4ff67" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0458b6e8-c766-11e1-8775-005056c00008" name="46-47" r="6.6211200000000003" x="22.12848" g1="0" b1="9.0679499999999998e-05" g2="0" b2="9.0679499999999998e-05" node1="33" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_0457f396-c766-11e1-8775-005056c00008" p1="-32.454109918896016" q1="1.2429092304851885" p2="32.853411463154799" q2="-3.1305756327573238">
+    <iidm:line id="_0458b6e8-c766-11e1-8775-005056c00008" name="46-47" r="6.6211200000000003" x="22.12848" g1="0" b1="9.0679499999999998e-05" g2="0" b2="9.0679499999999998e-05" node1="33" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_0457f396-c766-11e1-8775-005056c00008" p1="-32.354076424490721" q1="1.1896901629114636" p2="32.750826253647844" q2="-3.085959631522019">
         <iidm:alias>_04507980-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0464c4da-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9659,7 +9782,7 @@
             <iidm:temporaryLimit name="_06ca3245-2668-448f-a5c6-961924217a5c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044f8f22-c766-11e1-8775-005056c00008" name="82-83" r="1.9514879999999999" x="6.3858959999999998" g1="0" b1="0.0001089302" g2="0" b2="0.0001089302" node1="31" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728074-c766-11e1-8775-005056c00008" p1="-66.687900153277099" q1="38.00172422935232" p2="67.389204401696603" q2="-39.339362135566567">
+    <iidm:line id="_044f8f22-c766-11e1-8775-005056c00008" name="82-83" r="1.9514879999999999" x="6.3858959999999998" g1="0" b1="0.0001089302" g2="0" b2="0.0001089302" node1="31" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728074-c766-11e1-8775-005056c00008" p1="-66.296338429384377" q1="39.335983459744917" p2="67.005263304717744" q2="-40.640801576882026">
         <iidm:alias>_047a48a6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b3891-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9667,7 +9790,7 @@
             <iidm:temporaryLimit name="_dfbd2f07-76ab-41e3-910f-dc706979ea4b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045cfca6-c766-11e1-8775-005056c00008" name="108-109" r="1.82952" x="5.0181120000000004" g1="0" b1="2.1809000000000001e-05" g2="0" b2="2.1809000000000001e-05" node1="21" voltageLevelId1="_046c65f4-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b7b99-c766-11e1-8775-005056c00008" p1="20.785299052393803" q1="-0.53141282642152898" p2="-20.735996972000212" q2="-0.031088525397277023">
+    <iidm:line id="_045cfca6-c766-11e1-8775-005056c00008" name="108-109" r="1.82952" x="5.0181120000000004" g1="0" b1="2.1809000000000001e-05" g2="0" b2="2.1809000000000001e-05" node1="21" voltageLevelId1="_046c65f4-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b7b99-c766-11e1-8775-005056c00008" p1="20.788650223753269" q1="-0.53260030610553011" p2="-20.739332175810972" q2="-0.029856958913921511">
         <iidm:alias>_04481514-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04716f00-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9675,7 +9798,7 @@
             <iidm:temporaryLimit name="_11451cec-81c7-4f83-a7db-df7dcaffa94e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04784cd5-c766-11e1-8775-005056c00008" name="70-74" r="6.9870239999999999" x="23.051952400000001" g1="0" b1="9.6648299999999994e-05" g2="0" b2="9.6648299999999994e-05" node1="48" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047dcb11-c766-11e1-8775-005056c00008" p1="23.15061918822726" q1="12.592639408936328" p2="-22.842675105447654" q2="-14.720774313742115">
+    <iidm:line id="_04784cd5-c766-11e1-8775-005056c00008" name="70-74" r="6.9870239999999999" x="23.051952400000001" g1="0" b1="9.6648299999999994e-05" g2="0" b2="9.6648299999999994e-05" node1="48" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047dcb11-c766-11e1-8775-005056c00008" p1="22.881601617788711" q1="12.743561601944014" p2="-22.577095888241004" q2="-14.883496531801285">
         <iidm:alias>_045e5c33-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046ab84b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9683,7 +9806,7 @@
             <iidm:temporaryLimit name="_37a5cc00-bd7f-4ec7-a77c-e140e23450d2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04747c40-c766-11e1-8775-005056c00008" name="77-82" r="5.1923519999999996" x="14.8626719" g1="0" b1="0.0002345615" g2="0" b2="0.0002345615" node1="69" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_046512f8-c766-11e1-8775-005056c00008" p1="-27.704940775569774" q1="30.186327547957383" p2="28.281744852059017" q2="-36.576924799607681">
+    <iidm:line id="_04747c40-c766-11e1-8775-005056c00008" name="77-82" r="5.1923519999999996" x="14.8626719" g1="0" b1="0.0002345615" g2="0" b2="0.0002345615" node1="69" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_046512f8-c766-11e1-8775-005056c00008" p1="-27.50132130790066" q1="30.874918980117311" p2="28.089088973961225" q2="-37.226632205592615">
         <iidm:alias>_0451b202-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0452ea84-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9691,7 +9814,7 @@
             <iidm:temporaryLimit name="_e9798d58-b518-4fab-984c-c72076dfc2ae" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045e3524-c766-11e1-8775-005056c00008" name="23-24" r="2.3522400000000001" x="8.5726080000000007" g1="0" b1="0.00014290635" g2="0" b2="0.00014290635" node1="39" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_048c22fa-c766-11e1-8775-005056c00008" p1="54.533563136550221" q1="-8.8918484695848896" p2="-54.126278710690023" q2="5.4185048375131313">
+    <iidm:line id="_045e3524-c766-11e1-8775-005056c00008" name="23-24" r="2.3522400000000001" x="8.5726080000000007" g1="0" b1="0.00014290635" g2="0" b2="0.00014290635" node1="39" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_048c22fa-c766-11e1-8775-005056c00008" p1="53.109657537439389" q1="-8.5108727094889076" p2="-52.724520703004927" q2="4.9466486024887972">
         <iidm:alias>_046cb413-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f9fd3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9699,7 +9822,7 @@
             <iidm:temporaryLimit name="_e8ec73b8-1ecf-4d18-9ef9-80eabf3a4969" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0474f177-c766-11e1-8775-005056c00008" name="15-17" r="2.2999679999999998" x="7.6142880000000002" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="48" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-150.92558854626651" q1="-19.131690576939057" p2="154.30754777487937" q2="26.196181227981864">
+    <iidm:line id="_0474f177-c766-11e1-8775-005056c00008" name="15-17" r="2.2999679999999998" x="7.6142880000000002" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="48" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-159.95869796643737" q1="-15.595034064740453" p2="163.74000990834796" q2="23.985631937113151">
         <iidm:alias>_044c5ad2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046931a7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9707,7 +9830,7 @@
             <iidm:temporaryLimit name="_2ceac3d1-f73d-43db-8d37-9e329f1787bb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0483be84-c766-11e1-8775-005056c00008" name="8-30" r="2.0860400000000001" x="24.393599999999999" g1="0" b1="0.00053099175999999997" g2="0" b2="0.00053099175999999997" node1="30" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="38" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="87.767459204906885" q1="26.556430745648559" p2="-87.320859437748538" q2="-71.729709687595928">
+    <iidm:line id="_0483be84-c766-11e1-8775-005056c00008" name="8-30" r="2.0860400000000001" x="24.393599999999999" g1="0" b1="0.00053099175999999997" g2="0" b2="0.00053099175999999997" node1="30" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="38" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="103.74973084410293" q1="20.949792029155521" p2="-103.19808635698102" q2="-65.233350884757186">
         <iidm:alias>_0454e651-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04801506-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9715,7 +9838,7 @@
             <iidm:temporaryLimit name="_ca795ad3-97e5-4416-aaba-53cce27f6434" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0488eea6-c766-11e1-8775-005056c00008" name="49-69" r="17.16264" x="56.453762099999999" g1="0" b1="0.00023760329999999999" g2="0" b2="0.00023760329999999999" node1="115" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-75.496591616772193" q1="26.642106677500749" p2="81.740795914187927" q2="-14.887253169701456">
+    <iidm:line id="_0488eea6-c766-11e1-8775-005056c00008" name="49-69" r="17.16264" x="56.453762099999999" g1="0" b1="0.00023760329999999999" g2="0" b2="0.00023760329999999999" node1="115" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-75.312653528349927" q1="26.527508101027941" p2="81.52420348612182" q2="-14.880066461437677">
         <iidm:alias>_04492681-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046735d6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9723,7 +9846,7 @@
             <iidm:temporaryLimit name="_c42dc3ef-3a2e-4070-8efb-78e5c0cd5554" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047566a0-c766-11e1-8775-005056c00008" name="13-15" r="12.9634562" x="42.584255200000001" g1="0" b1="0.00017986685000000001" g2="0" b2="0.00017986685000000001" node1="21" voltageLevelId1="_04851e1b-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="15.046463506460366" q1="-1.2033753376109606" p2="-14.862938920438653" q2="-3.9295164022504929">
+    <iidm:line id="_047566a0-c766-11e1-8775-005056c00008" name="13-15" r="12.9634562" x="42.584255200000001" g1="0" b1="0.00017986685000000001" g2="0" b2="0.00017986685000000001" node1="21" voltageLevelId1="_04851e1b-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="10.926490462382485" q1="0.24285244816458304" p2="-10.82304646414434" q2="-5.6385603966692557">
         <iidm:alias>_04662461-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04865694-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9731,7 +9854,7 @@
             <iidm:temporaryLimit name="_ad988fd9-9270-4230-95a2-1858f32259df" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0476c63a-c766-11e1-8775-005056c00008" name="69-70" r="5.2271999999999998" x="22.12848" g1="0" b1="0.00035009184999999998" g2="0" b2="0.00035009184999999998" node1="59" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="76.664624486049874" q1="23.024874926011087" p2="-74.773923765995121" q2="-27.416736191573559">
+    <iidm:line id="_0476c63a-c766-11e1-8775-005056c00008" name="69-70" r="5.2271999999999998" x="22.12848" g1="0" b1="0.00035009184999999998" g2="0" b2="0.00035009184999999998" node1="59" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="77.469593905079137" q1="22.81167879548277" p2="-75.547663260653522" q2="-27.072773117866017">
         <iidm:alias>_047e193a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b1184-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9739,7 +9862,7 @@
             <iidm:temporaryLimit name="_519e3ecb-3561-4d11-ac6b-172a0b4b09b2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04520028-c766-11e1-8775-005056c00008" name="19-20" r="4.3908480000000001" x="20.38608" g1="0" b1="8.5514249999999999e-05" g2="0" b2="8.5514249999999999e-05" node1="39" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b2d70-c766-11e1-8775-005056c00008" p1="-14.774348263045098" q1="2.3436622013007136" p2="14.840396906736578" q2="-4.6700830821729706">
+    <iidm:line id="_04520028-c766-11e1-8775-005056c00008" name="19-20" r="4.3908480000000001" x="20.38608" g1="0" b1="8.5514249999999999e-05" g2="0" b2="8.5514249999999999e-05" node1="39" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b2d70-c766-11e1-8775-005056c00008" p1="-12.811604774419857" q1="1.2845978192789502" p2="12.860367945471301" q2="-3.6910504196008684">
         <iidm:alias>_0472f5a9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04745537-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9747,7 +9870,7 @@
             <iidm:temporaryLimit name="_b88528bf-cb1c-4c00-ad79-d5937197d40c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04862f83-c766-11e1-8775-005056c00008" name="94-95" r="2.2999679999999998" x="7.5620159999999998" g1="0" b1="3.1852600000000001e-05" g2="0" b2="3.1852600000000001e-05" node1="51" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f4108-c766-11e1-8775-005056c00008" p1="57.120386846003882" q1="6.3984447580728627" p2="-56.671784452383157" q2="-5.9935542949769705">
+    <iidm:line id="_04862f83-c766-11e1-8775-005056c00008" name="94-95" r="2.2999679999999998" x="7.5620159999999998" g1="0" b1="3.1852600000000001e-05" g2="0" b2="3.1852600000000001e-05" node1="51" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f4108-c766-11e1-8775-005056c00008" p1="57.17971023681978" q1="6.5777130962887647" p2="-56.729692722593185" q2="-6.1677029779091121">
         <iidm:alias>_044ca8f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04837060-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9755,7 +9878,7 @@
             <iidm:temporaryLimit name="_b70e76a1-6e79-4fb6-b487-dffa9bfeab7b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047b0bf6-c766-11e1-8775-005056c00008" name="12-16" r="3.6938879999999998" x="14.5316162" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="68" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046f7338-c766-11e1-8775-005056c00008" p1="16.368096831856814" q1="7.7309656485516145" p2="-16.293472402663827" q2="-9.5119937656841103">
+    <iidm:line id="_047b0bf6-c766-11e1-8775-005056c00008" name="12-16" r="3.6938879999999998" x="14.5316162" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="68" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046f7338-c766-11e1-8775-005056c00008" p1="9.7856105946421934" q1="9.5847961837602647" p2="-9.7404398336918607" q2="-11.481261405660081">
         <iidm:alias>_0450798a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045c8772-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9763,7 +9886,7 @@
             <iidm:temporaryLimit name="_af73f526-c58b-40e7-8e1c-14f05a39f6a2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04524e47-c766-11e1-8775-005056c00008" name="100-103" r="2.7878400000000001" x="9.1476000000000006" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="78" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0475b4c0-c766-11e1-8775-005056c00008" p1="115.38268522325161" q1="-20.641622586440008" p2="-113.27379790275027" q2="22.055646811937731">
+    <iidm:line id="_04524e47-c766-11e1-8775-005056c00008" name="100-103" r="2.7878400000000001" x="9.1476000000000006" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="78" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0475b4c0-c766-11e1-8775-005056c00008" p1="115.39366006118949" q1="-20.644233859618822" p2="-113.28436649199098" q2="22.059591123078867">
         <iidm:alias>_04684744-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048aea71-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9771,7 +9894,7 @@
             <iidm:temporaryLimit name="_1631e50b-21a3-470b-803b-f9665b6fcd60" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04682038-c766-11e1-8775-005056c00008" name="27-32" r="3.9900959999999999" x="13.1551189" g1="0" b1="5.5268600000000001e-05" g2="0" b2="5.5268600000000001e-05" node1="40" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="17.932700051658383" q1="-3.4018169456009391" p2="-17.852487429536872" q2="1.8677197127110448">
+    <iidm:line id="_04682038-c766-11e1-8775-005056c00008" name="27-32" r="3.9900959999999999" x="13.1551189" g1="0" b1="5.5268600000000001e-05" g2="0" b2="5.5268600000000001e-05" node1="40" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="15.990614824133182" q1="-2.1854147382127995" p2="-15.927839140083922" q2="0.5893572008477147">
         <iidm:alias>_0455347a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479ac63-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9779,7 +9902,7 @@
             <iidm:temporaryLimit name="_52eb4b09-42bb-4106-ac26-fe1059639d3a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0482fb31-c766-11e1-8775-005056c00008" name="59-61" r="5.7150720000000002" x="26.1360016" g1="0" b1="0.0001113407" g2="0" b2="0.0001113407" node1="68" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-100.77596337108005" q1="22.25185796331558" p2="104.4061994127778" q2="-9.4530534426845261">
+    <iidm:line id="_0482fb31-c766-11e1-8775-005056c00008" name="59-61" r="5.7150720000000002" x="26.1360016" g1="0" b1="0.0001113407" g2="0" b2="0.0001113407" node1="68" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-100.76056415774977" q1="22.245733493389658" p2="104.38965101872417" q2="-9.4521844643419026">
         <iidm:alias>_044a10e9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0473b8f5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9787,7 +9910,7 @@
             <iidm:temporaryLimit name="_b5a7dea0-bfce-4548-a04d-7bb7b6d9f80a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047d55e3-c766-11e1-8775-005056c00008" name="100-104" r="7.8582239999999999" x="35.544960000000003" g1="0" b1="0.00015524565000000001" g2="0" b2="0.00015524565000000001" node1="79" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="54.999930151372709" q1="10.980657013243423" p2="-53.598105649703918" q2="-9.9857543339709647">
+    <iidm:line id="_047d55e3-c766-11e1-8775-005056c00008" name="100-104" r="7.8582239999999999" x="35.544960000000003" g1="0" b1="0.00015524565000000001" g2="0" b2="0.00015524565000000001" node1="79" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="55.002297812443601" q1="10.980453164606748" p2="-53.600362187282194" q2="-9.9850472042432319">
         <iidm:alias>_04636547-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048aea76-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9795,7 +9918,7 @@
             <iidm:temporaryLimit name="_17a10cd0-b653-4dcf-bdc3-4d5005ea9591" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04653a02-c766-11e1-8775-005056c00008" name="75-77" r="10.4718237" x="34.830577900000002" g1="0" b1="0.00014284895" g2="0" b2="0.00014284895" node1="49" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-36.386127494093671" q1="-8.9905461467962962" p2="37.273317156673478" q2="7.1348494779430407">
+    <iidm:line id="_04653a02-c766-11e1-8775-005056c00008" name="75-77" r="10.4718237" x="34.830577900000002" g1="0" b1="0.00014284895" g2="0" b2="0.00014284895" node1="49" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-36.537754643691237" q1="-8.8692651840867782" p2="37.431098335758712" q2="7.0348183745081396">
         <iidm:alias>_04642894-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04720b47-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9803,7 +9926,7 @@
             <iidm:temporaryLimit name="_6f81df11-7e71-4b6e-a6ee-a8c5f72f4ba5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04483c2a-c766-11e1-8775-005056c00008" name="23-32" r="5.5234079999999999" x="20.089872400000001" g1="0" b1="0.00033660465000000001" g2="0" b2="0.00033660465000000001" node1="40" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="84.162609875857015" q1="4.7868979164586376" p2="-81.87972924591736" q2="-7.8091765204656705">
+    <iidm:line id="_04483c2a-c766-11e1-8775-005056c00008" name="23-32" r="5.5234079999999999" x="20.089872400000001" g1="0" b1="0.00033660465000000001" g2="0" b2="0.00033660465000000001" node1="40" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="80.508537184920286" q1="5.5108508261660623" p2="-78.415699452124713" q2="-9.2471293563033239">
         <iidm:alias>_044b978a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0461dea6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9811,7 +9934,7 @@
             <iidm:temporaryLimit name="_a8f6a7d2-e58d-4671-a776-97be7291355e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048719e5-c766-11e1-8775-005056c00008" name="96-97" r="3.0143520000000001" x="15.42024" g1="0" b1="6.8870549999999994e-05" g2="0" b2="6.8870549999999994e-05" node1="50" voltageLevelId1="_045a1672-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="3.1165225782834529" q1="-25.364312557083462" p2="-3.0110127772800164" q2="23.511784540744067">
+    <iidm:line id="_048719e5-c766-11e1-8775-005056c00008" name="96-97" r="3.0143520000000001" x="15.42024" g1="0" b1="6.8870549999999994e-05" g2="0" b2="6.8870549999999994e-05" node1="50" voltageLevelId1="_045a1672-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="3.0769356386390925" q1="-25.542815398862206" p2="-2.969845983731314" q2="23.699684320736658">
         <iidm:alias>_0451b207-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04828601-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9819,7 +9942,7 @@
             <iidm:temporaryLimit name="_ea6d39aa-df95-4d3e-b7b6-a800e552e72a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048481d0-c766-11e1-8775-005056c00008" name="25-27" r="5.5408330000000001" x="28.401121100000001" g1="0" b1="0.000506198385" g2="0" b2="0.000506198385" node1="30" voltageLevelId1="_04728079-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0476c639-c766-11e1-8775-005056c00008" p1="154.55953117889848" q1="30.807111835692151" p2="-147.19536351753192" q2="-11.038993069939837">
+    <iidm:line id="_048481d0-c766-11e1-8775-005056c00008" name="25-27" r="5.5408330000000001" x="28.401121100000001" g1="0" b1="0.000506198385" g2="0" b2="0.000506198385" node1="30" voltageLevelId1="_04728079-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0476c639-c766-11e1-8775-005056c00008" p1="149.19528985418157" q1="29.668014215794742" p2="-142.32736191442424" q2="-12.46839589133574">
         <iidm:alias>_046d2947-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04725960-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9827,7 +9950,7 @@
             <iidm:temporaryLimit name="_d9d53af2-5ffa-4f2a-a4e6-ed22371332d6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04885268-c766-11e1-8775-005056c00008" name="110-112" r="4.3037280000000004" x="11.1513615" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="41" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="13" voltageLevelId2="_04784cd1-c766-11e1-8775-005056c00008" p1="69.354400603531957" q1="11.007379773826829" p2="-68.000008783808966" q2="-13.00000261792213">
+    <iidm:line id="_04885268-c766-11e1-8775-005056c00008" name="110-112" r="4.3037280000000004" x="11.1513615" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="41" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="13" voltageLevelId2="_04784cd1-c766-11e1-8775-005056c00008" p1="69.354399985203457" q1="11.007382533398649" p2="-68.000007734378798" q2="-13.000002417239614">
         <iidm:alias>_04611b55-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0481c2ba-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9835,7 +9958,7 @@
             <iidm:temporaryLimit name="_d50299b9-a055-408a-aa1e-2e93a715120f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0484a8e4-c766-11e1-8775-005056c00008" name="89-92" r="1.7249760000000001" x="8.7991200000000003" g1="0" b1="0.00015725434999999999" g2="0" b2="0.00015725434999999999" node1="57" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="68" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="228.32686901998738" q1="-3.2467864816636327" p2="-223.21689128748355" q2="23.86298936966611">
+    <iidm:line id="_0484a8e4-c766-11e1-8775-005056c00008" name="89-92" r="1.7249760000000001" x="8.7991200000000003" g1="0" b1="0.00015725434999999999" g2="0" b2="0.00015725434999999999" node1="57" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="68" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="228.45600775155677" q1="-3.1570067485918174" p2="-223.34025554478788" q2="23.802941735781953">
         <iidm:alias>_04481517-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04808a3c-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9843,7 +9966,7 @@
             <iidm:temporaryLimit name="_eee9ca2b-764f-4ab8-a745-405338044743" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04689568-c766-11e1-8775-005056c00008" name="49-54" r="15.1414566" x="50.703842199999997" g1="0" b1="0.00020948120000000001" g2="0" b2="0.00020948120000000001" node1="116" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="46.513733295449619" q1="9.6262292210784377" p2="-44.574347550313021" q2="-10.295526805577996">
+    <iidm:line id="_04689568-c766-11e1-8775-005056c00008" name="49-54" r="15.1414566" x="50.703842199999997" g1="0" b1="0.00020948120000000001" g2="0" b2="0.00020948120000000001" node1="116" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="46.531335573617419" q1="9.6233287151108424" p2="-44.590659817512368" q2="-10.28830672472569">
         <iidm:alias>_046030f0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04605808-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9851,7 +9974,7 @@
             <iidm:temporaryLimit name="_690202a4-aad2-4ad3-8842-961b39e37709" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046c8d04-c766-11e1-8775-005056c00008" name="40-41" r="2.5264799999999998" x="8.4854880000000001" g1="0" b1="3.5066600000000001e-05" g2="0" b2="3.5066600000000001e-05" node1="40" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048c4a08-c766-11e1-8775-005056c00008" p1="26.459326259520981" q1="-1.6844823352878922" p2="-26.333033245626297" q2="1.1282589799095959">
+    <iidm:line id="_046c8d04-c766-11e1-8775-005056c00008" name="40-41" r="2.5264799999999998" x="8.4854880000000001" g1="0" b1="3.5066600000000001e-05" g2="0" b2="3.5066600000000001e-05" node1="40" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048c4a08-c766-11e1-8775-005056c00008" p1="26.649865680402002" q1="-1.8166245988371146" p2="-26.521568109935618" q2="1.2680275915617378">
         <iidm:alias>_045cae80-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a2194-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9859,7 +9982,7 @@
             <iidm:temporaryLimit name="_34f2ef7c-32da-4444-b989-d02f5f931c50" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046735d5-c766-11e1-8775-005056c00008" name="39-40" r="3.206016" x="10.54152" g1="0" b1="4.4536249999999999e-05" g2="0" b2="4.4536249999999999e-05" node1="22" voltageLevelId1="_046bf0c7-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="38.085295860569637" q1="3.7789059875068016" p2="-37.757071593634677" q2="-3.9641867083768463">
+    <iidm:line id="_046735d5-c766-11e1-8775-005056c00008" name="39-40" r="3.206016" x="10.54152" g1="0" b1="4.4536249999999999e-05" g2="0" b2="4.4536249999999999e-05" node1="22" voltageLevelId1="_046bf0c7-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="38.285151948735766" q1="3.6616519649306403" p2="-37.953408333849445" q2="-3.834106045051612">
         <iidm:alias>_045115c1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048badc2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9867,7 +9990,7 @@
             <iidm:temporaryLimit name="_38d58455-5205-46bb-8e44-c66873f62938" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0470d2c4-c766-11e1-8775-005056c00008" name="89-92" r="6.8476319999999999" x="27.5473423" g1="0" b1="0.00011880164999999999" g2="0" b2="0.00011880164999999999" node1="58" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="72.027133599219951" q1="-5.8506249514513717" p2="-70.003021877617215" q2="9.8762060554704441">
+    <iidm:line id="_0470d2c4-c766-11e1-8775-005056c00008" name="89-92" r="6.8476319999999999" x="27.5473423" g1="0" b1="0.00011880164999999999" g2="0" b2="0.00011880164999999999" node1="58" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="72.069294447312487" q1="-5.8243413480817239" p2="-70.04289540046922" q2="9.8593329831244461">
         <iidm:alias>_04690a97-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04690a98-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9875,7 +9998,7 @@
             <iidm:temporaryLimit name="_0cce41c7-b99f-4fec-93d2-73ea24433fa1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0479ac60-c766-11e1-8775-005056c00008" name="33-37" r="7.2309599999999996" x="24.742080000000001" g1="0" b1="0.00010502754999999999" g2="0" b2="0.00010502754999999999" node1="21" voltageLevelId1="_0456bb11-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="38.771942174193285" q1="-19.993437866651949" p2="-37.900335727551919" q2="19.721773609808071">
+    <iidm:line id="_0479ac60-c766-11e1-8775-005056c00008" name="33-37" r="7.2309599999999996" x="24.742080000000001" g1="0" b1="0.00010502754999999999" g2="0" b2="0.00010502754999999999" node1="21" voltageLevelId1="_0456bb11-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="39.757690079852345" q1="-20.282880799010897" p2="-38.843116153309616" q2="20.162052466080503">
         <iidm:alias>_04716f08-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0483be89-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9883,7 +10006,7 @@
             <iidm:temporaryLimit name="_343677c6-7477-4bf6-a12c-2c7e4a684d6f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048c4a00-c766-11e1-8775-005056c00008" name="105-108" r="4.5476640000000002" x="12.249072099999999" g1="0" b1="5.2915499999999998e-05" g2="0" b2="5.2915499999999998e-05" node1="50" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_046c65f4-c766-11e1-8775-005056c00008" p1="22.932598835958437" q1="-0.84222976948721062" p2="-22.785299484525261" q2="-0.46858752142266213">
+    <iidm:line id="_048c4a00-c766-11e1-8775-005056c00008" name="105-108" r="4.5476640000000002" x="12.249072099999999" g1="0" b1="5.2915499999999998e-05" g2="0" b2="5.2915499999999998e-05" node1="50" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_046c65f4-c766-11e1-8775-005056c00008" p1="22.935993620635561" q1="-0.84329918883607646" p2="-22.788650633068286" q2="-0.46740003044081602">
         <iidm:alias>_046adf53-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04795e46-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9891,7 +10014,7 @@
             <iidm:temporaryLimit name="_74cf84b9-e14f-4f81-9e8b-3a791cd474a0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04631724-c766-11e1-8775-005056c00008" name="34-37" r="0.44605400000000001" x="1.637856" g1="0" b1="2.8236900000000001e-05" g2="0" b2="2.8236900000000001e-05" node1="41" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-57.110913750476513" q1="-35.135105014702809" p2="57.239084868391757" q2="34.723428772205153">
+    <iidm:line id="_04631724-c766-11e1-8775-005056c00008" name="34-37" r="0.44605400000000001" x="1.637856" g1="0" b1="2.8236900000000001e-05" g2="0" b2="2.8236900000000001e-05" node1="41" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-56.374029853592333" q1="-35.474295476750896" p2="56.500615301956714" q2="35.057718647948377">
         <iidm:alias>_04592c19-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04719611-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9899,7 +10022,7 @@
             <iidm:temporaryLimit name="_8e90bf2e-3be4-41be-a84e-c1d4e709f8a1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04814d85-c766-11e1-8775-005056c00008" name="61-62" r="1.435738" x="6.5514239999999999" g1="0" b1="2.812215e-05" g2="0" b2="2.812215e-05" node1="40" voltageLevelId1="_0448d867-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="60.118313555271605" q1="-18.209140929054918" p2="-59.791355790757606" q2="18.728894180010975">
+    <iidm:line id="_04814d85-c766-11e1-8775-005056c00008" name="61-62" r="1.435738" x="6.5514239999999999" g1="0" b1="2.812215e-05" g2="0" b2="2.812215e-05" node1="40" voltageLevelId1="_0448d867-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="60.098653750471684" q1="-18.205377634346682" p2="-59.771903807396733" q2="18.724182527667999">
         <iidm:alias>_045a3d85-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047abdd8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9907,7 +10030,7 @@
             <iidm:temporaryLimit name="_39a23399-348e-44d9-8032-8fc62e6c7d63" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046a4318-c766-11e1-8775-005056c00008" name="101-102" r="4.2863040000000003" x="19.5148811" g1="0" b1="8.4366399999999999e-05" g2="0" b2="8.4366399999999999e-05" node1="22" voltageLevelId1="_046ed6f7-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="-44.087942799777053" q1="11.604011358237523" p2="44.617754858096653" q2="-12.070699373415767">
+    <iidm:line id="_046a4318-c766-11e1-8775-005056c00008" name="101-102" r="4.2863040000000003" x="19.5148811" g1="0" b1="8.4366399999999999e-05" g2="0" b2="8.4366399999999999e-05" node1="22" voltageLevelId1="_046ed6f7-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="-44.12274699905862" q1="11.630000703618776" p2="44.65352596651114" q2="-12.092082667975189">
         <iidm:alias>_04878f1b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04885261-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9915,7 +10038,7 @@
             <iidm:temporaryLimit name="_0501dacc-29fc-44a2-8cad-31a20b011d25" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c81e3-c766-11e1-8775-005056c00008" name="26-30" r="3.8671600000000002" x="41.624000000000002" g1="0" b1="0.00093801650000000002" g2="0" b2="0.00093801650000000002" node1="21" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="225.63301636556159" q1="0.37746984055726518" p2="-221.51221319391249" q2="-45.995761381823684">
+    <iidm:line id="_044c81e3-c766-11e1-8775-005056c00008" name="26-30" r="3.8671600000000002" x="41.624000000000002" g1="0" b1="0.00093801650000000002" g2="0" b2="0.00093801650000000002" node1="21" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="238.56821636209443" q1="-3.6729660214994464" p2="-234.0100762688235" q2="-37.645886469615256">
         <iidm:alias>_0463654b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04747c4a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9923,7 +10046,7 @@
             <iidm:temporaryLimit name="_c95a66fd-913c-48c7-b8ef-cf3007c60af6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048915b9-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="41" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="117" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-53.76211543584666" q1="-18.775760161169401" p2="56.435476545761496" q2="22.745634938278954">
+    <iidm:line id="_048915b9-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="41" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="117" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-53.571483129295018" q1="-18.917681155097998" p2="56.232576779154421" q2="22.834156240477359">
         <iidm:alias>_044bbe98-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0456e224-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9931,7 +10054,7 @@
             <iidm:temporaryLimit name="_6cd83bc2-204f-44d5-afd4-fbfef8d2146f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c5ad6-c766-11e1-8775-005056c00008" name="105-106" r="2.4393600000000002" x="9.5309279999999994" g1="0" b1="4.1150150000000001e-05" g2="0" b2="4.1150150000000001e-05" node1="51" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="9.6383566474973001" q1="6.1382348539945868" p2="-9.6174397328891832" q2="-7.3855444055743904">
+    <iidm:line id="_044c5ad6-c766-11e1-8775-005056c00008" name="105-106" r="2.4393600000000002" x="9.5309279999999994" g1="0" b1="4.1150150000000001e-05" g2="0" b2="4.1150150000000001e-05" node1="51" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="9.6367641419567924" q1="6.1388090743409451" p2="-9.6158506603153633" q2="-7.3861316091076281">
         <iidm:alias>_04505270-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04531190-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9939,7 +10062,7 @@
             <iidm:temporaryLimit name="_487e1317-48f9-4747-b931-f3f79e95f55a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048badc5-c766-11e1-8775-005056c00008" name="60-61" r="0.45999400000000001" x="2.3522400000000001" g1="0" b1="4.1781450000000003e-05" g2="0" b2="4.1781450000000003e-05" node1="30" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-169.31373499998932" q1="15.894507768302745" p2="170.08945783294584" q2="-13.365575362286339">
+    <iidm:line id="_048badc5-c766-11e1-8775-005056c00008" name="60-61" r="0.45999400000000001" x="2.3522400000000001" g1="0" b1="4.1781450000000003e-05" g2="0" b2="4.1781450000000003e-05" node1="30" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-169.29118012501681" q1="15.891190946583761" p2="170.06669494265435" q2="-13.363322620638973">
         <iidm:alias>_04793734-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048a4e31-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9947,7 +10070,7 @@
             <iidm:temporaryLimit name="_3c55a929-a755-409b-af5f-bae188892af1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044cd003-c766-11e1-8775-005056c00008" name="23-25" r="2.7181440000000001" x="13.9391994" g1="0" b1="0.00024793390000000002" g2="0" b2="0.00024793390000000002" node1="41" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="-204.53169039742681" q1="-11.509111175550506" p2="211.07009085604892" q2="35.959442571084082">
+    <iidm:line id="_044cd003-c766-11e1-8775-005056c00008" name="23-25" r="2.7181440000000001" x="13.9391994" g1="0" b1="0.00024793390000000002" g2="0" b2="0.00024793390000000002" node1="41" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="-197.32036157731397" q1="-12.865122827239173" p2="203.39717085434833" q2="34.939420186572512">
         <iidm:alias>_045ed161-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0473b8f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9955,7 +10078,7 @@
             <iidm:temporaryLimit name="_9658628a-596f-41a9-96a7-c5a8aaf5400c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0457a574-c766-11e1-8775-005056c00008" name="19-34" r="13.102848099999999" x="43.037277199999998" g1="0" b1="0.00018135905000000001" g2="0" b2="0.00018135905000000001" node1="40" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0483be8b-c766-11e1-8775-005056c00008" p1="51.3190181869128" q1="-15.750019549110366" p2="-48.935703106223869" q2="17.966480252912596">
+    <iidm:line id="_0457a574-c766-11e1-8775-005056c00008" name="19-34" r="13.102848099999999" x="43.037277199999998" g1="0" b1="0.00018135905000000001" g2="0" b2="0.00018135905000000001" node1="40" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0483be8b-c766-11e1-8775-005056c00008" p1="52.505799761998659" q1="-15.875711131389632" p2="-50.012646871706188" q2="18.458380173348722">
         <iidm:alias>_04502b61-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04686e5b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9963,7 +10086,7 @@
             <iidm:temporaryLimit name="_b69ab61b-751d-487a-a538-2d47eea7572e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04595326-c766-11e1-8775-005056c00008" name="59-60" r="5.5234079999999999" x="25.264800000000001" g1="0" b1="0.00010789715" g2="0" b2="0.00010789715" node1="69" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_045cfca4-c766-11e1-8775-005056c00008" p1="-89.128253903686172" q1="19.124830179284679" p2="91.867119545541215" q2="-10.2727457615508">
+    <iidm:line id="_04595326-c766-11e1-8775-005056c00008" name="59-60" r="5.5234079999999999" x="25.264800000000001" g1="0" b1="0.00010789715" g2="0" b2="0.00010789715" node1="69" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_045cfca4-c766-11e1-8775-005056c00008" p1="-89.114233824704343" q1="19.11947548583003" p2="91.852209638998559" q2="-10.271462181773694">
         <iidm:alias>_04611b57-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0463b366-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9971,7 +10094,7 @@
             <iidm:temporaryLimit name="_a38d4859-b54a-482f-a2ad-0b4ce4c4da2a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045a8ba1-c766-11e1-8775-005056c00008" name="15-19" r="2.0908799999999998" x="6.865056" g1="0" b1="2.8983e-05" g2="0" b2="2.8983e-05" node1="50" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="33.153354200219624" q1="10.759071032014353" p2="-32.990128630085117" q2="-11.124304717463792">
+    <iidm:line id="_045a8ba1-c766-11e1-8775-005056c00008" name="15-19" r="2.0908799999999998" x="6.865056" g1="0" b1="2.8983e-05" g2="0" b2="2.8983e-05" node1="50" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="32.531383788983646" q1="10.820143132879572" p2="-32.373268602910635" q2="-11.201329298421461">
         <iidm:alias>_047629f1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0481e9c1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9979,7 +10102,7 @@
             <iidm:temporaryLimit name="_15d16bd2-d87c-4584-93d2-b294dc1be116" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04513cd6-c766-11e1-8775-005056c00008" name="90-91" r="4.4256960000000003" x="14.566463499999999" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="31" voltageLevelId1="_047d07c3-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044f8f29-c766-11e1-8775-005056c00008" p1="4.3741119567797409" q1="-16.344991708682315" p2="-4.3034555002191697" q2="14.589192331663007">
+    <iidm:line id="_04513cd6-c766-11e1-8775-005056c00008" name="90-91" r="4.4256960000000003" x="14.566463499999999" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="31" voltageLevelId1="_047d07c3-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044f8f29-c766-11e1-8775-005056c00008" p1="4.3981745556116332" q1="-16.334764094416567" p2="-4.3275443961424287" q2="14.578965362647322">
         <iidm:alias>_045f94b9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04627ae1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9987,7 +10110,7 @@
             <iidm:temporaryLimit name="_7d2a67fb-9d8c-4745-a67e-ce6ade5e520e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0487b623-c766-11e1-8775-005056c00008" name="22-23" r="5.9590079999999999" x="27.704158799999998" g1="0" b1="0.00011593205" g2="0" b2="0.00011593205" node1="21" voltageLevelId1="_04773b6a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_047f9fdb-c766-11e1-8775-005056c00008" p1="-57.57933001289053" q1="-10.648328544745395" p2="58.837355345137986" q2="12.615374023353819">
+    <iidm:line id="_0487b623-c766-11e1-8775-005056c00008" name="22-23" r="5.9590079999999999" x="27.704158799999998" g1="0" b1="0.00011593205" g2="0" b2="0.00011593205" node1="21" voltageLevelId1="_04773b6a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_047f9fdb-c766-11e1-8775-005056c00008" p1="-55.530155442402808" q1="-11.299159157251447" p2="56.703982967008756" q2="12.866442713988985">
         <iidm:alias>_045e0e18-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0477b095-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9995,7 +10118,7 @@
             <iidm:temporaryLimit name="_6477d99a-dd64-4083-8f56-1396610879f0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048b1189-c766-11e1-8775-005056c00008" name="83-85" r="7.4923200000000003" x="25.787520000000001" g1="0" b1="9.9862250000000004e-05" g2="0" b2="9.9862250000000004e-05" node1="32" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-54.862169226718194" q1="18.368576632241428" p2="56.40554319189944" q2="-16.357238006446785">
+    <iidm:line id="_048b1189-c766-11e1-8775-005056c00008" name="83-85" r="7.4923200000000003" x="25.787520000000001" g1="0" b1="9.9862250000000004e-05" g2="0" b2="9.9862250000000004e-05" node1="32" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-54.688547193602609" q1="19.127787784899532" p2="56.241501448192885" q2="-17.070360834410895">
         <iidm:alias>_0455d0b1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0462c906-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10003,7 +10126,7 @@
             <iidm:temporaryLimit name="_38cb3e5b-af1a-4684-aa2f-242826ed460c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045868c5-c766-11e1-8775-005056c00008" name="17-31" r="8.2589760000000005" x="27.233711199999998" g1="0" b1="0.00011449725" g2="0" b2="0.00011449725" node1="60" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="12.896584744382153" q1="2.5223324071063775" p2="-12.804799111616536" q2="-6.0017202880635541">
+    <iidm:line id="_045868c5-c766-11e1-8775-005056c00008" name="17-31" r="8.2589760000000005" x="27.233711199999998" g1="0" b1="0.00011449725" g2="0" b2="0.00011449725" node1="60" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="17.206641012505173" q1="1.022200621116649" p2="-17.056156898198839" q2="-4.306157362658924">
         <iidm:alias>_04544a16-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0467f924-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10011,7 +10134,7 @@
             <iidm:temporaryLimit name="_9066b19a-f404-42c3-88ce-51d375f6fdb5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0488c796-c766-11e1-8775-005056c00008" name="89-90" r="9.0256319999999999" x="32.75712" g1="0" b1="0.00015151515000000001" g2="0" b2="0.00015151515000000001" node1="59" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="59.703094698435777" q1="9.2563401898254014" p2="-57.802126548682743" q2="-7.4452068967957281">
+    <iidm:line id="_0488c796-c766-11e1-8775-005056c00008" name="89-90" r="9.0256319999999999" x="32.75712" g1="0" b1="0.00015151515000000001" g2="0" b2="0.00015151515000000001" node1="59" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="59.712081026516159" q1="9.2619946917747562" p2="-57.810493272253751" q2="-7.4485436977512585">
         <iidm:alias>_0459ef61-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04837069-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10019,7 +10142,7 @@
             <iidm:temporaryLimit name="_924b4a0b-bef5-432a-ad87-ab5c10d9c019" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0462c907-c766-11e1-8775-005056c00008" name="70-75" r="7.4574720000000001" x="24.56784" g1="0" b1="0.0001033058" g2="0" b2="0.0001033058" node1="50" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="8.5001684862764915" q1="7.789801809542654" p2="-8.4276212746598329" q2="-10.949208217675334">
+    <iidm:line id="_0462c907-c766-11e1-8775-005056c00008" name="70-75" r="7.4574720000000001" x="24.56784" g1="0" b1="0.0001033058" g2="0" b2="0.0001033058" node1="50" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="8.1647715403478518" q1="7.9832439315115566" p2="-8.093070782411715" q2="-11.145813164475806">
         <iidm:alias>_04649dc9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04784cdb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10027,7 +10150,7 @@
             <iidm:temporaryLimit name="_d432d118-553c-4f4c-a734-e98e0762ec40" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045fbbc3-c766-11e1-8775-005056c00008" name="50-57" r="8.2589760000000005" x="23.34816" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="22" voltageLevelId1="_044d1e26-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="44.114825072320549" q1="6.74368291945561" p2="-43.159647667732557" q2="-7.2660047573025741">
+    <iidm:line id="_045fbbc3-c766-11e1-8775-005056c00008" name="50-57" r="8.2589760000000005" x="23.34816" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="22" voltageLevelId1="_044d1e26-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="44.130961145477464" q1="6.7391066544109144" p2="-43.175143029704564" q2="-7.2596070968724318">
         <iidm:alias>_04500455-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0468e383-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10035,7 +10158,7 @@
             <iidm:temporaryLimit name="_2f32bda4-7275-4485-9901-12f8cff9e4a1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044b9789-c766-11e1-8775-005056c00008" name="5-6" r="2.0734560000000002" x="9.4089600000000004" g1="0" b1="4.0920549999999999e-05" g2="0" b2="4.0920549999999999e-05" node1="49" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f6818-c766-11e1-8775-005056c00008" p1="95.833240231034424" q1="17.67175388834864" p2="-94.720279282605688" q2="-14.044852414241401">
+    <iidm:line id="_044b9789-c766-11e1-8775-005056c00008" name="5-6" r="2.0734560000000002" x="9.4089600000000004" g1="0" b1="4.0920549999999999e-05" g2="0" b2="4.0920549999999999e-05" node1="49" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f6818-c766-11e1-8775-005056c00008" p1="91.569920576334354" q1="19.179935184413189" p2="-90.545529743014271" q2="-15.957108636202946">
         <iidm:alias>_044a5f01-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0455d0b2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10043,7 +10166,7 @@
             <iidm:temporaryLimit name="_b3b0e81b-a434-4e9c-ad94-1161ff47b077" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04720b41-c766-11e1-8775-005056c00008" name="55-59" r="8.2572340000000004" x="37.600994100000001" g1="0" b1="0.00016201790000000001" g2="0" b2="0.00016201790000000001" node1="30" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-24.1910369016686" q1="-11.535911718451867" p2="24.539739461816477" q2="7.8302043365189657">
+    <iidm:line id="_04720b41-c766-11e1-8775-005056c00008" name="55-59" r="8.2572340000000004" x="37.600994100000001" g1="0" b1="0.00016201790000000001" g2="0" b2="0.00016201790000000001" node1="30" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-24.175824218906126" q1="-11.540185145384916" p2="24.524181858031334" q2="7.8329083441805709">
         <iidm:alias>_04656113-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04675ce4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10051,7 +10174,7 @@
             <iidm:temporaryLimit name="_6db0d250-4a2e-4169-abf0-f842aeca485d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048963d9-c766-11e1-8775-005056c00008" name="1-2" r="5.2794720000000002" x="17.4065762" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="22" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_045d4ac5-c766-11e1-8775-005056c00008" p1="-10.48382009554903" q1="-10.855179529746225" p2="10.550817418595289" q2="8.7030145490899624">
+    <iidm:line id="_048963d9-c766-11e1-8775-005056c00008" name="1-2" r="5.2794720000000002" x="17.4065762" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="22" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_045d4ac5-c766-11e1-8775-005056c00008" p1="-11.422353085423403" q1="-10.339498723904207" p2="11.492855221580225" q2="8.1976756656449066">
         <iidm:alias>_044b9786-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04845acb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10059,7 +10182,7 @@
             <iidm:temporaryLimit name="_9f39cb45-314c-445e-b177-909854a9ce45" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0484f709-c766-11e1-8775-005056c00008" name="11-12" r="1.0367280000000001" x="3.4151039999999999" g1="0" b1="1.4405399999999999e-05" g2="0" b2="1.4405399999999999e-05" node1="40" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="39.707157280787499" q1="-28.950616544617741" p2="-39.560422086869103" q2="28.943634275879869">
+    <iidm:line id="_0484f709-c766-11e1-8775-005056c00008" name="11-12" r="1.0367280000000001" x="3.4151039999999999" g1="0" b1="1.4405399999999999e-05" g2="0" b2="1.4405399999999999e-05" node1="40" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="34.705476553907715" q1="-25.32671886765398" p2="-34.593502626943845" q2="25.20501558716543">
         <iidm:alias>_0456e227-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04880440-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10067,7 +10190,7 @@
             <iidm:temporaryLimit name="_70fad3e1-4529-4a7f-9e6c-8ab249d65460" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044bbe91-c766-11e1-8775-005056c00008" name="8-9" r="1.18096" x="14.762" g1="0" b1="0.001200413215" g2="0" b2="0.001200413215" node1="31" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_045c8779-c766-11e1-8775-005056c00008" p1="-486.65625965426733" q1="-86.219771909129676" p2="492.39971487675405" q2="37.085931979112189">
+    <iidm:line id="_044bbe91-c766-11e1-8775-005056c00008" name="8-9" r="1.18096" x="14.762" g1="0" b1="0.001200413215" g2="0" b2="0.001200413215" node1="31" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_045c8779-c766-11e1-8775-005056c00008" p1="-486.60806564688352" q1="-83.566363625991144" p2="492.32298176951969" q2="33.697613031047055">
         <iidm:alias>_04745535-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048a7548-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="2000">
@@ -10075,7 +10198,7 @@
             <iidm:temporaryLimit name="_205e5d8a-f05a-479d-adaa-3514f48f6857" acceptableDuration="60" value="2400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04566cf8-c766-11e1-8775-005056c00008" name="64-65" r="1.30196" x="14.6168" g1="0" b1="0.000392562" g2="0" b2="0.000392562" node1="35" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-157.45662250362699" q1="-33.950384472219909" p2="158.1364473245911" q2="3.5804924122416621">
+    <iidm:line id="_04566cf8-c766-11e1-8775-005056c00008" name="64-65" r="1.30196" x="14.6168" g1="0" b1="0.000392562" g2="0" b2="0.000392562" node1="35" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-157.42820096330695" q1="-33.95220709807608" p2="158.10778320504548" q2="3.5795656886913476">
         <iidm:alias>_044a10e2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04793738-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10083,7 +10206,7 @@
             <iidm:temporaryLimit name="_8cee2b62-2953-439b-ba4b-4a48d55116c0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046783f3-c766-11e1-8775-005056c00008" name="54-56" r="0.47915999999999997" x="1.6639919999999999" g1="0" b1="2.1005500000000001e-05" g2="0" b2="2.1005500000000001e-05" node1="60" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="29.565457890183882" q1="2.695034172781245" p2="-29.538824323262396" q2="-3.2693416684621113">
+    <iidm:line id="_046783f3-c766-11e1-8775-005056c00008" name="54-56" r="0.47915999999999997" x="1.6639919999999999" g1="0" b1="2.1005500000000001e-05" g2="0" b2="2.1005500000000001e-05" node1="60" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="29.575983177624764" q1="2.6944866372367997" p2="-29.549330941952977" q2="-3.2687291481317522">
         <iidm:alias>_0460f444-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d2949-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10091,7 +10214,7 @@
             <iidm:temporaryLimit name="_640627c7-0672-413e-8dc8-c9965709a5cb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04670ec6-c766-11e1-8775-005056c00008" name="84-85" r="5.2620480000000001" x="11.1687832" g1="0" b1="3.541095e-05" g2="0" b2="3.541095e-05" node1="21" voltageLevelId1="_047b0bf4-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-44.528880875282468" q1="13.789053285770178" p2="45.234438960393156" q2="-13.453780759421532">
+    <iidm:line id="_04670ec6-c766-11e1-8775-005056c00008" name="84-85" r="5.2620480000000001" x="11.1687832" g1="0" b1="3.541095e-05" g2="0" b2="3.541095e-05" node1="21" voltageLevelId1="_047b0bf4-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-44.327053657009351" q1="14.278396419804723" p2="45.034580470441135" q2="-13.933315381315897">
         <iidm:alias>_0453fbf5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046512f7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10099,7 +10222,7 @@
             <iidm:temporaryLimit name="_8b888209-5038-4b98-80fc-062b5ea55747" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0460cd36-c766-11e1-8775-005056c00008" name="34-36" r="1.51763" x="4.669632" g1="0" b1="1.6299349999999998e-05" g2="0" b2="1.6299349999999998e-05" node1="43" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="34.475357342258107" q1="11.249637407625052" p2="-34.346366465544733" q2="-11.355920686202007">
+    <iidm:line id="_0460cd36-c766-11e1-8775-005056c00008" name="34-36" r="1.51763" x="4.669632" g1="0" b1="1.6299349999999998e-05" g2="0" b2="1.6299349999999998e-05" node1="43" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="34.555770810187994" q1="11.216808925278043" p2="-34.426174120570188" q2="-11.320690031840659">
         <iidm:alias>_046a6a26-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0487b620-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10107,7 +10230,7 @@
             <iidm:temporaryLimit name="_c0a08025-3a61-4d24-9944-f3ef0b079f64" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04549836-c766-11e1-8775-005056c00008" name="24-70" r="0.38507000000000002" x="71.699759999999998" g1="0" b1="0.00029264234999999998" g2="0" b2="0.00029264234999999998" node1="32" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="17.073977076498238" q1="-0.76048736128610861" p2="-17.067069217310294" q2="-7.9094529635809634">
+    <iidm:line id="_04549836-c766-11e1-8775-005056c00008" name="24-70" r="0.38507000000000002" x="71.699759999999998" g1="0" b1="0.00029264234999999998" g2="0" b2="0.00029264234999999998" node1="32" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="16.33296594315685" q1="-0.59924435797040709" p2="-16.326589244443181" q2="-8.18111097010914">
         <iidm:alias>_04549834-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04854522-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10115,7 +10238,7 @@
             <iidm:temporaryLimit name="_32793450-bbfd-4dcd-a911-89e199600780" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0452273a-c766-11e1-8775-005056c00008" name="85-86" r="6.0983999999999998" x="21.431519999999999" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="50" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0484f70a-c766-11e1-8775-005056c00008" p1="21.232047291034434" q1="12.278297035904458" p2="-20.997159018395124" q2="-14.000636874663041">
+    <iidm:line id="_0452273a-c766-11e1-8775-005056c00008" name="85-86" r="6.0983999999999998" x="21.431519999999999" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="50" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0484f70a-c766-11e1-8775-005056c00008" p1="21.280852418632488" q1="16.349714700149569" p2="-20.996781394899298" q2="-17.872067008815232">
         <iidm:alias>_044afb43-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479fa85-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10123,7 +10246,7 @@
             <iidm:temporaryLimit name="_2ec4bef5-7abb-4f52-bb62-49ee474d672b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0450eeb5-c766-11e1-8775-005056c00008" name="16-17" r="7.9104960000000002" x="31.380622899999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="22" voltageLevelId1="_046f7338-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-8.7058504098822365" q1="-0.48755491057723865" p2="8.7431835636805033" q2="-3.836665925974962">
+    <iidm:line id="_0450eeb5-c766-11e1-8775-005056c00008" name="16-17" r="7.9104960000000002" x="31.380622899999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="22" voltageLevelId1="_046f7338-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-15.258915746177923" q1="1.4816909792455604" p2="15.375750953503955" q2="-5.4873991212385018">
         <iidm:alias>_044ef2ea-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04837066-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10131,7 +10254,7 @@
             <iidm:temporaryLimit name="_9280074c-8555-49ff-9e62-8ed8f7d95060" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048a4e33-c766-11e1-8775-005056c00008" name="62-66" r="8.3983679999999996" x="37.984317799999999" g1="0" b1="0.00016586315" g2="0" b2="0.00016586315" node1="41" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-15.277868061078431" q1="-21.571274751356874" p2="15.560583817165934" q2="16.817810727082943">
+    <iidm:line id="_048a4e33-c766-11e1-8775-005056c00008" name="62-66" r="8.3983679999999996" x="37.984317799999999" g1="0" b1="0.00016586315" g2="0" b2="0.00016586315" node1="41" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-15.291449109923933" q1="-21.567784751335505" p2="15.574302873507317" q2="16.814946548251786">
         <iidm:alias>_046e13a9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a96c7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10139,7 +10262,7 @@
             <iidm:temporaryLimit name="_ace48562-0a49-4b76-ae82-c896a00b04f9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0478e913-c766-11e1-8775-005056c00008" name="76-77" r="7.736256" x="25.787520000000001" g1="0" b1="0.00010560145" g2="0" b2="0.00010560145" node1="21" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-62.336122090637524" q1="-22.751512759061058" p2="64.536624346026343" q2="26.630535886571305">
+    <iidm:line id="_0478e913-c766-11e1-8775-005056c00008" name="76-77" r="7.736256" x="25.787520000000001" g1="0" b1="0.00010560145" g2="0" b2="0.00010560145" node1="21" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-62.448869123710196" q1="-22.660113886674598" p2="64.654932188398035" q2="26.558467384647379">
         <iidm:alias>_044b9785-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04725965-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10147,7 +10270,7 @@
             <iidm:temporaryLimit name="_3f744dba-88dc-4d89-90d4-a6f196054b28" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048badc1-c766-11e1-8775-005056c00008" name="60-62" r="2.1431520000000002" x="9.7748640000000009" g1="0" b1="4.2125800000000002e-05" g2="0" b2="4.2125800000000002e-05" node1="32" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="-0.55330748619662407" q1="-8.6217570707257973" p2="0.56113647867895089" q2="7.2048436191513243">
+    <iidm:line id="_048badc1-c766-11e1-8775-005056c00008" name="60-62" r="2.1431520000000002" x="9.7748640000000009" g1="0" b1="4.2125800000000002e-05" g2="0" b2="4.2125800000000002e-05" node1="32" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="-0.5609547878058363" q1="-8.6197238826991125" p2="0.56878082961446275" q2="7.2027965772577804">
         <iidm:alias>_045b7600-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04720b44-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10155,7 +10278,7 @@
             <iidm:temporaryLimit name="_43f91aaf-c5f4-4995-85a2-37afac616331" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0472a780-c766-11e1-8775-005056c00008" name="27-28" r="3.3332109999999999" x="14.89752" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="42" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04819ba0-c766-11e1-8775-005056c00008" p1="34.518878601055832" q1="-1.1480769882361463" p2="-34.275328651492444" q2="0.22793130283562391">
+    <iidm:line id="_0472a780-c766-11e1-8775-005056c00008" name="27-28" r="3.3332109999999999" x="14.89752" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="42" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04819ba0-c766-11e1-8775-005056c00008" p1="32.658133317843621" q1="-1.4804088283889254" p2="-32.440747076980344" q2="0.43596922136801447">
         <iidm:alias>_04531198-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0475188b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10163,7 +10286,7 @@
             <iidm:temporaryLimit name="_2c20e8bd-84e6-4a1e-b88e-071f631327cb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c81e1-c766-11e1-8775-005056c00008" name="45-46" r="6.9695999999999998" x="23.626943600000001" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="31" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="34" voltageLevelId2="_048a7544-c766-11e1-8775-005056c00008" p1="-33.816869016142412" q1="-6.956706630841877" p2="34.302252742080888" q2="5.3219082789851049">
+    <iidm:line id="_044c81e1-c766-11e1-8775-005056c00008" name="45-46" r="6.9695999999999998" x="23.626943600000001" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="31" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="34" voltageLevelId2="_048a7544-c766-11e1-8775-005056c00008" p1="-33.686149427520171" q1="-7.028797325835157" p2="34.168239047724882" q2="5.3829559816912091">
         <iidm:alias>_04561ed6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045c877a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10171,7 +10294,7 @@
             <iidm:temporaryLimit name="_6ad31f7e-233f-4801-898f-9ffc883ec724" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c1249-c766-11e1-8775-005056c00008" name="18-19" r="1.949746" x="8.5900320000000008" g1="0" b1="3.2770900000000002e-05" g2="0" b2="3.2770900000000002e-05" node1="22" voltageLevelId1="_04689563-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="48.845902653936328" q1="0.76129309884053686" p2="-48.547546349038292" q2="-0.46286479181883305">
+    <iidm:line id="_045c1249-c766-11e1-8775-005056c00008" name="18-19" r="1.949746" x="8.5900320000000008" g1="0" b1="3.2770900000000002e-05" g2="0" b2="3.2770900000000002e-05" node1="22" voltageLevelId1="_04689563-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="52.661027356128578" q1="-0.28516924392861798" p2="-52.314062323638424" q2="0.79880010429075332">
         <iidm:alias>_046b066b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047ae4e0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10179,7 +10302,7 @@
             <iidm:temporaryLimit name="_a025c9d8-58f9-4320-a1fe-73ecc68d4147" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044a5f09-c766-11e1-8775-005056c00008" name="9-10" r="1.2487200000000001" x="15.584800700000001" g1="0" b1="0.0012706611300000001" g2="0" b2="0.0012706611300000001" node1="21" voltageLevelId1="_045c8779-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_044f4102-c766-11e1-8775-005056c00008" p1="-492.39971487675376" q1="-37.085931979112786" p2="498.25508848765469" q2="-23.566102281853674">
+    <iidm:line id="_044a5f09-c766-11e1-8775-005056c00008" name="9-10" r="1.2487200000000001" x="15.584800700000001" g1="0" b1="0.0012706611300000001" g2="0" b2="0.0012706611300000001" node1="21" voltageLevelId1="_045c8779-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_044f4102-c766-11e1-8775-005056c00008" p1="-492.32298176952014" q1="-33.697613031046572" p2="498.169113613869" q2="-27.21212490571363">
         <iidm:alias>_04614262-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04834957-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="2000">
@@ -10187,7 +10310,7 @@
             <iidm:temporaryLimit name="_b7fac0a3-c5af-48b9-af49-261fd8d46e00" acceptableDuration="60" value="2400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0480b14b-c766-11e1-8775-005056c00008" name="85-88" r="3.4847999999999999" x="17.772480000000002" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="51" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0470f9d2-c766-11e1-8775-005056c00008" p1="-63.074904527039408" q1="4.9446104291023723" p2="63.923638074786581" q2="-3.2525332075554472">
+    <iidm:line id="_0480b14b-c766-11e1-8775-005056c00008" name="85-88" r="3.4847999999999999" x="17.772480000000002" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="51" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0470f9d2-c766-11e1-8775-005056c00008" p1="-62.974222312029859" q1="3.506824161702192" p2="63.821314705245634" q2="-1.8134990928277916">
         <iidm:alias>_047602e2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04765105-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10195,7 +10318,7 @@
             <iidm:temporaryLimit name="_51646744-d343-42b5-8ba7-fcedc7cc3a98" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04486330-c766-11e1-8775-005056c00008" name="69-77" r="5.3840159999999999" x="17.598240000000001" g1="0" b1="0.00029786500000000002" g2="0" b2="0.00029786500000000002" node1="60" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="32.483343205838551" q1="18.621827758302917" p2="-32.010302766777734" q2="-27.846120950506599">
+    <iidm:line id="_04486330-c766-11e1-8775-005056c00008" name="69-77" r="5.3840159999999999" x="17.598240000000001" g1="0" b1="0.00029786500000000002" g2="0" b2="0.00029786500000000002" node1="60" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="32.589201895066452" q1="18.737376507229779" p2="-32.11255865922341" q2="-27.948411267101264">
         <iidm:alias>_046205b9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479d379-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10203,7 +10326,7 @@
             <iidm:temporaryLimit name="_76311a15-b79a-4439-a7ce-47afa8fa6fe2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04553477-c766-11e1-8775-005056c00008" name="11-13" r="3.8768400000000001" x="12.7369442" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="41" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04851e1b-c766-11e1-8775-005056c00008" p1="49.667104584602527" q1="15.054193590104958" p2="-49.045004447107878" q2="-14.795480909831781">
+    <iidm:line id="_04553477-c766-11e1-8775-005056c00008" name="11-13" r="3.8768400000000001" x="12.7369442" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="41" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04851e1b-c766-11e1-8775-005056c00008" p1="45.464209655196299" q1="16.226305722534136" p2="-44.925090627929215" q2="-16.241754641780545">
         <iidm:alias>_0479fa89-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0485452a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10211,7 +10334,7 @@
             <iidm:temporaryLimit name="_efbf8de7-4b84-4834-bb7c-6250b6072211" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04488a45-c766-11e1-8775-005056c00008" name="103-105" r="9.3218399999999999" x="28.314" g1="0" b1="0.0001170799" g2="0" b2="0.0001170799" node1="42" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="43.796589517389521" q1="12.535315211779185" p2="-42.678560531040446" q2="-13.121412868926525">
+    <iidm:line id="_04488a45-c766-11e1-8775-005056c00008" name="103-105" r="9.3218399999999999" x="28.314" g1="0" b1="0.0001170799" g2="0" b2="0.0001170799" node1="42" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="43.796462716937079" q1="12.535409863777364" p2="-42.678438094874217" q2="-13.121520340624187">
         <iidm:alias>_044f8f24-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04611b58-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10219,7 +10342,7 @@
             <iidm:temporaryLimit name="_22b6919a-a7a0-49fc-9e90-329069c55055" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046009e6-c766-11e1-8775-005056c00008" name="45-49" r="11.918016400000001" x="32.408639999999998" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="32" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="118" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-40.857315584669998" q1="-7.9987776561694881" p2="42.063550011012147" q2="6.8019185447220227">
+    <iidm:line id="_046009e6-c766-11e1-8775-005056c00008" name="45-49" r="11.918016400000001" x="32.408639999999998" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="32" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="118" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-40.729850633757565" q1="-8.0758233200663998" p2="41.929458811469736" q2="6.8611113350319801">
         <iidm:alias>_044ca8f9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047dcb1b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10227,7 +10350,7 @@
             <iidm:temporaryLimit name="_8b91f4fd-4038-45b7-870c-fbc08592b95a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046a6a27-c766-11e1-8775-005056c00008" name="88-89" r="2.4219360000000001" x="12.4058876" g1="0" b1="5.549815e-05" g2="0" b2="5.549815e-05" node1="22" voltageLevelId1="_0470f9d2-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-111.92183184912408" q1="-6.7468402429936845" p2="113.73334245744016" q2="14.117283480773535">
+    <iidm:line id="_046a6a27-c766-11e1-8775-005056c00008" name="88-89" r="2.4219360000000001" x="12.4058876" g1="0" b1="5.549815e-05" g2="0" b2="5.549815e-05" node1="22" voltageLevelId1="_0470f9d2-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-111.81938080433171" q1="-8.1858292008881168" p2="113.63413508766232" q2="15.574856155361182">
         <iidm:alias>_045ef879-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04649dc1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10235,7 +10358,7 @@
             <iidm:temporaryLimit name="_970bc323-73bf-440d-a3c5-00aebc3a1992" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048a7540-c766-11e1-8775-005056c00008" name="80-98" r="4.1469120000000004" x="18.817920000000001" g1="0" b1="8.20707e-05" g2="0" b2="8.20707e-05" node1="79" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04773b62-c766-11e1-8775-005056c00008" p1="11.403890949309368" q1="11.977167206913524" p2="-11.335029516704124" q2="-14.7090336453088">
+    <iidm:line id="_048a7540-c766-11e1-8775-005056c00008" name="80-98" r="4.1469120000000004" x="18.817920000000001" g1="0" b1="8.20707e-05" g2="0" b2="8.20707e-05" node1="79" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04773b62-c766-11e1-8775-005056c00008" p1="11.411693625273966" q1="11.975345058623299" p2="-11.342803867724063" q2="-14.707083684923127">
         <iidm:alias>_045338a2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04887972-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10243,7 +10366,7 @@
             <iidm:temporaryLimit name="_cb084dc7-1b26-415f-9495-4695df661912" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04640183-c766-11e1-8775-005056c00008" name="91-92" r="6.7430880000000002" x="22.163329999999998" g1="0" b1="9.3778700000000004e-05" g2="0" b2="9.3778700000000004e-05" node1="22" voltageLevelId1="_044f8f29-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="-5.6964688015449223" q1="-14.589192366106563" p2="5.7798733068885779" q2="11.726136320187909">
+    <iidm:line id="_04640183-c766-11e1-8775-005056c00008" name="91-92" r="6.7430880000000002" x="22.163329999999998" g1="0" b1="9.3778700000000004e-05" g2="0" b2="9.3778700000000004e-05" node1="22" voltageLevelId1="_044f8f29-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="-5.672378989713776" q1="-14.578965357409738" p2="5.755566978894973" q2="11.71545300946536">
         <iidm:alias>_04492680-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_044c5ad5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10251,7 +10374,7 @@
             <iidm:temporaryLimit name="_3a165a76-f6ba-461b-84d6-159a5e0b5077" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0474a358-c766-11e1-8775-005056c00008" name="7-12" r="1.501949" x="5.9241599999999996" g1="0" b1="2.5080350000000001e-05" g2="0" b2="2.5080350000000001e-05" node1="22" voltageLevelId1="_047eb571-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="23.632582354719972" q1="-9.817382630370119" p2="-23.575568128155865" q2="9.1867025826276887">
+    <iidm:line id="_0474a358-c766-11e1-8775-005056c00008" name="7-12" r="1.501949" x="5.9241599999999996" g1="0" b1="2.5080350000000001e-05" g2="0" b2="2.5080350000000001e-05" node1="22" voltageLevelId1="_047eb571-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="19.474993526819954" q1="-7.8267071130213344" p2="-19.436753679377691" q2="7.1216849374508895">
         <iidm:alias>_046ab848-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0477feb7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10259,7 +10382,7 @@
             <iidm:temporaryLimit name="_b19bc945-cc51-4d77-8eaa-3f6afe2d9316" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04765108-c766-11e1-8775-005056c00008" name="99-100" r="3.13632" x="14.165711399999999" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_04644fa4-c766-11e1-8775-005056c00008" node2="80" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-40.041731454705975" q1="12.289264373783283" p2="40.350223837720193" q2="-13.136674766440438">
+    <iidm:line id="_04765108-c766-11e1-8775-005056c00008" name="99-100" r="3.13632" x="14.165711399999999" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_04644fa4-c766-11e1-8775-005056c00008" node2="80" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-40.033892183644248" q1="12.287471384516008" p2="40.342267548485026" q2="-13.135410687826257">
         <iidm:alias>_0471e436-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047e4040-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10267,7 +10390,7 @@
             <iidm:temporaryLimit name="_a9e283ed-fcad-4f4c-ab57-8531875bb098" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047b8128-c766-11e1-8775-005056c00008" name="114-115" r="0.400752" x="1.8120959999999999" g1="0" b1="7.9201000000000006e-06" g2="0" b2="7.9201000000000006e-06" node1="22" voltageLevelId1="_04791027-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="-1.6493151694229546" q1="2.7780682748212371" p2="1.6495930764050613" q2="-3.0317141008469117">
+    <iidm:line id="_047b8128-c766-11e1-8775-005056c00008" name="114-115" r="0.400752" x="1.8120959999999999" g1="0" b1="7.9201000000000006e-06" g2="0" b2="7.9201000000000006e-06" node1="22" voltageLevelId1="_04791027-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="-0.59209309451808567" q1="2.1894069454121583" p2="0.59223515598127463" q2="-2.4442998299740077">
         <iidm:alias>_046c17d3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d0233-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10275,7 +10398,7 @@
             <iidm:temporaryLimit name="_c59e4022-b1c0-4811-a32e-f54656bff32d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046931a5-c766-11e1-8775-005056c00008" name="83-84" r="10.890000000000001" x="22.999680000000001" g1="0" b1="7.4035799999999993e-05" g2="0" b2="7.4035799999999993e-05" node1="33" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b0bf4-c766-11e1-8775-005056c00008" p1="-32.524467423257967" q1="20.476907413931123" p2="33.530006951653313" q2="-20.787859398281999">
+    <iidm:line id="_046931a5-c766-11e1-8775-005056c00008" name="83-84" r="10.890000000000001" x="22.999680000000001" g1="0" b1="7.4035799999999993e-05" g2="0" b2="7.4035799999999993e-05" node1="33" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b0bf4-c766-11e1-8775-005056c00008" p1="-32.31407946280693" q1="20.993158303149141" p2="33.328240591050275" q2="-21.277136817490277">
         <iidm:alias>_0465d645-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479102b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10283,7 +10406,7 @@
             <iidm:temporaryLimit name="_1268eb09-e233-44ce-b8af-22dc30eb16ad" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047ae4ea-c766-11e1-8775-005056c00008" name="14-15" r="10.367279999999999" x="33.976799999999997" g1="0" b1="0.0001440542" g2="0" b2="0.0001440542" node1="21" voltageLevelId1="_047b8129-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="21.161871556879642" q1="5.8820711424672183" p2="-20.840387905517613" q2="-9.4876991508491209">
+    <iidm:line id="_047ae4ea-c766-11e1-8775-005056c00008" name="14-15" r="10.367279999999999" x="33.976799999999997" g1="0" b1="0.0001440542" g2="0" b2="0.0001440542" node1="21" voltageLevelId1="_047b8129-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="16.49881979861328" q1="7.3754903030304533" p2="-16.26988942900141" q2="-11.282414318904552">
         <iidm:alias>_0449e9d9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046ed6fa-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10291,7 +10414,7 @@
             <iidm:temporaryLimit name="_9c0c454b-ecc3-40f6-b505-f32fec412522" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046e3ab2-c766-11e1-8775-005056c00008" name="80-96" r="6.2029439999999996" x="31.711680000000001" g1="0" b1="0.0001417585" g2="0" b2="0.0001417585" node1="80" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="4.6781494137659267" q1="26.268313376916332" p2="-4.3952844740326986" q2="-29.903640157872463">
+    <iidm:line id="_046e3ab2-c766-11e1-8775-005056c00008" name="80-96" r="6.2029439999999996" x="31.711680000000001" g1="0" b1="0.0001417585" g2="0" b2="0.0001417585" node1="80" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="4.7202655186829841" q1="26.467589847770174" p2="-4.4334608942739742" q2="-30.081004166121854">
         <iidm:alias>_045338a4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04865695-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10299,7 +10422,7 @@
             <iidm:temporaryLimit name="_1432f4d6-9299-4b0d-bd7f-16e059f9de66" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04893cc4-c766-11e1-8775-005056c00008" name="56-59" r="13.9914722" x="41.643360000000001" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="59" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-20.145030213271642" q1="-7.6716754998168382" p2="20.527373779367938" q2="3.7711116734256707">
+    <iidm:line id="_04893cc4-c766-11e1-8775-005056c00008" name="56-59" r="13.9914722" x="41.643360000000001" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="59" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-20.131403283635564" q1="-7.6770685755710097" p2="20.513312491791787" q2="3.7752130927132934">
         <iidm:alias>_046b5484-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04798557-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10307,7 +10430,7 @@
             <iidm:temporaryLimit name="_193f6952-4267-4cc8-a541-726c095028ba" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c1243-c766-11e1-8775-005056c00008" name="92-100" r="11.290752400000001" x="51.400799999999997" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="71" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="36.825445942603267" q1="-17.279867053792188" p2="-35.77947971377607" q2="17.290306223352427">
+    <iidm:line id="_045c1243-c766-11e1-8775-005056c00008" name="92-100" r="11.290752400000001" x="51.400799999999997" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="71" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="36.862366868783617" q1="-17.299343765307885" p2="-35.814100871089124" q2="17.320490568406083">
         <iidm:alias>_045e8348-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045ed164-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10315,7 +10438,7 @@
             <iidm:temporaryLimit name="_579249ce-1c81-4d29-8d3f-5fc627a18f99" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0474a356-c766-11e1-8775-005056c00008" name="43-44" r="10.593792000000001" x="42.7584953" g1="0" b1="0.00017412765" g2="0" b2="0.00017412765" node1="22" voltageLevelId1="_045e8349-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04544a15-c766-11e1-8775-005056c00008" p1="-5.4976148442647865" q1="-11.158762188679793" p2="5.5658730052143914" q2="5.817079585429175">
+    <iidm:line id="_0474a356-c766-11e1-8775-005056c00008" name="43-44" r="10.593792000000001" x="42.7584953" g1="0" b1="0.00017412765" g2="0" b2="0.00017412765" node1="22" voltageLevelId1="_045e8349-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04544a15-c766-11e1-8775-005056c00008" p1="-5.2417790718894057" q1="-11.311100746531819" p2="5.3100064015804458" q2="5.9720755782202968">
         <iidm:alias>_04642899-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047b0bf2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10323,7 +10446,7 @@
             <iidm:temporaryLimit name="_3d2cb4b5-ee82-4866-9855-4a5f4803cd3b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04627ae6-c766-11e1-8775-005056c00008" name="109-110" r="4.8438720000000002" x="13.2770882" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="22" voltageLevelId1="_046b7b99-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="12.735995260063335" q1="-2.9689125063787842" p2="-12.68549686948394" q2="1.260980821037343">
+    <iidm:line id="_04627ae6-c766-11e1-8775-005056c00008" name="109-110" r="4.8438720000000002" x="13.2770882" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="22" voltageLevelId1="_046b7b99-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="12.739330563153867" q1="-2.9701440361774862" p2="-12.688804834169179" q2="1.2622879734902916">
         <iidm:alias>_0466e7b5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a6fbb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10331,7 +10454,7 @@
             <iidm:temporaryLimit name="_6fc48d8d-05f8-4104-a6a2-3686d430a091" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0478c207-c766-11e1-8775-005056c00008" name="68-81" r="0.84699999999999998" x="9.7767990000000005" g1="0" b1="0.00083471078000000004" g2="0" b2="0.00083471078000000004" node1="38" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_048a272b-c766-11e1-8775-005056c00008" p1="-150.65126720524128" q1="-3.8531924577934529" p2="151.07280393227077" q2="-71.524010285418157">
+    <iidm:line id="_0478c207-c766-11e1-8775-005056c00008" name="68-81" r="0.84699999999999998" x="9.7767990000000005" g1="0" b1="0.00083471078000000004" g2="0" b2="0.00083471078000000004" node1="38" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_048a272b-c766-11e1-8775-005056c00008" p1="-150.06710962521444" q1="-3.9140865984727187" p2="150.48548356109615" q2="-71.500057846325987">
         <iidm:alias>_044a37f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045b4ef6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10339,7 +10462,7 @@
             <iidm:temporaryLimit name="_191836a1-39cd-402b-8dcf-4f3867c45bd0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0467d215-c766-11e1-8775-005056c00008" name="85-89" r="4.1643359999999996" x="30.143518400000001" g1="0" b1="0.00013487144999999999" g2="0" b2="0.00013487144999999999" node1="52" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-83.795076159910437" q1="-2.4097555272675653" p2="85.567715580624792" q2="10.64266831816642">
+    <iidm:line id="_0467d215-c766-11e1-8775-005056c00008" name="85-89" r="4.1643359999999996" x="30.143518400000001" g1="0" b1="0.00013487144999999999" g2="0" b2="0.00013487144999999999" node1="52" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-83.580515176766241" q1="-3.850573222525469" p2="85.35399881945898" q2="12.101190988628924">
         <iidm:alias>_047629f9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0478e915-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10347,7 +10470,7 @@
             <iidm:temporaryLimit name="_66cbdeeb-a4e4-4bfc-aec1-9fb7a2d2b6bc" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044a37f2-c766-11e1-8775-005056c00008" name="89-90" r="4.1469120000000004" x="17.371727" g1="0" b1="0.00030417815" g2="0" b2="0.00030417815" node1="62" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="112.73254875675897" q1="21.237372476286591" p2="-109.57130790341465" q2="-18.20950965212587">
+    <iidm:line id="_044a37f2-c766-11e1-8775-005056c00008" name="89-90" r="4.1469120000000004" x="17.371727" g1="0" b1="0.00030417815" g2="0" b2="0.00030417815" node1="62" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="112.74926340889637" q1="21.248713810296955" p2="-109.58699217580157" q2="-18.216396238750356">
         <iidm:alias>_045386c2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048719e9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10355,7 +10478,7 @@
             <iidm:temporaryLimit name="_8489e809-6588-4ed2-a9a4-43c44a0d47da" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04658820-c766-11e1-8775-005056c00008" name="98-100" r="6.9173280000000004" x="31.188960999999999" g1="0" b1="0.0001365932" g2="0" b2="0.0001365932" node1="22" voltageLevelId1="_04773b62-c766-11e1-8775-005056c00008" node2="82" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-22.664950696123192" q1="6.7090414060833048" p2="22.891771879838128" q2="-10.640561139205513">
+    <iidm:line id="_04658820-c766-11e1-8775-005056c00008" name="98-100" r="6.9173280000000004" x="31.188960999999999" g1="0" b1="0.0001365932" g2="0" b2="0.0001365932" node1="22" voltageLevelId1="_04773b62-c766-11e1-8775-005056c00008" node2="82" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-22.657177992474733" q1="6.7070910173659817" p2="22.88385194929289" q2="-10.63927559758408">
         <iidm:alias>_046f4c22-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046fe865-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10363,7 +10486,7 @@
             <iidm:temporaryLimit name="_620beaaf-63c8-4020-bea5-c3609c0eaadf" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c5ada-c766-11e1-8775-005056c00008" name="28-29" r="4.1294880000000003" x="16.430831900000001" g1="0" b1="6.8296599999999999e-05" g2="0" b2="6.8296599999999999e-05" node1="22" voltageLevelId1="_04819ba0-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04588fd5-c766-11e1-8775-005056c00008" p1="17.276051400892634" q1="-7.2274355483458566" p2="-17.189860783456286" q2="5.3669773622092602">
+    <iidm:line id="_044c5ada-c766-11e1-8775-005056c00008" name="28-29" r="4.1294880000000003" x="16.430831900000001" g1="0" b1="6.8296599999999999e-05" g2="0" b2="6.8296599999999999e-05" node1="22" voltageLevelId1="_04819ba0-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04588fd5-c766-11e1-8775-005056c00008" p1="15.441077273014086" q1="-5.2258041668774275" p2="-15.375842968092545" q2="3.2760313078394834">
         <iidm:alias>_0461697a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04697fc1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10371,7 +10494,13 @@
             <iidm:temporaryLimit name="_6748d0d0-aec8-4b7b-a9ab-be6aecda7c5d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0468e382-c766-11e1-8775-005056c00008" name="3-5" r="4.1991839999999998" x="18.817920000000001" g1="0" b1="8.1496799999999995e-05" g2="0" b2="8.1496799999999995e-05" node1="31" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-72.362877800312305" q1="-15.607976530097591" p2="73.749569642590444" q2="19.033901345811252">
+    <iidm:line id="_044c5ada-c766-11e1-8775-005056c00008-1" name="28-29-open-ended" r="4.1294880000000003" x="16.430831900000001" g1="0" b1="6.8296599999999999e-05" g2="0" b2="6.8296599999999999e-05" node1="25" voltageLevelId1="_04819ba0-c766-11e1-8775-005056c00008" node2="25" voltageLevelId2="_04588fd5-c766-11e1-8775-005056c00008" p1="0.00031212941953185237" q1="-2.2097241143198421" p2="0" q2="0">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_accb8136-1faf-4399-9787-3cd567284fd2-1" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_6748d0d0-aec8-4b7b-a9ab-be6aecda7c5d-1" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0468e382-c766-11e1-8775-005056c00008" name="3-5" r="4.1991839999999998" x="18.817920000000001" g1="0" b1="8.1496799999999995e-05" g2="0" b2="8.1496799999999995e-05" node1="31" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-70.182817718681562" q1="-16.751302360338624" p2="71.49770114512755" q2="19.851423428631634">
         <iidm:alias>_046b0668-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04742e24-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10379,7 +10508,7 @@
             <iidm:temporaryLimit name="_828ca44c-560b-4f94-b825-21e237285fae" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0447c6f1-c766-11e1-8775-005056c00008" name="82-96" r="2.8226879999999999" x="9.2347199999999994" g1="0" b1="0.00015610649999999999" g2="0" b2="0.00015610649999999999" node1="33" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="-15.586269442829771" q1="-9.1437220943928583" p2="15.634263529253728" q2="4.0259361049735514">
+    <iidm:line id="_0447c6f1-c766-11e1-8775-005056c00008" name="82-96" r="2.8226879999999999" x="9.2347199999999994" g1="0" b1="0.00015610649999999999" g2="0" b2="0.00015610649999999999" node1="33" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="-15.785062341771194" q1="-9.8591727024767142" p2="15.835851996462289" q2="4.7566989649931921">
         <iidm:alias>_0478e91a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0480d856-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10387,7 +10516,7 @@
             <iidm:temporaryLimit name="_233b7735-85f4-4a6f-9d87-15129fe42ef5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0483e594-c766-11e1-8775-005056c00008" name="38-65" r="4.3608399999999996" x="47.7224" g1="0" b1="0.0010805785" g2="0" b2="0.0010805785" node1="29" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-162.0188053734216" q1="-97.486995449124819" p2="165.13580997069971" q2="34.765214056752278">
+    <iidm:line id="_0483e594-c766-11e1-8775-005056c00008" name="38-65" r="4.3608399999999996" x="47.7224" g1="0" b1="0.0010805785" g2="0" b2="0.0010805785" node1="29" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-160.67112607716373" q1="-98.013808515510874" p2="163.74940916108548" q2="34.890128696621623">
         <iidm:alias>_04638c56-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d5054-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10395,7 +10524,7 @@
             <iidm:temporaryLimit name="_990ce3c5-c90c-41b9-abee-fb803d9df3a5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04784cd4-c766-11e1-8775-005056c00008" name="106-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_04479fe8-c766-11e1-8775-005056c00008" node2="24" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="23.852756964364726" q1="-0.69453418833064984" p2="-23.524352741160445" q2="-2.4550660802088382">
+    <iidm:line id="_04784cd4-c766-11e1-8775-005056c00008" name="106-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_04479fe8-c766-11e1-8775-005056c00008" node2="24" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="23.852986894450535" q1="-0.69461278131162318" p2="-23.524576358945502" q2="-2.4549640423435206">
         <iidm:alias>_04483c21-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f0395-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10403,7 +10532,7 @@
             <iidm:temporaryLimit name="_1372c3b0-62d7-47d7-a8c0-ed8e10bc1f1a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046f9a43-c766-11e1-8775-005056c00008" name="27-115" r="2.8575360000000001" x="12.9111843" g1="0" b1="5.6588600000000002e-05" g2="0" b2="5.6588600000000002e-05" node1="43" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="23.748700043875974" q1="2.5903851774820987" p2="-23.647710107353376" q2="-3.9672880609285905">
+    <iidm:line id="_046f9a43-c766-11e1-8775-005056c00008" name="27-115" r="2.8575360000000001" x="12.9111843" g1="0" b1="5.6588600000000002e-05" g2="0" b2="5.6588600000000002e-05" node1="43" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="22.683214961632032" q1="3.1356242013306868" p2="-22.590446135068813" q2="-4.5547511100252107">
         <iidm:alias>_046d0238-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048c22f4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10411,7 +10540,7 @@
             <iidm:temporaryLimit name="_64cfd0fb-1d8e-45d2-a52f-469238dfc0c6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04529c61-c766-11e1-8775-005056c00008" name="12-14" r="3.7461600000000002" x="12.3187675" g1="0" b1="5.2112050000000002e-05" g2="0" b2="5.2112050000000002e-05" node1="71" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b8129-c766-11e1-8775-005056c00008" p1="35.447643363258877" q1="6.0655679840793866" p2="-35.161390387901299" q2="-6.8820140900035129">
+    <iidm:line id="_04529c61-c766-11e1-8775-005056c00008" name="12-14" r="3.7461600000000002" x="12.3187675" g1="0" b1="5.2112050000000002e-05" g2="0" b2="5.2112050000000002e-05" node1="71" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b8129-c766-11e1-8775-005056c00008" p1="30.720260075881239" q1="7.3473440596318778" p2="-30.498352927543575" q2="-8.3754347412326862">
         <iidm:alias>_045fbbc1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047bf65b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10419,7 +10548,7 @@
             <iidm:temporaryLimit name="_efe2501d-bcee-42ff-a037-3d8a280487b0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0463da77-c766-11e1-8775-005056c00008" name="76-118" r="2.8575360000000001" x="9.4786560000000009" g1="0" b1="3.8911849999999999e-05" g2="0" b2="3.8911849999999999e-05" node1="22" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="-5.5714724708385992" q1="-13.166760178464521" p2="5.6069548679351175" q2="12.088424915485101">
+    <iidm:line id="_0463da77-c766-11e1-8775-005056c00008" name="76-118" r="2.8575360000000001" x="9.4786560000000009" g1="0" b1="3.8911849999999999e-05" g2="0" b2="3.8911849999999999e-05" node1="22" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="-5.4587610929797377" q1="-13.258108162193441" p2="5.4944492048415006" q2="12.180610567789548">
         <iidm:alias>_046931a0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04806320-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10427,7 +10556,7 @@
             <iidm:temporaryLimit name="_2ae204bf-78cc-49cb-b886-a933b33057e4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046931a3-c766-11e1-8775-005056c00008" name="74-75" r="2.1431520000000002" x="7.0741440000000004" g1="0" b1="2.9671699999999999e-05" g2="0" b2="2.9671699999999999e-05" node1="23" voltageLevelId1="_047dcb11-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="-44.929824689566203" q1="-12.127880735145288" p2="45.222283636578297" q2="12.145416497892507">
+    <iidm:line id="_046931a3-c766-11e1-8775-005056c00008" name="74-75" r="2.1431520000000002" x="7.0741440000000004" g1="0" b1="2.9671699999999999e-05" g2="0" b2="2.9671699999999999e-05" node1="23" voltageLevelId1="_047dcb11-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="-45.195505053397319" q1="-11.965066539670641" p2="45.490690954729857" q2="11.991599899381161">
         <iidm:alias>_044f4103-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04638c58-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10435,7 +10564,7 @@
             <iidm:temporaryLimit name="_e822432e-79af-4bba-8f40-5250468f81a0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045ed162-c766-11e1-8775-005056c00008" name="3-12" r="8.4332159999999998" x="27.878398900000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="32" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-7.4165581005881664" q1="-10.394484333190311" p2="7.4814901648754457" q2="6.7003198371027644">
+    <iidm:line id="_045ed162-c766-11e1-8775-005056c00008" name="3-12" r="8.4332159999999998" x="27.878398900000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="32" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-8.6497166828906327" q1="-9.7383280307134203" p2="8.7192384608547133" q2="6.0575393297378683">
         <iidm:alias>_047a48a1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047b5a14-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10443,7 +10572,7 @@
             <iidm:temporaryLimit name="_c437e52c-43d7-4ae9-87ad-dc19396dc6ff" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04499bb6-c766-11e1-8775-005056c00008" name="49-51" r="8.468064" x="23.8708782" g1="0" b1="9.81405e-05" g2="0" b2="9.81405e-05" node1="119" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04542300-c766-11e1-8775-005056c00008" p1="76.825441517919117" q1="18.66803092670369" p2="-73.901485894190884" q2="-13.816904425126381">
+    <iidm:line id="_04499bb6-c766-11e1-8775-005056c00008" name="49-51" r="8.468064" x="23.8708782" g1="0" b1="9.81405e-05" g2="0" b2="9.81405e-05" node1="119" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04542300-c766-11e1-8775-005056c00008" p1="76.8456069256044" q1="18.664825588962859" p2="-73.920278642443591" q2="-13.809821518382986">
         <iidm:alias>_0487dd38-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b1180-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10451,7 +10580,7 @@
             <iidm:temporaryLimit name="_90dcdbe1-437b-443f-b0b5-c2353f7c6954" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04839779-c766-11e1-8775-005056c00008" name="40-42" r="9.6703209999999995" x="31.885919999999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="42" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="-0.74226839600562644" q1="-9.5804678851888507" p2="0.78354376230796186" q2="5.8950155605342172">
+    <iidm:line id="_04839779-c766-11e1-8775-005056c00008" name="40-42" r="9.6703209999999995" x="31.885919999999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="42" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="-0.54891039576885625" q1="-9.7170508606219723" p2="0.59153683606339769" q2="6.0389416798598363">
         <iidm:alias>_044974a9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04616975-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10459,7 +10588,7 @@
             <iidm:temporaryLimit name="_9b8510fa-bd0e-4e63-8f4c-0e5443a3eb63" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0484a8e1-c766-11e1-8775-005056c00008" name="32-113" r="10.71576" x="35.370719999999999" g1="0" b1="0.00014864555000000001" g2="0" b2="0.00014864555000000001" node1="52" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="4.7967293501037913" q1="-10.099421559351859" p2="-4.7425459093928017" q2="5.3853979777841987">
+    <iidm:line id="_0484a8e1-c766-11e1-8775-005056c00008" name="32-113" r="10.71576" x="35.370719999999999" g1="0" b1="0.00014864555000000001" g2="0" b2="0.00014864555000000001" node1="52" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="0.84097665221599494" q1="-8.3743657838293366" p2="-0.81713726678489029" q2="3.5569046786679945">
         <iidm:alias>_04723258-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0482860a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10467,7 +10596,7 @@
             <iidm:temporaryLimit name="_336bfd86-a922-4154-9e06-cd87382cdc5f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04898ae4-c766-11e1-8775-005056c00008" name="51-58" r="4.4431200000000004" x="12.5278568" g1="0" b1="5.1308550000000002e-05" g2="0" b2="5.1308550000000002e-05" node1="31" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="25.293642585915322" q1="0.49522510686239829" p2="-25.118226648392184" q2="-1.6552107172901807">
+    <iidm:line id="_04898ae4-c766-11e1-8775-005056c00008" name="51-58" r="4.4431200000000004" x="12.5278568" g1="0" b1="5.1308550000000002e-05" g2="0" b2="5.1308550000000002e-05" node1="31" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="25.30622742424038" q1="0.49001244328215898" p2="-25.130640247164916" q2="-1.6495079527092087">
         <iidm:alias>_044778d4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04789af1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10475,7 +10604,7 @@
             <iidm:temporaryLimit name="_2be10dec-f0ac-470d-83f7-a2a4e70f3491" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046efe04-c766-11e1-8775-005056c00008" name="29-31" r="1.8817919999999999" x="5.7673439999999996" g1="0" b1="2.3817700000000001e-05" g2="0" b2="2.3817700000000001e-05" node1="22" voltageLevelId1="_04588fd5-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="-6.8098763375765454" q1="-9.3669043767636211" p2="6.8246677557463222" q2="8.6391991142780551">
+    <iidm:line id="_046efe04-c766-11e1-8775-005056c00008" name="29-31" r="1.8817919999999999" x="5.7673439999999996" g1="0" b1="2.3817700000000001e-05" g2="0" b2="2.3817700000000001e-05" node1="22" voltageLevelId1="_04588fd5-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="-8.6239226924610648" q1="-7.2759661719194773" p2="8.6380938485151493" q2="6.5459477028120592">
         <iidm:alias>_04492688-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047cb9a5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10483,7 +10612,7 @@
             <iidm:temporaryLimit name="_f0e21213-6535-44a7-89b6-3063f8738d6b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044a10e4-c766-11e1-8775-005056c00008" name="65-68" r="0.66791999999999996" x="7.7439999999999998" g1="0" b1="0.00065909092999999995" g2="0" b2="0.00065909092999999995" node1="41" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0449e9d2-c766-11e1-8775-005056c00008" p1="-163.6808424915352" q1="23.943967460343284" p2="164.08999261945735" q2="-83.234978646084457">
+    <iidm:line id="_044a10e4-c766-11e1-8775-005056c00008" name="65-68" r="0.66791999999999996" x="7.7439999999999998" g1="0" b1="0.00065909092999999995" g2="0" b2="0.00065909092999999995" node1="41" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0449e9d2-c766-11e1-8775-005056c00008" p1="-162.17672473532443" q1="23.751467299327867" p2="162.5788832817141" q2="-83.123767236713348">
         <iidm:alias>_0461dea7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047629f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10491,7 +10620,7 @@
             <iidm:temporaryLimit name="_ab31cd46-6d0c-4d9c-95f1-396a45a237e1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046b7b92-c766-11e1-8775-005056c00008" name="49-54" r="12.719519999999999" x="50.355361899999998" g1="0" b1="0.00021177684999999999" g2="0" b2="0.00021177684999999999" node1="120" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="46.761043640844299" q1="11.852057503195862" p2="-45.069846099633097" q2="-12.398946537295599">
+    <iidm:line id="_046b7b92-c766-11e1-8775-005056c00008" name="49-54" r="12.719519999999999" x="50.355361899999998" g1="0" b1="0.00021177684999999999" g2="0" b2="0.00021177684999999999" node1="120" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="46.779087817369351" q1="11.849871917397325" p2="-45.086765351225857" q2="-12.392307738909835">
         <iidm:alias>_0462f017-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047120e1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10499,7 +10628,7 @@
             <iidm:temporaryLimit name="_1bf78539-b6fa-4d8b-ba8e-9b5970019be6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04607f15-c766-11e1-8775-005056c00008" name="70-71" r="1.536797" x="6.1855200000000004" g1="0" b1="2.5195149999999999e-05" g2="0" b2="2.5195149999999999e-05" node1="52" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04664b78-c766-11e1-8775-005056c00008" p1="-5.7111952053229276" q1="-5.0063033202385432" p2="5.7161184373265579" q2="4.1805933341191643">
+    <iidm:line id="_04607f15-c766-11e1-8775-005056c00008" name="70-71" r="1.536797" x="6.1855200000000004" g1="0" b1="2.5195149999999999e-05" g2="0" b2="2.5195149999999999e-05" node1="52" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04664b78-c766-11e1-8775-005056c00008" p1="-5.0735959459072308" q1="-5.4229482166999494" p2="5.0782533438830741" q2="4.5958808515517831">
         <iidm:alias>_04486336-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f51b4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10507,7 +10636,7 @@
             <iidm:temporaryLimit name="_08ff3ae4-d1dd-49f7-9eda-32ffc8eb0010" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c5ad7-c766-11e1-8775-005056c00008" name="55-56" r="0.85029100000000002" x="2.631024" g1="0" b1="1.0732300000000001e-05" g2="0" b2="1.0732300000000001e-05" node1="31" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="-28.676460069393269" q1="-7.0078108072332057" p2="28.723327558270988" q2="6.8134695794409419">
+    <iidm:line id="_044c5ad7-c766-11e1-8775-005056c00008" name="55-56" r="0.85029100000000002" x="2.631024" g1="0" b1="1.0732300000000001e-05" g2="0" b2="1.0732300000000001e-05" node1="31" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="-28.687724932166763" q1="-7.0041715154598787" p2="28.734624608528048" q2="6.8099300531620122">
         <iidm:alias>_04558294-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045868c2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10515,7 +10644,7 @@
             <iidm:temporaryLimit name="_94316214-afd8-4c0d-bca4-916acb92af85" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048a2725-c766-11e1-8775-005056c00008" name="35-37" r="1.9166399999999999" x="8.6597279999999994" g1="0" b1="3.7821399999999997e-05" g2="0" b2="3.7821399999999997e-05" node1="21" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-29.636807717839787" q1="-14.400867013825758" p2="29.770350206233807" q2="13.829749121917542">
+    <iidm:line id="_048a2725-c766-11e1-8775-005056c00008" name="35-37" r="1.9166399999999999" x="8.6597279999999994" g1="0" b1="3.7821399999999997e-05" g2="0" b2="3.7821399999999997e-05" node1="21" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-29.556957381100592" q1="-14.436404843152694" p2="29.690176986778194" q2="13.865057572730205">
         <iidm:alias>_0471bd29-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04808a30-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10523,7 +10652,7 @@
             <iidm:temporaryLimit name="_4ea6b532-d914-4b0c-97ee-9f02a14a40b3" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04614263-c766-11e1-8775-005056c00008" name="4-5" r="0.30666199999999999" x="1.3904350000000001" g1="0" b1="6.0261499999999999e-06" g2="0" b2="6.0261499999999999e-06" node1="22" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-113.01218839675597" q1="-18.12344825892529" p2="113.24012617351833" q2="18.943855251360286">
+    <iidm:line id="_04614263-c766-11e1-8775-005056c00008" name="4-5" r="0.30666199999999999" x="1.3904350000000001" g1="0" b1="6.0261499999999999e-06" g2="0" b2="6.0261499999999999e-06" node1="22" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-108.55194280487692" q1="-19.943507560153463" p2="108.76350128845473" q2="20.689255973918197">
         <iidm:alias>_04529c66-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04753f92-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10531,7 +10660,7 @@
             <iidm:temporaryLimit name="_2a95fb2b-6661-46e7-a9f6-fe63c1b7433c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0451b208-c766-11e1-8775-005056c00008" name="20-21" r="3.1885919999999999" x="14.7929754" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_046b2d70-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0460f448-c766-11e1-8775-005056c00008" p1="-32.836747858547298" q1="1.6710956536411217" p2="33.061588028811087" q2="-2.5448858761247437">
+    <iidm:line id="_0451b208-c766-11e1-8775-005056c00008" name="20-21" r="3.1885919999999999" x="14.7929754" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_046b2d70-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0460f448-c766-11e1-8775-005056c00008" p1="-30.856795937976301" q1="0.69204347811157241" p2="31.054501053850224" q2="-1.6939571161730802">
         <iidm:alias>_046c65f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048c22f6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10539,7 +10668,7 @@
             <iidm:temporaryLimit name="_4b67f5f5-f0e1-4bfb-9d57-4d3474720a45" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047d55e4-c766-11e1-8775-005056c00008" name="104-105" r="1.731946" x="6.5862720000000001" g1="0" b1="2.8294300000000001e-05" g2="0" b2="2.8294300000000001e-05" node1="32" voltageLevelId1="_0483977a-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="48.030108550718019" q1="0.86569996943788863" p2="-47.786506137926494" q2="-0.86314817013222056">
+    <iidm:line id="_047d55e4-c766-11e1-8775-005056c00008" name="104-105" r="1.731946" x="6.5862720000000001" g1="0" b1="2.8294300000000001e-05" g2="0" b2="2.8294300000000001e-05" node1="32" voltageLevelId1="_0483977a-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="48.031819561628382" q1="0.86524910111846554" p2="-47.788199872311935" q2="-0.86263138693569186">
         <iidm:alias>_0451d910-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046c65f2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10547,7 +10676,7 @@
             <iidm:temporaryLimit name="_1ca40dc7-6736-4fa8-b4cb-ca696949e421" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046dc589-c766-11e1-8775-005056c00008" name="44-45" r="3.9029759999999998" x="15.699023199999999" g1="0" b1="6.4279149999999996e-05" g2="0" b2="6.4279149999999996e-05" node1="23" voltageLevelId1="_04544a15-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_045d23b4-c766-11e1-8775-005056c00008" p1="-21.564423590879723" q1="-4.3137617492340148" p2="21.67655199127422" q2="2.6187365357849659">
+    <iidm:line id="_046dc589-c766-11e1-8775-005056c00008" name="44-45" r="3.9029759999999998" x="15.699023199999999" g1="0" b1="6.4279149999999996e-05" g2="0" b2="6.4279149999999996e-05" node1="23" voltageLevelId1="_04544a15-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_045d23b4-c766-11e1-8775-005056c00008" p1="-21.308553586835625" q1="-4.4711062756342157" p2="21.418370174840568" q2="2.7671294200933798">
         <iidm:alias>_04518afa-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04667287-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10555,7 +10684,7 @@
             <iidm:temporaryLimit name="_ba738481-ddba-4ebe-a218-8aad0b537f5b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04642896-c766-11e1-8775-005056c00008" name="4-11" r="3.641616" x="11.9877129" g1="0" b1="5.0160700000000002e-05" g2="0" b2="5.0160700000000002e-05" node1="23" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="74.012936081171588" q1="6.1238317126920698" p2="-72.870608915126596" q2="-4.0980643549085007">
+    <iidm:line id="_04642896-c766-11e1-8775-005056c00008" name="4-11" r="3.641616" x="11.9877129" g1="0" b1="5.0160700000000002e-05" g2="0" b2="5.0160700000000002e-05" node1="23" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="69.552651954902956" q1="7.9438711349584841" p2="-68.538523113124867" q2="-6.342439561661231">
         <iidm:alias>_0455f7c5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04803c17-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10563,7 +10692,7 @@
             <iidm:temporaryLimit name="_b1d87c24-e527-4174-aa04-cd0b9de271ea" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047d07c0-c766-11e1-8775-005056c00008" name="92-93" r="4.4953919999999998" x="14.775551800000001" g1="0" b1="6.2557400000000005e-05" g2="0" b2="6.2557400000000005e-05" node1="72" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04789af0-c766-11e1-8775-005056c00008" p1="70.553516910088263" q1="-12.759301000492695" p2="-69.205627599416644" q2="15.069011978982777">
+    <iidm:line id="_047d07c0-c766-11e1-8775-005056c00008" name="92-93" r="4.4953919999999998" x="14.775551800000001" g1="0" b1="6.2557400000000005e-05" g2="0" b2="6.2557400000000005e-05" node1="72" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04789af0-c766-11e1-8775-005056c00008" p1="70.61080054888842" q1="-12.6960633391756" p2="-69.261029076390287" q2="15.012323165396047">
         <iidm:alias>_044a5f07-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047602e5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10571,7 +10700,7 @@
             <iidm:temporaryLimit name="_4e1daf8e-7708-4b96-8d3f-67f58f2505f9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044f4109-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="43" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="121" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-53.76211543584666" q1="-18.775760161169401" p2="56.435476545761496" q2="22.745634938278954">
+    <iidm:line id="_044f4109-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="43" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="121" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-53.571483129295018" q1="-18.917681155097998" p2="56.232576779154421" q2="22.834156240477359">
         <iidm:alias>_046958b0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04758db0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10579,7 +10708,7 @@
             <iidm:temporaryLimit name="_c58940cb-bd36-4dfc-9615-11716dd652a7" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046e61c8-c766-11e1-8775-005056c00008" name="69-75" r="7.0567200000000003" x="21.257280000000002" g1="0" b1="0.00035583104999999999" g2="0" b2="0.00035583104999999999" node1="61" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="89.735661569570652" q1="28.497866400823892" p2="-86.22440614912081" q2="-30.310521730376017">
+    <iidm:line id="_046e61c8-c766-11e1-8775-005056c00008" name="69-75" r="7.0567200000000003" x="21.257280000000002" g1="0" b1="0.00035583104999999999" g2="0" b2="0.00035583104999999999" node1="61" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="90.09663506770184" q1="28.427460823253924" p2="-86.562706405180251" q2="-30.171643677262335">
         <iidm:alias>_046d294a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048ac362-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10587,7 +10716,7 @@
             <iidm:temporaryLimit name="_3c9a454c-10ee-4c72-a059-77f723f5b7c7" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0463da71-c766-11e1-8775-005056c00008" name="79-80" r="2.7181440000000001" x="12.2664957" g1="0" b1="5.3661600000000001e-05" g2="0" b2="5.3661600000000001e-05" node1="23" voltageLevelId1="_04481510-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-66.382425808515563" q1="-32.879677746403182" p2="67.217947901906797" q2="34.69165471877119">
+    <iidm:line id="_0463da71-c766-11e1-8775-005056c00008" name="79-80" r="2.7181440000000001" x="12.2664957" g1="0" b1="5.3661600000000001e-05" g2="0" b2="5.3661600000000001e-05" node1="23" voltageLevelId1="_04481510-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-66.468130903686301" q1="-32.990202933328696" p2="67.306656057505705" q2="34.81591215143925">
         <iidm:alias>_0464ebe9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04662468-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10595,7 +10724,7 @@
             <iidm:temporaryLimit name="_270a7d04-9ff9-4178-8b72-b610735a72ac" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044fdd41-c766-11e1-8775-005056c00008" name="51-52" r="3.5370720000000002" x="10.2453117" g1="0" b1="4.0059699999999999e-05" g2="0" b2="4.0059699999999999e-05" node1="32" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04806326-c766-11e1-8775-005056c00008" p1="31.607861267811753" q1="5.3216934066882091" p2="-31.382628455005168" q2="-5.9576318887046797">
+    <iidm:line id="_044fdd41-c766-11e1-8775-005056c00008" name="51-52" r="3.5370720000000002" x="10.2453117" g1="0" b1="4.0059699999999999e-05" g2="0" b2="4.0059699999999999e-05" node1="32" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04806326-c766-11e1-8775-005056c00008" p1="31.61406859252962" q1="5.3198229039996088" p2="-31.388754067028714" q2="-5.9555178813890537">
         <iidm:alias>_045115c2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0464ebe5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10603,7 +10732,7 @@
             <iidm:temporaryLimit name="_9d1eb182-ceb5-426e-9440-5f4d426a31cb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c3958-c766-11e1-8775-005056c00008" name="53-54" r="4.5825120000000004" x="21.257280000000002" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="22" voltageLevelId1="_04876804-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="-9.7002689845689929" q1="-6.7109983866450005" p2="9.7363058290241611" q2="4.0792696734976319">
+    <iidm:line id="_045c3958-c766-11e1-8775-005056c00008" name="53-54" r="4.5825120000000004" x="21.257280000000002" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="22" voltageLevelId1="_04876804-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="-9.6942125173593929" q1="-6.7134020544384398" p2="9.7302224444662642" q2="4.0815523224386014">
         <iidm:alias>_044f6817-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0455f7c6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10611,7 +10740,7 @@
             <iidm:temporaryLimit name="_735ac8df-6a6a-43f0-86f2-49d3280c9a3b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044ef2e1-c766-11e1-8775-005056c00008" name="54-55" r="2.9446560000000002" x="12.3187675" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="63" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04767817-c766-11e1-8775-005056c00008" p1="10.152883645447883" q1="1.7064021210528677" p2="-10.132503202666133" q2="-3.4562775414478151">
+    <iidm:line id="_044ef2e1-c766-11e1-8775-005056c00008" name="54-55" r="2.9446560000000002" x="12.3187675" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="63" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04767817-c766-11e1-8775-005056c00008" p1="10.156847481114841" q1="1.7058290756087848" p2="-10.13645267918484" q2="-3.4556439852314278">
         <iidm:alias>_04640181-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047dcb17-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10619,7 +10748,7 @@
             <iidm:temporaryLimit name="_52aadf8d-53f2-4827-8c70-421bdf1ba822" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0456e226-c766-11e1-8775-005056c00008" name="80-97" r="3.1885919999999999" x="16.2740154" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="82" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="12.189518238837357" q1="30.871038664881194" p2="-11.988464734783486" q2="-32.511262045175087">
+    <iidm:line id="_0456e226-c766-11e1-8775-005056c00008" name="80-97" r="3.1885919999999999" x="16.2740154" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="82" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="12.23305251735794" q1="31.071529525029302" p2="-12.029624739177233" q2="-32.699154253771482">
         <iidm:alias>_04479fe9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047df222-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10627,7 +10756,7 @@
             <iidm:temporaryLimit name="_fece5807-6af8-4161-8de8-8f8473d92f11" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0487b624-c766-11e1-8775-005056c00008" name="103-110" r="6.8058139999999998" x="31.5897121" g1="0" b1="0.00013228879999999999" g2="0" b2="0.00013228879999999999" node1="43" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="57.717777105701614" q1="18.497614962777746" p2="-56.275754167096267" q2="-16.258099314345877">
+    <iidm:line id="_0487b624-c766-11e1-8775-005056c00008" name="103-110" r="6.8058139999999998" x="31.5897121" g1="0" b1="0.00013228879999999999" g2="0" b2="0.00013228879999999999" node1="43" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="57.72139225653504" q1="18.497290980482035" p2="-56.279214681019788" q2="-16.257056868139674">
         <iidm:alias>_046a9139-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b3895-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10635,7 +10764,7 @@
             <iidm:temporaryLimit name="_3eacc034-737e-41de-a7b6-b610d3bd0921" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045338a8-c766-11e1-8775-005056c00008" name="56-58" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="61" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="-13.053928359395586" q1="-0.68599873750669471" p2="13.118234852584068" q2="-1.3447858623608531">
+    <iidm:line id="_045338a8-c766-11e1-8775-005056c00008" name="56-58" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="61" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="-13.06621862334058" q1="-0.67994501615555247" p2="13.130648079103585" q2="-1.35048871510258">
         <iidm:alias>_0451d915-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04817494-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10643,7 +10772,7 @@
             <iidm:temporaryLimit name="_0d0c3ec5-798a-48a4-9bc8-d19c57128a13" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04854529-c766-11e1-8775-005056c00008" name="15-33" r="6.6211200000000003" x="21.675455100000001" g1="0" b1="9.1655200000000003e-05" g2="0" b2="9.1655200000000003e-05" node1="52" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456bb11-c766-11e1-8775-005056c00008" p1="63.487133963658401" q1="-8.2037406200082881" p2="-61.766979648657269" q2="10.996673189841493">
+    <iidm:line id="_04854529-c766-11e1-8775-005056c00008" name="15-33" r="6.6211200000000003" x="21.675455100000001" g1="0" b1="9.1655200000000003e-05" g2="0" b2="9.1655200000000003e-05" node1="52" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456bb11-c766-11e1-8775-005056c00008" p1="64.531572496414555" q1="-8.297842549570591" p2="-62.752737394153677" q2="11.286113101755332">
         <iidm:alias>_0448d862-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047d2ed5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10651,7 +10780,7 @@
             <iidm:temporaryLimit name="_5b0395f4-534d-4975-a1af-e0b6ef439193" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04649dc2-c766-11e1-8775-005056c00008" name="35-36" r="0.39029799999999998" x="1.7772479999999999" g1="0" b1="7.6905500000000004e-06" g2="0" b2="7.6905500000000004e-06" node1="22" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="-3.3539756908164464" q1="5.4050570890186398" p2="3.3550375143464457" q2="-5.6361531127913755">
+    <iidm:line id="_04649dc2-c766-11e1-8775-005056c00008" name="35-36" r="0.39029799999999998" x="1.7772479999999999" g1="0" b1="7.6905500000000004e-06" g2="0" b2="7.6905500000000004e-06" node1="22" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="-3.4337903718135552" q1="5.4406168799876182" p2="3.4348771201655066" q2="-5.6713465612934186">
         <iidm:alias>_044c0cb5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0456e225-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10659,7 +10788,7 @@
             <iidm:temporaryLimit name="_74c4b341-7b99-4a81-b88a-2ed3b0c4b1de" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0470d2c9-c766-11e1-8775-005056c00008" name="37-40" r="10.3324327" x="29.272320000000001" g1="0" b1="0.0001205234" g2="0" b2="0.0001205234" node1="61" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="56.108725639867693" q1="10.32012352654759" p2="-53.939511777802331" q2="-7.7589663852908473">
+    <iidm:line id="_0470d2c9-c766-11e1-8775-005056c00008" name="37-40" r="10.3324327" x="29.272320000000001" g1="0" b1="0.0001205234" g2="0" b2="0.0001205234" node1="61" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="56.311961036654125" q1="10.229693658922789" p2="-54.126955197700724" q2="-7.620239239879675">
         <iidm:alias>_045b9d10-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046a4317-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10667,7 +10796,7 @@
             <iidm:temporaryLimit name="_e98d56fe-a54b-45e4-acff-0ac310beb3dd" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044e56a2-c766-11e1-8775-005056c00008" name="48-49" r="3.1188959999999999" x="8.7991200000000003" g1="0" b1="3.6099649999999999e-05" g2="0" b2="3.6099649999999999e-05" node1="23" voltageLevelId1="_044778d3-c766-11e1-8775-005056c00008" node2="122" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-28.875306383914673" q1="1.3278530752275541" p2="29.019205307181146" q2="-2.2381807544377676">
+    <iidm:line id="_044e56a2-c766-11e1-8775-005056c00008" name="48-49" r="3.1188959999999999" x="8.7991200000000003" g1="0" b1="3.6099649999999999e-05" g2="0" b2="3.6099649999999999e-05" node1="23" voltageLevelId1="_044778d3-c766-11e1-8775-005056c00008" node2="122" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-28.844704711903095" q1="1.3181447400908826" p2="28.988293392345927" q2="-2.2293487794780007">
         <iidm:alias>_0454bf49-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0460a623-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10675,7 +10804,7 @@
             <iidm:temporaryLimit name="_f2e58700-2366-46e0-8408-9472d85acd23" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047eb573-c766-11e1-8775-005056c00008" name="56-59" r="14.3748007" x="43.734237700000001" g1="0" b1="0.0001632805" g2="0" b2="0.0001632805" node1="62" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-19.190627369335832" q1="-7.7087258220916901" p2="19.548342827421052" q2="3.4482925890511358">
+    <iidm:line id="_047eb573-c766-11e1-8775-005056c00008" name="56-59" r="14.3748007" x="43.734237700000001" g1="0" b1="0.0001632805" g2="0" b2="0.0001632805" node1="62" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-19.177590005397711" q1="-7.7137865897111375" p2="19.534899084081538" q2="3.4521181883065433">
         <iidm:alias>_0468bc78-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048915b0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10683,7 +10812,7 @@
             <iidm:temporaryLimit name="_89654167-95a6-4c76-aad7-63a881116e17" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046f9a4b-c766-11e1-8775-005056c00008" name="94-100" r="3.1014719999999998" x="10.105919999999999" g1="0" b1="0.00017332415000000001" g2="0" b2="0.00017332415000000001" node1="52" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-6.1019935181327423" q1="-52.055011001227967" p2="6.5495071483968079" q2="47.447504272780641">
+    <iidm:line id="_046f9a4b-c766-11e1-8775-005056c00008" name="94-100" r="3.1014719999999998" x="10.105919999999999" g1="0" b1="0.00017332415000000001" g2="0" b2="0.00017332415000000001" node1="52" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-6.1179148879794365" q1="-52.329737576533283" p2="6.570582865084063" q2="47.740041218997192">
         <iidm:alias>_04812676-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048a2722-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10691,7 +10820,7 @@
             <iidm:temporaryLimit name="_216c0f3b-03e8-4b7d-96fc-a5f891331f7f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046735d0-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="123" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-92.489470649272761" q1="-2.4716501013365941" p2="93.955284161166759" q2="7.2970856685822927">
+    <iidm:line id="_046735d0-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="123" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-92.396864158787182" q1="-2.4971681711489251" p2="93.85975454129543" q2="7.3076802673118895">
         <iidm:alias>_04570934-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b3894-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10699,7 +10828,7 @@
             <iidm:temporaryLimit name="_32655e4f-e7da-46b0-a908-b601224ddb73" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046d294b-c766-11e1-8775-005056c00008" name="21-22" r="3.641616" x="16.901281399999998" g1="0" b1="7.0592299999999998e-05" g2="0" b2="7.0592299999999998e-05" node1="22" voltageLevelId1="_0460f448-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04773b6a-c766-11e1-8775-005056c00008" p1="-47.0583522204956" q1="-5.4520336923177393" p2="47.58183953563988" q2="5.6504189765302">
+    <iidm:line id="_046d294b-c766-11e1-8775-005056c00008" name="21-22" r="3.641616" x="16.901281399999998" g1="0" b1="7.0592299999999998e-05" g2="0" b2="7.0592299999999998e-05" node1="22" voltageLevelId1="_0460f448-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04773b6a-c766-11e1-8775-005056c00008" p1="-45.051335555934372" q1="-6.3030266377918931" p2="45.532615086360117" q2="6.3012099820268013">
         <iidm:alias>_044a37f0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_044be5a2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10707,7 +10836,7 @@
             <iidm:temporaryLimit name="_bafaeace-e459-4dc2-87a0-467a9ea25f8d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_6a131803-f462-47e2-bc21-bda919364fe9" name="reactor1" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="36" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="37" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="1.5265566588595902e-14" q1="-83.151382149556341" p2="-1.6653345369377348e-14" q2="92.151021337527013">
+    <iidm:line id="_6a131803-f462-47e2-bc21-bda919364fe9" name="reactor1" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="36" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="37" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="3.0531133177191805e-14" q1="-83.151383685010629" p2="-3.0531133177191805e-14" q2="92.15102303916656">
         <iidm:alias>_04531196-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_ca0adad2-ffe3-4efa-b56b-7d333b8ae18f</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10715,7 +10844,7 @@
             <iidm:temporaryLimit name="_ae4eadea-f3fc-4ac6-8899-c1698ece7a89" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_9803b364-2a93-4f21-94b7-8bdbe27a16f2" name="reactor2" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="38" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="2.8601562090946331e-08" q1="27.474502856239923" p2="-2.8601562437891026e-08" q2="-26.589293096026839">
+    <iidm:line id="_9803b364-2a93-4f21-94b7-8bdbe27a16f2" name="reactor2" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="38" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="-2.5291995026099912e-07" q1="27.473969468280075" p2="2.5291995060794381e-07" q2="-26.588794111830161">
         <iidm:alias>_0461b792-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_afe0e60b-3870-44fb-ba93-a056228f9636</iidm:alias>
     </iidm:line>

--- a/tests/main_sa/reference/launch/static_var_compensator_contingency/outputIIDM.xml
+++ b/tests/main_sa/reference/launch/static_var_compensator_contingency/outputIIDM.xml
@@ -31,8 +31,8 @@
                     <iidm:alias>_bea273f1-1e21-476d-b0d0-92dd6cb9a2d4</iidm:alias>
                     <iidm:alias>_c94e6b68-da6c-43d1-94fd-09ad60c74134</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_047abdd7-c766-11e1-8775-005056c00008-BREAKER" name="BREAKER-Jay LD" kind="BREAKER" retained="true" open="false" node1="0" node2="8"/>
                 <iidm:internalConnection node1="7" node2="0"/>
-                <iidm:internalConnection node1="8" node2="0"/>
                 <iidm:internalConnection node1="9" node2="1"/>
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="4"/>
@@ -47,9 +47,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="124.97659309676114" angle="0.91238151316641491" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.79204018006952" angle="-3.8304404884758374" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047abdd7-c766-11e1-8775-005056c00008" name="Jay LD" loadType="UNDEFINED" p0="14" q0="8" node="8" p="13.998678424327405" q="7.99874139610729">
+            <iidm:load id="_047abdd7-c766-11e1-8775-005056c00008" name="Jay LD" loadType="UNDEFINED" p0="14" q0="8" node="8" p="13.998836159794422" q="7.9988916114717066">
                 <iidm:alias>_04590500-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -139,12 +139,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="127.8724259833902" angle="3.6501433273620427" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="127.91085128600186" angle="-0.60730112575114525" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045b00d5-c766-11e1-8775-005056c00008" name="Madison LD" loadType="UNDEFINED" p0="62" q0="13" node="14" p="61.999088622641644" q="12.999681509472977">
+            <iidm:load id="_045b00d5-c766-11e1-8775-005056c00008" name="Madison LD" loadType="UNDEFINED" p0="62" q0="13" node="14" p="61.999275275554588" q="12.999746737067715">
                 <iidm:alias>_045b27e3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_04689566-c766-11e1-8775-005056c00008" name="Madison NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="15" p="8.9998677032866894" q="0">
+            <iidm:load id="_04689566-c766-11e1-8775-005056c00008" name="Madison NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="15" p="8.9998947980643749" q="0">
                 <iidm:alias>_04765100-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -272,16 +272,16 @@
                 <iidm:internalConnection node1="61" node2="12"/>
                 <iidm:internalConnection node1="62" node2="15"/>
                 <iidm:internalConnection node1="63" node2="18"/>
-                <iidm:bus v="126.06000018418371" angle="-6.8403553736671148" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63"/>
+                <iidm:bus v="126.06000005838324" angle="-18.73002796994458" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_046c3ee7-c766-11e1-8775-005056c00008" name="Torrey SM" energySource="THERMAL" minP="20" maxP="80" ratedS="100" voltageRegulatorOn="true" targetP="48" targetV="126.06" targetQ="0" node="21" p="-50.24302794950848" q="-4.1705959049397636">
+            <iidm:generator id="_046c3ee7-c766-11e1-8775-005056c00008" name="Torrey SM" energySource="THERMAL" minP="20" maxP="80" ratedS="100" voltageRegulatorOn="true" targetP="48" targetV="126.06" targetQ="0" node="21" p="-53.142715748221178" q="-7.2793522004389963">
                 <iidm:alias>_047147f3-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_b97aee41-3115-4cfd-9071-b52fb44d0b66"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_5005c073-28d1-4a7d-b257-649dec43ec73"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-30" maxQ="85"/>
             </iidm:generator>
-            <iidm:load id="_044afb44-c766-11e1-8775-005056c00008" name="Torrey LD" loadType="UNDEFINED" p0="113" q0="32" node="20" p="113.00000024765299" q="32.000000116886376">
+            <iidm:load id="_044afb44-c766-11e1-8775-005056c00008" name="Torrey LD" loadType="UNDEFINED" p0="113" q0="32" node="20" p="113.00000007850196" q="32.000000037051073">
                 <iidm:alias>_04522737-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -332,9 +332,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="123.86441769042574" angle="2.9563536694814743" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="123.82770652186352" angle="-3.0041361350516076" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04481515-c766-11e1-8775-005056c00008" name="Darrah LD" loadType="UNDEFINED" p0="68" q0="36" node="8" p="68.000013460761139" q="36.00001187714296">
+            <iidm:load id="_04481515-c766-11e1-8775-005056c00008" name="Darrah LD" loadType="UNDEFINED" p0="68" q0="36" node="8" p="67.999986590783138" q="35.999988168338838">
                 <iidm:alias>_044e7db8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -385,9 +385,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.61192498665605" angle="14.9236997631699" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.45862446722461" angle="11.42948600067019" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044c0cb3-c766-11e1-8775-005056c00008" name="Smythe LD" loadType="UNDEFINED" p0="5" q0="3" node="8" p="4.9999825913104434" q="2.9999825913306482">
+            <iidm:load id="_044c0cb3-c766-11e1-8775-005056c00008" name="Smythe LD" loadType="UNDEFINED" p0="5" q0="3" node="8" p="4.9999729154694865" q="2.9999729155183905">
                 <iidm:alias>_045163e8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -514,9 +514,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="125.91451293894376" angle="-6.9175392035183361" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="125.90818358123313" angle="-18.902448851295294" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0450a093-c766-11e1-8775-005056c00008" name="Sunnysde LD" loadType="UNDEFINED" p0="84" q0="18" node="20" p="84.000001921300381" q="18.000000686178712">
+            <iidm:load id="_0450a093-c766-11e1-8775-005056c00008" name="Sunnysde LD" loadType="UNDEFINED" p0="84" q0="18" node="20" p="84.000000561647909" q="18.000000200588538">
                 <iidm:alias>_045f4695-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -568,12 +568,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="126.70002610639455" angle="2.9625190777799935" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="126.73545898601341" angle="-3.1630286982709293" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044b2251-c766-11e1-8775-005056c00008" name="Bellefnt LD" loadType="UNDEFINED" p0="68" q0="27" node="8" p="68.000122081274966" q="27.000080789127363">
+            <iidm:load id="_044b2251-c766-11e1-8775-005056c00008" name="Bellefnt LD" loadType="UNDEFINED" p0="68" q0="27" node="8" p="68.000204348686665" q="27.000135230883991">
                 <iidm:alias>_04622cc1-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0449e9d5-c766-11e1-8775-005056c00008" name="Bellefnt SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.40300000000001" targetDeadband="1" node="9" q="-11.060445767983767">
+            <iidm:shunt id="_0449e9d5-c766-11e1-8775-005056c00008" name="Bellefnt SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.40300000000001" targetDeadband="1" node="9" q="-11.06663295286849">
                 <iidm:alias>_047bcf48-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_6cc38790-c6a6-4309-99f4-a3258e24e785"/>
                 <iidm:shuntLinearModel bPerSection="0.00013779999999999999" gPerSection="0" maximumSectionCount="10"/>
@@ -665,12 +665,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="126.05936060079597" angle="0.80149534916531451" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="126.06590761628753" angle="-2.916485211052489" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04682035-c766-11e1-8775-005056c00008" name="Fieldale LD" loadType="UNDEFINED" p0="39" q0="30" node="14" p="39.000000418236148" q="30.000000536200183">
+            <iidm:load id="_04682035-c766-11e1-8775-005056c00008" name="Fieldale LD" loadType="UNDEFINED" p0="39" q0="30" node="14" p="39.00000377854964" q="30.000004844294565">
                 <iidm:alias>_0478c20a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_045c6067-c766-11e1-8775-005056c00008" name="Fieldale SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.066" targetDeadband="1" node="15" q="-5.4664910639080411">
+            <iidm:shunt id="_045c6067-c766-11e1-8775-005056c00008" name="Fieldale SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.066" targetDeadband="1" node="15" q="-5.4670588937127116">
                 <iidm:alias>_0451b209-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_2d222dd9-7306-4afd-baa5-fd303b0eeb40"/>
                 <iidm:shuntLinearModel bPerSection="6.8800000000000005e-05" gPerSection="0" maximumSectionCount="10"/>
@@ -780,7 +780,7 @@
                 <iidm:internalConnection node1="51" node2="9"/>
                 <iidm:internalConnection node1="52" node2="12"/>
                 <iidm:internalConnection node1="53" node2="15"/>
-                <iidm:bus v="137.95738961862978" angle="1.9733290772816647" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
+                <iidm:bus v="138.01483043925168" angle="-6.9372949805035526" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="_047f0391-c766-11e1-8775-005056c00008" name="Muskngum SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="392" targetV="138.59999099999999" targetQ="0" node="18" p="-0" q="-0">
                 <iidm:alias>_047eb572-c766-11e1-8775-005056c00008</iidm:alias>
@@ -789,7 +789,7 @@
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
-            <iidm:load id="_047e1936-c766-11e1-8775-005056c00008" name="Muskngum LD" loadType="UNDEFINED" p0="39" q0="18" node="17" p="38.999731112687783" q="17.999793164081336">
+            <iidm:load id="_047e1936-c766-11e1-8775-005056c00008" name="Muskngum LD" loadType="UNDEFINED" p0="39" q0="18" node="17" p="38.999749436773143" q="17.99980725946903">
                 <iidm:alias>_046e88d5-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -876,9 +876,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="221.10000054328628" angle="6.4855086077368025" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="221.10000019053976" angle="-1.7775679779974256" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0458ddf1-c766-11e1-8775-005056c00008" name="Muskngum SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="391" targetV="221.09999999999999" targetQ="0" node="14" p="-409.27133183870455" q="-181.04196445961307">
+            <iidm:generator id="_0458ddf1-c766-11e1-8775-005056c00008" name="Muskngum SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="391" targetV="221.09999999999999" targetQ="0" node="14" p="-432.89170536571839" q="-159.61532362162239">
                 <iidm:alias>_04522732-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_5036c3a5-56f9-489c-9ecb-8c15aa7c70c5"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_12b01822-ca11-4cf8-a6b4-2f8ff805ca20"/>
@@ -886,7 +886,7 @@
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045cae83-c766-11e1-8775-005056c00008" name="65-66" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="42" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="238.85728929637494" q1="95.790401343742175" p2="-238.85728929637503" q2="-74.580510580763431">
+        <iidm:twoWindingsTransformer id="_045cae83-c766-11e1-8775-005056c00008" name="65-66" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="42" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="273.1627528686397" q1="97.424137816589564" p2="-273.16275286863964" q2="-70.487889341585586">
             <iidm:alias>_044b2254-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_044b4964-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_045645e1-c766-11e1-8775-005056c00008</iidm:alias>
@@ -961,9 +961,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="124.29975003402878" angle="-0.73252979636197979" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.12691909998762" angle="-5.5373298243234643" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0453d4e2-c766-11e1-8775-005056c00008" name="Adams LD" loadType="UNDEFINED" p0="18" q0="3" node="8" p="17.998006893185458" q="2.9994463796529751">
+            <iidm:load id="_0453d4e2-c766-11e1-8775-005056c00008" name="Adams LD" loadType="UNDEFINED" p0="18" q0="3" node="8" p="17.998265349967827" q="2.999518168247457">
                 <iidm:alias>_0448ff77-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1053,16 +1053,16 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="133.31999340093705" angle="6.6698134179422732" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="133.31999262906379" angle="2.8252217109208297" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_046bf0c4-c766-11e1-8775-005056c00008" name="Claytor SM" energySource="THERMAL" minP="0" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="40" targetV="133.31999200000001" targetQ="0" node="15" p="-41.86918995792373" q="-84.325863437108211">
+            <iidm:generator id="_046bf0c4-c766-11e1-8775-005056c00008" name="Claytor SM" energySource="THERMAL" minP="0" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="40" targetV="133.31999200000001" targetQ="0" node="15" p="-44.285596456850989" q="-83.073970249332703">
                 <iidm:alias>_0460a627-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e56da2eb-bb6a-4133-953c-40073c5bc5f4"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_d41be6b4-155e-4c8f-b46b-16b50c49f0f4"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-60" maxQ="170"/>
             </iidm:generator>
-            <iidm:load id="_048433b6-c766-11e1-8775-005056c00008" name="Claytor LD" loadType="UNDEFINED" p0="23" q0="16" node="14" p="23.000000362528734" q="16.000000420323175">
+            <iidm:load id="_048433b6-c766-11e1-8775-005056c00008" name="Claytor LD" loadType="UNDEFINED" p0="23" q0="16" node="14" p="23.000000162786545" q="16.000000188738021">
                 <iidm:alias>_0480ff6b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1133,12 +1133,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="129.41450175880888" angle="-6.510629679436537" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="129.73419674281357" angle="-15.551841549116642" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0449e9d7-c766-11e1-8775-005056c00008" name="N.Newark LD" loadType="UNDEFINED" p0="53" q0="22" node="11" p="52.996889216476461" q="21.99784792771834">
+            <iidm:load id="_0449e9d7-c766-11e1-8775-005056c00008" name="N.Newark LD" loadType="UNDEFINED" p0="53" q0="22" node="11" p="52.997765056793035" q="21.998453834609368">
                 <iidm:alias>_04531191-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_04684741-c766-11e1-8775-005056c00008" name="N.Newark SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.32300000000001" targetDeadband="1" node="12" q="-9.6134170143859503">
+            <iidm:shunt id="_04684741-c766-11e1-8775-005056c00008" name="N.Newark SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.32300000000001" targetDeadband="1" node="12" q="-9.6609720757847555">
                 <iidm:alias>_04607f19-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_eae61817-d3cb-488f-a1f3-13bc8e31431b"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -1191,9 +1191,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="131.18161625076377" angle="5.0719947065824114" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="131.03784865639591" angle="-0.36078227475804897" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0448d86a-c766-11e1-8775-005056c00008" name="Hillsbro NegG LD" loadType="UNDEFINED" p0="12" q0="0" node="8" p="11.999887353182537" q="0">
+            <iidm:load id="_0448d86a-c766-11e1-8775-005056c00008" name="Hillsbro NegG LD" loadType="UNDEFINED" p0="12" q0="0" node="8" p="11.999891105383281" q="0">
                 <iidm:alias>_044ef2e8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1244,9 +1244,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="123.91521918373539" angle="-8.4593998410361859" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="125.27548306028527" angle="-17.129612573061106" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047dcb12-c766-11e1-8775-005056c00008" name="S.Kenton LD" loadType="UNDEFINED" p0="18" q0="7" node="8" p="17.99529980914436" q="6.9969538451708075">
+            <iidm:load id="_047dcb12-c766-11e1-8775-005056c00008" name="S.Kenton LD" loadType="UNDEFINED" p0="18" q0="7" node="8" p="17.996532436672876" q="6.9977526495749602">
                 <iidm:alias>_0451b205-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1281,6 +1281,9 @@
                     <iidm:alias>_8ef85f09-3622-4a12-87bf-fefcecc01e4a</iidm:alias>
                     <iidm:alias>_a0244ab3-80e5-4c20-b201-a142d50e6ec1</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_dffdb415-95a8-496a-ad1a-93cdeb444fae-1" name="DISCONNECTOR723-1" kind="DISCONNECTOR" retained="false" open="false" node1="24" node2="25"/>
+                <iidm:switch id="_aa063f2e-1205-4d1a-a549-3ccc5b31e65d-1" name="BREAKER362-1" kind="BREAKER" retained="false" open="false" node1="23" node2="24"/>
+                <iidm:switch id="_28b3e895-483c-478d-a5a3-7b9d7c9e11f3-1" name="DISCONNECTOR724-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="23"/>
                 <iidm:internalConnection node1="7" node2="0"/>
                 <iidm:internalConnection node1="8" node2="0"/>
                 <iidm:internalConnection node1="9" node2="1"/>
@@ -1297,9 +1300,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="125.41584494849533" angle="13.635356844451106" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.17890882508692" angle="10.032358188330525" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044afb49-c766-11e1-8775-005056c00008" name="Hazard LD" loadType="UNDEFINED" p0="21" q0="10" node="8" p="20.998389455986612" q="9.9987218231422386">
+            <iidm:load id="_044afb49-c766-11e1-8775-005056c00008" name="Hazard LD" loadType="UNDEFINED" p0="21" q0="10" node="8" p="20.997903151633167" q="9.9983358900190442">
                 <iidm:alias>_045e5c31-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1320,6 +1323,9 @@
                     <iidm:alias>_2a61ce12-8d9c-4aae-8bc7-c8f820ecae6c</iidm:alias>
                     <iidm:alias>_a3d5e8cc-be34-4d4a-a586-ce582737826b</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_83a05cd7-017e-4e7a-bc5e-a01ee9681f9f-1" name="DISCONNECTOR725-1" kind="DISCONNECTOR" retained="false" open="false" node1="14" node2="15"/>
+                <iidm:switch id="_cf4393c0-21c2-4e35-b330-c1acda2647ba-1" name="BREAKER363-1" kind="BREAKER" retained="false" open="true" node1="13" node2="14"/>
+                <iidm:switch id="_b9ab29b9-3d90-4536-8d1a-7757d8c22ae4-1" name="DISCONNECTOR726-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="13"/>
                 <iidm:internalConnection node1="4" node2="0"/>
                 <iidm:internalConnection node1="5" node2="0"/>
                 <iidm:internalConnection node1="6" node2="1"/>
@@ -1329,14 +1335,14 @@
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="3"/>
-                <iidm:bus v="31.35396123712383" angle="13.635356844451108" nodes="0,1,4,5,6,8,9"/>
+                <iidm:bus v="31.04472720627173" angle="10.032358188330527" nodes="0,1,4,5,6,8,9,13"/>
             </iidm:nodeBreakerTopology>
             <iidm:staticVarCompensator id="_047fc6e6-c766-11e1-8775-005056c00008" name="Pinevlle SVC" bMin="-10" bMax="10" voltageSetpoint="33.494999999999997" regulationMode="VOLTAGE" node="5" p="-0" q="-0">
                 <iidm:alias>_046ab846-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_98f667da-02d1-4a31-b826-44314a1fbbfe"/>
             </iidm:staticVarCompensator>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045e3525-c766-11e1-8775-005056c00008" name="86-87" r="0.30796918750000002" x="2.2585859312499998" g="0" b="-0.0040863184000000004" ratedU1="132" ratedU2="33" node1="22" voltageLevelId1="_0484f70a-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_04555b88-c766-11e1-8775-005056c00008" p1="1.700029006457271e-14" q1="4.0171406469383841" p2="-2.858411415249498e-14" q2="2.8342817050625171e-14">
+        <iidm:twoWindingsTransformer id="_045e3525-c766-11e1-8775-005056c00008" name="86-87" r="0.30796918750000002" x="2.2585859312499998" g="0" b="-0.0040863184000000004" ratedU1="132" ratedU2="33" node1="22" voltageLevelId1="_0484f70a-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_04555b88-c766-11e1-8775-005056c00008" p1="2.688821387764051e-15" q1="3.9382918727439016" p2="1.5515669671657632e-14" q2="-2.7749094364655542e-14">
             <iidm:alias>_0452755a-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04682034-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_048c7110-c766-11e1-8775-005056c00008</iidm:alias>
@@ -1412,6 +1418,82 @@
                 <iidm:temporaryLimit name="_257d56c1-d70a-4a96-b85c-d928ade03ad4" acceptableDuration="60" value="12246"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
+        <iidm:twoWindingsTransformer id="_045e3525-c766-11e1-8775-005056c00008-1" name="86-87-open-ended" r="0.30796918750000002" x="2.2585859312499998" g="0" b="-0.0040863184000000004" ratedU1="132" ratedU2="33" node1="25" voltageLevelId1="_0484f70a-c766-11e1-8775-005056c00008" node2="15" voltageLevelId2="_04555b88-c766-11e1-8775-005056c00008" p1="-8.6736173798840355e-17" q1="3.9382918727439304" p2="0" q2="0">
+            <iidm:alias>_0452755a-c766-11e1-8775-005056c00008-1</iidm:alias>
+            <iidm:alias>_04682034-c766-11e1-8775-005056c00008-1</iidm:alias>
+            <iidm:alias>_048c7110-c766-11e1-8775-005056c00008-1</iidm:alias>
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="31" loadTapChangingCapabilities="false">
+                <iidm:step r="-78.460970487743992" x="-78.460970487743992" g="364.27347129590328" b="364.27347129590328" rho="0.4641016"/>
+                <iidm:step r="-76.770985444658564" x="-76.770985444658564" g="330.49609255595948" b="330.49609255595948" rho="0.48196488000000004"/>
+                <iidm:step r="-75.017181047101431" x="-75.017181047101431" g="300.27508580410921" b="300.27508580410921" rho="0.49982816000000002"/>
+                <iidm:step r="-73.199557295072623" x="-73.199557295072623" g="273.1281647135425" b="273.1281647135425" rho="0.51769144000000011"/>
+                <iidm:step r="-71.318114188572153" x="-71.318114188572153" g="248.65210975826625" b="248.65210975826625" rho="0.53555472000000004"/>
+                <iidm:step r="-69.372851727600008" x="-69.372851727600008" g="226.50770848984379" b="226.50770848984379" rho="0.55341799999999997"/>
+                <iidm:step r="-67.363769912156158" x="-67.363769912156158" g="206.40793906293555" b="206.40793906293555" rho="0.57128128"/>
+                <iidm:step r="-65.290868742240633" x="-65.290868742240633" g="188.10862264852744" b="188.10862264852744" rho="0.58914456000000004"/>
+                <iidm:step r="-63.154148217853432" x="-63.154148217853432" g="171.40097232995538" b="171.40097232995538" rho="0.60700784000000008"/>
+                <iidm:step r="-60.953608338994556" x="-60.953608338994556" g="156.10561116167679" b="156.10561116167679" rho="0.62487112"/>
+                <iidm:step r="-58.689249105663997" x="-58.689249105663997" g="142.06773741726079" b="142.06773741726079" rho="0.64273440000000004"/>
+                <iidm:step r="-56.361070517861769" x="-56.361070517861769" g="129.15319231405709" b="129.15319231405709" rho="0.66059767999999996"/>
+                <iidm:step r="-53.969072575587838" x="-53.969072575587838" g="117.24524269951107" b="117.24524269951107" rho="0.67846096"/>
+                <iidm:step r="-51.51325527884223" x="-51.51325527884223" g="106.24193390397649" b="106.24193390397649" rho="0.69632424000000004"/>
+                <iidm:step r="-48.993618627624947" x="-48.993618627624947" g="96.053900138385018" b="96.053900138385018" rho="0.71418752000000008"/>
+                <iidm:step r="-46.410162621936003" x="-46.410162621936003" g="86.602544237115268" b="86.602544237115268" rho="0.7320508"/>
+                <iidm:step r="-43.762887261775354" x="-43.762887261775354" g="77.81851722275475" b="77.81851722275475" rho="0.74991407999999993"/>
+                <iidm:step r="-41.051792547143037" x="-41.051792547143037" g="69.640442552852292" b="69.640442552852292" rho="0.76777735999999996"/>
+                <iidm:step r="-38.276878478039045" x="-38.276878478039045" g="62.013841060226049" b="62.013841060226049" rho="0.78564064"/>
+                <iidm:step r="-35.438145054463355" x="-35.438145054463355" g="54.890221299184191" b="54.890221299184191" rho="0.80350392000000004"/>
+                <iidm:step r="-32.53559227641599" x="-32.53559227641599" g="48.2263068397802" b="48.2263068397802" rho="0.82136720000000008"/>
+                <iidm:step r="-29.569220143896956" x="-29.569220143896956" g="41.983377444222199" b="41.983377444222199" rho="0.83923048"/>
+                <iidm:step r="-26.53902865690624" x="-26.53902865690624" g="36.126705339843348" b="36.126705339843348" rho="0.85709376000000004"/>
+                <iidm:step r="-23.445017815443848" x="-23.445017815443848" g="30.625071218648301" b="30.625071218648301" rho="0.87495704000000007"/>
+                <iidm:step r="-20.287187619509762" x="-20.287187619509762" g="25.450347332714429" b="25.450347332714429" rho="0.89282032000000011"/>
+                <iidm:step r="-17.06553806910399" x="-17.06553806910399" g="20.577137262099331" b="20.577137262099331" rho="0.91068360000000004"/>
+                <iidm:step r="-13.780069164226571" x="-13.780069164226571" g="15.982463718828566" b="15.982463718828566" rho="0.92854687999999996"/>
+                <iidm:step r="-10.430780904877434" x="-10.430780904877434" g="11.645497203453271" b="11.645497203453271" rho="0.94641016"/>
+                <iidm:step r="-7.0176732910566368" x="-7.0176732910566368" g="7.5473195169912355" b="7.5473195169912355" rho="0.96427344000000004"/>
+                <iidm:step r="-3.5407463227641656" x="-3.5407463227641656" g="3.6707171036300279" b="3.6707171036300279" rho="0.98213671999999985"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1"/>
+                <iidm:step r="3.6045656772358381" x="3.6045656772358381" g="-3.4791571719583358" b="-3.4791571719583358" rho="1.01786328"/>
+                <iidm:step r="7.272950708943382" x="7.272950708943382" g="-6.7798551833225922" b="-6.7798551833225922" rho="1.0357265600000001"/>
+                <iidm:step r="11.005155095122543" x="11.005155095122543" g="-9.9140937064517427" b="-9.9140937064517427" rho="1.0535898399999999"/>
+                <iidm:step r="14.801178835773431" x="14.801178835773431" g="-12.892880531259154" b="-12.892880531259154" rho="1.0714531199999999"/>
+                <iidm:step r="18.661021930895984" x="18.661021930895984" g="-15.726328348801433" b="-15.726328348801433" rho="1.0893164"/>
+                <iidm:step r="22.584684380490238" x="22.584684380490238" g="-18.423740693731116" b="-18.423740693731116" rho="1.10717968"/>
+                <iidm:step r="26.572166184556178" x="26.572166184556178" g="-20.993688411566747" b="-20.993688411566747" rho="1.12504296"/>
+                <iidm:step r="30.623467343093779" x="30.623467343093779" g="-23.444077826121855" b="-23.444077826121855" rho="1.1429062400000001"/>
+                <iidm:step r="34.738587856103067" x="34.738587856103067" g="-25.782211620922489" b="-25.782211620922489" rho="1.1607695200000001"/>
+                <iidm:step r="38.917527723583987" x="38.917527723583987" g="-28.014843311220961" b="-28.014843311220961" rho="1.1786327999999999"/>
+                <iidm:step r="43.16028694553664" x="43.16028694553664" g="-30.148226066322692" b="-30.148226066322692" rho="1.19649608"/>
+                <iidm:step r="47.466865521960955" x="47.466865521960955" g="-32.188156542116317" b="-32.188156542116317" rho="1.21435936"/>
+                <iidm:step r="51.837263452856973" x="51.837263452856973" g="-34.140014298236885" b="-34.140014298236885" rho="1.23222264"/>
+                <iidm:step r="56.271480738224653" x="56.271480738224653" g="-36.0087973009527" b="-36.0087973009527" rho="1.2500859200000001"/>
+                <iidm:step r="60.769517378063973" x="60.769517378063973" g="-37.799153949786998" b="-37.799153949786998" rho="1.2679491999999999"/>
+                <iidm:step r="65.331373372375026" x="65.331373372375026" g="-39.515412011505823" b="-39.515412011505823" rho="1.2858124799999999"/>
+                <iidm:step r="69.957048721157761" x="69.957048721157761" g="-41.161604798123854" b="-41.161604798123854" rho="1.30367576"/>
+                <iidm:step r="74.646543424412172" x="74.646543424412172" g="-42.741494884907091" b="-42.741494884907091" rho="1.32153904"/>
+                <iidm:step r="79.399857482138245" x="79.399857482138245" g="-44.258595629064871" b="-44.258595629064871" rho="1.33940232"/>
+                <iidm:step r="84.216990894335964" x="84.216990894335964" g="-45.716190719151165" b="-45.716190719151165" rho="1.3572655999999998"/>
+                <iidm:step r="89.097943661005473" x="89.097943661005473" g="-47.11735195848069" b="-47.11735195848069" rho="1.3751288800000001"/>
+                <iidm:step r="94.04271578214653" x="94.04271578214653" g="-48.464955462553469" b="-48.464955462553469" rho="1.3929921599999999"/>
+                <iidm:step r="99.051307257759348" x="99.051307257759348" g="-49.761696430103783" b="-49.761696430103783" rho="1.41085544"/>
+                <iidm:step r="104.12371808784383" x="104.12371808784383" g="-51.010102629540867" b="-51.010102629540867" rho="1.42871872"/>
+                <iidm:step r="109.25994827240002" x="109.25994827240002" g="-52.212546726893493" b="-52.212546726893493" rho="1.446582"/>
+                <iidm:step r="114.45999781142788" x="114.45999781142788" g="-53.371257567609966" b="-53.371257567609966" rho="1.4644452800000001"/>
+                <iidm:step r="119.72386670492732" x="119.72386670492732" g="-54.488330512455207" b="-54.488330512455207" rho="1.4823085599999999"/>
+                <iidm:step r="125.05155495289854" x="125.05155495289854" g="-55.565736917068101" b="-55.565736917068101" rho="1.5001718399999999"/>
+                <iidm:step r="130.44306255534144" x="130.44306255534144" g="-56.605332835313817" b="-56.605332835313817" rho="1.51803512"/>
+                <iidm:step r="135.89838951225599" x="135.89838951225599" g="-57.608867018227542" b="-57.608867018227542" rho="1.5358984"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="2186">
+                <iidm:temporaryLimit name="_580d3b53-5508-4d8d-97cc-4ea463e0cdb9-1" acceptableDuration="900" value="2514"/>
+                <iidm:temporaryLimit name="_a867e68a-58d1-49cb-955f-bb8e59cf2a11-1" acceptableDuration="60" value="3061"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="8747">
+                <iidm:temporaryLimit name="_1a7f23f9-e2c0-46a6-a93c-687f2209e33d-1" acceptableDuration="900" value="10059"/>
+                <iidm:temporaryLimit name="_257d56c1-d70a-4a96-b85c-d928ade03ad4-1" acceptableDuration="60" value="12246"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
     </iidm:substation>
     <iidm:substation id="_045beb3a-c766-11e1-8775-005056c00008" name="Minas Tirith" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
         <iidm:voltageLevel id="_048a9c58-c766-11e1-8775-005056c00008" name="MNT132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -1460,12 +1542,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="132.98504691877889" angle="4.7277593337545349" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="132.85832529158301" angle="0.13777328507104822" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0447ee05-c766-11e1-8775-005056c00008" name="NwCarlsl NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="8" p="8.9998793404443624" q="0">
+            <iidm:load id="_0447ee05-c766-11e1-8775-005056c00008" name="NwCarlsl NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="8" p="8.999876188876808" q="0">
                 <iidm:alias>_04731cb7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_047a48a8-c766-11e1-8775-005056c00008" name="NwCarlsl LD" loadType="UNDEFINED" p0="30" q0="12" node="9" p="29.999597801481208" q="11.999731868852393">
+            <iidm:load id="_047a48a8-c766-11e1-8775-005056c00008" name="NwCarlsl LD" loadType="UNDEFINED" p0="30" q0="12" node="9" p="29.999587296256031" q="11.999724865432352">
                 <iidm:alias>_044c0cb9-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1516,9 +1598,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.61348253143737" angle="1.8992909728224046" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.62189045088952" angle="-1.8976032930834847" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044ecbd1-c766-11e1-8775-005056c00008" name="Blaine LD" loadType="UNDEFINED" p0="2" q0="1" node="8" p="2.0000001552674296" q="1.000000129389528">
+            <iidm:load id="_044ecbd1-c766-11e1-8775-005056c00008" name="Blaine LD" loadType="UNDEFINED" p0="2" q0="1" node="8" p="2.0000003807408038" q="1.0000003172840233">
                 <iidm:alias>_04700f74-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1569,9 +1651,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="133.30900910266774" angle="9.2785440177401561" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="133.16026810858446" angle="4.1197156111278046" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046b7b95-c766-11e1-8775-005056c00008" name="Sundial LD" loadType="UNDEFINED" p0="15" q0="9" node="8" p="14.999928616002215" q="8.9999286161154508">
+            <iidm:load id="_046b7b95-c766-11e1-8775-005056c00008" name="Sundial LD" loadType="UNDEFINED" p0="15" q0="9" node="8" p="14.99988991519424" q="8.9998899154635446">
                 <iidm:alias>_046efe07-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1622,9 +1704,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.79961645355964" angle="0.031655613201488852" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.74823895265418" angle="-4.5023488113324728" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045645e2-c766-11e1-8775-005056c00008" name="Riversde LD" loadType="UNDEFINED" p0="51" q0="27" node="8" p="50.999685155398367" q="26.999722196511406">
+            <iidm:load id="_045645e2-c766-11e1-8775-005056c00008" name="Riversde LD" loadType="UNDEFINED" p0="51" q0="27" node="8" p="50.999665211447301" q="26.999704598982238">
                 <iidm:alias>_0476ed4b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1675,9 +1757,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.14987330477868" angle="3.525485941578304" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.96610139796293" angle="-1.1457645815331707" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04887973-c766-11e1-8775-005056c00008" name="Randolph LD" loadType="UNDEFINED" p0="10" q0="5" node="8" p="9.9993086721120026" q="4.9994239067027211">
+            <iidm:load id="_04887973-c766-11e1-8775-005056c00008" name="Randolph LD" loadType="UNDEFINED" p0="10" q0="5" node="8" p="9.9993838656236864" q="4.9994865652315212">
                 <iidm:alias>_0462f018-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1728,9 +1810,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.63389414580345" angle="-6.8509888790978604" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.48448961552843" angle="-18.102272631400325" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0477627b-c766-11e1-8775-005056c00008" name="WNwPhil2 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="12.000014481848936" q="3.0000060341061499">
+            <iidm:load id="_0477627b-c766-11e1-8775-005056c00008" name="WNwPhil2 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="11.999991369989491" q="2.9999964041631499">
                 <iidm:alias>_045841b6-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1800,9 +1882,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="126.72186690714315" angle="2.7006076991175769" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="126.73055186856615" angle="-1.1672207271613606" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0476781a-c766-11e1-8775-005056c00008" name="Cloverdl LD" loadType="UNDEFINED" p0="43" q0="16" node="11" p="43.000003912097384" q="16.000002426106981">
+            <iidm:load id="_0476781a-c766-11e1-8775-005056c00008" name="Cloverdl LD" loadType="UNDEFINED" p0="43" q0="16" node="11" p="43.000009518496725" q="16.000005902944139">
                 <iidm:alias>_0481749a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1872,9 +1954,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="128.11184952785388" angle="4.0647472645699008" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="128.11689217309697" angle="0.20203526283114057" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046b0665-c766-11e1-8775-005056c00008" name="Hancock LD" loadType="UNDEFINED" p0="38" q0="25" node="11" p="38.000001716641464" q="25.00000188228233">
+            <iidm:load id="_046b0665-c766-11e1-8775-005056c00008" name="Hancock LD" loadType="UNDEFINED" p0="38" q0="25" node="11" p="38.000004679090786" q="25.00000513058222">
                 <iidm:alias>_0464c4d5-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1926,12 +2008,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="128.0337451185226" angle="-7.7129144723898335" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="128.64880035513062" angle="-16.654977196212503" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044bbe92-c766-11e1-8775-005056c00008" name="WMVernon LD" loadType="UNDEFINED" p0="16" q0="8" node="8" p="15.998139148336389" q="7.9984493503986149">
+            <iidm:load id="_044bbe92-c766-11e1-8775-005056c00008" name="WMVernon LD" loadType="UNDEFINED" p0="16" q0="8" node="8" p="15.998642825734308" q="7.9988690534233688">
                 <iidm:alias>_04500452-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_047825c8-c766-11e1-8775-005056c00008" name="WMVernon SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.21199999999999" targetDeadband="1" node="9" q="-9.4093752963289425">
+            <iidm:shunt id="_047825c8-c766-11e1-8775-005056c00008" name="WMVernon SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.21199999999999" targetDeadband="1" node="9" q="-9.4999949400353856">
                 <iidm:alias>_047084aa-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_2a6c1dcd-201b-4911-83b2-c16acc50a0f4"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -1965,9 +2047,9 @@
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="3"/>
-                <iidm:bus v="230.99998527118473" angle="26.162549268863682" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="230.99998508963023" angle="22.437217372900857" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_045868c0-c766-11e1-8775-005056c00008" name="Breed SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="450" targetV="230.99998500000001" targetQ="0" node="5" p="-471.02838702664201" q="35.655799378722449">
+            <iidm:generator id="_045868c0-c766-11e1-8775-005056c00008" name="Breed SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="450" targetV="230.99998500000001" targetQ="0" node="5" p="-498.21296013957362" q="27.224315355095118">
                 <iidm:alias>_045b7606-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_f26d4eb3-ebdb-4025-8080-f856ce656b42"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_7566f2a7-61eb-42fe-a59a-8276257fdbc6"/>
@@ -2041,9 +2123,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="127.70175047954808" angle="-6.2861598676067922" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="127.47310382087915" angle="-16.996602455237547" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044d1e22-c766-11e1-8775-005056c00008" name="Newcmrst LD" loadType="UNDEFINED" p0="17" q0="8" node="11" p="17.000032331219117" q="8.0000253578349909">
+            <iidm:load id="_044d1e22-c766-11e1-8775-005056c00008" name="Newcmrst LD" loadType="UNDEFINED" p0="17" q0="8" node="11" p="16.999981211358374" q="7.9999852638159172">
                 <iidm:alias>_048a754b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2113,9 +2195,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="138.59999112499" angle="16.74383776755262" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="138.59999103592369" angle="12.494763020710744" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_045ab2b0-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="220" targetV="138.59999099999999" targetQ="0" node="11" p="-230.28054476858054" q="-45.071934361589051">
+            <iidm:generator id="_045ab2b0-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="220" targetV="138.59999099999999" targetQ="0" node="11" p="-243.57078051268041" q="-45.757300492463862">
                 <iidm:alias>_046ba2a5-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_56975783-9739-40fc-8ec1-e1de8cb06c9a"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b8449cd9-5a17-497e-bf04-70f728b0f9f2"/>
@@ -2168,9 +2250,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="223.30000020776595" angle="19.017275802969419" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="223.30000005958215" angle="14.647005664123434" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0483224a-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="314" targetV="223.30000000000001" targetQ="0" node="8" p="-328.6731411697013" q="-16.159811490283506">
+            <iidm:generator id="_0483224a-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="314" targetV="223.30000000000001" targetQ="0" node="8" p="-347.64193218628026" q="-18.508267764350528">
                 <iidm:alias>_045cd594-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_05df66ba-3f64-40cb-8b18-c66d26c4e2c1"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_c1d29442-5f57-41d1-bb60-4b74b4994c20"/>
@@ -2178,7 +2260,7 @@
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045b7604-c766-11e1-8775-005056c00008" name="26-25" r="0" x="6.6559680000000006" g="0" b="0" ratedU1="220" ratedU2="132" node1="22" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="115.28352565817769" q1="22.469440214258331" p2="-115.28352565817772" q2="-17.755319613105851">
+        <iidm:twoWindingsTransformer id="_045b7604-c766-11e1-8775-005056c00008" name="26-25" r="0" x="6.6559680000000006" g="0" b="0" ratedU1="220" ratedU2="132" node1="22" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="109.14081368330446" q1="22.232082274985643" p2="-109.14081368330446" q2="-17.992677377805329">
             <iidm:alias>_0447c6f3-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0463b364-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04803c1c-c766-11e1-8775-005056c00008</iidm:alias>
@@ -2321,9 +2403,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="136.62000053721343" angle="10.229420082351229" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="136.62000021388522" angle="3.5197296624766006" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_048aea70-c766-11e1-8775-005056c00008" name="Sporn SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="513.43743900000004" targetV="136.62" targetQ="-62.132553100000003" node="20" p="-537.43024162502195" q="59.489330036249079">
+            <iidm:generator id="_048aea70-c766-11e1-8775-005056c00008" name="Sporn SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="513.43743900000004" targetV="136.62" targetQ="-62.132553100000003" node="20" p="-568.44708073482616" q="50.687783611115876">
                 <iidm:alias>_04555b84-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_27799004-aa1e-4889-ba95-ee6fdae64895"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_827a9c80-183d-4e33-9e73-ef0aab3dfb13"/>
@@ -2413,9 +2495,9 @@
                 <iidm:internalConnection node1="39" node2="9"/>
                 <iidm:internalConnection node1="40" node2="12"/>
                 <iidm:internalConnection node1="41" node2="3"/>
-                <iidm:bus v="219.73920006653717" angle="7.147836007152824" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41"/>
+                <iidm:bus v="219.70738614002818" angle="-0.25236281198961158" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41"/>
             </iidm:nodeBreakerTopology>
-            <iidm:danglingLine id="_0482fb33-c766-11e1-8775-005056c00008" name="68-116" p0="184" q0="0" r="0.16456000000000001" x="1.9601999999999999" g="0" b="0.00033884300000000002" ucteXnodeCode="XWE_BR21" node="41" p="184.11553644571731" q="-14.9849131646553">
+            <iidm:danglingLine id="_0482fb33-c766-11e1-8775-005056c00008" name="68-116" p0="184" q0="0" r="0.16456000000000001" x="1.9601999999999999" g="0" b="0.00033884300000000002" ucteXnodeCode="XWE_BR21" node="41" p="184.11556918264631" q="-14.979776836735512">
                 <iidm:alias>_0459c855-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_04684742-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_5631ccc0-d9d2-11e2-bb49-005056c00008</iidm:alias>
@@ -2428,7 +2510,7 @@
                 </iidm:currentLimits>
             </iidm:danglingLine>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_044f6815-c766-11e1-8775-005056c00008" name="68-69" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-160.64006202337941" q1="100.32162101767257" p2="160.64006202337933" q2="-88.691547637011396">
+        <iidm:twoWindingsTransformer id="_044f6815-c766-11e1-8775-005056c00008" name="68-69" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-196.55989794342423" q1="102.01294362525107" p2="196.55989794342426" q2="-86.107235438655678">
             <iidm:alias>_047e8e67-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04840ca7-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0487dd39-c766-11e1-8775-005056c00008</iidm:alias>
@@ -2535,9 +2617,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="131.61527082589703" angle="1.8061335249315078" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="131.60565057134383" angle="-8.273990397255508" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04547126-c766-11e1-8775-005056c00008" name="Natrium LD" loadType="UNDEFINED" p0="77" q0="14" node="14" p="76.999912099743753" q="13.999973363568852">
+            <iidm:load id="_04547126-c766-11e1-8775-005056c00008" name="Natrium LD" loadType="UNDEFINED" p0="77" q0="14" node="14" p="76.999906088566789" q="13.999971542001507">
                 <iidm:alias>_047b3307-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2588,9 +2670,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="121.87311807381572" angle="-7.5899430333932871" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="123.75555056666856" angle="-16.129470667078859" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045d4ac9-c766-11e1-8775-005056c00008" name="Sterling LD" loadType="UNDEFINED" p0="31" q0="17" node="8" p="30.989127377926351" q="16.990063819063689">
+            <iidm:load id="_045d4ac9-c766-11e1-8775-005056c00008" name="Sterling LD" loadType="UNDEFINED" p0="31" q0="17" node="8" p="30.991977358169727" q="16.992668110455021">
                 <iidm:alias>_0477b094-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2698,9 +2780,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="130.49822769613672" angle="10.796178910997943" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="130.27253555632404" angle="6.6640577405644663" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0466246a-c766-11e1-8775-005056c00008" name="Switchbk LD" loadType="UNDEFINED" p0="30" q0="16" node="17" p="29.999807146434783" q="15.99982857497603">
+            <iidm:load id="_0466246a-c766-11e1-8775-005056c00008" name="Switchbk LD" loadType="UNDEFINED" p0="30" q0="16" node="17" p="29.999701946688873" q="15.999735064600834">
                 <iidm:alias>_04882b59-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2751,9 +2833,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="135.10602226575537" angle="8.922623993207349" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="135.08662668997917" angle="3.9303412440960099" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046adf5a-c766-11e1-8775-005056c00008" name="Bradley LD" loadType="UNDEFINED" p0="34" q0="8" node="8" p="33.999998933704475" q="7.9999995818448948">
+            <iidm:load id="_046adf5a-c766-11e1-8775-005056c00008" name="Bradley LD" loadType="UNDEFINED" p0="34" q0="8" node="8" p="33.999983262109751" q="7.9999934361225478">
                 <iidm:alias>_04555b85-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2788,6 +2870,9 @@
                     <iidm:alias>_7f359893-b7c5-41b0-ada8-8df06cf7a8e6</iidm:alias>
                     <iidm:alias>_a4edf081-2fb2-4da4-94db-98a2a596247f</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_312f25f3-55bc-4417-848c-236d31d823f4-1" name="DISCONNECTOR524-1" kind="DISCONNECTOR" retained="false" open="false" node1="24" node2="25"/>
+                <iidm:switch id="_686e884a-a0b1-454e-b7d1-33c7ad46f89f-1" name="BREAKER262-1" kind="BREAKER" retained="false" open="false" node1="23" node2="24"/>
+                <iidm:switch id="_346a5319-3ec2-40a2-aefd-38dfacbbe97c-1" name="DISCONNECTOR523-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="23"/>
                 <iidm:internalConnection node1="7" node2="0"/>
                 <iidm:internalConnection node1="8" node2="0"/>
                 <iidm:internalConnection node1="9" node2="1"/>
@@ -2804,9 +2889,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.98530765177081" angle="1.9126970528364673" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.16478077796252" angle="-2.325661518809643" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047a48a2-c766-11e1-8775-005056c00008" name="Mullin LD" loadType="UNDEFINED" p0="17" q0="7" node="8" p="16.999844230547176" q="6.9998930997216267">
+            <iidm:load id="_047a48a2-c766-11e1-8775-005056c00008" name="Mullin LD" loadType="UNDEFINED" p0="17" q0="7" node="8" p="16.999908517982167" q="6.9999372183356705">
                 <iidm:alias>_0474553a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2972,16 +3057,16 @@
                 <iidm:internalConnection node1="81" node2="18"/>
                 <iidm:internalConnection node1="82" node2="21"/>
                 <iidm:internalConnection node1="83" node2="24"/>
-                <iidm:bus v="134.24398936655842" angle="10.320026297849321" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
+                <iidm:bus v="134.24398860913297" angle="6.3660669943694668" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_044cd00a-c766-11e1-8775-005056c00008" name="Glen Lyn SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="252" targetV="134.243988" targetQ="0" node="27" p="-263.77589673491946" q="-82.930325499078776">
+            <iidm:generator id="_044cd00a-c766-11e1-8775-005056c00008" name="Glen Lyn SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="252" targetV="134.243988" targetQ="0" node="27" p="-278.9992576781612" q="-84.322512905639556">
                 <iidm:alias>_045e5c30-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e54b499b-436c-4b89-9803-b1d75e2fa364"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_32c8ab65-80f7-4c17-b3f5-ff075cce0ba5"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
-            <iidm:load id="_04566cf5-c766-11e1-8775-005056c00008" name="Glen Lyn LD" loadType="UNDEFINED" p0="37" q0="18" node="26" p="37.000000564971231" q="18.000000458084781">
+            <iidm:load id="_04566cf5-c766-11e1-8775-005056c00008" name="Glen Lyn LD" loadType="UNDEFINED" p0="37" q0="18" node="26" p="37.000000251831608" q="18.000000204187785">
                 <iidm:alias>_04577e64-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3032,9 +3117,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.70232936149853" angle="2.4545659586017989" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.63639084730966" angle="-2.0931058724276719" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044ea4c0-c766-11e1-8775-005056c00008" name="Kankakee LD" loadType="UNDEFINED" p0="52" q0="22" node="8" p="51.99960257922158" q="21.999719768113749">
+            <iidm:load id="_044ea4c0-c766-11e1-8775-005056c00008" name="Kankakee LD" loadType="UNDEFINED" p0="52" q0="22" node="8" p="51.9995919026194" q="21.999712239779289">
                 <iidm:alias>_047e6758-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3143,12 +3228,12 @@
                 <iidm:internalConnection node1="51" node2="9"/>
                 <iidm:internalConnection node1="52" node2="12"/>
                 <iidm:internalConnection node1="53" node2="15"/>
-                <iidm:bus v="127.41828510795469" angle="2.9490104232802343" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
+                <iidm:bus v="127.42279771685885" angle="-0.90022211362094973" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0484cffb-c766-11e1-8775-005056c00008" name="Roanoke LD" loadType="UNDEFINED" p0="31" q0="26" node="17" p="30.999999902220253" q="25.999999863318635">
+            <iidm:load id="_0484cffb-c766-11e1-8775-005056c00008" name="Roanoke LD" loadType="UNDEFINED" p0="31" q0="26" node="17" p="31.000002425367896" q="26.000003390299298">
                 <iidm:alias>_0454983a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0489d903-c766-11e1-8775-005056c00008" name="Roanoke SC" sectionCount="5" voltageRegulatorOn="true" targetV="127.423" targetDeadband="1" node="18" q="-18.638261448070132">
+            <iidm:shunt id="_0489d903-c766-11e1-8775-005056c00008" name="Roanoke SC" sectionCount="5" voltageRegulatorOn="true" targetV="127.423" targetDeadband="1" node="18" q="-18.639581645934282">
                 <iidm:alias>_0476c638-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_5be38d1a-9d01-42d8-b8bb-e9a26cfbcf1a"/>
                 <iidm:shuntLinearModel bPerSection="0.0002296" gPerSection="0" maximumSectionCount="10"/>
@@ -3240,12 +3325,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="119.45318071765325" angle="-12.579094245970296" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="120.56805477156185" angle="-21.439919511505416" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047a219a-c766-11e1-8775-005056c00008" name="Howard LD" loadType="UNDEFINED" p0="37" q0="23" node="14" p="36.988824553536816" q="22.988423000470654">
+            <iidm:load id="_047a219a-c766-11e1-8775-005056c00008" name="Howard LD" loadType="UNDEFINED" p0="37" q0="23" node="14" p="36.991839567525496" q="22.991546119455105">
                 <iidm:alias>_04882b51-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_04488a49-c766-11e1-8775-005056c00008" name="Howard NegG LD" loadType="UNDEFINED" p0="59" q0="0" node="15" p="58.982179693477619" q="0">
+            <iidm:load id="_04488a49-c766-11e1-8775-005056c00008" name="Howard NegG LD" loadType="UNDEFINED" p0="59" q0="0" node="15" p="58.986987418486606" q="0">
                 <iidm:alias>_046d9e74-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3295,7 +3380,7 @@
                 <iidm:internalConnection node1="19" node2="6"/>
                 <iidm:internalConnection node1="20" node2="3"/>
                 <iidm:internalConnection node1="21" node2="6"/>
-                <iidm:bus v="218.75988882425631" angle="8.2534456142616879" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
+                <iidm:bus v="218.77338099918748" angle="1.53387838225746" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_046efe09-c766-11e1-8775-005056c00008" name="CRI132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -3458,20 +3543,20 @@
                 <iidm:internalConnection node1="81" node2="18"/>
                 <iidm:internalConnection node1="82" node2="21"/>
                 <iidm:internalConnection node1="83" node2="24"/>
-                <iidm:bus v="137.2800008602681" angle="10.023970466065455" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
+                <iidm:bus v="137.28000036137851" angle="4.4198226674120544" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_045868c1-c766-11e1-8775-005056c00008" name="CabinCrk SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="477" targetV="137.28" targetQ="0" node="27" p="-499.29009024824052" q="-127.89476970187825">
+            <iidm:generator id="_045868c1-c766-11e1-8775-005056c00008" name="CabinCrk SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="477" targetV="137.28" targetQ="0" node="27" p="-528.10573774794796" q="-140.8334155280269">
                 <iidm:alias>_0487dd36-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_a6ec9760-88da-48df-a23f-7877e7c85ccd"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_e6131af8-c298-413b-84e3-4e21c3b6b06f"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-225" maxQ="640"/>
             </iidm:generator>
-            <iidm:load id="_04747c44-c766-11e1-8775-005056c00008" name="CabinCrk LD" loadType="UNDEFINED" p0="130" q0="26" node="26" p="130.00000122197176" q="26.00000040732392">
+            <iidm:load id="_04747c44-c766-11e1-8775-005056c00008" name="CabinCrk LD" loadType="UNDEFINED" p0="130" q0="26" node="26" p="130.00000051332174" q="26.000000171107246">
                 <iidm:alias>_046a9138-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_0488c79b-c766-11e1-8775-005056c00008" name="81-80" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="21" voltageLevelId1="_048a272b-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-92.358164779624701" q1="68.944281075849915" p2="92.358164779624801" q2="-64.59875504906276">
+        <iidm:twoWindingsTransformer id="_0488c79b-c766-11e1-8775-005056c00008" name="81-80" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="21" voltageLevelId1="_048a272b-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-150.51280843893915" q1="71.501290058434236" p2="150.51280843893912" q2="-62.418837970549767">
             <iidm:alias>_044974a0-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_045a3d83-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_046adf57-c766-11e1-8775-005056c00008</iidm:alias>
@@ -3551,12 +3636,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="134.73984181325707" angle="-3.0550396867807597" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="134.74747188381366" angle="-12.287090522690139" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04524e4a-c766-11e1-8775-005056c00008" name="Zanesvll LD" loadType="UNDEFINED" p0="20" q0="11" node="8" p="20.000000774698123" q="11.000000710139958">
+            <iidm:load id="_04524e4a-c766-11e1-8775-005056c00008" name="Zanesvll LD" loadType="UNDEFINED" p0="20" q0="11" node="8" p="20.000003425524497" q="11.000003140064301">
                 <iidm:alias>_045c1240-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_048b5fa9-c766-11e1-8775-005056c00008" name="Zanesvll SC" sectionCount="5" voltageRegulatorOn="true" targetV="134.72300000000001" targetDeadband="1" node="9" q="-15.631304300772786">
+            <iidm:shunt id="_048b5fa9-c766-11e1-8775-005056c00008" name="Zanesvll SC" sectionCount="5" voltageRegulatorOn="true" targetV="134.72300000000001" targetDeadband="1" node="9" q="-15.633074695187146">
                 <iidm:alias>_04736ad5-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_99c6c4ad-5247-4058-96d4-ee8495103e85"/>
                 <iidm:shuntLinearModel bPerSection="0.00017220000000000001" gPerSection="0" maximumSectionCount="10"/>
@@ -3609,9 +3694,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.99895203823289" angle="13.20372209337539" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.75940142055114" angle="9.4191975683271831" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044ca8f2-c766-11e1-8775-005056c00008" name="Tazewell LD" loadType="UNDEFINED" p0="12" q0="7" node="8" p="11.999926290966249" q="6.9999283385861366">
+            <iidm:load id="_044ca8f2-c766-11e1-8775-005056c00008" name="Tazewell LD" loadType="UNDEFINED" p0="12" q0="7" node="8" p="11.999885802312511" q="6.999888974822686">
                 <iidm:alias>_04542305-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3662,9 +3747,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="118.02371207780352" angle="-11.002308268837941" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="119.77106675299088" angle="-19.63163681628156" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04778989-c766-11e1-8775-005056c00008" name="NwLibrty LD" loadType="UNDEFINED" p0="27" q0="11" node="8" p="26.989291547550849" q="10.992729789897796">
+            <iidm:load id="_04778989-c766-11e1-8775-005056c00008" name="NwLibrty LD" loadType="UNDEFINED" p0="27" q0="11" node="8" p="26.992135114965787" q="10.994660164515411">
                 <iidm:alias>_0483e592-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3697,12 +3782,12 @@
                 <iidm:internalConnection node1="11" node2="2"/>
                 <iidm:internalConnection node1="12" node2="3"/>
                 <iidm:internalConnection node1="13" node2="3"/>
-                <iidm:bus v="122.59850137384299" angle="-1.8459416980534271" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13"/>
+                <iidm:bus v="122.6052800723336" angle="-5.563643195825791" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0463da70-c766-11e1-8775-005056c00008" name="Danville LD" loadType="UNDEFINED" p0="25" q0="13" node="5" p="24.999999803154765" q="12.999999829400796">
+            <iidm:load id="_0463da70-c766-11e1-8775-005056c00008" name="Danville LD" loadType="UNDEFINED" p0="25" q0="13" node="5" p="25.000002657872116" q="13.00000230348925">
                 <iidm:alias>_0488eeab-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_0448b150-c766-11e1-8775-005056c00008" name="Danville NegG LD" loadType="UNDEFINED" p0="43" q0="0" node="6" p="42.999999661426195" q="0">
+            <iidm:load id="_0448b150-c766-11e1-8775-005056c00008" name="Danville NegG LD" loadType="UNDEFINED" p0="43" q0="0" node="6" p="43.000004571540039" q="0">
                 <iidm:alias>_0457cc88-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3753,9 +3838,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.73581944022729" angle="18.448555319716004" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.4561200503081" angle="15.216684555102701" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045cae82-c766-11e1-8775-005056c00008" name="Fremont LD" loadType="UNDEFINED" p0="48" q0="10" node="8" p="47.999312453020764" q="9.999761269549845">
+            <iidm:load id="_045cae82-c766-11e1-8775-005056c00008" name="Fremont LD" loadType="UNDEFINED" p0="48" q0="10" node="8" p="47.999068076150557" q="9.999676417424201">
                 <iidm:alias>_045f4693-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3901,9 +3986,9 @@
                 <iidm:internalConnection node1="70" node2="15"/>
                 <iidm:internalConnection node1="71" node2="18"/>
                 <iidm:internalConnection node1="72" node2="21"/>
-                <iidm:bus v="132.41778933857211" angle="7.8103493175898784" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
+                <iidm:bus v="132.33286880786503" angle="2.1070291482343415" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0448d863-c766-11e1-8775-005056c00008" name="Turner LD" loadType="UNDEFINED" p0="61" q0="28" node="23" p="60.999841094093888" q="27.9998784327457">
+            <iidm:load id="_0448d863-c766-11e1-8775-005056c00008" name="Turner LD" loadType="UNDEFINED" p0="61" q0="28" node="23" p="60.999755164076433" q="27.999812694079569">
                 <iidm:alias>_046e3ab3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3938,6 +4023,9 @@
                     <iidm:alias>_0b877750-4384-4ec3-bb38-08ee5ccf16d3</iidm:alias>
                     <iidm:alias>_1ed822d3-f3ab-4432-80f0-4c55ae3b4b78</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_3be2355e-0065-43df-a264-57a295042faa-1" name="DISCONNECTOR526-1" kind="DISCONNECTOR" retained="false" open="false" node1="24" node2="25"/>
+                <iidm:switch id="_2463ff2c-7690-4dd6-bf44-039f9f475bb1-1" name="BREAKER263-1" kind="BREAKER" retained="false" open="true" node1="23" node2="24"/>
+                <iidm:switch id="_ddcf7aac-e7c3-45e9-bd81-6146e951addd-1" name="DISCONNECTOR525-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="23"/>
                 <iidm:internalConnection node1="7" node2="0"/>
                 <iidm:internalConnection node1="8" node2="0"/>
                 <iidm:internalConnection node1="9" node2="1"/>
@@ -3954,9 +4042,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.16043227503444" angle="0.904754266419172" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.20628158514818" angle="-3.2832211914781095" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047d7cf6-c766-11e1-8775-005056c00008" name="Grant LD" loadType="UNDEFINED" p0="24" q0="4" node="8" p="23.999944446227598" q="3.9999845684084621">
+            <iidm:load id="_047d7cf6-c766-11e1-8775-005056c00008" name="Grant LD" loadType="UNDEFINED" p0="24" q0="4" node="8" p="23.999967670162917" q="3.9999910194937316">
                 <iidm:alias>_0481e9c0-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4026,9 +4114,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="221.85159948373973" angle="10.544311843534002" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="221.49048683274822" angle="5.8721729985051239" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04867dab-c766-11e1-8775-005056c00008" name="Olive NegG LD" loadType="UNDEFINED" p0="28" q0="0" node="11" p="27.999416871250641" q="0">
+            <iidm:load id="_04867dab-c766-11e1-8775-005056c00008" name="Olive NegG LD" loadType="UNDEFINED" p0="28" q0="0" node="11" p="27.999398918009621" q="0">
                 <iidm:alias>_048433b8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4134,15 +4222,15 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="133.45558164711565" angle="5.2018074974471098" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="133.3209859714984" angle="0.60631514097403394" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:shunt id="_0447c6f6-c766-11e1-8775-005056c00008" name="Olive SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.67599999999999" targetDeadband="1" node="17" q="-40.892660658279809">
+            <iidm:shunt id="_0447c6f6-c766-11e1-8775-005056c00008" name="Olive SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.67599999999999" targetDeadband="1" node="17" q="-40.810218249747052">
                 <iidm:alias>_045e8340-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_c701959a-91c1-4a35-9a37-71fb790426ca"/>
                 <iidm:shuntLinearModel bPerSection="0.00045919999999999999" gPerSection="0" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_04575750-c766-11e1-8775-005056c00008" name="8-5" r="0" x="4.6522079999999999" g="0" b="0" ratedU1="220" ratedU2="132" node1="32" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="360.95074192366144" q1="65.712475301328439" p2="-360.95074192366133" q2="-31.423024054004351">
+        <iidm:twoWindingsTransformer id="_04575750-c766-11e1-8775-005056c00008" name="8-5" r="0" x="4.6522079999999999" g="0" b="0" ratedU1="220" ratedU2="132" node1="32" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="354.84967566883188" q1="62.634572727415957" p2="-354.84967566883182" q2="-29.450318122081619">
             <iidm:alias>_045eaa55-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_046b2d74-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04745533-c766-11e1-8775-005056c00008</iidm:alias>
@@ -4213,9 +4301,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.87890473352661" angle="12.064170636040757" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.77391345510728" angle="8.34815711523982" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047b0bf0-c766-11e1-8775-005056c00008" name="Wythe LD" loadType="UNDEFINED" p0="22" q0="15" node="8" p="21.999947591684059" q="14.999940445142816">
+            <iidm:load id="_047b0bf0-c766-11e1-8775-005056c00008" name="Wythe LD" loadType="UNDEFINED" p0="22" q0="15" node="8" p="21.999917494787503" q="14.999906244193909">
                 <iidm:alias>_0479d376-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4266,9 +4354,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="121.92678697500224" angle="-7.6084784465724642" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="123.82446616627357" angle="-16.160390032299368" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0458ddf5-c766-11e1-8775-005056c00008" name="WestLima LD" loadType="UNDEFINED" p0="33" q0="9" node="8" p="32.98843163853563" q="8.9947422683527449">
+            <iidm:load id="_0458ddf5-c766-11e1-8775-005056c00008" name="WestLima LD" loadType="UNDEFINED" p0="33" q0="9" node="8" p="32.991470057898233" q="8.996123087667252">
                 <iidm:alias>_04492686-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4376,9 +4464,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="128.65332651604865" angle="14.956975015835434" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="128.11502217706376" angle="11.287399923838377" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044b2257-c766-11e1-8775-005056c00008" name="BeaverCk LD" loadType="UNDEFINED" p0="24" q0="15" node="17" p="23.999282432291917" q="14.999252541086856">
+            <iidm:load id="_044b2257-c766-11e1-8775-005056c00008" name="BeaverCk LD" loadType="UNDEFINED" p0="24" q0="15" node="17" p="23.999035043679392" q="14.998994850637459">
                 <iidm:alias>_045868c4-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4437,6 +4525,9 @@
                     <iidm:alias>_2b636cdd-aa2f-4a65-92fc-12b4fc392e5f</iidm:alias>
                     <iidm:alias>_c96e50b9-ea15-4421-b6c8-bd9c9158a69a</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_e5318967-afcc-4fcc-b0de-d5f2522a95a6-1" name="DISCONNECTOR699-1" kind="DISCONNECTOR" retained="false" open="false" node1="43" node2="44"/>
+                <iidm:switch id="_e9f91b69-a29b-44ea-aa0f-cff86ee80320-1" name="BREAKER350-1" kind="BREAKER" retained="true" open="true" node1="42" node2="43"/>
+                <iidm:switch id="_ad86e83d-6334-4dd8-b642-b4c16d65329a-1" name="DISCONNECTOR700-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="42"/>
                 <iidm:internalConnection node1="13" node2="0"/>
                 <iidm:internalConnection node1="14" node2="1"/>
                 <iidm:internalConnection node1="15" node2="2"/>
@@ -4466,7 +4557,7 @@
                 <iidm:internalConnection node1="39" node2="9"/>
                 <iidm:internalConnection node1="40" node2="12"/>
                 <iidm:internalConnection node1="41" node2="3"/>
-                <iidm:bus v="215.63222351216018" angle="8.5767021540006443" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41"/>
+                <iidm:bus v="215.62243273110113" angle="2.9506591267098106" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_047bcf46-c766-11e1-8775-005056c00008" name="STN132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -4546,6 +4637,9 @@
                     <iidm:alias>_4aab41d6-d1b6-4dbe-a6aa-cb7ccd941912</iidm:alias>
                     <iidm:alias>_e9315b98-af75-40bb-bf8e-05bd03d43db5</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_b8b0b9a9-af8b-41d2-a4f8-940637e63f70-1" name="DISCONNECTOR701-1" kind="DISCONNECTOR" retained="false" open="false" node1="64" node2="65"/>
+                <iidm:switch id="_0b78ffaa-9859-4658-af17-c8d355633556-1" name="BREAKER351-1" kind="BREAKER" retained="true" open="false" node1="63" node2="64"/>
+                <iidm:switch id="_9dfeeaef-5c49-4c2c-97b1-03876970bee4-1" name="DISCONNECTOR702-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="63"/>
                 <iidm:internalConnection node1="19" node2="0"/>
                 <iidm:internalConnection node1="20" node2="0"/>
                 <iidm:internalConnection node1="21" node2="1"/>
@@ -4590,9 +4684,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="129.66509638746572" angle="2.3325166035725897" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="129.32223913463702" angle="-1.6103497352217038" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045dbff4-c766-11e1-8775-005056c00008" name="Sorenson LD" loadType="UNDEFINED" p0="11" q0="3" node="20" p="10.99930902303932" q="2.9996859261398079">
+            <iidm:load id="_045dbff4-c766-11e1-8775-005056c00008" name="Sorenson LD" loadType="UNDEFINED" p0="11" q0="3" node="20" p="10.999398445461717" q="2.9997265711033982">
                 <iidm:alias>_044d4536-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4613,6 +4707,9 @@
                     <iidm:alias>_340082f1-db9c-446d-97df-80e45aa0058b</iidm:alias>
                     <iidm:alias>_90c04b95-703a-4bae-82b8-7edf3075aa24</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_4d08a684-cdcb-484a-a767-03b10f4ada7f-1" name="DISCONNECTOR735-1" kind="DISCONNECTOR" retained="false" open="false" node1="14" node2="15"/>
+                <iidm:switch id="_f468d841-1bf6-470e-85d4-55d34fab8bff-1" name="BREAKER368-1" kind="BREAKER" retained="true" open="false" node1="13" node2="14"/>
+                <iidm:switch id="_f193bd8f-badf-4600-82ac-f212d1f33534-1" name="DISCONNECTOR736-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="13"/>
                 <iidm:internalConnection node1="4" node2="0"/>
                 <iidm:internalConnection node1="5" node2="1"/>
                 <iidm:internalConnection node1="6" node2="2"/>
@@ -4622,13 +4719,13 @@
                 <iidm:internalConnection node1="10" node2="3"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="0"/>
-                <iidm:bus v="387.15785585137854" angle="8.5767021540006425" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="389.21344466755352" angle="0" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15"/>
             </iidm:nodeBreakerTopology>
-            <iidm:lccConverterStation id="_7393a68e-c4e6-48dd-9347-543858363fdb" name="Conv1" lossFactor="0" powerFactor="0.80000000000000004" node="12" p="0" q="0">
+            <iidm:lccConverterStation id="_7393a68e-c4e6-48dd-9347-543858363fdb" name="Conv1" lossFactor="0" powerFactor="0.80000000000000004" node="12" p="10" q="6">
                 <iidm:alias>_739658a7-e08b-4395-8d79-93e87b7855e3</iidm:alias>
             </iidm:lccConverterStation>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_047120e9-c766-11e1-8775-005056c00008" name="30-17" r="0" x="6.7605125399999997" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_047b8123-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="281.14495449400937" q1="117.10357847195989" p2="-281.14495449400943" q2="-82.578632169619766">
+        <iidm:twoWindingsTransformer id="_047120e9-c766-11e1-8775-005056c00008" name="30-17" r="0" x="6.7605125399999997" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_047b8123-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="204.99679338522134" q1="116.64015529775679" p2="-204.99679338522131" q2="-95.93254878961605">
             <iidm:alias>_044f6811-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0463b36a-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_047d2ed8-c766-11e1-8775-005056c00008</iidm:alias>
@@ -4647,7 +4744,7 @@
                 <iidm:temporaryLimit name="_f62f2fc6-4b6c-4571-a8c5-40d6a89ac703" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_b08e9e50-4e0c-4ac0-9f21-4a27429caeb2" name="PowTrans1" r="0.4840000000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_3bbfa58a-a1ad-4b23-a526-3d76b096c1f4" node2="41" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="1.8028741154402485e-14" q1="-1.1953822613214828e-13" p2="4.4628107498942874e-15" q2="-2.9590334457465677e-14">
+        <iidm:twoWindingsTransformer id="_b08e9e50-4e0c-4ac0-9f21-4a27429caeb2" name="PowTrans1" r="0.4840000000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_3bbfa58a-a1ad-4b23-a526-3d76b096c1f4" node2="41" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="-132.01423203288337" q1="20.72568067210079" p2="132.19815441927906" q2="-13.828591182263494">
             <iidm:alias>_046ba2aa-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_a5bf9702-545a-437d-9663-773550202828</iidm:alias>
             <iidm:alias>_ee9505e1-96d7-49b3-9d1a-924397ffb27e</iidm:alias>
@@ -4667,6 +4764,32 @@
                 <iidm:temporaryLimit name="_611bb05e-9b9a-469c-b1d1-80a944c3ce2f" acceptableDuration="60" value="1400"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
+        <iidm:threeWindingsTransformer id="_86d83c7d-7826-4c16-b161-4ce17174e77f-1" name="T422" r1="-1.5199999809265099" x1="23.199999999999999" g1="0" b1="0" ratedU1="400" r2="2.0000000630528461" x2="19.999999999999996" g2="0" b2="0" ratedU2="220" r3="1.2000000564689806" x3="12" g3="0" b3="0" ratedU3="132" ratedU0="400" node1="15" voltageLevelId1="_3bbfa58a-a1ad-4b23-a526-3d76b096c1f4" node2="44" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" node3="65" voltageLevelId3="_047bcf46-c766-11e1-8775-005056c00008" p1="122.01423203830215" q1="-26.72568066885178" p2="0" q2="0" p3="-122.04718899493059" q3="30.350946753815567">
+            <iidm:alias>_1b2d419c-ac88-4dae-8dfe-2eb92d18c40a-1</iidm:alias>
+            <iidm:alias>_206474da-93c8-46b1-863f-9a308bfc2117-1</iidm:alias>
+            <iidm:alias>_9ac069ea-557b-4b8c-b12e-f9f2aecc3bf5-1</iidm:alias>
+            <iidm:alias>_ae46e10e-1fbe-4139-b493-ed8e2844ee8d-1</iidm:alias>
+            <iidm:ratioTapChanger1 lowTapPosition="1" tapPosition="11" targetDeadband="0" loadTapChangingCapabilities="true" regulating="false" targetV="220">
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.95238095238095233"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.96385542168674687"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.97560975609756106"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.98765432098765438"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0126582278481011"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0256410256410258"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0389610389610389"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0526315789473684"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0666666666666667"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0810810810810809"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.095890410958904"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.1111111111111112"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.1267605633802817"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.1428571428571428"/>
+            </iidm:ratioTapChanger1>
+            <iidm:currentLimits1 permanentLimit="500">
+                <iidm:temporaryLimit name="_3fd18f6e-749a-4fa7-af1b-b0c2d3952638-1" acceptableDuration="1800" value="533"/>
+            </iidm:currentLimits1>
+        </iidm:threeWindingsTransformer>
     </iidm:substation>
     <iidm:substation id="_04642898-c766-11e1-8775-005056c00008" name="Rómenna" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
         <iidm:voltageLevel id="_0457f394-c766-11e1-8775-005056c00008" name="RÓM132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -4905,16 +5028,16 @@
                 <iidm:internalConnection node1="121" node2="30"/>
                 <iidm:internalConnection node1="122" node2="33"/>
                 <iidm:internalConnection node1="123" node2="36"/>
-                <iidm:bus v="135.30000010123902" angle="-2.1733799075692866" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123"/>
+                <iidm:bus v="135.30000002302828" angle="-11.470035909112406" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04859346-c766-11e1-8775-005056c00008" name="Philo SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="204" targetV="135.30000000000001" targetQ="0" node="39" p="-213.53286878541104" q="-175.34223406999183">
+            <iidm:generator id="_04859346-c766-11e1-8775-005056c00008" name="Philo SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="204" targetV="135.30000000000001" targetQ="0" node="39" p="-225.85654192993999" q="-175.17339105003845">
                 <iidm:alias>_048719e2-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e3753d6d-b894-4cce-b6fa-307c50dc107f"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_dff93c01-9c84-4c1f-8529-66c054ed9e37"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
-            <iidm:load id="_045163e2-c766-11e1-8775-005056c00008" name="Philo LD" loadType="UNDEFINED" p0="87" q0="30" node="38" p="87.000000097647373" q="30.000000056119173">
+            <iidm:load id="_045163e2-c766-11e1-8775-005056c00008" name="Philo LD" loadType="UNDEFINED" p0="87" q0="30" node="38" p="87.000000022211282" q="30.00000001276511">
                 <iidm:alias>_04513cd3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4965,9 +5088,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.07860360424829" angle="13.211359224315711" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.51288519048788" angle="9.2749469833782907" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04524e46-c766-11e1-8775-005056c00008" name="BetsyLne LD" loadType="UNDEFINED" p0="11" q0="7" node="8" p="10.999682325023652" q="6.9996630752382369">
+            <iidm:load id="_04524e46-c766-11e1-8775-005056c00008" name="BetsyLne LD" loadType="UNDEFINED" p0="11" q0="7" node="8" p="10.999565067046488" q="6.9995387135533136">
                 <iidm:alias>_04549830-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5020,15 +5143,15 @@
                 <iidm:internalConnection node1="22" node2="6"/>
                 <iidm:internalConnection node1="23" node2="3"/>
                 <iidm:internalConnection node1="24" node2="6"/>
-                <iidm:bus v="124.75230804711627" angle="-0.016637686868423304" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24"/>
+                <iidm:bus v="124.75913518233665" angle="-3.8748604563550844" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04566cf3-c766-11e1-8775-005056c00008" name="Reusens NegG LD" loadType="UNDEFINED" p0="22" q0="0" node="8" p="21.999998437988818" q="0">
+            <iidm:load id="_04566cf3-c766-11e1-8775-005056c00008" name="Reusens NegG LD" loadType="UNDEFINED" p0="22" q0="0" node="8" p="22.000001413669207" q="0">
                 <iidm:alias>_0483be81-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_0482fb36-c766-11e1-8775-005056c00008" name="Reusens LD" loadType="UNDEFINED" p0="28" q0="12" node="9" p="27.99999801198577" q="11.999998579989867">
+            <iidm:load id="_0482fb36-c766-11e1-8775-005056c00008" name="Reusens LD" loadType="UNDEFINED" p0="28" q0="12" node="9" p="28.000001799215358" q="12.00000128515385">
                 <iidm:alias>_0486cbc1-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_04558293-c766-11e1-8775-005056c00008" name="Reusens SC" sectionCount="5" voltageRegulatorOn="true" targetV="124.76300000000001" targetDeadband="1" node="10" q="-5.3537195969004125">
+            <iidm:shunt id="_04558293-c766-11e1-8775-005056c00008" name="Reusens SC" sectionCount="5" voltageRegulatorOn="true" targetV="124.76300000000001" targetDeadband="1" node="10" q="-5.3543055831369273">
                 <iidm:alias>_04893ccc-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_99303cd3-6b53-4ee2-a5ce-fe8d5feeb304"/>
                 <iidm:shuntLinearModel bPerSection="6.8800000000000005e-05" gPerSection="0" maximumSectionCount="10"/>
@@ -5101,12 +5224,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="126.47493230729694" angle="16.511798707765667" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="126.42254655824063" angle="13.464913537904755" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045c8777-c766-11e1-8775-005056c00008" name="Holston NegG LD" loadType="UNDEFINED" p0="85" q0="0" node="11" p="84.999876143357454" q="0">
+            <iidm:load id="_045c8777-c766-11e1-8775-005056c00008" name="Holston NegG LD" loadType="UNDEFINED" p0="85" q0="0" node="11" p="84.999793913193443" q="0">
                 <iidm:alias>_0487dd31-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_0451d918-c766-11e1-8775-005056c00008" name="Holston LD" loadType="UNDEFINED" p0="78" q0="42" node="12" p="77.999886343316263" q="41.999898000461563">
+            <iidm:load id="_0451d918-c766-11e1-8775-005056c00008" name="Holston LD" loadType="UNDEFINED" p0="78" q0="42" node="12" p="77.999810885048106" q="41.99983028159059">
                 <iidm:alias>_0485ba54-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5214,9 +5337,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="127.69901732014338" angle="4.0854789039226089" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="127.72914951955111" angle="-2.0571615258416833" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04742e27-c766-11e1-8775-005056c00008" name="SthPoint LD" loadType="UNDEFINED" p0="47" q0="11" node="17" p="47.000070390819495" q="11.000027457425567">
+            <iidm:load id="_04742e27-c766-11e1-8775-005056c00008" name="SthPoint LD" loadType="UNDEFINED" p0="47" q0="11" node="17" p="47.000110085147114" q="11.000042941048358">
                 <iidm:alias>_047b3303-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5268,12 +5391,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="132.96742173902715" angle="7.7936237819784742" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="132.90968800714367" angle="2.1248536811179171" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04716f06-c766-11e1-8775-005056c00008" name="CapitlHl LD" loadType="UNDEFINED" p0="39" q0="32" node="8" p="38.999928344631698" q="31.999902009812768">
+            <iidm:load id="_04716f06-c766-11e1-8775-005056c00008" name="CapitlHl LD" loadType="UNDEFINED" p0="39" q0="32" node="8" p="38.99988748331694" q="31.999846131179687">
                 <iidm:alias>_04700f70-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0466c0a0-c766-11e1-8775-005056c00008" name="CapitlHl SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.00200000000001" targetDeadband="1" node="9" q="-20.297024860025108">
+            <iidm:shunt id="_0466c0a0-c766-11e1-8775-005056c00008" name="CapitlHl SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.00200000000001" targetDeadband="1" node="9" q="-20.279402970747405">
                 <iidm:alias>_045e8346-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_99931a87-ee15-4fd0-b251-9556df7fe598"/>
                 <iidm:shuntLinearModel bPerSection="0.0002296" gPerSection="0" maximumSectionCount="10"/>
@@ -5326,9 +5449,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="132.11835430639496" angle="7.4999774428560535" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="132.04375760715592" angle="1.8079414166353611" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046efe03-c766-11e1-8775-005056c00008" name="Chemical LD" loadType="UNDEFINED" p0="71" q0="26" node="8" p="70.999833291162517" q="25.999898252901826">
+            <iidm:load id="_046efe03-c766-11e1-8775-005056c00008" name="Chemical LD" loadType="UNDEFINED" p0="71" q0="26" node="8" p="70.999739695164209" q="25.999841128698129">
                 <iidm:alias>_045d71d5-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5379,9 +5502,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.6065347460345" angle="1.9498339341378048" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.5650471099141" angle="-2.5778334548619442" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046a4319-c766-11e1-8775-005056c00008" name="JacksnRd LD" loadType="UNDEFINED" p0="19" q0="2" node="8" p="18.999910063206666" q="1.9999842216401005">
+            <iidm:load id="_046a4319-c766-11e1-8775-005056c00008" name="JacksnRd LD" loadType="UNDEFINED" p0="19" q0="2" node="8" p="18.999907428810683" q="1.9999837594668464">
                 <iidm:alias>_046c8d06-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5527,9 +5650,9 @@
                 <iidm:internalConnection node1="70" node2="15"/>
                 <iidm:internalConnection node1="71" node2="18"/>
                 <iidm:internalConnection node1="72" node2="21"/>
-                <iidm:bus v="130.75627909995595" angle="16.509298775357991" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
+                <iidm:bus v="130.59976560703657" angle="13.126743606812759" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0458ddf4-c766-11e1-8775-005056c00008" name="Saltvlle LD" loadType="UNDEFINED" p0="65" q0="10" node="23" p="64.999765505341259" q="9.9999398732367304">
+            <iidm:load id="_0458ddf4-c766-11e1-8775-005056c00008" name="Saltvlle LD" loadType="UNDEFINED" p0="65" q0="10" node="23" p="64.999635691433525" q="9.9999065877215738">
                 <iidm:alias>_045645e4-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5599,9 +5722,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="131.97886138477332" angle="7.2137148901664965" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="131.7421570522063" angle="2.3619277788908648" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0476ed42-c766-11e1-8775-005056c00008" name="Trenton NegG LD" loadType="UNDEFINED" p0="13" q0="0" node="11" p="12.999753413322532" q="0">
+            <iidm:load id="_0476ed42-c766-11e1-8775-005056c00008" name="Trenton NegG LD" loadType="UNDEFINED" p0="13" q0="0" node="11" p="12.999748906086245" q="0">
                 <iidm:alias>_0471e432-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5671,9 +5794,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="128.47176697808482" angle="0.94260088184125956" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="128.40807346822746" angle="-3.600907828519925" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044a5f08-c766-11e1-8775-005056c00008" name="HickryCk LD" loadType="UNDEFINED" p0="39" q0="10" node="11" p="38.999717386905495" q="9.9998792254650191">
+            <iidm:load id="_044a5f08-c766-11e1-8775-005056c00008" name="HickryCk LD" loadType="UNDEFINED" p0="39" q0="10" node="11" p="38.999702998894783" q="9.9998730767729551">
                 <iidm:alias>_047d7cf3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5802,9 +5925,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="123.31399354740937" angle="-6.6700604400619916" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="125.26464902658061" angle="-15.312914663059754" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:shunt id="_0450eeb7-c766-11e1-8775-005056c00008" name="EastLima SC" sectionCount="5" voltageRegulatorOn="true" targetV="131.565" targetDeadband="1" node="20" q="-21.821099341616094">
+            <iidm:shunt id="_0450eeb7-c766-11e1-8775-005056c00008" name="EastLima SC" sectionCount="5" voltageRegulatorOn="true" targetV="131.565" targetDeadband="1" node="20" q="-22.516918344404726">
                 <iidm:alias>_044aad27-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_6c36f421-303e-4932-93a9-5b0ff86cb7d4"/>
                 <iidm:shuntLinearModel bPerSection="0.00028699999999999998" gPerSection="0" maximumSectionCount="10"/>
@@ -5892,16 +6015,16 @@
                 <iidm:internalConnection node1="41" node2="7"/>
                 <iidm:internalConnection node1="42" node2="12"/>
                 <iidm:internalConnection node1="43" node2="11"/>
-                <iidm:bus v="218.38286713486681" angle="4.8415872717982085" nodes="0,1,2,3,8,9,10,13,17,18,21,22,23,24,25,26,31,32,33,34,35,39,40"/>
-                <iidm:bus v="199.35455935841412" angle="14.656301302101694" nodes="11,15,37,43"/>
-                <iidm:bus v="218.38286713486681" angle="4.8415872717982085" nodes="12,16,38,42"/>
-                <iidm:bus v="204.63772044471449" angle="1.6087047404988777" nodes="4,5,6,7,14,19,20,27,28,29,30,36,41"/>
+                <iidm:bus v="218.90707191871263" angle="-4.4789090526049433" nodes="0,1,2,3,8,9,10,13,17,18,21,22,23,24,25,26,31,32,33,34,35,39,40"/>
+                <iidm:bus v="237.93768317781519" angle="-16.223645588226951" nodes="11,15,37,43"/>
+                <iidm:bus v="226.19467219386968" angle="-4.4789090526249717" nodes="12,16,38,42"/>
+                <iidm:bus v="214.70024894495131" angle="-16.223645588226947" nodes="4,5,6,7,14,19,20,27,28,29,30,36,41"/>
             </iidm:nodeBreakerTopology>
-            <iidm:vscConverterStation id="_b46bfb8e-7af6-459e-acf3-53a42c943a7c" name="VSC2" voltageRegulatorOn="true" lossFactor="0.32362458" voltageSetpoint="218.47" reactivePowerSetpoint="0" node="42" p="0" q="0">
+            <iidm:vscConverterStation id="_b46bfb8e-7af6-459e-acf3-53a42c943a7c" name="VSC2" voltageRegulatorOn="true" lossFactor="0.32362458" voltageSetpoint="218.47" reactivePowerSetpoint="0" node="42" p="-0" q="-27.473605874890218">
                 <iidm:alias>_a168e701-bd48-4f66-8f0b-0f69b2545530</iidm:alias>
                 <iidm:minMaxReactiveLimits minQ="-1.7976931348623157e+308" maxQ="1.7976931348623157e+308"/>
             </iidm:vscConverterStation>
-            <iidm:vscConverterStation id="_b48ce7cf-abf5-413f-bc51-9e1d3103c9bd" name="VSC1" voltageRegulatorOn="true" lossFactor="0.32467531999999999" voltageSetpoint="213.53999999999999" reactivePowerSetpoint="0" node="43" p="-153.5" q="5.5511151231257827e-15">
+            <iidm:vscConverterStation id="_b48ce7cf-abf5-413f-bc51-9e1d3103c9bd" name="VSC1" voltageRegulatorOn="true" lossFactor="0.32467531999999999" voltageSetpoint="213.53999999999999" reactivePowerSetpoint="0" node="43" p="-0" q="-92.151020935009214">
                 <iidm:alias>_071bb138-ff00-4874-8acc-a884aa5cf4a9</iidm:alias>
                 <iidm:minMaxReactiveLimits minQ="-1.7976931348623157e+308" maxQ="1.7976931348623157e+308"/>
             </iidm:vscConverterStation>
@@ -5969,7 +6092,7 @@
                 <iidm:internalConnection node1="29" node2="6"/>
                 <iidm:internalConnection node1="30" node2="9"/>
                 <iidm:internalConnection node1="31" node2="3"/>
-                <iidm:bus v="196.50383170899883" angle="-1.7980244845541682" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
+                <iidm:bus v="201.7637276826629" angle="-11.36962188822657" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_0448d867-c766-11e1-8775-005056c00008" name="EDO132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -6055,9 +6178,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="131.3400003134542" angle="3.3485402323497899" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="131.3400001120313" angle="-6.8843258285153945" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0472a789-c766-11e1-8775-005056c00008" name="W.Kammer SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="160" targetV="131.34" targetQ="0" node="14" p="-167.47675983169492" q="82.825674766813961">
+            <iidm:generator id="_0472a789-c766-11e1-8775-005056c00008" name="W.Kammer SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="160" targetV="131.34" targetQ="0" node="14" p="-177.14238582740396" q="94.093546616543492">
                 <iidm:alias>_04697fc0-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_17852426-f663-4add-9a2b-0a635d51f101"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b512ea0a-96d0-4a48-9de1-a5cf499bf0dd"/>
@@ -6206,16 +6329,16 @@
                 <iidm:internalConnection node1="71" node2="15"/>
                 <iidm:internalConnection node1="72" node2="18"/>
                 <iidm:internalConnection node1="73" node2="21"/>
-                <iidm:bus v="130.0200002737765" angle="-1.9506372198844204" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
+                <iidm:bus v="130.02000009716636" angle="-16.223645588226947" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04839777-c766-11e1-8775-005056c00008" name="Tidd SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="155" targetV="130.02000000000001" targetQ="0" node="24" p="-162.24311108695446" q="-179.77481721995264">
+            <iidm:generator id="_04839777-c766-11e1-8775-005056c00008" name="Tidd SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="155" targetV="130.02000000000001" targetQ="0" node="24" p="-171.60668627029759" q="-94.866162518414839">
                 <iidm:alias>_045fe2d8-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_d2a96d8d-65be-4fd6-a012-ceeeabd2bee6"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_29df1e0b-36ca-4536-97b4-6f98b84d49d8"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-90" maxQ="255"/>
             </iidm:generator>
-            <iidm:load id="_04798556-c766-11e1-8775-005056c00008" name="Tidd LD" loadType="UNDEFINED" p0="277" q0="113" node="23" p="277.0000008748973" q="113.0000005948459">
+            <iidm:load id="_04798556-c766-11e1-8775-005056c00008" name="Tidd LD" loadType="UNDEFINED" p0="277" q0="113" node="23" p="277.00000031051081" q="113.00000021111747">
                 <iidm:alias>_04502b62-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6245,13 +6368,13 @@
                 <iidm:internalConnection node1="10" node2="3"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="0"/>
-                <iidm:bus v="343.50732601291378" angle="0" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="360.89133818521606" angle="-11.108410191049558" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
             </iidm:nodeBreakerTopology>
-            <iidm:lccConverterStation id="_9793118d-5ba1-4a9c-b2e0-db1d15be5913" name="Conv2" lossFactor="0" powerFactor="-0.75741000000000003" node="12" p="-63.800000000000004" q="55.000000000000007">
+            <iidm:lccConverterStation id="_9793118d-5ba1-4a9c-b2e0-db1d15be5913" name="Conv2" lossFactor="0" powerFactor="-0.75741000000000003" node="12" p="-10" q="8.6206896551724146">
                 <iidm:alias>_453bdc57-5855-4eb5-8712-d6a0255e0da8</iidm:alias>
             </iidm:lccConverterStation>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045c1248-c766-11e1-8775-005056c00008" name="38-37" r="0" x="6.5340005399999992" g="0" b="0" ratedU1="220" ratedU2="132" node1="30" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="202.11950019345309" q1="62.340542523906336" p2="-202.11950019345309" q2="-43.95651863509741">
+        <iidm:twoWindingsTransformer id="_045c1248-c766-11e1-8775-005056c00008" name="38-37" r="0" x="6.5340005399999992" g="0" b="0" ratedU1="220" ratedU2="132" node1="30" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="170.69687783028797" q1="89.287392983336701" p2="-170.69687783028806" q2="-74.822983531216153">
             <iidm:alias>_0453d4e8-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0477d7aa-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_047df228-c766-11e1-8775-005056c00008</iidm:alias>
@@ -6275,7 +6398,7 @@
                 <iidm:temporaryLimit name="_c97df399-5a91-4c8b-b72c-496cade334b5" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_0485ba57-c766-11e1-8775-005056c00008" name="64-61" r="0" x="4.669632" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="97.487658944265249" q1="49.274035396446195" p2="-97.487658944265249" q2="-46.125413401608732">
+        <iidm:twoWindingsTransformer id="_0485ba57-c766-11e1-8775-005056c00008" name="64-61" r="0" x="4.669632" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="157.40889965098643" q1="60.541872019493411" p2="-157.40889965098643" q2="-53.072112679292381">
             <iidm:alias>_04549831-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0472ce92-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0489d905-c766-11e1-8775-005056c00008</iidm:alias>
@@ -6301,7 +6424,7 @@
                 <iidm:temporaryLimit name="_f6b1a81c-eda7-4a08-b290-bd29a5ed9fa4" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_044cd007-c766-11e1-8775-005056c00008" name="63-59" r="0" x="6.7256646120000001" g="0" b="0" ratedU1="220" ratedU2="132" node1="41" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="73" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="153.50000064643427" q1="-35.572604863715462" p2="-153.5000006464343" q2="45.780579251767442">
+        <iidm:twoWindingsTransformer id="_044cd007-c766-11e1-8775-005056c00008" name="63-59" r="0" x="6.7256646120000001" g="0" b="0" ratedU1="220" ratedU2="132" node1="41" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="73" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-2.7755575615628914e-14" q1="83.15138191063032" p2="1.1102230246251565e-13" q2="-80.568830353878653">
             <iidm:alias>_044e7db4-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_046eafe5-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0488797a-c766-11e1-8775-005056c00008</iidm:alias>
@@ -6347,7 +6470,7 @@
                 <iidm:temporaryLimit name="_f2daef4d-6f1a-44d1-9c9b-228acff12575" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_ffd940c8-03c8-4dcf-ad46-62018a0d813d" name="PowTrans2" r="0.3932500000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_04f97116-552a-4a34-afd9-4862f62ac7aa" node2="31" voltageLevelId2="_04742e21-c766-11e1-8775-005056c00008" p1="63.799999026123366" q1="-54.999999160451175" p2="-63.72376921001166" q2="58.518298365607393">
+        <iidm:twoWindingsTransformer id="_ffd940c8-03c8-4dcf-ad46-62018a0d813d" name="PowTrans2" r="0.3932500000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_04f97116-552a-4a34-afd9-4862f62ac7aa" node2="31" voltageLevelId2="_04742e21-c766-11e1-8775-005056c00008" p1="9.9999999080467816" q1="-8.620689633901149" p2="-9.9983032176072815" q2="8.6989984234180504">
             <iidm:alias>_04479fea-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_c089eb25-9f67-4d82-88a8-635dd4808bae</iidm:alias>
             <iidm:alias>_ea8cd467-31f0-40dc-95d7-4064463724c4</iidm:alias>
@@ -6414,9 +6537,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="124.91076932903593" angle="-7.9140102880508802" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.78799367293141" angle="-19.391768693112962" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0481c2b3-c766-11e1-8775-005056c00008" name="Wooster LD" loadType="UNDEFINED" p0="23" q0="11" node="8" p="23.000025817005117" q="11.000020578779894">
+            <iidm:load id="_0481c2b3-c766-11e1-8775-005056c00008" name="Wooster LD" loadType="UNDEFINED" p0="23" q0="11" node="8" p="22.999983835671493" q="10.999987115393338">
                 <iidm:alias>_04614268-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6486,9 +6609,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="125.57666197447725" angle="-7.0546873266910621" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="125.56949177766818" angle="-19.154904422030299" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044974a8-c766-11e1-8775-005056c00008" name="Wagenhls LD" loadType="UNDEFINED" p0="63" q0="22" node="11" p="63.000000404248546" q="22.000000235276932">
+            <iidm:load id="_044974a8-c766-11e1-8775-005056c00008" name="Wagenhls LD" loadType="UNDEFINED" p0="63" q0="22" node="11" p="62.999999683725264" q="21.999999815924753">
                 <iidm:alias>_048481d4-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6539,9 +6662,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.4226035647404" angle="0.29042791456297445" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.32902098504975" angle="-4.2870852319437365" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047fedf2-c766-11e1-8775-005056c00008" name="Concord LD" loadType="UNDEFINED" p0="34" q0="16" node="8" p="33.998789235671531" q="15.999050392191098">
+            <iidm:load id="_047fedf2-c766-11e1-8775-005056c00008" name="Concord LD" loadType="UNDEFINED" p0="34" q0="16" node="8" p="33.998920590761571" q="15.999153413477959">
                 <iidm:alias>_046d9e75-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6649,9 +6772,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="127.59710704531116" angle="2.9049748698892133" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="127.56318620840317" angle="-1.364436666997294" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045f94ba-c766-11e1-8775-005056c00008" name="Delaware LD" loadType="UNDEFINED" p0="59" q0="23" node="17" p="58.998895986982646" q="22.999282707880852">
+            <iidm:load id="_045f94ba-c766-11e1-8775-005056c00008" name="Delaware LD" loadType="UNDEFINED" p0="59" q0="23" node="17" p="58.999065101416114" q="22.99939258322447">
                 <iidm:alias>_0463654a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6759,9 +6882,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="125.41764754465993" angle="-1.1021296508234166" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="125.21052564799763" angle="-5.8127282053485674" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04697fc9-c766-11e1-8775-005056c00008" name="FtWayne LD" loadType="UNDEFINED" p0="90" q0="30" node="17" p="89.990091164210227" q="29.994495293257177">
+            <iidm:load id="_04697fc9-c766-11e1-8775-005056c00008" name="FtWayne LD" loadType="UNDEFINED" p0="90" q0="30" node="17" p="89.991453301929411" q="29.995251984707327">
                 <iidm:alias>_044d1e25-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6812,9 +6935,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.15075815869898" angle="-6.0541006702521418" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.01455116869172" angle="-17.15174160747242" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0474f170-c766-11e1-8775-005056c00008" name="WNwPhil1 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="12.000011444317163" q="3.0000047684669999">
+            <iidm:load id="_0474f170-c766-11e1-8775-005056c00008" name="WNwPhil1 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="11.999993587289513" q="2.999997328037773">
                 <iidm:alias>_0466c0a7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6885,12 +7008,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="129.87175473784754" angle="8.899132455983775" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="129.50959609543747" angle="4.0901197175545239" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044a5f05-c766-11e1-8775-005056c00008" name="Logan LD" loadType="UNDEFINED" p0="54" q0="27" node="11" p="53.99922455581617" q="26.999353799606656">
+            <iidm:load id="_044a5f05-c766-11e1-8775-005056c00008" name="Logan LD" loadType="UNDEFINED" p0="54" q0="27" node="11" p="53.99887125189202" q="26.999059383130565">
                 <iidm:alias>_04767811-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0475dbd6-c766-11e1-8775-005056c00008" name="Logan SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.41900000000001" targetDeadband="1" node="12" q="-19.36294023513339">
+            <iidm:shunt id="_0475dbd6-c766-11e1-8775-005056c00008" name="Logan SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.41900000000001" targetDeadband="1" node="12" q="-19.255100331962247">
                 <iidm:alias>_04577e67-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_a7768441-642e-48a2-b4a8-0ae06bebf676"/>
                 <iidm:shuntLinearModel bPerSection="0.0002296" gPerSection="0" maximumSectionCount="10"/>
@@ -6964,19 +7087,19 @@
                 <iidm:internalConnection node1="32" node2="3"/>
                 <iidm:internalConnection node1="33" node2="6"/>
                 <iidm:internalConnection node1="34" node2="9"/>
-                <iidm:bus v="132.66000005950985" angle="-4.0389674864562251" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34"/>
+                <iidm:bus v="132.66000000924714" angle="-13.027029335423581" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04633e31-c766-11e1-8775-005056c00008" name="W.Lancst SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="19" targetV="132.66" targetQ="0" node="13" p="-19.887865230013769" q="0.31755721253469693">
+            <iidm:generator id="_04633e31-c766-11e1-8775-005056c00008" name="W.Lancst SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="19" targetV="132.66" targetQ="0" node="13" p="-21.035658317004216" q="1.4897395756029717">
                 <iidm:alias>_047bcf42-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_83fae784-1da1-4055-8108-ba978276d1b6"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_5f711f63-f631-45d3-b26c-33821ab2ee56"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-15" maxQ="45"/>
             </iidm:generator>
-            <iidm:load id="_048a9c51-c766-11e1-8775-005056c00008" name="W.Lancst LD" loadType="UNDEFINED" p0="28" q0="10" node="11" p="28.000000018840758" q="10.000000011214736">
+            <iidm:load id="_048a9c51-c766-11e1-8775-005056c00008" name="W.Lancst LD" loadType="UNDEFINED" p0="28" q0="10" node="11" p="28.000000002927639" q="10.00000000174264">
                 <iidm:alias>_044e7db6-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_045b00d9-c766-11e1-8775-005056c00008" name="W.Lancst SC" sectionCount="5" voltageRegulatorOn="true" targetV="132.66" targetDeadband="1" node="12" q="-10.101639803462975">
+            <iidm:shunt id="_045b00d9-c766-11e1-8775-005056c00008" name="W.Lancst SC" sectionCount="5" voltageRegulatorOn="true" targetV="132.66" targetDeadband="1" node="12" q="-10.101639795808284">
                 <iidm:alias>_04758db6-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_be267a3c-f7a7-4bdf-bb17-71b773247fbf"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -7086,9 +7209,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="129.85033192667433" angle="4.484869240829263" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="129.90079385966658" angle="-1.5885891010639743" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045dbff2-c766-11e1-8775-005056c00008" name="Portsmth LD" loadType="UNDEFINED" p0="66" q0="20" node="17" p="66.00005102289623" q="20.000025769146152">
+            <iidm:load id="_045dbff2-c766-11e1-8775-005056c00008" name="Portsmth LD" loadType="UNDEFINED" p0="66" q0="20" node="17" p="66.00018032957648" q="20.000091075626628">
                 <iidm:alias>_0454bf45-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7159,16 +7282,16 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="127.64400000945145" angle="1.0163293876672288" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="127.64400000000184" angle="-3.1528814280072619" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04856c34-c766-11e1-8775-005056c00008" name="DeerCrk SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="7" targetV="127.64400000000001" targetQ="0" node="12" p="-7.3271082426366529" q="-36.443376070057802">
+            <iidm:generator id="_04856c34-c766-11e1-8775-005056c00008" name="DeerCrk SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="7" targetV="127.64400000000001" targetQ="0" node="12" p="-7.7499793799489218" q="-37.15631805039871">
                 <iidm:alias>_0477d7a5-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e5a479a8-ab8d-4a54-bb52-376874ae2784"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b55d80d5-720f-46f9-897f-ff8c5eaf8b44"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-15" maxQ="45"/>
             </iidm:generator>
-            <iidm:load id="_04791028-c766-11e1-8775-005056c00008" name="DeerCrk LD" loadType="UNDEFINED" p0="43" q0="27" node="11" p="43.000000004775934" q="27.000000004998071">
+            <iidm:load id="_04791028-c766-11e1-8775-005056c00008" name="DeerCrk LD" loadType="UNDEFINED" p0="43" q0="27" node="11" p="43.000000000000938" q="27.000000000000981">
                 <iidm:alias>_04486337-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7219,9 +7342,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.01584889717473" angle="2.6638932286633286" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.01737904431005" angle="-1.5995108570797143" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0462c904-c766-11e1-8775-005056c00008" name="Medford LD" loadType="UNDEFINED" p0="22" q0="7" node="8" p="21.999620341877733" q="6.9997986673054378">
+            <iidm:load id="_0462c904-c766-11e1-8775-005056c00008" name="Medford LD" loadType="UNDEFINED" p0="22" q0="7" node="8" p="21.999686303719198" q="6.999833646702375">
                 <iidm:alias>_0489b1f7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7310,9 +7433,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="132.3168502334062" angle="8.479404025784774" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="132.17094311292786" angle="3.9198447421467852" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046205b5-c766-11e1-8775-005056c00008" name="CollCrnr LD" loadType="UNDEFINED" p0="7" q0="3" node="14" p="6.9998490257372525" q="2.9998921620161751">
+            <iidm:load id="_046205b5-c766-11e1-8775-005056c00008" name="CollCrnr LD" loadType="UNDEFINED" p0="7" q0="3" node="14" p="6.9998584597566058" q="2.9998989005075636">
                 <iidm:alias>_04486334-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7363,9 +7486,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.16069472908262" angle="9.6345157059171971" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.89356453982472" angle="5.2435042448301461" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0483be82-c766-11e1-8775-005056c00008" name="Caldwell LD" loadType="UNDEFINED" p0="42" q0="31" node="8" p="41.999642737535197" q="30.999560511706104">
+            <iidm:load id="_0483be82-c766-11e1-8775-005056c00008" name="Caldwell LD" loadType="UNDEFINED" p0="42" q0="31" node="8" p="41.999447701097317" q="30.999320587661316">
                 <iidm:alias>_045841b9-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7416,9 +7539,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.32293254896317" angle="1.5028821577794356" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.33147547755046" angle="-2.2724233945130665" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045f94b4-c766-11e1-8775-005056c00008" name="Franklin LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="8.0000006003618775" q="3.0000003752261826">
+            <iidm:load id="_045f94b4-c766-11e1-8775-005056c00008" name="Franklin LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="8.0000014981756191" q="3.0000009363598208">
                 <iidm:alias>_047da403-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7469,9 +7592,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="125.14160057306536" angle="-0.46077977816543247" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.8456197088407" angle="-4.8778951071334458" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045f6da2-c766-11e1-8775-005056c00008" name="McKinley LD" loadType="UNDEFINED" p0="60" q0="34" node="8" p="59.99382607148388" q="33.994169267513513">
+            <iidm:load id="_045f6da2-c766-11e1-8775-005056c00008" name="McKinley LD" loadType="UNDEFINED" p0="60" q0="34" node="8" p="59.994588986022237" q="33.994889751536199">
                 <iidm:alias>_0465d641-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7618,19 +7741,19 @@
                 <iidm:internalConnection node1="71" node2="18"/>
                 <iidm:internalConnection node1="72" node2="21"/>
                 <iidm:internalConnection node1="73" node2="12"/>
-                <iidm:bus v="130.68000800675298" angle="1.49227518626908" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
+                <iidm:bus v="130.6800080005618" angle="-3.0024830525347435" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_044ca8f0-c766-11e1-8775-005056c00008" name="TwinBrch SM" energySource="THERMAL" minP="50" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="85" targetV="130.68000799999999" targetQ="0" node="24" p="-88.972028660587938" q="-83.436892867492844">
+            <iidm:generator id="_044ca8f0-c766-11e1-8775-005056c00008" name="TwinBrch SM" energySource="THERMAL" minP="50" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="85" targetV="130.68000799999999" targetQ="0" node="24" p="-94.106892470808333" q="-86.915457517944901">
                 <iidm:alias>_04633e38-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_0f6ab5a4-6b72-42f4-92bc-1993e1ae58a3"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_668eb671-5c36-4351-a95d-53ca850581db"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-60" maxQ="170"/>
             </iidm:generator>
-            <iidm:load id="_048740f1-c766-11e1-8775-005056c00008" name="TwinBrch LD" loadType="UNDEFINED" p0="47" q0="10" node="23" p="47.000000003643144" q="10.000000001291896">
+            <iidm:load id="_048740f1-c766-11e1-8775-005056c00008" name="TwinBrch LD" loadType="UNDEFINED" p0="47" q0="10" node="23" p="47.000000000303096" q="10.000000000107482">
                 <iidm:alias>_044ecbda-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:danglingLine id="_045338a1-c766-11e1-8775-005056c00008" name="12-117" p0="20" q0="8" r="5.7324960000000003" x="24.393599999999999" g="0" b="0.00020546369999999999" ucteXnodeCode="XMO_TE32" node="73" p="20.161793618021353" q="5.1797255244355105">
+            <iidm:danglingLine id="_045338a1-c766-11e1-8775-005056c00008" name="12-117" p0="20" q0="8" r="5.7324960000000003" x="24.393599999999999" g="0" b="0.00020546369999999999" ucteXnodeCode="XMO_TE32" node="73" p="20.161793616110945" q="5.1797255239446001">
                 <iidm:alias>_044afb42-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_0457f391-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_5631f3d0-d9d2-11e2-bb49-005056c00008</iidm:alias>
@@ -7728,9 +7851,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="124.20910327771924" angle="-1.6632060380723104" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="124.06288454469005" angle="-6.5498186343140752" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0479fa87-c766-11e1-8775-005056c00008" name="Lincoln LD" loadType="UNDEFINED" p0="45" q0="25" node="14" p="44.994247178493112" q="24.994673540411494">
+            <iidm:load id="_0479fa87-c766-11e1-8775-005056c00008" name="Lincoln LD" loadType="UNDEFINED" p0="45" q0="25" node="14" p="44.995072291752521" q="24.995437473725612">
                 <iidm:alias>_047fc6e2-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7781,9 +7904,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="134.66264142508746" angle="8.8629778688846521" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="134.64613504570946" angle="4.4341609648191334" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044c81e4-c766-11e1-8775-005056c00008" name="Hinton NegG LD" loadType="UNDEFINED" p0="42" q0="0" node="8" p="41.9999992279485" q="0">
+            <iidm:load id="_044c81e4-c766-11e1-8775-005056c00008" name="Hinton NegG LD" loadType="UNDEFINED" p0="42" q0="0" node="8" p="41.99998287057727" q="0">
                 <iidm:alias>_04494d96-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7834,9 +7957,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.34027118155652" angle="0.97090431916889319" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.22561933357022" angle="-3.3521159988732658" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_048bfbe0-c766-11e1-8775-005056c00008" name="N. E. LD" loadType="UNDEFINED" p0="25" q0="10" node="8" p="24.999485736429765" q="9.9996571599706687">
+            <iidm:load id="_048bfbe0-c766-11e1-8775-005056c00008" name="N. E. LD" loadType="UNDEFINED" p0="25" q0="10" node="8" p="24.999548457453585" q="9.9996989734480906">
                 <iidm:alias>_0480b140-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7887,9 +8010,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.38123161746159" angle="-7.159120027048095" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.13837206317051" angle="-18.075520960845896" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04854525-c766-11e1-8775-005056c00008" name="SCoshoct LD" loadType="UNDEFINED" p0="18" q0="5" node="8" p="18.000038052137629" q="5.0000176167427979">
+            <iidm:load id="_04854525-c766-11e1-8775-005056c00008" name="SCoshoct LD" loadType="UNDEFINED" p0="18" q0="5" node="8" p="17.999977850571238" q="4.9999897456390388">
                 <iidm:alias>_04747c42-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7940,9 +8063,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="125.04262188812224" angle="3.0975384746603822" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="125.04319165524905" angle="-2.9608776898805838" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044aad24-c766-11e1-8775-005056c00008" name="WHuntngd LD" loadType="UNDEFINED" p0="33" q0="15" node="8" p="33.000036625262055" q="15.00002774642091">
+            <iidm:load id="_044aad24-c766-11e1-8775-005056c00008" name="WHuntngd LD" loadType="UNDEFINED" p0="33" q0="15" node="8" p="33.000045715294888" q="15.000034632815149">
                 <iidm:alias>_04784cd2-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7974,9 +8097,9 @@
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="3"/>
-                <iidm:bus v="129.36000145318167" angle="2.2487935234317713" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="129.36000066230335" angle="-1.3601407065273134" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0452ea80-c766-11e1-8775-005056c00008" name="DanRiver SM" energySource="THERMAL" minP="20" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="36" targetV="129.36000000000001" targetQ="0" node="5" p="-37.682270962131362" q="-20.911425418639922">
+            <iidm:generator id="_0452ea80-c766-11e1-8775-005056c00008" name="DanRiver SM" energySource="THERMAL" minP="20" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="36" targetV="129.36000000000001" targetQ="0" node="5" p="-39.857036811165884" q="-20.275187661395123">
                 <iidm:alias>_046a4316-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_fec62959-21c5-4921-90b2-7c85e9f3bfab"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_9db08c95-4586-4a2b-87e3-5a17c944b43a"/>
@@ -8049,9 +8172,9 @@
                 <iidm:internalConnection node1="29" node2="3"/>
                 <iidm:internalConnection node1="30" node2="9"/>
                 <iidm:internalConnection node1="31" node2="6"/>
-                <iidm:bus v="130.15686387011877" angle="4.4612702751090962" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
+                <iidm:bus v="130.17228991502492" angle="-1.5059577024157291" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
             </iidm:nodeBreakerTopology>
-            <iidm:danglingLine id="_044ef2e7-c766-11e1-8775-005056c00008" name="71-73" p0="6" q0="0" r="1.508918" x="7.9104960000000002" g="0" b="6.76079e-05" ucteXnodeCode="XMO_TE31" node="31" p="6.0032100144984497" q="-1.1285042396695528">
+            <iidm:danglingLine id="_044ef2e7-c766-11e1-8775-005056c00008" name="71-73" p0="6" q0="0" r="1.508918" x="7.9104960000000002" g="0" b="6.76079e-05" ucteXnodeCode="XMO_TE31" node="31" p="6.003209229992029" q="-1.1287797373026356">
                 <iidm:alias>_04670ec2-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_046b2d7a-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_26a070b9-db0c-47cd-9991-0a461576aec2</iidm:alias>
@@ -8111,9 +8234,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="134.27920934633377" angle="1.0861540429176397" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="134.29657210365298" angle="-8.3537152255170302" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0453add4-c766-11e1-8775-005056c00008" name="Summerfl LD" loadType="UNDEFINED" p0="28" q0="7" node="8" p="27.999899196306941" q="6.9999579985116283">
+            <iidm:load id="_0453add4-c766-11e1-8775-005056c00008" name="Summerfl LD" loadType="UNDEFINED" p0="28" q0="7" node="8" p="27.999904508412936" q="6.9999602118839546">
                 <iidm:alias>_04851e16-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8240,9 +8363,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="132.66000170358254" angle="22.734712027262045" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="132.66000077304321" angle="19.792364714522527" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0489b1fa-c766-11e1-8775-005056c00008" name="ClinchRv SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="607" targetV="132.66" targetQ="0" node="20" p="-635.36495761149274" q="-43.074852330396176">
+            <iidm:generator id="_0489b1fa-c766-11e1-8775-005056c00008" name="ClinchRv SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="607" targetV="132.66" targetQ="0" node="20" p="-672.03392623271372" q="-49.027948709119116">
                 <iidm:alias>_04840caa-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_2621b09a-22e3-4630-b3bd-32c102e36741"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b0d662e5-64c9-4d59-b8e0-9b1ed175769b"/>
@@ -8297,9 +8420,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.50868035287004" angle="0.53636028637524813" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.48840490108273" angle="-3.9730695300116845" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0485e168-c766-11e1-8775-005056c00008" name="Pokagon LD" loadType="UNDEFINED" p0="20" q0="9" node="8" p="19.999953451218168" q="8.9999650884407068">
+            <iidm:load id="_0485e168-c766-11e1-8775-005056c00008" name="Pokagon LD" loadType="UNDEFINED" p0="20" q0="9" node="8" p="19.99994997997053" q="8.9999624850091706">
                 <iidm:alias>_0462c902-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8350,9 +8473,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.11221058792026" angle="0.36635222596212491" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.05255139105137" angle="-4.1836114263218347" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04812679-c766-11e1-8775-005056c00008" name="GoshenJt LD" loadType="UNDEFINED" p0="14" q0="1" node="8" p="13.999590477790724" q="0.99995124783140399">
+            <iidm:load id="_04812679-c766-11e1-8775-005056c00008" name="GoshenJt LD" loadType="UNDEFINED" p0="14" q0="1" node="8" p="13.999645990394354" q="0.99995785635455225">
                 <iidm:alias>_045b9d17-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8403,9 +8526,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="116.46012253627595" angle="-13.459055978611103" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="117.95382084786111" angle="-22.147698928787641" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0489b1f2-c766-11e1-8775-005056c00008" name="S.Tiffin LD" loadType="UNDEFINED" p0="37" q0="10" node="8" p="36.985502013158992" q="9.9934702283151662">
+            <iidm:load id="_0489b1f2-c766-11e1-8775-005056c00008" name="S.Tiffin LD" loadType="UNDEFINED" p0="37" q0="10" node="8" p="36.989376787440342" q="9.9952152271005783">
                 <iidm:alias>_046476b8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8456,9 +8579,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="123.02323942191873" angle="-4.598493854104909" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="123.52448335609795" angle="-11.168701003259383" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045cfca7-c766-11e1-8775-005056c00008" name="Haviland LD" loadType="UNDEFINED" p0="23" q0="9" node="8" p="22.994659353552429" q="8.9965172393039481">
+            <iidm:load id="_045cfca7-c766-11e1-8775-005056c00008" name="Haviland LD" loadType="UNDEFINED" p0="23" q0="9" node="8" p="22.995723215312346" q="8.9972109654803099">
                 <iidm:alias>_0482ad17-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8528,9 +8651,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="131.07174568660591" angle="2.2469496893970002" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="131.00725382704488" angle="-8.2358825381498661" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04555b82-c766-11e1-8775-005056c00008" name="SWKammer LD" loadType="UNDEFINED" p0="78" q0="3" node="11" p="77.999978416135818" q="2.9999986164190902">
+            <iidm:load id="_04555b82-c766-11e1-8775-005056c00008" name="SWKammer LD" loadType="UNDEFINED" p0="78" q0="3" node="11" p="77.999921402547528" q="2.9999949617034569">
                 <iidm:alias>_0474ca6b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8638,9 +8761,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="130.64726719260071" angle="9.2323966546167142" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="130.35291439993969" angle="4.5184836169935458" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04817492-c766-11e1-8775-005056c00008" name="Baileysv LD" loadType="UNDEFINED" p0="38" q0="15" node="17" p="37.99963885059136" q="14.999762402457547">
+            <iidm:load id="_04817492-c766-11e1-8775-005056c00008" name="Baileysv LD" loadType="UNDEFINED" p0="38" q0="15" node="17" p="37.999455362082166" q="14.999641687292229">
                 <iidm:alias>_0474f17b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8691,9 +8814,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.13685724194039" angle="16.180573252532731" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.04242417391498" angle="12.99750134345974" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0461b790-c766-11e1-8775-005056c00008" name="HolstonT NegG LD" loadType="UNDEFINED" p0="10" q0="0" node="8" p="9.9999765883825305" q="0">
+            <iidm:load id="_0461b790-c766-11e1-8775-005056c00008" name="HolstonT NegG LD" loadType="UNDEFINED" p0="10" q0="0" node="8" p="9.9999624432616621" q="0">
                 <iidm:alias>_0464ebe7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8744,9 +8867,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.05276901547228" angle="2.657642937338093" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.04915314916174" angle="-1.6066467104087794" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044c81e5-c766-11e1-8775-005056c00008" name="WMedford LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="7.999859966438458" q="2.9999124795346983">
+            <iidm:load id="_044c81e5-c766-11e1-8775-005056c00008" name="WMedford LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="7.999883831485807" q="2.9999273950300656">
                 <iidm:alias>_04570939-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8836,12 +8959,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="122.76758337666958" angle="-7.0764093889283366" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="124.60098415209238" angle="-15.594592922963445" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04854520-c766-11e1-8775-005056c00008" name="Rockhill LD" loadType="UNDEFINED" p0="59" q0="26" node="14" p="58.980264322542219" q="25.985506485945422">
+            <iidm:load id="_04854520-c766-11e1-8775-005056c00008" name="Rockhill LD" loadType="UNDEFINED" p0="59" q0="26" node="14" p="58.985412347346745" q="25.989286787869325">
                 <iidm:alias>_0461b799-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0460cd38-c766-11e1-8775-005056c00008" name="Rockhill SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.81399999999999" targetDeadband="1" node="15" q="-12.102719261102456">
+            <iidm:shunt id="_0460cd38-c766-11e1-8775-005056c00008" name="Rockhill SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.81399999999999" targetDeadband="1" node="15" q="-12.466900417090992">
                 <iidm:alias>_048b86b4-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_069d84c6-bd26-4c26-ac6c-e801a0202a00"/>
                 <iidm:shuntLinearModel bPerSection="0.0001606" gPerSection="0" maximumSectionCount="10"/>
@@ -8914,12 +9037,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="129.0373865092661" angle="10.304898993213252" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="128.53063397461696" angle="5.825784488338364" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047a48a5-c766-11e1-8775-005056c00008" name="Sprigg LD" loadType="UNDEFINED" p0="20" q0="10" node="11" p="19.999573155098016" q="9.999644298445526">
+            <iidm:load id="_047a48a5-c766-11e1-8775-005056c00008" name="Sprigg LD" loadType="UNDEFINED" p0="20" q0="10" node="11" p="19.999396045022387" q="9.9994967092514742">
                 <iidm:alias>_0472ce97-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_04553478-c766-11e1-8775-005056c00008" name="Sprigg SC" sectionCount="5" voltageRegulatorOn="true" targetV="129.935" targetDeadband="1" node="12" q="-9.5574714452393525">
+            <iidm:shunt id="_04553478-c766-11e1-8775-005056c00008" name="Sprigg SC" sectionCount="5" voltageRegulatorOn="true" targetV="129.935" targetDeadband="1" node="12" q="-9.4825511013323336">
                 <iidm:alias>_045bc428-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_f4cdc674-4a66-4ab8-8d4f-552cb066e259"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -9011,12 +9134,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="116.80384252008351" angle="-12.551126398376121" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="118.41197771688771" angle="-21.206411770259319" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04819ba4-c766-11e1-8775-005056c00008" name="West End NegG LD" loadType="UNDEFINED" p0="46" q0="0" node="14" p="45.981573448794357" q="0">
+            <iidm:load id="_04819ba4-c766-11e1-8775-005056c00008" name="West End NegG LD" loadType="UNDEFINED" p0="46" q0="0" node="14" p="45.986479508228555" q="0">
                 <iidm:alias>_04627ae0-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_04555b89-c766-11e1-8775-005056c00008" name="West End LD" loadType="UNDEFINED" p0="20" q0="23" node="15" p="19.991988455997546" q="22.984646591102205">
+            <iidm:load id="_04555b89-c766-11e1-8775-005056c00008" name="West End LD" loadType="UNDEFINED" p0="20" q0="23" node="15" p="19.994121525316764" q="22.988734027446913">
                 <iidm:alias>_04592c18-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9067,9 +9190,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.43383573183669" angle="2.2981548979341837" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.13104411300759" angle="-1.6866746459658899" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046d0232-c766-11e1-8775-005056c00008" name="Deer Crk NegG LD" loadType="UNDEFINED" p0="6" q0="0" node="8" p="5.9996560974330144" q="0">
+            <iidm:load id="_046d0232-c766-11e1-8775-005056c00008" name="Deer Crk NegG LD" loadType="UNDEFINED" p0="6" q0="0" node="8" p="5.9997010670075124" q="0">
                 <iidm:alias>_0480150a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9139,9 +9262,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="134.08741246811766" angle="-1.7841224813441436" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="133.9247648665536" angle="-10.658114886526178" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046c3ee3-c766-11e1-8775-005056c00008" name="Crooksvl LD" loadType="UNDEFINED" p0="34" q0="0" node="11" p="33.999859358110164" q="0">
+            <iidm:load id="_046c3ee3-c766-11e1-8775-005056c00008" name="Crooksvl LD" loadType="UNDEFINED" p0="34" q0="0" node="11" p="33.999805634678644" q="0">
                 <iidm:alias>_047e4047-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9192,9 +9315,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="132.18253274082602" angle="-3.972181362451491" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="132.05288188674893" angle="-13.893057920484555" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046dc585-c766-11e1-8775-005056c00008" name="WCambrdg LD" loadType="UNDEFINED" p0="17" q0="4" node="8" p="17.000015643979541" q="4.0000061348958189">
+            <iidm:load id="_046dc585-c766-11e1-8775-005056c00008" name="WCambrdg LD" loadType="UNDEFINED" p0="17" q0="4" node="8" p="16.999991329787392" q="3.9999965999172029">
                 <iidm:alias>_045dbff8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9283,9 +9406,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="130.34720954746575" angle="2.0220355562266343" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="130.29470853534758" angle="-2.5162752030941871" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_048b5fa5-c766-11e1-8775-005056c00008" name="SouthBnd LD" loadType="UNDEFINED" p0="70" q0="23" node="14" p="69.999306132134507" q="22.999620025995821">
+            <iidm:load id="_048b5fa5-c766-11e1-8775-005056c00008" name="SouthBnd LD" loadType="UNDEFINED" p0="70" q0="23" node="14" p="69.999340160222943" q="22.999638660305077">
                 <iidm:alias>_04522734-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9335,11 +9458,11 @@
                 <iidm:internalConnection node1="19" node2="6"/>
                 <iidm:internalConnection node1="20" node2="3"/>
                 <iidm:internalConnection node1="21" node2="6"/>
-                <iidm:bus v="228.48127764504525" angle="18.21154980965207" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
+                <iidm:bus v="228.02742550374603" angle="14.016269172211256" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:line id="_044cd006-c766-11e1-8775-005056c00008" name="31-32" r="5.1923519999999996" x="17.16264" g1="0" b1="7.20271e-05" g2="0" b2="7.20271e-05" node1="31" voltageLevelId1="_04636548-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="-28.413503063778219" q1="8.2869049279020004" p2="28.699309527502916" q2="-9.6884207194610727">
+    <iidm:line id="_044cd006-c766-11e1-8775-005056c00008" name="31-32" r="5.1923519999999996" x="17.16264" g1="0" b1="7.20271e-05" g2="0" b2="7.20271e-05" node1="31" voltageLevelId1="_04636548-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="-26.831498238809399" q1="8.0071998651847078" p2="27.087790567121623" q2="-9.5056473559806101">
         <iidm:alias>_04682030-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0471bd25-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9347,7 +9470,7 @@
             <iidm:temporaryLimit name="_de6da3cb-8cb5-4900-9c33-8ad45632b535" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045a3d89-c766-11e1-8775-005056c00008" name="2-12" r="3.2582879999999999" x="10.7331839" g1="0" b1="4.5110200000000001e-05" g2="0" b2="4.5110200000000001e-05" node1="21" voltageLevelId1="_045d4ac5-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-31.065990873863829" q1="-17.093830727586127" p2="31.309138218029332" q2="16.379456323189071">
+    <iidm:line id="_045a3d89-c766-11e1-8775-005056c00008" name="2-12" r="3.2582879999999999" x="10.7331839" g1="0" b1="4.5110200000000001e-05" g2="0" b2="4.5110200000000001e-05" node1="21" voltageLevelId1="_045d4ac5-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-31.493418521790012" q1="-17.195759250792815" p2="31.742581318642689" q2="16.501435512299178">
         <iidm:alias>_046adf51-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046fe868-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9355,7 +9478,7 @@
             <iidm:temporaryLimit name="_6bd63dd1-1344-4183-b7bd-af326919f4eb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04513cd7-c766-11e1-8775-005056c00008" name="32-114" r="2.3522400000000001" x="10.6634884" g1="0" b1="4.6717149999999997e-05" g2="0" b2="4.6717149999999997e-05" node1="49" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04791027-c766-11e1-8775-005056c00008" p1="7.6312705220222927" q1="4.0836302299603302" p2="-7.6194663001003731" q2="-5.5448478971945203">
+    <iidm:line id="_04513cd7-c766-11e1-8775-005056c00008" name="32-114" r="2.3522400000000001" x="10.6634884" g1="0" b1="4.6717149999999997e-05" g2="0" b2="4.6717149999999997e-05" node1="49" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04791027-c766-11e1-8775-005056c00008" p1="7.4231242876308361" q1="3.7651064077607557" p2="-7.4121987085626948" q2="-5.2298599837856274">
         <iidm:alias>_046d0237-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0470d2c7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9363,7 +9486,7 @@
             <iidm:temporaryLimit name="_5f05650a-c63d-46e5-a426-2db4f036929f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045d71d4-c766-11e1-8775-005056c00008" name="24-72" r="8.5029120000000002" x="34.151040000000002" g1="0" b1="0.00014003675" g2="0" b2="0.00014003675" node1="30" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="18.645222519222777" q1="-3.6463559596206694" p2="-18.474806409075644" q2="-0.51824351789266987">
+    <iidm:line id="_045d71d4-c766-11e1-8775-005056c00008" name="24-72" r="8.5029120000000002" x="34.151040000000002" g1="0" b1="0.00014003675" g2="0" b2="0.00014003675" node1="30" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="23.381367643034068" q1="-4.9643562255702944" p2="-23.110392915951159" q2="1.2176605569261045">
         <iidm:alias>_04667281-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d0234-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9371,7 +9494,7 @@
             <iidm:temporaryLimit name="_d2074163-ab09-4251-a1d7-6983091dc4f1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045f94b8-c766-11e1-8775-005056c00008" name="17-18" r="2.1431520000000002" x="8.7991200000000003" g1="0" b1="3.7247499999999999e-05" g2="0" b2="3.7247499999999999e-05" node1="57" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04689563-c766-11e1-8775-005056c00008" p1="100.66610377359129" q1="43.705046149620159" p2="-99.123857672701504" q2="-38.582615230712861">
+    <iidm:line id="_045f94b8-c766-11e1-8775-005056c00008" name="17-18" r="2.1431520000000002" x="8.7991200000000003" g1="0" b1="3.7247499999999999e-05" g2="0" b2="3.7247499999999999e-05" node1="57" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04689563-c766-11e1-8775-005056c00008" p1="114.54186525137224" q1="40.255453471174299" p2="-112.64646643794376" q2="-33.677023205425584">
         <iidm:alias>_045e0e17-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0485ba59-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9379,7 +9502,7 @@
             <iidm:temporaryLimit name="_2b6693c7-4e29-4c2c-91d0-3485bbe8fe87" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048963d8-c766-11e1-8775-005056c00008" name="17-113" r="1.590811" x="5.244624" g1="0" b1="2.2038549999999999e-05" g2="0" b2="2.2038549999999999e-05" node1="58" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="3.3457605748160444" q1="4.3327537121441146" p2="-3.3426083823541757" q2="-5.0621108746064341">
+    <iidm:line id="_048963d8-c766-11e1-8775-005056c00008" name="17-113" r="1.590811" x="5.244624" g1="0" b1="2.2038549999999999e-05" g2="0" b2="2.2038549999999999e-05" node1="58" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="5.1945777868197567" q1="2.77311407944722" p2="-5.1910722443991295" q2="-3.4976239548288888">
         <iidm:alias>_045841b5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046958b4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9387,7 +9510,7 @@
             <iidm:temporaryLimit name="_786432da-fa4d-4751-a275-87d0e20529f1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0458ddf0-c766-11e1-8775-005056c00008" name="49-50" r="4.6522079999999999" x="13.102848099999999" g1="0" b1="5.3776400000000002e-05" g2="0" b2="5.3776400000000002e-05" node1="112" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044d1e26-c766-11e1-8775-005056c00008" p1="48.410133863879231" q1="14.690965186570946" p2="-47.752113905259883" q2="-14.761694330548178">
+    <iidm:line id="_0458ddf0-c766-11e1-8775-005056c00008" name="49-50" r="4.6522079999999999" x="13.102848099999999" g1="0" b1="5.3776400000000002e-05" g2="0" b2="5.3776400000000002e-05" node1="112" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044d1e26-c766-11e1-8775-005056c00008" p1="62.150917495380618" q1="11.697565630029606" p2="-61.128389847693278" q2="-10.739824076777493">
         <iidm:alias>_0464ebe8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f9fd8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9395,7 +9518,7 @@
             <iidm:temporaryLimit name="_1f0844a5-ea5c-42b2-abcb-6fac2c426092" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04535fb7-c766-11e1-8775-005056c00008" name="1-3" r="2.2476959999999999" x="7.3877759999999997" g1="0" b1="3.1049149999999997e-05" g2="0" b2="3.1049149999999997e-05" node1="21" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_047eb579-c766-11e1-8775-005056c00008" p1="-40.000431077075227" q1="-16.750433744895879" p2="40.261034096517776" q2="16.595310677543402">
+    <iidm:line id="_04535fb7-c766-11e1-8775-005056c00008" name="1-3" r="2.2476959999999999" x="7.3877759999999997" g1="0" b1="3.1049149999999997e-05" g2="0" b2="3.1049149999999997e-05" node1="21" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_047eb579-c766-11e1-8775-005056c00008" p1="-39.576691872857253" q1="-16.662052389376502" p2="39.832389405679621" q2="16.491718341805733">
         <iidm:alias>_044ef2e9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047c4474-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9403,7 +9526,7 @@
             <iidm:temporaryLimit name="_4ea43e34-67a3-42b8-9601-2189db7790d4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0478e912-c766-11e1-8775-005056c00008" name="92-102" r="2.1431520000000002" x="9.7400160000000007" g1="0" b1="4.2011000000000001e-05" g2="0" b2="4.2011000000000001e-05" node1="66" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="46.824865523709278" q1="-8.4121316782447533" p2="-46.542604672045023" q2="8.2599706696004258">
+    <iidm:line id="_0478e912-c766-11e1-8775-005056c00008" name="92-102" r="2.1431520000000002" x="9.7400160000000007" g1="0" b1="4.2011000000000001e-05" g2="0" b2="4.2011000000000001e-05" node1="66" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="49.97607607128959" q1="-9.0531356627124673" p2="-49.6535148783286" q2="9.0875281038198121">
         <iidm:alias>_045a1673-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0468bc79-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9411,7 +9534,7 @@
             <iidm:temporaryLimit name="_23cc194e-9273-46e9-a793-84a9c2911737" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04547127-c766-11e1-8775-005056c00008" name="93-94" r="3.8855520000000001" x="12.7543688" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="21" voltageLevelId1="_04789af0-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="50.03740313703404" q1="-20.068208344432868" p2="-49.377357404972791" q2="20.408261272828899">
+    <iidm:line id="_04547127-c766-11e1-8775-005056c00008" name="93-94" r="3.8855520000000001" x="12.7543688" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="21" voltageLevelId1="_04789af0-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="57.268232648922954" q1="-22.041371284271385" p2="-56.408314506403855" q2="23.044025834530043">
         <iidm:alias>_04500450-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047b0bfb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9419,7 +9542,7 @@
             <iidm:temporaryLimit name="_1a9fe09e-3f63-4904-8e36-aa38c5e16c59" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04791021-c766-11e1-8775-005056c00008" name="46-48" r="10.4718237" x="32.931359999999998" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044778d3-c766-11e1-8775-005056c00008" p1="-10.861175128203843" q1="-7.2282784333314849" p2="10.945334145865461" q2="2.6502928460514186">
+    <iidm:line id="_04791021-c766-11e1-8775-005056c00008" name="46-48" r="10.4718237" x="32.931359999999998" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044778d3-c766-11e1-8775-005056c00008" p1="-8.7815566532960538" q1="-7.9550798202257713" p2="8.8459135122047634" q2="3.3145427175428157">
         <iidm:alias>_0459ef69-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04640186-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9427,7 +9550,7 @@
             <iidm:temporaryLimit name="_467ba04d-dbad-4fe1-81c8-3bc87b41fcd1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046958b6-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="113" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-84.836607800458694" q1="-4.0884776849363513" p2="86.071017630276401" q2="7.7335982153874969">
+    <iidm:line id="_046958b6-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="113" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-92.394649110057614" q1="-2.4976571423204668" p2="93.857469627832103" q2="7.3078129485038721">
         <iidm:alias>_04776270-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a96c8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9435,7 +9558,7 @@
             <iidm:temporaryLimit name="_d0737ab4-5a3a-46c8-8aeb-789313f0f332" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046f4c26-c766-11e1-8775-005056c00008" name="75-118" r="2.5264799999999998" x="8.3809430000000003" g1="0" b1="3.4377849999999998e-05" g2="0" b2="3.4377849999999998e-05" node1="48" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="41.376955175509764" q1="27.724367807611539" p2="-40.987752091173668" q2="-27.531408607796287">
+    <iidm:line id="_046f4c26-c766-11e1-8775-005056c00008" name="75-118" r="2.5264799999999998" x="8.3809430000000003" g1="0" b1="3.4377849999999998e-05" g2="0" b2="3.4377849999999998e-05" node1="48" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="38.930922333759561" q1="28.875393140115023" p2="-38.562031687657509" q2="-28.75008468439626">
         <iidm:alias>_04619088-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04814d8a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9443,7 +9566,7 @@
             <iidm:temporaryLimit name="_173dc7ff-ae18-4410-b2e1-a4c2abac8ff6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c3954-c766-11e1-8775-005056c00008" name="94-96" r="4.6870560000000001" x="15.1414566" g1="0" b1="6.60009e-05" g2="0" b2="6.60009e-05" node1="49" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="27.796836849466928" q1="-10.593677277088091" p2="-27.559497862341086" q2="9.1098655198355285">
+    <iidm:line id="_045c3954-c766-11e1-8775-005056c00008" name="94-96" r="4.6870560000000001" x="15.1414566" g1="0" b1="6.60009e-05" g2="0" b2="6.60009e-05" node1="49" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="38.34321004978699" q1="-12.894577334746534" p2="-37.898878342642881" q2="12.088407128316039">
         <iidm:alias>_046ba2a0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0472ce94-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9451,7 +9574,7 @@
             <iidm:temporaryLimit name="_efde58bf-c92e-496d-b558-d0095a271083" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04518af7-c766-11e1-8775-005056c00008" name="62-67" r="4.4953919999999998" x="20.38608" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="39" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="6.7860692853389333" q1="-20.167693073806891" p2="-6.6840802767468164" q2="17.485234836975401">
+    <iidm:line id="_04518af7-c766-11e1-8775-005056c00008" name="62-67" r="4.4953919999999998" x="20.38608" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="39" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="-2.5024504124933142" q1="-18.359771749474849" p2="2.577496694126272" q2="15.554941813009682">
         <iidm:alias>_04544a10-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04814d86-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9459,7 +9582,7 @@
             <iidm:temporaryLimit name="_8a81d4ae-2bc8-4038-8650-27a6150946b1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0452c375-c766-11e1-8775-005056c00008" name="47-49" r="3.3279839999999998" x="10.890000000000001" g1="0" b1="4.6028449999999998e-05" g2="0" b2="4.6028449999999998e-05" node1="30" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="114" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="6.1889808733238594" q1="-17.610934356137093" p2="-6.1297518231135619" q2="16.13458025639839">
+    <iidm:line id="_0452c375-c766-11e1-8775-005056c00008" name="47-49" r="3.3279839999999998" x="10.890000000000001" g1="0" b1="4.6028449999999998e-05" g2="0" b2="4.6028449999999998e-05" node1="30" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="114" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="16.883792976883981" q1="-22.730769349091375" p2="-16.741866146046934" q2="21.527029622145456">
         <iidm:alias>_0465fd54-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0471e431-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9467,7 +9590,7 @@
             <iidm:temporaryLimit name="_8d6a074c-900d-4a37-830c-5da4c1de1ab5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046c17d9-c766-11e1-8775-005056c00008" name="100-106" r="10.54152" x="39.900959999999998" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="76" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="60.021564710347384" q1="10.008495994887415" p2="-57.812106989812243" q2="-7.708763554624344">
+    <iidm:line id="_046c17d9-c766-11e1-8775-005056c00008" name="100-106" r="10.54152" x="39.900959999999998" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="76" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="59.403254835004695" q1="10.058375507008304" p2="-57.236217602020425" q2="-7.9196014666364096">
         <iidm:alias>_045d98e5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0480d851-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9475,7 +9598,7 @@
             <iidm:temporaryLimit name="_3154dc30-b0e5-4570-8e52-9333bae20ef2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046b2d77-c766-11e1-8775-005056c00008" name="77-78" r="0.655142" x="2.1605759999999998" g1="0" b1="3.6271800000000001e-05" g2="0" b2="3.6271800000000001e-05" node1="66" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044fb634-c766-11e1-8775-005056c00008" p1="45.298668606648079" q1="4.0989102193783236" p2="-45.221163032430042" q2="-5.1124470798264481">
+    <iidm:line id="_046b2d77-c766-11e1-8775-005056c00008" name="77-78" r="0.655142" x="2.1605759999999998" g1="0" b1="3.6271800000000001e-05" g2="0" b2="3.6271800000000001e-05" node1="66" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044fb634-c766-11e1-8775-005056c00008" p1="43.610327126889381" q1="3.9589672119515127" p2="-43.538386900281765" q2="-4.9893276407827525">
         <iidm:alias>_046ed6fb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04893cc3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9483,7 +9606,7 @@
             <iidm:temporaryLimit name="_cce754c5-b9d5-4105-a431-32da96e4a6cf" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c8776-c766-11e1-8775-005056c00008" name="6-7" r="0.79976199999999997" x="3.6241919999999999" g1="0" b1="1.5782850000000001e-05" g2="0" b2="1.5782850000000001e-05" node1="21" voltageLevelId1="_044f6818-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047eb571-c766-11e1-8775-005056c00008" p1="40.331204527594302" q1="-5.5321526526242826" p2="-40.253756839022692" q2="5.3442687812599727">
+    <iidm:line id="_045c8776-c766-11e1-8775-005056c00008" name="6-7" r="0.79976199999999997" x="3.6241919999999999" g1="0" b1="1.5782850000000001e-05" g2="0" b2="1.5782850000000001e-05" node1="21" voltageLevelId1="_044f6818-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047eb571-c766-11e1-8775-005056c00008" p1="38.543024686248266" q1="-6.0347065554317494" p2="-38.471848587138027" q2="5.8188454115572634">
         <iidm:alias>_046efe08-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04720b4a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9491,7 +9614,7 @@
             <iidm:temporaryLimit name="_361a9cc3-fb33-4037-9b9a-c20adb90b66b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047ba839-c766-11e1-8775-005056c00008" name="77-80" r="5.1226560000000001" x="18.295200000000001" g1="0" b1="6.5426999999999995e-05" g2="0" b2="6.5426999999999995e-05" node1="67" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="76" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-44.533309733858381" q1="-23.128355527974868" p2="45.253858719916373" q2="23.321492866771841">
+    <iidm:line id="_047ba839-c766-11e1-8775-005056c00008" name="77-80" r="5.1226560000000001" x="18.295200000000001" g1="0" b1="6.5426999999999995e-05" g2="0" b2="6.5426999999999995e-05" node1="67" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="76" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-46.239139951545674" q1="-23.173529837653984" p2="47.006509438020124" q2="23.535354238285446">
         <iidm:alias>_047c6b85-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0480b148-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9499,7 +9622,7 @@
             <iidm:temporaryLimit name="_da00c66f-a882-4938-923b-f2455f7f9a81" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04592c16-c766-11e1-8775-005056c00008" name="78-79" r="0.95135000000000003" x="4.2514560000000001" g1="0" b1="1.8595050000000001e-05" g2="0" b2="1.8595050000000001e-05" node1="22" voltageLevelId1="_044fb634-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04481510-c766-11e1-8775-005056c00008" p1="-25.778670444962653" q1="-20.887451137857056" p2="25.837934578879736" q2="20.498946489679877">
+    <iidm:line id="_04592c16-c766-11e1-8775-005056c00008" name="78-79" r="0.95135000000000003" x="4.2514560000000001" g1="0" b1="1.8595050000000001e-05" g2="0" b2="1.8595050000000001e-05" node1="22" voltageLevelId1="_044fb634-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04481510-c766-11e1-8775-005056c00008" p1="-27.461352855838967" q1="-21.010513495697765" p2="27.525849927446011" q2="20.646046009145241">
         <iidm:alias>_0453add6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045b7605-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9507,7 +9630,7 @@
             <iidm:temporaryLimit name="_ba4abe9d-8490-4c19-b19b-c9d2c3597fc9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047b3301-c766-11e1-8775-005056c00008" name="103-104" r="8.1195839999999997" x="27.599615100000001" g1="0" b1="0.00011679295" g2="0" b2="0.00011679295" node1="40" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="32.87170375258269" q1="14.050997210779856" p2="-32.259281732197501" q2="-15.962073098450194">
+    <iidm:line id="_047b3301-c766-11e1-8775-005056c00008" name="103-104" r="8.1195839999999997" x="27.599615100000001" g1="0" b1="0.00011679295" g2="0" b2="0.00011679295" node1="40" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="33.048495054303579" q1="13.983576222368916" p2="-32.431740528562088" q2="-15.880076191901651">
         <iidm:alias>_0459a142-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045d98e6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9515,7 +9638,7 @@
             <iidm:temporaryLimit name="_2320da74-eda7-4f7f-ade9-1ed0e994f3af" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045e5c32-c766-11e1-8775-005056c00008" name="95-96" r="2.9795039999999999" x="9.5309279999999994" g1="0" b1="4.2298000000000001e-05" g2="0" b2="4.2298000000000001e-05" node1="21" voltageLevelId1="_044f4108-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="5.5948327853827893" q1="-22.556705329633335" p2="-5.5039658430565579" q2="21.419765285805859">
+    <iidm:line id="_045e5c32-c766-11e1-8775-005056c00008" name="95-96" r="2.9795039999999999" x="9.5309279999999994" g1="0" b1="4.2298000000000001e-05" g2="0" b2="4.2298000000000001e-05" node1="21" voltageLevelId1="_044f4108-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="14.740445597492558" q1="-24.905491116302354" p2="-14.596424298751694" q2="23.944748209756394">
         <iidm:alias>_04597a34-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04801509-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9523,7 +9646,7 @@
             <iidm:temporaryLimit name="_3bc03415-e95f-47a7-8e92-01089d304a9c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045ed169-c766-11e1-8775-005056c00008" name="77-80" r="2.9620799999999998" x="8.4506409999999992" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="68" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="77" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-97.278568841787234" q1="-42.860773105651475" p2="99.154055495932681" q2="43.283888495412768">
+    <iidm:line id="_045ed169-c766-11e1-8775-005056c00008" name="77-80" r="2.9620799999999998" x="8.4506409999999992" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="68" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="77" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-100.89665257326783" q1="-42.724567943011159" p2="102.89400633897763" q2="43.498408279269931">
         <iidm:alias>_0464289a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04828605-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9531,7 +9654,7 @@
             <iidm:temporaryLimit name="_f93b6d4c-39fa-4f6f-a42d-c63a4cf21a67" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047f78c2-c766-11e1-8775-005056c00008" name="5-11" r="3.5370720000000002" x="11.8831682" g1="0" b1="4.987375e-05" g2="0" b2="4.987375e-05" node1="48" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="84.752839037213079" q1="11.047498330388732" p2="-83.298023057984139" q2="-7.8955356504938958">
+    <iidm:line id="_047f78c2-c766-11e1-8775-005056c00008" name="5-11" r="3.5370720000000002" x="11.8831682" g1="0" b1="4.987375e-05" g2="0" b2="4.987375e-05" node1="48" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="83.025190642657378" q1="10.523900596144999" p2="-81.627558191362397" q2="-7.5615787519742046">
         <iidm:alias>_045bc426-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0476c633-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9539,7 +9662,7 @@
             <iidm:temporaryLimit name="_3bc4ab96-7a0d-4e18-b9f5-d89f63a82f0a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04845ac7-c766-11e1-8775-005056c00008" name="71-72" r="7.7711040000000002" x="31.363201100000001" g1="0" b1="0.00012752525" g2="0" b2="0.00012752525" node1="29" voltageLevelId1="_04664b78-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="-6.452663392992541" q1="-4.7833365158208938" p2="6.4749190473547964" q2="0.5182435015775968">
+    <iidm:line id="_04845ac7-c766-11e1-8775-005056c00008" name="71-72" r="7.7711040000000002" x="31.363201100000001" g1="0" b1="0.00012752525" g2="0" b2="0.00012752525" node1="29" voltageLevelId1="_04664b78-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="-11.054207012586049" q1="-2.90575932765696" p2="11.110501809799816" q2="-1.2176605661142834">
         <iidm:alias>_04642891-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046b0661-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9547,7 +9670,7 @@
             <iidm:temporaryLimit name="_bcb69c6e-125e-449c-acb3-a4deb151668d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047343c2-c766-11e1-8775-005056c00008" name="66-67" r="3.9029759999999998" x="17.685359999999999" g1="0" b1="7.6962800000000001e-05" g2="0" b2="7.6962800000000001e-05" node1="50" voltageLevelId1="_047147f4-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="21.529650992033339" q1="22.601635730129093" p2="-21.315818939089521" q2="-24.485192841949292">
+    <iidm:line id="_047343c2-c766-11e1-8775-005056c00008" name="66-67" r="3.9029759999999998" x="17.685359999999999" g1="0" b1="7.6962800000000001e-05" g2="0" b2="7.6962800000000001e-05" node1="50" voltageLevelId1="_047147f4-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="30.876691118618773" q1="21.056996926125013" p2="-30.57740120695663" q2="-22.554902029550849">
         <iidm:alias>_0465af34-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04860874-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9555,7 +9678,7 @@
             <iidm:temporaryLimit name="_b4b8a31d-dc3c-4b51-88ad-a22e070eb96c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04569409-c766-11e1-8775-005056c00008" name="34-43" r="7.1961120000000003" x="29.289743399999999" g1="0" b1="0.0001212695" g2="0" b2="0.0001212695" node1="40" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_045e8349-c766-11e1-8775-005056c00008" p1="10.742558266695813" q1="-9.1260694245026066" p2="-10.662027300612216" q2="5.7639977699162692">
+    <iidm:line id="_04569409-c766-11e1-8775-005056c00008" name="34-43" r="7.1961120000000003" x="29.289743399999999" g1="0" b1="0.0001212695" g2="0" b2="0.0001212695" node1="40" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_045e8349-c766-11e1-8775-005056c00008" p1="12.842949113051775" q1="-7.7162302283668911" p2="-12.750725065008922" q2="4.3056469972962601">
         <iidm:alias>_04500454-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04505274-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9563,7 +9686,7 @@
             <iidm:temporaryLimit name="_5585c67a-0839-48e6-8847-4393e1e9b9c7" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04817498-c766-11e1-8775-005056c00008" name="52-53" r="7.0567200000000003" x="28.488240000000001" g1="0" b1="0.00011644859999999999" g2="0" b2="0.00011644859999999999" node1="21" voltageLevelId1="_04806326-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04876804-c766-11e1-8775-005056c00008" p1="8.4123379600752752" q1="2.6277156603294047" p2="-8.3721743567781495" q2="-6.1424284695394942">
+    <iidm:line id="_04817498-c766-11e1-8775-005056c00008" name="52-53" r="7.0567200000000003" x="28.488240000000001" g1="0" b1="0.00011644859999999999" g2="0" b2="0.00011644859999999999" node1="21" voltageLevelId1="_04806326-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04876804-c766-11e1-8775-005056c00008" p1="13.387760445556045" q1="0.95587497955439693" p2="-13.304769544033915" q2="-4.2869810233023218">
         <iidm:alias>_045115c7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0472a784-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9571,7 +9694,7 @@
             <iidm:temporaryLimit name="_e7c9dfab-fb45-4470-964f-4ba9e391f60b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044b7078-c766-11e1-8775-005056c00008" name="105-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="49" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="23" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="26.821043124260445" q1="1.3542181563629707" p2="-26.404684444535654" q2="-4.2235691206775545">
+    <iidm:line id="_044b7078-c766-11e1-8775-005056c00008" name="105-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="49" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="23" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="26.893995013041305" q1="1.3281758933369807" p2="-26.475541319144764" q2="-4.1906796155338046">
         <iidm:alias>_0452c378-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0481c2b7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9579,7 +9702,7 @@
             <iidm:temporaryLimit name="_fff133bf-25fd-46b2-b144-a227c31ee882" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048ac367-c766-11e1-8775-005056c00008" name="100-101" r="4.8264480000000001" x="21.9890881" g1="0" b1="9.4123049999999997e-05" g2="0" b2="9.4123049999999997e-05" node1="77" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046ed6f7-c766-11e1-8775-005056c00008" p1="-18.821953366504971" q1="23.349165625596346" p2="19.08482579101204" q2="-25.460024760400746">
+    <iidm:line id="_048ac367-c766-11e1-8775-005056c00008" name="100-101" r="4.8264480000000001" x="21.9890881" g1="0" b1="9.4123049999999997e-05" g2="0" b2="9.4123049999999997e-05" node1="77" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046ed6f7-c766-11e1-8775-005056c00008" p1="-21.808154101042458" q1="24.753084893682519" p2="22.12288232505869" q2="-26.625105553024714">
         <iidm:alias>_044afb45-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b5fa2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9587,7 +9710,7 @@
             <iidm:temporaryLimit name="_217e3c95-24b5-438f-a721-d2257e1a43b4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0481c2b1-c766-11e1-8775-005056c00008" name="56-57" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="57" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="-18.069744779710923" q1="-11.305088924762158" p2="18.232076643512965" q2="9.520804319590118">
+    <iidm:line id="_0481c2b1-c766-11e1-8775-005056c00008" name="56-57" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="57" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="-30.80767740589765" q1="-5.4715595794429586" p2="31.172688604114978" q2="4.2606198987752322">
         <iidm:alias>_045e0e12-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0487dd35-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9595,7 +9718,7 @@
             <iidm:temporaryLimit name="_f5547027-3d48-4a53-937b-bd5ba63ef70d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047a6fb7-c766-11e1-8775-005056c00008" name="47-69" r="14.705855400000001" x="48.403869999999998" g1="0" b1="0.00020351240000000001" g2="0" b2="0.00020351240000000001" node1="31" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="57" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-71.763305721206933" q1="19.416967272334876" p2="76.411151752743336" q2="-11.576326990239775">
+    <iidm:line id="_047a6fb7-c766-11e1-8775-005056c00008" name="47-69" r="14.705855400000001" x="48.403869999999998" g1="0" b1="0.00020351240000000001" g2="0" b2="0.00020351240000000001" node1="31" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="57" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-83.633037778569047" q1="25.815550195616453" p2="90.079789654601228" q2="-12.044995309503163">
         <iidm:alias>_04758db9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0485ba56-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9603,7 +9726,7 @@
             <iidm:temporaryLimit name="_e9fec217-cf6f-4d39-9495-26ed10c05100" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0453fbf0-c766-11e1-8775-005056c00008" name="110-111" r="3.8332799999999998" x="13.1551189" g1="0" b1="5.7392100000000002e-05" g2="0" b2="5.7392100000000002e-05" node1="40" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_046a1c00-c766-11e1-8775-005056c00008" p1="-37.247419070658054" q1="-21.291506158524232" p2="37.682271922405555" q2="20.911426279964516">
+    <iidm:line id="_0453fbf0-c766-11e1-8775-005056c00008" name="110-111" r="3.8332799999999998" x="13.1551189" g1="0" b1="5.7392100000000002e-05" g2="0" b2="5.7392100000000002e-05" node1="40" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_046a1c00-c766-11e1-8775-005056c00008" p1="-39.389838832390666" q1="-20.544358481861806" p2="39.857037282988287" q2="20.275188084694214">
         <iidm:alias>_0447c6f5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04812675-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9611,7 +9734,7 @@
             <iidm:temporaryLimit name="_ea48fee0-31b6-4990-a332-25d08b7d731f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04778984-c766-11e1-8775-005056c00008" name="41-42" r="7.14384" x="23.522401800000001" g1="0" b1="9.8714400000000005e-05" g2="0" b2="9.8714400000000005e-05" node1="21" voltageLevelId1="_048c4a08-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="-12.41679322825658" q1="-12.316806370514225" p2="12.561478178474635" q2="10.045786668006805">
+    <iidm:line id="_04778984-c766-11e1-8775-005056c00008" name="41-42" r="7.14384" x="23.522401800000001" g1="0" b1="9.8714400000000005e-05" g2="0" b2="9.8714400000000005e-05" node1="21" voltageLevelId1="_048c4a08-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="-10.469970146717001" q1="-11.256683766185169" p2="10.576410208537665" q2="8.7987562099410717">
         <iidm:alias>_044d1e2a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046512f1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9619,7 +9742,7 @@
             <iidm:temporaryLimit name="_063af52c-fe10-4c1e-85d4-dd80dcc1d2f9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04653a08-c766-11e1-8775-005056c00008" name="80-99" r="7.9104960000000002" x="35.893439999999998" g1="0" b1="0.00015668044999999999" g2="0" b2="0.00015668044999999999" node1="78" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04644fa4-c766-11e1-8775-005056c00008" p1="12.07841356931738" q1="4.501517667708395" p2="-11.993853362028799" q2="-9.9118461044439243">
+    <iidm:line id="_04653a08-c766-11e1-8775-005056c00008" name="80-99" r="7.9104960000000002" x="35.893439999999998" g1="0" b1="0.00015668044999999999" g2="0" b2="0.00015668044999999999" node1="78" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04644fa4-c766-11e1-8775-005056c00008" p1="1.9943715979939252" q1="6.6813360292562098" p2="-1.9537426772533721" q2="-12.29030374450323">
         <iidm:alias>_04773b69-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0477b092-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9627,7 +9750,7 @@
             <iidm:temporaryLimit name="_c05229ce-6abb-4209-ad4f-0dcd4a070f28" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04581aa5-c766-11e1-8775-005056c00008" name="54-59" r="8.7642720000000001" x="39.953229999999998" g1="0" b1="0.0001716024" g2="0" b2="0.0001716024" node1="58" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-35.66501581937694" q1="-5.9048936325776173" p2="36.372115514967859" q2="3.5003842332838451">
+    <iidm:line id="_04581aa5-c766-11e1-8775-005056c00008" name="54-59" r="8.7642720000000001" x="39.953229999999998" g1="0" b1="0.0001716024" g2="0" b2="0.0001716024" node1="58" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-19.64920287833921" q1="-10.518739286402587" p2="19.895623697356658" q2="6.0141571149369346">
         <iidm:alias>_0457cc82-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045cae81-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9635,7 +9758,7 @@
             <iidm:temporaryLimit name="_ac528cbe-6fc1-41dd-ba9d-d8b7a4c77576" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04690a93-c766-11e1-8775-005056c00008" name="92-94" r="8.3809430000000003" x="27.529920000000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="67" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="57.667044296397961" q1="-15.243136293886646" p2="-55.950835461102741" q2="16.904582091869884">
+    <iidm:line id="_04690a93-c766-11e1-8775-005056c00008" name="92-94" r="8.3809430000000003" x="27.529920000000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="67" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="65.18674706717708" q1="-16.352452033820615" p2="-62.997365481089297" q2="19.57980948065093">
         <iidm:alias>_044c33c1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0483706b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9643,7 +9766,7 @@
             <iidm:temporaryLimit name="_6ac84228-6b04-4b10-b560-29655c8e93b4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046009e3-c766-11e1-8775-005056c00008" name="37-39" r="5.5931040000000003" x="18.469439999999999" g1="0" b1="7.7479350000000006e-05" g2="0" b2="7.7479350000000006e-05" node1="57" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046bf0c7-c766-11e1-8775-005056c00008" p1="64.947806147788839" q1="16.726527816760612" p2="-63.278373769844421" q2="-13.47119397102464">
+    <iidm:line id="_046009e3-c766-11e1-8775-005056c00008" name="37-39" r="5.5931040000000003" x="18.469439999999999" g1="0" b1="7.7479350000000006e-05" g2="0" b2="7.7479350000000006e-05" node1="57" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046bf0c7-c766-11e1-8775-005056c00008" p1="67.00792068273141" q1="18.057682138678068" p2="-65.27504064397381" q2="-14.662595300548764">
         <iidm:alias>_044c33c9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04789afa-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9651,7 +9774,7 @@
             <iidm:temporaryLimit name="_2ccdc288-c132-40d1-a928-3887bec4ff67" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0458b6e8-c766-11e1-8775-005056c00008" name="46-47" r="6.6211200000000003" x="22.12848" g1="0" b1="9.0679499999999998e-05" g2="0" b2="9.0679499999999998e-05" node1="33" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_0457f396-c766-11e1-8775-005056c00008" p1="-31.207317705447128" q1="-0.19312578025601143" p2="31.574465476267726" q2="-1.8060329299721452">
+    <iidm:line id="_0458b6e8-c766-11e1-8775-005056c00008" name="46-47" r="6.6211200000000003" x="22.12848" g1="0" b1="9.0679499999999998e-05" g2="0" b2="9.0679499999999998e-05" node1="33" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_0457f396-c766-11e1-8775-005056c00008" p1="-32.352724946610294" q1="1.1883891931421475" p2="32.749439167192762" q2="-3.0847808559441789">
         <iidm:alias>_04507980-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0464c4da-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9659,7 +9782,7 @@
             <iidm:temporaryLimit name="_06ca3245-2668-448f-a5c6-961924217a5c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044f8f22-c766-11e1-8775-005056c00008" name="82-83" r="1.9514879999999999" x="6.3858959999999998" g1="0" b1="0.0001089302" g2="0" b2="0.0001089302" node1="31" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728074-c766-11e1-8775-005056c00008" p1="-53.91844134862297" q1="32.398450377181007" p2="54.390417913996181" q2="-34.505039697350455">
+    <iidm:line id="_044f8f22-c766-11e1-8775-005056c00008" name="82-83" r="1.9514879999999999" x="6.3858959999999998" g1="0" b1="0.0001089302" g2="0" b2="0.0001089302" node1="31" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728074-c766-11e1-8775-005056c00008" p1="-66.325422889664424" q1="39.491406660915985" p2="67.03588104283908" q2="-40.793157049825254">
         <iidm:alias>_047a48a6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b3891-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9667,7 +9790,7 @@
             <iidm:temporaryLimit name="_dfbd2f07-76ab-41e3-910f-dc706979ea4b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045cfca6-c766-11e1-8775-005056c00008" name="108-109" r="1.82952" x="5.0181120000000004" g1="0" b1="2.1809000000000001e-05" g2="0" b2="2.1809000000000001e-05" node1="21" voltageLevelId1="_046c65f4-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b7b99-c766-11e1-8775-005056c00008" p1="21.848036477433688" q1="-0.90781245458170057" p2="-21.793525311830127" q2="0.3596925304345826">
+    <iidm:line id="_045cfca6-c766-11e1-8775-005056c00008" name="108-109" r="1.82952" x="5.0181120000000004" g1="0" b1="2.1809000000000001e-05" g2="0" b2="2.1809000000000001e-05" node1="21" voltageLevelId1="_046c65f4-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b7b99-c766-11e1-8775-005056c00008" p1="20.786939727156341" q1="-0.53199406125631554" p2="-20.737629829630468" q2="-0.030485706266171995">
         <iidm:alias>_04481514-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04716f00-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9675,7 +9798,7 @@
             <iidm:temporaryLimit name="_11451cec-81c7-4f83-a7db-df7dcaffa94e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04784cd5-c766-11e1-8775-005056c00008" name="70-74" r="6.9870239999999999" x="23.051952400000001" g1="0" b1="9.6648299999999994e-05" g2="0" b2="9.6648299999999994e-05" node1="48" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047dcb11-c766-11e1-8775-005056c00008" p1="22.361317104183453" q1="9.590109303308946" p2="-22.101948012414958" q2="-11.915467987401286">
+    <iidm:line id="_04784cd5-c766-11e1-8775-005056c00008" name="70-74" r="6.9870239999999999" x="23.051952400000001" g1="0" b1="9.6648299999999994e-05" g2="0" b2="9.6648299999999994e-05" node1="48" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047dcb11-c766-11e1-8775-005056c00008" p1="22.997694088869899" q1="9.505256776801458" p2="-22.727348035739794" q2="-11.796534418606463">
         <iidm:alias>_045e5c33-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046ab84b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9683,7 +9806,7 @@
             <iidm:temporaryLimit name="_37a5cc00-bd7f-4ec7-a77c-e140e23450d2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04747c40-c766-11e1-8775-005056c00008" name="77-82" r="5.1923519999999996" x="14.8626719" g1="0" b1="0.0002345615" g2="0" b2="0.0002345615" node1="69" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_046512f8-c766-11e1-8775-005056c00008" p1="-12.467265661540324" q1="23.135194335807043" p2="12.733151718001245" q2="-30.443301657531872">
+    <iidm:line id="_04747c40-c766-11e1-8775-005056c00008" name="77-82" r="5.1923519999999996" x="14.8626719" g1="0" b1="0.0002345615" g2="0" b2="0.0002345615" node1="69" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_046512f8-c766-11e1-8775-005056c00008" p1="-27.520917472630302" q1="31.33514980829235" p2="28.117952999271971" q2="-37.668061917547128">
         <iidm:alias>_0451b202-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0452ea84-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9691,7 +9814,7 @@
             <iidm:temporaryLimit name="_e9798d58-b518-4fab-984c-c72076dfc2ae" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045e3524-c766-11e1-8775-005056c00008" name="23-24" r="2.3522400000000001" x="8.5726080000000007" g1="0" b1="0.00014290635" g2="0" b2="0.00014290635" node1="39" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_048c22fa-c766-11e1-8775-005056c00008" p1="43.303664506749399" q1="-8.6702540653264037" p2="-43.046610602829915" q2="4.6159014478277181">
+    <iidm:line id="_045e3524-c766-11e1-8775-005056c00008" name="23-24" r="2.3522400000000001" x="8.5726080000000007" g1="0" b1="0.00014290635" g2="0" b2="0.00014290635" node1="39" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_048c22fa-c766-11e1-8775-005056c00008" p1="53.234459283271683" q1="-9.7417052961249908" p2="-52.84580239563568" q2="6.1814080635687638">
         <iidm:alias>_046cb413-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f9fd3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9699,7 +9822,7 @@
             <iidm:temporaryLimit name="_e8ec73b8-1ecf-4d18-9ef9-80eabf3a4969" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0474f177-c766-11e1-8775-005056c00008" name="15-17" r="2.2999679999999998" x="7.6142880000000002" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="48" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-135.55866244443632" q1="-27.182286358129577" p2="138.33830336378389" q2="32.238312123025004">
+    <iidm:line id="_0474f177-c766-11e1-8775-005056c00008" name="15-17" r="2.2999679999999998" x="7.6142880000000002" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="48" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-159.93947068551279" q1="-15.582428012142655" p2="163.71931031294309" q2="23.967645130873652">
         <iidm:alias>_044c5ad2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046931a7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9707,7 +9830,7 @@
             <iidm:temporaryLimit name="_2ceac3d1-f73d-43db-8d37-9e329f1787bb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0483be84-c766-11e1-8775-005056c00008" name="8-30" r="2.0860400000000001" x="24.393599999999999" g1="0" b1="0.00053099175999999997" g2="0" b2="0.00053099175999999997" node1="30" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="38" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="71.744772915966109" q1="25.449668924812141" p2="-71.413832237184963" q2="-72.403818500007588">
+    <iidm:line id="_0483be84-c766-11e1-8775-005056c00008" name="8-30" r="2.0860400000000001" x="24.393599999999999" g1="0" b1="0.00053099175999999997" g2="0" b2="0.00053099175999999997" node1="30" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="38" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="103.80103342947172" q1="20.899665173771325" p2="-103.24914743334664" q2="-65.182886742784603">
         <iidm:alias>_0454e651-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04801506-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9715,7 +9838,7 @@
             <iidm:temporaryLimit name="_ca795ad3-97e5-4416-aaba-53cce27f6434" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0488eea6-c766-11e1-8775-005056c00008" name="49-69" r="17.16264" x="56.453762099999999" g1="0" b1="0.00023760329999999999" g2="0" b2="0.00023760329999999999" node1="115" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-63.130412736052634" q1="19.320900593582174" p2="67.392213942187112" q2="-14.086845287560767">
+    <iidm:line id="_0488eea6-c766-11e1-8775-005056c00008" name="49-69" r="17.16264" x="56.453762099999999" g1="0" b1="0.00023760329999999999" g2="0" b2="0.00023760329999999999" node1="115" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-75.303479203445576" q1="26.521811216863483" p2="81.51340412596754" q2="-14.879714183411053">
         <iidm:alias>_04492681-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046735d6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9723,7 +9846,7 @@
             <iidm:temporaryLimit name="_c42dc3ef-3a2e-4070-8efb-78e5c0cd5554" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047566a0-c766-11e1-8775-005056c00008" name="13-15" r="12.9634562" x="42.584255200000001" g1="0" b1="0.00017986685000000001" g2="0" b2="0.00017986685000000001" node1="21" voltageLevelId1="_04851e1b-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="10.048988798468637" q1="0.13064582295826435" p2="-9.9609308763556488" q2="-5.5910231246421578">
+    <iidm:line id="_047566a0-c766-11e1-8775-005056c00008" name="13-15" r="12.9634562" x="42.584255200000001" g1="0" b1="0.00017986685000000001" g2="0" b2="0.00017986685000000001" node1="21" voltageLevelId1="_04851e1b-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="10.924137787813139" q1="0.22548301131408519" p2="-10.820825900553823" q2="-5.6221267841212663">
         <iidm:alias>_04662461-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04865694-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9731,7 +9854,7 @@
             <iidm:temporaryLimit name="_ad988fd9-9270-4230-95a2-1858f32259df" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0476c63a-c766-11e1-8775-005056c00008" name="69-70" r="5.2271999999999998" x="22.12848" g1="0" b1="0.00035009184999999998" g2="0" b2="0.00035009184999999998" node1="59" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="86.254751135317704" q1="18.911991973481722" p2="-83.989847513352885" q2="-21.761309686059032">
+    <iidm:line id="_0476c63a-c766-11e1-8775-005056c00008" name="69-70" r="5.2271999999999998" x="22.12848" g1="0" b1="0.00035009184999999998" g2="0" b2="0.00035009184999999998" node1="59" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="77.629337209101195" q1="19.79731928446958" p2="-75.747470022545897" q2="-24.272746720312039">
         <iidm:alias>_047e193a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b1184-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9739,7 +9862,7 @@
             <iidm:temporaryLimit name="_519e3ecb-3561-4d11-ac6b-172a0b4b09b2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04520028-c766-11e1-8775-005056c00008" name="19-20" r="4.3908480000000001" x="20.38608" g1="0" b1="8.5514249999999999e-05" g2="0" b2="8.5514249999999999e-05" node1="39" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b2d70-c766-11e1-8775-005056c00008" p1="-11.848940943654929" q1="0.78038657567634162" p2="11.890153393455906" q2="-3.2295802211559996">
+    <iidm:line id="_04520028-c766-11e1-8775-005056c00008" name="19-20" r="4.3908480000000001" x="20.38608" g1="0" b1="8.5514249999999999e-05" g2="0" b2="8.5514249999999999e-05" node1="39" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b2d70-c766-11e1-8775-005056c00008" p1="-12.812253627668188" q1="1.1716101734178737" p2="12.86084834581164" q2="-3.5797530380939713">
         <iidm:alias>_0472f5a9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04745537-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9747,7 +9870,7 @@
             <iidm:temporaryLimit name="_b88528bf-cb1c-4c00-ad79-d5937197d40c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04862f83-c766-11e1-8775-005056c00008" name="94-95" r="2.2999679999999998" x="7.5620159999999998" g1="0" b1="3.1852600000000001e-05" g2="0" b2="3.1852600000000001e-05" node1="51" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f4108-c766-11e1-8775-005056c00008" p1="47.915406439452155" q1="8.424213368241027" p2="-47.594475581532869" q2="-8.4428551389783753">
+    <iidm:line id="_04862f83-c766-11e1-8775-005056c00008" name="94-95" r="2.2999679999999998" x="7.5620159999999998" g1="0" b1="3.1852600000000001e-05" g2="0" b2="3.1852600000000001e-05" node1="51" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f4108-c766-11e1-8775-005056c00008" p1="57.189873595452212" q1="6.5035572267924184" p2="-56.739893231109107" q2="-6.0938294828930237">
         <iidm:alias>_044ca8f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04837060-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9755,7 +9878,7 @@
             <iidm:temporaryLimit name="_b70e76a1-6e79-4fb6-b487-dffa9bfeab7b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047b0bf6-c766-11e1-8775-005056c00008" name="12-16" r="3.6938879999999998" x="14.5316162" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="68" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046f7338-c766-11e1-8775-005056c00008" p1="12.829729755157624" q1="7.7861676104950668" p2="-12.777241975472906" q2="-9.6557043648266347">
+    <iidm:line id="_047b0bf6-c766-11e1-8775-005056c00008" name="12-16" r="3.6938879999999998" x="14.5316162" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="68" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046f7338-c766-11e1-8775-005056c00008" p1="9.7890032234598099" q1="9.5636332938387625" p2="-9.7439153533496263" q2="-11.460460523875177">
         <iidm:alias>_0450798a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045c8772-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9763,7 +9886,7 @@
             <iidm:temporaryLimit name="_af73f526-c58b-40e7-8e1c-14f05a39f6a2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04524e47-c766-11e1-8775-005056c00008" name="100-103" r="2.7878400000000001" x="9.1476000000000006" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="78" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0475b4c0-c766-11e1-8775-005056c00008" p1="118.86389281160928" q1="-21.467993871783889" p2="-116.62418279699422" q2="23.311280032584509">
+    <iidm:line id="_04524e47-c766-11e1-8775-005056c00008" name="100-103" r="2.7878400000000001" x="9.1476000000000006" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="78" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0475b4c0-c766-11e1-8775-005056c00008" p1="115.38805784487283" q1="-20.642900904238466" p2="-113.27897164808884" q2="22.057577725716097">
         <iidm:alias>_04684744-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048aea71-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9771,7 +9894,7 @@
             <iidm:temporaryLimit name="_1631e50b-21a3-470b-803b-f9665b6fcd60" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04682038-c766-11e1-8775-005056c00008" name="27-32" r="3.9900959999999999" x="13.1551189" g1="0" b1="5.5268600000000001e-05" g2="0" b2="5.5268600000000001e-05" node1="40" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="15.543841899724509" q1="-2.8372474818737063" p2="-15.483971132507163" q2="1.2310920811665409">
+    <iidm:line id="_04682038-c766-11e1-8775-005056c00008" name="27-32" r="3.9900959999999999" x="13.1551189" g1="0" b1="5.5268600000000001e-05" g2="0" b2="5.5268600000000001e-05" node1="40" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="15.97812326731345" q1="-2.2618676110647362" p2="-15.915412205515327" q2="0.66501165296701403">
         <iidm:alias>_0455347a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479ac63-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9779,7 +9902,7 @@
             <iidm:temporaryLimit name="_52eb4b09-42bb-4106-ac26-fe1059639d3a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0482fb31-c766-11e1-8775-005056c00008" name="59-61" r="5.7150720000000002" x="26.1360016" g1="0" b1="0.0001113407" g2="0" b2="0.0001113407" node1="68" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-58.377984106197466" q1="7.1089594960564257" p2="59.557438815298056" q2="-5.5179971273327659">
+    <iidm:line id="_0482fb31-c766-11e1-8775-005056c00008" name="59-61" r="5.7150720000000002" x="26.1360016" g1="0" b1="0.0001113407" g2="0" b2="0.0001113407" node1="68" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-100.75611234435095" q1="22.243967428245746" p2="104.38486718825028" q2="-9.4519366731797057">
         <iidm:alias>_044a10e9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0473b8f5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9787,7 +9910,7 @@
             <iidm:temporaryLimit name="_b5a7dea0-bfce-4548-a04d-7bb7b6d9f80a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047d55e3-c766-11e1-8775-005056c00008" name="100-104" r="7.8582239999999999" x="35.544960000000003" g1="0" b1="0.00015524565000000001" g2="0" b2="0.00015524565000000001" node1="79" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="55.751036935008237" q1="10.917045642935005" p2="-54.313702002055756" q2="-9.7613184020557799">
+    <iidm:line id="_047d55e3-c766-11e1-8775-005056c00008" name="100-104" r="7.8582239999999999" x="35.544960000000003" g1="0" b1="0.00015524565000000001" g2="0" b2="0.00015524565000000001" node1="79" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="55.001088868096979" q1="10.980556864620556" p2="-53.599209984596342" q2="-9.9854078764861427">
         <iidm:alias>_04636547-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048aea76-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9795,7 +9918,7 @@
             <iidm:temporaryLimit name="_17a10cd0-b653-4dcf-bdc3-4d5005ea9591" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04653a02-c766-11e1-8775-005056c00008" name="75-77" r="10.4718237" x="34.830577900000002" g1="0" b1="0.00014284895" g2="0" b2="0.00014284895" node1="49" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-33.412429050285922" q1="-8.5588009172295667" p2="34.154256037277776" q2="6.19198485711751">
+    <iidm:line id="_04653a02-c766-11e1-8775-005056c00008" name="75-77" r="10.4718237" x="34.830577900000002" g1="0" b1="0.00014284895" g2="0" b2="0.00014284895" node1="49" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-36.619444415372975" q1="-6.9223249694710001" p2="37.493705456729145" q2="4.9981131037434299">
         <iidm:alias>_04642894-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04720b47-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9803,7 +9926,7 @@
             <iidm:temporaryLimit name="_6f81df11-7e71-4b6e-a6ee-a8c5f72f4ba5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04483c2a-c766-11e1-8775-005056c00008" name="23-32" r="5.5234079999999999" x="20.089872400000001" g1="0" b1="0.00033660465000000001" g2="0" b2="0.00033660465000000001" node1="40" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="84.858753088009976" q1="5.835875249246282" p2="-82.543551633036699" q2="-8.7884261388371794">
+    <iidm:line id="_04483c2a-c766-11e1-8775-005056c00008" name="23-32" r="5.5234079999999999" x="20.089872400000001" g1="0" b1="0.00033660465000000001" g2="0" b2="0.00033660465000000001" node1="40" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="80.520125309720271" q1="5.8631133681882446" p2="-78.426568703585119" q2="-9.6059330412569235">
         <iidm:alias>_044b978a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0461dea6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9811,7 +9934,7 @@
             <iidm:temporaryLimit name="_a8f6a7d2-e58d-4671-a776-97be7291355e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048719e5-c766-11e1-8775-005056c00008" name="96-97" r="3.0143520000000001" x="15.42024" g1="0" b1="6.8870549999999994e-05" g2="0" b2="6.8870549999999994e-05" node1="50" voltageLevelId1="_045a1672-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="-5.122252471518264" q1="-22.725350629865023" p2="5.208898634899211" q2="20.769148359347973">
+    <iidm:line id="_048719e5-c766-11e1-8775-005056c00008" name="96-97" r="3.0143520000000001" x="15.42024" g1="0" b1="6.8870549999999994e-05" g2="0" b2="6.8870549999999994e-05" node1="50" voltageLevelId1="_045a1672-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="3.0827426382640337" q1="-25.477177959209175" p2="-2.9762442835099989" q2="23.630552432291601">
         <iidm:alias>_0451b207-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04828601-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9819,7 +9942,7 @@
             <iidm:temporaryLimit name="_ea6d39aa-df95-4d3e-b7b6-a800e552e72a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048481d0-c766-11e1-8775-005056c00008" name="25-27" r="5.5408330000000001" x="28.401121100000001" g1="0" b1="0.000506198385" g2="0" b2="0.000506198385" node1="30" voltageLevelId1="_04728079-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0476c639-c766-11e1-8775-005056c00008" p1="149.07469689897269" q1="29.768315449023007" p2="-142.21486161995281" q2="-12.607351829924825">
+    <iidm:line id="_048481d0-c766-11e1-8775-005056c00008" name="25-27" r="5.5408330000000001" x="28.401121100000001" g1="0" b1="0.000506198385" g2="0" b2="0.000506198385" node1="30" voltageLevelId1="_04728079-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0476c639-c766-11e1-8775-005056c00008" p1="149.17073440913725" q1="29.58759914135447" p2="-142.30674519567728" q2="-12.410318529151683">
         <iidm:alias>_046d2947-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04725960-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9827,7 +9950,7 @@
             <iidm:temporaryLimit name="_d9d53af2-5ffa-4f2a-a4e6-ed22371332d6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04885268-c766-11e1-8775-005056c00008" name="110-112" r="4.3037280000000004" x="11.1513615" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="41" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="13" voltageLevelId2="_04784cd1-c766-11e1-8775-005056c00008" p1="69.354543048679872" q1="11.008359506434202" p2="-67.999999834679087" q2="-12.999999759092598">
+    <iidm:line id="_04885268-c766-11e1-8775-005056c00008" name="110-112" r="4.3037280000000004" x="11.1513615" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="41" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="13" voltageLevelId2="_04784cd1-c766-11e1-8775-005056c00008" p1="69.354399394384529" q1="11.007380795507473" p2="-68.000007397543996" q2="-13.000002269863797">
         <iidm:alias>_04611b55-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0481c2ba-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9835,7 +9958,7 @@
             <iidm:temporaryLimit name="_d50299b9-a055-408a-aa1e-2e93a715120f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0484a8e4-c766-11e1-8775-005056c00008" name="89-92" r="1.7249760000000001" x="8.7991200000000003" g1="0" b1="0.00015725434999999999" g2="0" b2="0.00015725434999999999" node1="57" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="68" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="213.47500765416521" q1="-4.2904242757043187" p2="-209.0079738534186" q2="21.620730667200505">
+    <iidm:line id="_0484a8e4-c766-11e1-8775-005056c00008" name="89-92" r="1.7249760000000001" x="8.7991200000000003" g1="0" b1="0.00015725434999999999" g2="0" b2="0.00015725434999999999" node1="57" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="68" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="228.46792927886338" q1="-3.1856552663563797" p2="-223.35164094034292" q2="23.834248258715608">
         <iidm:alias>_04481517-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04808a3c-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9843,7 +9966,7 @@
             <iidm:temporaryLimit name="_eee9ca2b-764f-4ab8-a745-405338044743" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04689568-c766-11e1-8775-005056c00008" name="49-54" r="15.1414566" x="50.703842199999997" g1="0" b1="0.00020948120000000001" g2="0" b2="0.00020948120000000001" node1="116" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="32.194546663715009" q1="12.322759418099203" p2="-31.121304248978571" q2="-15.892490958538602">
+    <iidm:line id="_04689568-c766-11e1-8775-005056c00008" name="49-54" r="15.1414566" x="50.703842199999997" g1="0" b1="0.00020948120000000001" g2="0" b2="0.00020948120000000001" node1="116" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="46.528474056584805" q1="9.6237975407512266" p2="-44.58800804047295" q2="-10.289477643762652">
         <iidm:alias>_046030f0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04605808-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9851,7 +9974,7 @@
             <iidm:temporaryLimit name="_690202a4-aad2-4ad3-8842-961b39e37709" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046c8d04-c766-11e1-8775-005056c00008" name="40-41" r="2.5264799999999998" x="8.4854880000000001" g1="0" b1="3.5066600000000001e-05" g2="0" b2="3.5066600000000001e-05" node1="40" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048c4a08-c766-11e1-8775-005056c00008" p1="24.682593939220801" q1="-2.8948259520456028" p2="-24.568693401534446" q2="2.3233493064687902">
+    <iidm:line id="_046c8d04-c766-11e1-8775-005056c00008" name="40-41" r="2.5264799999999998" x="8.4854880000000001" g1="0" b1="3.5066600000000001e-05" g2="0" b2="3.5066600000000001e-05" node1="40" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048c4a08-c766-11e1-8775-005056c00008" p1="26.647662444497033" q1="-1.8102536827911617" p2="-26.519398416453054" q2="1.2614759522168035">
         <iidm:alias>_045cae80-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a2194-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9859,7 +9982,7 @@
             <iidm:temporaryLimit name="_34f2ef7c-32da-4444-b989-d02f5f931c50" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046735d5-c766-11e1-8775-005056c00008" name="39-40" r="3.206016" x="10.54152" g1="0" b1="4.4536249999999999e-05" g2="0" b2="4.4536249999999999e-05" node1="22" voltageLevelId1="_046bf0c7-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="36.289093739780292" q1="2.4784771303962949" p2="-35.983788126228653" q2="-2.7026051841812171">
+    <iidm:line id="_046735d5-c766-11e1-8775-005056c00008" name="39-40" r="3.206016" x="10.54152" g1="0" b1="4.4536249999999999e-05" g2="0" b2="4.4536249999999999e-05" node1="22" voltageLevelId1="_046bf0c7-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="38.282911678902558" q1="3.6679424273661985" p2="-37.95122059250027" q2="-3.8406654676865881">
         <iidm:alias>_045115c1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048badc2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9867,7 +9990,7 @@
             <iidm:temporaryLimit name="_38d58455-5205-46bb-8e44-c66873f62938" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0470d2c4-c766-11e1-8775-005056c00008" name="89-92" r="6.8476319999999999" x="27.5473423" g1="0" b1="0.00011880164999999999" g2="0" b2="0.00011880164999999999" node1="58" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="67.325034169994652" q1="-5.9451513624137418" p2="-65.555598773168384" q2="8.9414860710996003">
+    <iidm:line id="_0470d2c4-c766-11e1-8775-005056c00008" name="89-92" r="6.8476319999999999" x="27.5473423" g1="0" b1="0.00011880164999999999" g2="0" b2="0.00011880164999999999" node1="58" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="72.072602780233936" q1="-5.8335680832268535" p2="-70.045991366406085" q2="9.8693560228017727">
         <iidm:alias>_04690a97-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04690a98-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9875,7 +9998,7 @@
             <iidm:temporaryLimit name="_0cce41c7-b99f-4fec-93d2-73ea24433fa1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0479ac60-c766-11e1-8775-005056c00008" name="33-37" r="7.2309599999999996" x="24.742080000000001" g1="0" b1="0.00010502754999999999" g2="0" b2="0.00010502754999999999" node1="21" voltageLevelId1="_0456bb11-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="20.138377397743042" q1="-8.520051813135419" p2="-19.921666268239051" q2="6.0749223802641232">
+    <iidm:line id="_0479ac60-c766-11e1-8775-005056c00008" name="33-37" r="7.2309599999999996" x="24.742080000000001" g1="0" b1="0.00010502754999999999" g2="0" b2="0.00010502754999999999" node1="21" voltageLevelId1="_0456bb11-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="39.739206470778306" q1="-20.269039104360107" p2="-38.825689972110212" q2="20.144253061613231">
         <iidm:alias>_04716f08-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0483be89-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9883,7 +10006,7 @@
             <iidm:temporaryLimit name="_343677c6-7477-4bf6-a12c-2c7e4a684d6f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048c4a00-c766-11e1-8775-005056c00008" name="105-108" r="4.5476640000000002" x="12.249072099999999" g1="0" b1="5.2915499999999998e-05" g2="0" b2="5.2915499999999998e-05" node1="50" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_046c65f4-c766-11e1-8775-005056c00008" p1="24.009535724358443" q1="-1.1802090547871169" p2="-23.84803664337571" q2="-0.092187669439210668">
+    <iidm:line id="_048c4a00-c766-11e1-8775-005056c00008" name="105-108" r="4.5476640000000002" x="12.249072099999999" g1="0" b1="5.2915499999999998e-05" g2="0" b2="5.2915499999999998e-05" node1="50" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_046c65f4-c766-11e1-8775-005056c00008" p1="22.934260826497493" q1="-0.84275323251361778" p2="-22.786940112755435" q2="-0.46800625354548986">
         <iidm:alias>_046adf53-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04795e46-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9891,7 +10014,7 @@
             <iidm:temporaryLimit name="_74cf84b9-e14f-4f81-9e8b-3a791cd474a0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04631724-c766-11e1-8775-005056c00008" name="34-37" r="0.44605400000000001" x="1.637856" g1="0" b1="2.8236900000000001e-05" g2="0" b2="2.8236900000000001e-05" node1="41" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-71.351882178921358" q1="-21.718012764526271" p2="71.515971067349042" q2="21.465564106665987">
+    <iidm:line id="_04631724-c766-11e1-8775-005056c00008" name="34-37" r="0.44605400000000001" x="1.637856" g1="0" b1="2.8236900000000001e-05" g2="0" b2="2.8236900000000001e-05" node1="41" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-56.385964380113016" q1="-35.455811291617501" p2="56.512539761077541" q2="35.039119612617036">
         <iidm:alias>_04592c19-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04719611-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9899,7 +10022,7 @@
             <iidm:temporaryLimit name="_8e90bf2e-3be4-41be-a84e-c1d4e709f8a1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04814d85-c766-11e1-8775-005056c00008" name="61-62" r="1.435738" x="6.5514239999999999" g1="0" b1="2.812215e-05" g2="0" b2="2.812215e-05" node1="40" voltageLevelId1="_0448d867-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="66.813106282408867" q1="-19.689623953821236" p2="-66.410870789470295" q2="20.552806183925458">
+    <iidm:line id="_04814d85-c766-11e1-8775-005056c00008" name="61-62" r="1.435738" x="6.5514239999999999" g1="0" b1="2.812215e-05" g2="0" b2="2.812215e-05" node1="40" voltageLevelId1="_0448d867-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="60.101841031239275" q1="-18.206016041395824" p2="-59.775057308748949" q2="18.724975094776202">
         <iidm:alias>_045a3d85-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047abdd8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9907,7 +10030,7 @@
             <iidm:temporaryLimit name="_39a23399-348e-44d9-8032-8fc62e6c7d63" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046a4318-c766-11e1-8775-005056c00008" name="101-102" r="4.2863040000000003" x="19.5148811" g1="0" b1="8.4366399999999999e-05" g2="0" b2="8.4366399999999999e-05" node1="22" voltageLevelId1="_046ed6f7-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="-41.084773483055223" q1="10.460084378576555" p2="41.542622057915338" q2="-11.259953249801743">
+    <iidm:line id="_046a4318-c766-11e1-8775-005056c00008" name="101-102" r="4.2863040000000003" x="19.5148811" g1="0" b1="8.4366399999999999e-05" g2="0" b2="8.4366399999999999e-05" node1="22" voltageLevelId1="_046ed6f7-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="-44.122799852400654" q1="11.625199327892817" p2="44.653541956409839" q2="-12.087501017311203">
         <iidm:alias>_04878f1b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04885261-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9915,7 +10038,7 @@
             <iidm:temporaryLimit name="_0501dacc-29fc-44a2-8cad-31a20b011d25" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c81e3-c766-11e1-8775-005056c00008" name="26-30" r="3.8671600000000002" x="41.624000000000002" g1="0" b1="0.00093801650000000002" g2="0" b2="0.00093801650000000002" node1="21" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="213.38961496366423" q1="-6.3096277112147492" p2="-209.73112225682428" q2="-44.699759971952496">
+    <iidm:line id="_044c81e3-c766-11e1-8775-005056c00008" name="26-30" r="3.8671600000000002" x="41.624000000000002" g1="0" b1="0.00093801650000000002" g2="0" b2="0.00093801650000000002" node1="21" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="238.501118138631" q1="-3.7238140713117707" p2="-233.94580037115364" q2="-37.628677372708893">
         <iidm:alias>_0463654b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04747c4a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9923,7 +10046,7 @@
             <iidm:temporaryLimit name="_c95a66fd-913c-48c7-b8ef-cf3007c60af6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048915b9-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="41" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="117" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-55.54670422818775" q1="-20.137290323546541" p2="58.481613504760418" q2="25.356598926816542">
+    <iidm:line id="_048915b9-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="41" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="117" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-53.574726106195392" q1="-18.911263454974495" p2="56.235824252758214" q2="22.82759669880004">
         <iidm:alias>_044bbe98-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0456e224-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9931,7 +10054,7 @@
             <iidm:temporaryLimit name="_6cd83bc2-204f-44d5-afd4-fbfef8d2146f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c5ad6-c766-11e1-8775-005056c00008" name="105-106" r="2.4393600000000002" x="9.5309279999999994" g1="0" b1="4.1150150000000001e-05" g2="0" b2="4.1150150000000001e-05" node1="51" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="9.1334932648495517" q1="6.3205560447837952" p2="-9.1136210144054868" q2="-7.5718091333473234">
+    <iidm:line id="_044c5ad6-c766-11e1-8775-005056c00008" name="105-106" r="2.4393600000000002" x="9.5309279999999994" g1="0" b1="4.1150150000000001e-05" g2="0" b2="4.1150150000000001e-05" node1="51" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="9.6375765694385169" q1="6.1385157329240796" p2="-9.6166613373465957" q2="-7.3858316465054639">
         <iidm:alias>_04505270-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04531190-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9939,7 +10062,7 @@
             <iidm:temporaryLimit name="_487e1317-48f9-4747-b931-f3f79e95f55a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048badc5-c766-11e1-8775-005056c00008" name="60-61" r="0.45999400000000001" x="2.3522400000000001" g1="0" b1="4.1781450000000003e-05" g2="0" b2="4.1781450000000003e-05" node1="30" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-138.07857260216338" q1="12.689169339173034" p2="138.59387459355563" q2="-11.492639877405704">
+    <iidm:line id="_048badc5-c766-11e1-8775-005056c00008" name="60-61" r="0.45999400000000001" x="2.3522400000000001" g1="0" b1="4.1781450000000003e-05" g2="0" b2="4.1781450000000003e-05" node1="30" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-169.2890818645603" q1="15.89125171833961" p2="170.06457760778321" q2="-13.363480991932692">
         <iidm:alias>_04793734-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048a4e31-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9947,7 +10070,7 @@
             <iidm:temporaryLimit name="_3c55a929-a755-409b-af5f-bae188892af1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044cd003-c766-11e1-8775-005056c00008" name="23-25" r="2.7181440000000001" x="13.9391994" g1="0" b1="0.00024793390000000002" g2="0" b2="0.00024793390000000002" node1="41" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="-190.82405274002485" q1="-13.109579259759274" p2="196.48937319717774" q2="33.058939284799372">
+    <iidm:line id="_044cd003-c766-11e1-8775-005056c00008" name="23-25" r="2.7181440000000001" x="13.9391994" g1="0" b1="0.00024793390000000002" g2="0" b2="0.00024793390000000002" node1="41" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="-197.46442166083597" q1="-12.095156373775678" p2="203.54085960478119" q2="34.16237904918605">
         <iidm:alias>_045ed161-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0473b8f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9955,7 +10078,7 @@
             <iidm:temporaryLimit name="_9658628a-596f-41a9-96a7-c5a8aaf5400c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0457a574-c766-11e1-8775-005056c00008" name="19-34" r="13.102848099999999" x="43.037277199999998" g1="0" b1="0.00018135905000000001" g2="0" b2="0.00018135905000000001" node1="40" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0483be8b-c766-11e1-8775-005056c00008" p1="32.189500787966459" q1="-6.8576842070740831" p2="-31.295493994083152" q2="4.2627046001820306">
+    <iidm:line id="_0457a574-c766-11e1-8775-005056c00008" name="19-34" r="13.102848099999999" x="43.037277199999998" g1="0" b1="0.00018135905000000001" g2="0" b2="0.00018135905000000001" node1="40" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0483be8b-c766-11e1-8775-005056c00008" p1="52.488411303442838" q1="-15.856670942785724" p2="-49.997737424291593" q2="18.430395601650311">
         <iidm:alias>_04502b61-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04686e5b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9963,7 +10086,7 @@
             <iidm:temporaryLimit name="_b69ab61b-751d-487a-a538-2d47eea7572e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04595326-c766-11e1-8775-005056c00008" name="59-60" r="5.5234079999999999" x="25.264800000000001" g1="0" b1="0.00010789715" g2="0" b2="0.00010789715" node1="69" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_045cfca4-c766-11e1-8775-005056c00008" p1="-47.872914948606741" q1="5.0387937684757427" p2="48.637104503237062" q2="-5.2209641767109698">
+    <iidm:line id="_04595326-c766-11e1-8775-005056c00008" name="59-60" r="5.5234079999999999" x="25.264800000000001" g1="0" b1="0.00010789715" g2="0" b2="0.00010789715" node1="69" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_045cfca4-c766-11e1-8775-005056c00008" p1="-89.109791838161343" q1="19.11778357863767" p2="91.847485895798314" q2="-10.271059237850007">
         <iidm:alias>_04611b57-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0463b366-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9971,7 +10094,7 @@
             <iidm:temporaryLimit name="_a38d4859-b54a-482f-a2ad-0b4ce4c4da2a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045a8ba1-c766-11e1-8775-005056c00008" name="15-19" r="2.0908799999999998" x="6.865056" g1="0" b1="2.8983e-05" g2="0" b2="2.8983e-05" node1="50" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="26.518590446330411" q1="13.655066993623906" p2="-26.398643520200675" q2="-14.164278717469012">
+    <iidm:line id="_045a8ba1-c766-11e1-8775-005056c00008" name="15-19" r="2.0908799999999998" x="6.865056" g1="0" b1="2.8983e-05" g2="0" b2="2.8983e-05" node1="50" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="32.523983522025212" q1="10.758692605463871" p2="-32.366138336785291" q2="-11.140915046166642">
         <iidm:alias>_047629f1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0481e9c1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9979,7 +10102,7 @@
             <iidm:temporaryLimit name="_15d16bd2-d87c-4584-93d2-b294dc1be116" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04513cd6-c766-11e1-8775-005056c00008" name="90-91" r="4.4256960000000003" x="14.566463499999999" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="31" voltageLevelId1="_047d07c3-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044f8f29-c766-11e1-8775-005056c00008" p1="1.879610492545766" q1="-15.964635981602257" p2="-1.8165272854967995" q2="14.181675895942785">
+    <iidm:line id="_04513cd6-c766-11e1-8775-005056c00008" name="90-91" r="4.4256960000000003" x="14.566463499999999" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="31" voltageLevelId1="_047d07c3-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044f8f29-c766-11e1-8775-005056c00008" p1="4.399245273577284" q1="-16.340063702003579" p2="-4.3285679821106617" q2="14.584397493270886">
         <iidm:alias>_045f94b9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04627ae1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9987,7 +10110,7 @@
             <iidm:temporaryLimit name="_7d2a67fb-9d8c-4745-a67e-ce6ade5e520e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0487b623-c766-11e1-8775-005056c00008" name="22-23" r="5.9590079999999999" x="27.704158799999998" g1="0" b1="0.00011593205" g2="0" b2="0.00011593205" node1="21" voltageLevelId1="_04773b6a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_047f9fdb-c766-11e1-8775-005056c00008" p1="-54.530944207769259" q1="-11.590636276976021" p2="55.661786135134207" q2="12.944065910310352">
+    <iidm:line id="_0487b623-c766-11e1-8775-005056c00008" name="22-23" r="5.9590079999999999" x="27.704158799999998" g1="0" b1="0.00011593205" g2="0" b2="0.00011593205" node1="21" voltageLevelId1="_04773b6a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_047f9fdb-c766-11e1-8775-005056c00008" p1="-55.536200706929563" q1="-11.410917257202589" p2="56.709978620724335" q2="12.973849403613974">
         <iidm:alias>_045e0e18-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0477b095-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9995,7 +10118,7 @@
             <iidm:temporaryLimit name="_6477d99a-dd64-4083-8f56-1396610879f0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048b1189-c766-11e1-8775-005056c00008" name="83-85" r="7.4923200000000003" x="25.787520000000001" g1="0" b1="9.9862250000000004e-05" g2="0" b2="9.9862250000000004e-05" node1="32" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-47.064951001681678" q1="16.054125656764207" p2="48.202928551975276" q2="-15.453024649954394">
+    <iidm:line id="_048b1189-c766-11e1-8775-005056c00008" name="83-85" r="7.4923200000000003" x="25.787520000000001" g1="0" b1="9.9862250000000004e-05" g2="0" b2="9.9862250000000004e-05" node1="32" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-54.714055051802347" q1="19.217327686653693" p2="56.269226882811687" q2="-17.153464921747201">
         <iidm:alias>_0455d0b1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0462c906-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10003,7 +10126,7 @@
             <iidm:temporaryLimit name="_38cb3e5b-af1a-4684-aa2f-242826ed460c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045868c5-c766-11e1-8775-005056c00008" name="17-31" r="8.2589760000000005" x="27.233711199999998" g1="0" b1="0.00011449725" g2="0" b2="0.00011449725" node1="60" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="15.500901561672903" q1="3.1572903402745425" p2="-15.370182741530252" q2="-6.5167983399829721">
+    <iidm:line id="_045868c5-c766-11e1-8775-005056c00008" name="17-31" r="8.2589760000000005" x="27.233711199999998" g1="0" b1="0.00011449725" g2="0" b2="0.00011449725" node1="60" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="17.216487114019067" q1="1.0529495956944963" p2="-17.065761774349674" q2="-4.3363198701412493">
         <iidm:alias>_04544a16-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0467f924-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10011,7 +10134,7 @@
             <iidm:temporaryLimit name="_9066b19a-f404-42c3-88ce-51d375f6fdb5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0488c796-c766-11e1-8775-005056c00008" name="89-90" r="9.0256319999999999" x="32.75712" g1="0" b1="0.00015151515000000001" g2="0" b2="0.00015151515000000001" node1="59" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="58.790713018202169" q1="9.2011845407564969" p2="-56.945863743057515" q2="-7.5956810948177553">
+    <iidm:line id="_0488c796-c766-11e1-8775-005056c00008" name="89-90" r="9.0256319999999999" x="32.75712" g1="0" b1="0.00015151515000000001" g2="0" b2="0.00015151515000000001" node1="59" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="59.712515163299827" q1="9.2602012796311239" p2="-57.810922782017357" q2="-7.4467502588879961">
         <iidm:alias>_0459ef61-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04837069-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10019,7 +10142,7 @@
             <iidm:temporaryLimit name="_924b4a0b-bef5-432a-ad87-ab5c10d9c019" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0462c907-c766-11e1-8775-005056c00008" name="70-75" r="7.4574720000000001" x="24.56784" g1="0" b1="0.0001033058" g2="0" b2="0.0001033058" node1="50" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="7.4726536227844083" q1="7.3767643180910492" p2="-7.4111801038359237" q2="-10.600708452234896">
+    <iidm:line id="_0462c907-c766-11e1-8775-005056c00008" name="70-75" r="7.4574720000000001" x="24.56784" g1="0" b1="0.0001033058" g2="0" b2="0.0001033058" node1="50" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="8.2548147269345531" q1="7.2560859904053583" p2="-8.1889078562725839" q2="-10.467574113826938">
         <iidm:alias>_04649dc9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04784cdb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10027,7 +10150,7 @@
             <iidm:temporaryLimit name="_d432d118-553c-4f4c-a734-e98e0762ec40" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045fbbc3-c766-11e1-8775-005056c00008" name="50-57" r="8.2589760000000005" x="23.34816" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="22" voltageLevelId1="_044d1e26-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="30.752098253180986" q1="10.761688198982377" p2="-30.232088095528336" q2="-12.520809084938422">
+    <iidm:line id="_045fbbc3-c766-11e1-8775-005056c00008" name="50-57" r="8.2589760000000005" x="23.34816" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="22" voltageLevelId1="_044d1e26-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="44.128398516199816" q1="6.7398274769309419" p2="-43.172682193316248" q2="-7.2606172266348672">
         <iidm:alias>_04500455-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0468e383-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10035,7 +10158,7 @@
             <iidm:temporaryLimit name="_2f32bda4-7275-4485-9901-12f8cff9e4a1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044b9789-c766-11e1-8775-005056c00008" name="5-6" r="2.0734560000000002" x="9.4089600000000004" g1="0" b1="4.0920549999999999e-05" g2="0" b2="4.0920549999999999e-05" node1="49" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f6818-c766-11e1-8775-005056c00008" p1="93.395703080884758" q1="19.872007392549474" p2="-92.330807092767557" q2="-16.467567120232136">
+    <iidm:line id="_044b9789-c766-11e1-8775-005056c00008" name="5-6" r="2.0734560000000002" x="9.4089600000000004" g1="0" b1="4.0920549999999999e-05" g2="0" b2="4.0920549999999999e-05" node1="49" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f6818-c766-11e1-8775-005056c00008" p1="91.566964378521618" q1="19.187620254001345" p2="-90.542616578667094" q2="-15.965005676000471">
         <iidm:alias>_044a5f01-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0455d0b2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10043,7 +10166,7 @@
             <iidm:temporaryLimit name="_b3b0e81b-a434-4e9c-ad94-1161ff47b077" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04720b41-c766-11e1-8775-005056c00008" name="55-59" r="8.2572340000000004" x="37.600994100000001" g1="0" b1="0.00016201790000000001" g2="0" b2="0.00016201790000000001" node1="30" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-39.602000216537697" q1="-6.9759558488021653" p2="40.433438406815526" q2="5.468192683689634">
+    <iidm:line id="_04720b41-c766-11e1-8775-005056c00008" name="55-59" r="8.2572340000000004" x="37.600994100000001" g1="0" b1="0.00016201790000000001" g2="0" b2="0.00016201790000000001" node1="30" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-24.177433702825656" q1="-11.539725362375997" p2="24.525827743427666" q2="7.8326142002829409">
         <iidm:alias>_04656113-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04675ce4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10051,7 +10174,7 @@
             <iidm:temporaryLimit name="_6db0d250-4a2e-4169-abf0-f842aeca485d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048963d9-c766-11e1-8775-005056c00008" name="1-2" r="5.2794720000000002" x="17.4065762" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="22" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_045d4ac5-c766-11e1-8775-005056c00008" p1="-10.999254067977466" q1="-10.249288454142103" p2="11.066037423077118" q2="8.0938656384880172">
+    <iidm:line id="_048963d9-c766-11e1-8775-005056c00008" name="1-2" r="5.2794720000000002" x="17.4065762" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="22" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_045d4ac5-c766-11e1-8775-005056c00008" p1="-11.422973332416943" q1="-10.337652201612736" p2="11.49346854201575" q2="8.1957967664009921">
         <iidm:alias>_044b9786-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04845acb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10059,7 +10182,7 @@
             <iidm:temporaryLimit name="_9f39cb45-314c-445e-b177-909854a9ce45" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0484f709-c766-11e1-8775-005056c00008" name="11-12" r="1.0367280000000001" x="3.4151039999999999" g1="0" b1="1.4405399999999999e-05" g2="0" b2="1.4405399999999999e-05" node1="40" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="38.753936495747226" q1="-24.498345962643146" p2="-38.626401515424803" q2="24.427702929355323">
+    <iidm:line id="_0484f709-c766-11e1-8775-005056c00008" name="11-12" r="1.0367280000000001" x="3.4151039999999999" g1="0" b1="1.4405399999999999e-05" g2="0" b2="1.4405399999999999e-05" node1="40" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="34.702296585802564" q1="-25.299800734818511" p2="-34.590419739473397" q2="25.177775089028621">
         <iidm:alias>_0456e227-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04880440-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10067,7 +10190,7 @@
             <iidm:temporaryLimit name="_70fad3e1-4529-4a7f-9e6c-8ab249d65460" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044bbe91-c766-11e1-8775-005056c00008" name="8-9" r="1.18096" x="14.762" g1="0" b1="0.001200413215" g2="0" b2="0.001200413215" node1="31" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_045c8779-c766-11e1-8775-005056c00008" p1="-460.69493168059239" q1="-91.16214426250697" p2="465.81219410888377" q2="33.379823882777075">
+    <iidm:line id="_044bbe91-c766-11e1-8775-005056c00008" name="8-9" r="1.18096" x="14.762" g1="0" b1="0.001200413215" g2="0" b2="0.001200413215" node1="31" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_045c8779-c766-11e1-8775-005056c00008" p1="-486.65010797691093" q1="-83.534237914852994" p2="492.36582865014816" q2="33.673538030393502">
         <iidm:alias>_04745535-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048a7548-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="2000">
@@ -10075,7 +10198,7 @@
             <iidm:temporaryLimit name="_205e5d8a-f05a-479d-adaa-3514f48f6857" acceptableDuration="60" value="2400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04566cf8-c766-11e1-8775-005056c00008" name="64-65" r="1.30196" x="14.6168" g1="0" b1="0.000392562" g2="0" b2="0.000392562" node1="35" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-97.487658944265249" q1="-49.274035396445434" p2="97.772595523255319" q2="14.560771299043292">
+    <iidm:line id="_04566cf8-c766-11e1-8775-005056c00008" name="64-65" r="1.30196" x="14.6168" g1="0" b1="0.000392562" g2="0" b2="0.000392562" node1="35" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-157.40889965127496" q1="-33.953418060349158" p2="158.0883172025105" q2="3.5789127295094092">
         <iidm:alias>_044a10e2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04793738-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10083,7 +10206,7 @@
             <iidm:temporaryLimit name="_8cee2b62-2953-439b-ba4b-4a48d55116c0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046783f3-c766-11e1-8775-005056c00008" name="54-56" r="0.47915999999999997" x="1.6639919999999999" g1="0" b1="2.1005500000000001e-05" g2="0" b2="2.1005500000000001e-05" node1="60" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="14.799216502224299" q1="6.4350607725432223" p2="-14.791231037797225" q2="-7.0741613856947412">
+    <iidm:line id="_046783f3-c766-11e1-8775-005056c00008" name="54-56" r="0.47915999999999997" x="1.6639919999999999" g1="0" b1="2.1005500000000001e-05" g2="0" b2="2.1005500000000001e-05" node1="60" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="29.576140977591582" q1="2.6939475620323603" p2="-29.549488558162718" q2="-3.2681894506224882">
         <iidm:alias>_0460f444-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d2949-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10091,7 +10214,7 @@
             <iidm:temporaryLimit name="_640627c7-0672-413e-8dc8-c9965709a5cb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04670ec6-c766-11e1-8775-005056c00008" name="84-85" r="5.2620480000000001" x="11.1687832" g1="0" b1="3.541095e-05" g2="0" b2="3.541095e-05" node1="21" voltageLevelId1="_047b0bf4-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-39.055201987911275" q1="11.913541649411332" p2="39.59456072978567" q2="-11.935740310310466">
+    <iidm:line id="_04670ec6-c766-11e1-8775-005056c00008" name="84-85" r="5.2620480000000001" x="11.1687832" g1="0" b1="3.541095e-05" g2="0" b2="3.541095e-05" node1="21" voltageLevelId1="_047b0bf4-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-44.336705044268356" q1="14.340594147786007" p2="45.04488209939781" q2="-13.994458516261876">
         <iidm:alias>_0453fbf5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046512f7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10099,7 +10222,7 @@
             <iidm:temporaryLimit name="_8b888209-5038-4b98-80fc-062b5ea55747" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0460cd36-c766-11e1-8775-005056c00008" name="34-36" r="1.51763" x="4.669632" g1="0" b1="1.6299349999999998e-05" g2="0" b2="1.6299349999999998e-05" node1="43" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="32.924572705294111" q1="12.6986113402911" p2="-32.798547419215865" q2="-12.7985981397947">
+    <iidm:line id="_0460cd36-c766-11e1-8775-005056c00008" name="34-36" r="1.51763" x="4.669632" g1="0" b1="1.6299349999999998e-05" g2="0" b2="1.6299349999999998e-05" node1="43" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="34.555350628686796" q1="11.219271602912844" p2="-34.425762924610908" q2="-11.323225771344424">
         <iidm:alias>_046a6a26-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0487b620-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10107,7 +10230,7 @@
             <iidm:temporaryLimit name="_c0a08025-3a61-4d24-9944-f3ef0b079f64" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04549836-c766-11e1-8775-005056c00008" name="24-70" r="0.38507000000000002" x="71.699759999999998" g1="0" b1="0.00029264234999999998" g2="0" b2="0.00029264234999999998" node1="32" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="11.401634678991181" q1="-0.96954551408976242" p2="-11.398384141646133" q2="-8.4568485381121121">
+    <iidm:line id="_04549836-c766-11e1-8775-005056c00008" name="24-70" r="0.38507000000000002" x="71.699759999999998" g1="0" b1="0.00029264234999999998" g2="0" b2="0.00029264234999999998" node1="32" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="16.464685861682014" q1="-1.2170518520225511" p2="-16.458340474307107" q2="-7.6186512702077698">
         <iidm:alias>_04549834-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04854522-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10115,7 +10238,7 @@
             <iidm:temporaryLimit name="_32793450-bbfd-4dcd-a911-89e199600780" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0452273a-c766-11e1-8775-005056c00008" name="85-86" r="6.0983999999999998" x="21.431519999999999" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="50" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0484f70a-c766-11e1-8775-005056c00008" p1="21.2325707399505" q1="12.282169154961251" p2="-20.998388701595399" q2="-14.015862428874287">
+    <iidm:line id="_0452273a-c766-11e1-8775-005056c00008" name="85-86" r="6.0983999999999998" x="21.431519999999999" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="50" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0484f70a-c766-11e1-8775-005056c00008" p1="21.281954552351383" q1="16.351883999753525" p2="-20.997902073930145" q2="-17.874919186086483">
         <iidm:alias>_044afb43-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479fa85-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10123,7 +10246,7 @@
             <iidm:temporaryLimit name="_2ec4bef5-7abb-4f52-bb62-49ee474d672b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0450eeb5-c766-11e1-8775-005056c00008" name="16-17" r="7.9104960000000002" x="31.380622899999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="22" voltageLevelId1="_046f7338-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-12.222243725209138" q1="-0.34395278172994359" p2="12.294576327807627" q2="-3.8544560266410546">
+    <iidm:line id="_0450eeb5-c766-11e1-8775-005056c00008" name="16-17" r="7.9104960000000002" x="31.380622899999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="22" voltageLevelId1="_046f7338-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-15.255633081233889" q1="1.460761574080758" p2="15.37234356948527" q2="-5.4672867530995433">
         <iidm:alias>_044ef2ea-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04837066-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10131,7 +10254,7 @@
             <iidm:temporaryLimit name="_9280074c-8555-49ff-9e62-8ed8f7d95060" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048a4e33-c766-11e1-8775-005056c00008" name="62-66" r="8.3983679999999996" x="37.984317799999999" g1="0" b1="0.00016586315" g2="0" b2="0.00016586315" node1="41" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-5.9617970951123072" q1="-23.528359897766375" p2="6.1858719329924741" q2="18.511885244294831">
+    <iidm:line id="_048a4e33-c766-11e1-8775-005056c00008" name="62-66" r="8.3983679999999996" x="37.984317799999999" g1="0" b1="0.00016586315" g2="0" b2="0.00016586315" node1="41" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-15.288550447433808" q1="-21.56843744972225" p2="15.571373067923505" q2="16.815459252577288">
         <iidm:alias>_046e13a9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a96c7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10139,7 +10262,7 @@
             <iidm:temporaryLimit name="_ace48562-0a49-4b76-ae82-c896a00b04f9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0478e913-c766-11e1-8775-005056c00008" name="76-77" r="7.736256" x="25.787520000000001" g1="0" b1="0.00010560145" g2="0" b2="0.00010560145" node1="21" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-60.055512716716372" q1="-22.406563145582858" p2="62.092008065492251" q2="25.723036369613901">
+    <iidm:line id="_0478e913-c766-11e1-8775-005056c00008" name="76-77" r="7.736256" x="25.787520000000001" g1="0" b1="0.00010560145" g2="0" b2="0.00010560145" node1="21" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-62.481332402897038" q1="-21.188607416538009" p2="64.644231627847532" q2="24.929761348310187">
         <iidm:alias>_044b9785-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04725965-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10147,7 +10270,7 @@
             <iidm:temporaryLimit name="_3f744dba-88dc-4d89-90d4-a6f196054b28" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048badc1-c766-11e1-8775-005056c00008" name="60-62" r="2.1431520000000002" x="9.7748640000000009" g1="0" b1="4.2125800000000002e-05" g2="0" b2="4.2125800000000002e-05" node1="32" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="11.441489591819431" q1="-10.468203778754109" p2="-11.413313582157727" q2="9.1432734266015832">
+    <iidm:line id="_048badc1-c766-11e1-8775-005056c00008" name="60-62" r="2.1431520000000002" x="9.7748640000000009" g1="0" b1="4.2125800000000002e-05" g2="0" b2="4.2125800000000002e-05" node1="32" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="-0.55832546544600126" q1="-8.6201874481302507" p2="0.56615205296214488" q2="7.2032625597239814">
         <iidm:alias>_045b7600-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04720b44-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10155,7 +10278,7 @@
             <iidm:temporaryLimit name="_43f91aaf-c5f4-4995-85a2-37afac616331" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0472a780-c766-11e1-8775-005056c00008" name="27-28" r="3.3332109999999999" x="14.89752" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="42" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04819ba0-c766-11e1-8775-005056c00008" p1="33.201238351916196" q1="-0.3263869263802337" p2="-32.976434608796048" q2="-0.68188565003983392">
+    <iidm:line id="_0472a780-c766-11e1-8775-005056c00008" name="27-28" r="3.3332109999999999" x="14.89752" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="42" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04819ba0-c766-11e1-8775-005056c00008" p1="32.649270449256257" q1="-1.4223606639983934" p2="-32.432068917322141" q2="0.37667414447142694">
         <iidm:alias>_04531198-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0475188b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10163,7 +10286,7 @@
             <iidm:temporaryLimit name="_2c20e8bd-84e6-4a1e-b88e-071f631327cb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c81e1-c766-11e1-8775-005056c00008" name="45-46" r="6.9695999999999998" x="23.626943600000001" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="31" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="34" voltageLevelId2="_048a7544-c766-11e1-8775-005056c00008" p1="-33.468477778782258" q1="-8.8238246065297847" p2="33.956357350118225" q2="7.20548683652967">
+    <iidm:line id="_044c81e1-c766-11e1-8775-005056c00008" name="45-46" r="6.9695999999999998" x="23.626943600000001" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="31" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="34" voltageLevelId2="_048a7544-c766-11e1-8775-005056c00008" p1="-33.687828442727259" q1="-7.0243762278515938" p2="34.169939711523533" q2="5.3785908589671134">
         <iidm:alias>_04561ed6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045c877a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10171,7 +10294,7 @@
             <iidm:temporaryLimit name="_6ad31f7e-233f-4801-898f-9ffc883ec724" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c1249-c766-11e1-8775-005056c00008" name="18-19" r="1.949746" x="8.5900320000000008" g1="0" b1="3.2770900000000002e-05" g2="0" b2="3.2770900000000002e-05" node1="22" voltageLevelId1="_04689563-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="39.130033446844145" q1="4.5884480929373508" p2="-38.93616138576327" q2="-4.7530946450992868">
+    <iidm:line id="_045c1249-c766-11e1-8775-005056c00008" name="18-19" r="1.949746" x="8.5900320000000008" g1="0" b1="3.2770900000000002e-05" g2="0" b2="3.2770900000000002e-05" node1="22" voltageLevelId1="_04689563-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="52.651878845038915" q1="-0.31786468184975891" p2="-52.305090098433126" q2="0.83054041388761002">
         <iidm:alias>_046b066b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047ae4e0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10179,7 +10302,7 @@
             <iidm:temporaryLimit name="_a025c9d8-58f9-4320-a1fe-73ecc68d4147" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044a5f09-c766-11e1-8775-005056c00008" name="9-10" r="1.2487200000000001" x="15.584800700000001" g1="0" b1="0.0012706611300000001" g2="0" b2="0.0012706611300000001" node1="21" voltageLevelId1="_045c8779-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_044f4102-c766-11e1-8775-005056c00008" p1="-465.81219410888394" q1="-33.379823882777096" p2="471.02838685582498" q2="-35.655797880511699">
+    <iidm:line id="_044a5f09-c766-11e1-8775-005056c00008" name="9-10" r="1.2487200000000001" x="15.584800700000001" g1="0" b1="0.0012706611300000001" g2="0" b2="0.0012706611300000001" node1="21" voltageLevelId1="_045c8779-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_044f4102-c766-11e1-8775-005056c00008" p1="-492.36582865014827" q1="-33.673538030392379" p2="498.21295988398401" q2="-27.224314634054771">
         <iidm:alias>_04614262-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04834957-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="2000">
@@ -10187,7 +10310,7 @@
             <iidm:temporaryLimit name="_b7fac0a3-c5af-48b9-af49-261fd8d46e00" acceptableDuration="60" value="2400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0480b14b-c766-11e1-8775-005056c00008" name="85-88" r="3.4847999999999999" x="17.772480000000002" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="51" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0470f9d2-c766-11e1-8775-005056c00008" p1="-56.228567581757019" q1="3.6215133598258675" p2="56.899345794901258" q2="-2.8445196467002805">
+    <iidm:line id="_0480b14b-c766-11e1-8775-005056c00008" name="85-88" r="3.4847999999999999" x="17.772480000000002" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="51" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0470f9d2-c766-11e1-8775-005056c00008" p1="-62.991360739106696" q1="3.5774140105944303" p2="63.83885287573132" q2="-1.8824904007210042">
         <iidm:alias>_047602e2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04765105-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10195,7 +10318,7 @@
             <iidm:temporaryLimit name="_51646744-d343-42b5-8ba7-fcedc7cc3a98" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04486330-c766-11e1-8775-005056c00008" name="69-77" r="5.3840159999999999" x="17.598240000000001" g1="0" b1="0.00029786500000000002" g2="0" b2="0.00029786500000000002" node1="60" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="49.05891956687465" q1="12.970266693148226" p2="-48.265629717631604" q2="-21.159875538162755">
+    <iidm:line id="_04486330-c766-11e1-8775-005056c00008" name="69-77" r="5.3840159999999999" x="17.598240000000001" g1="0" b1="0.00029786500000000002" g2="0" b2="0.00029786500000000002" node1="60" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="32.558197145898077" q1="18.073913664397086" p2="-32.091309422233003" q2="-27.323706387973367">
         <iidm:alias>_046205b9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479d379-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10203,7 +10326,7 @@
             <iidm:temporaryLimit name="_76311a15-b79a-4439-a7ce-47afa8fa6fe2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04553477-c766-11e1-8775-005056c00008" name="11-13" r="3.8768400000000001" x="12.7369442" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="41" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04851e1b-c766-11e1-8775-005056c00008" p1="44.566617131724463" q1="16.045555990950781" p2="-44.047777891833242" q2="-16.129696116521615">
+    <iidm:line id="_04553477-c766-11e1-8775-005056c00008" name="11-13" r="3.8768400000000001" x="12.7369442" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="41" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04851e1b-c766-11e1-8775-005056c00008" p1="45.461986358531547" q1="16.208515996871807" p2="-44.923058279858083" q2="-16.224636311386856">
         <iidm:alias>_0479fa89-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0485452a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10211,7 +10334,7 @@
             <iidm:temporaryLimit name="_efbf8de7-4b84-4834-bb7c-6250b6072211" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04488a45-c766-11e1-8775-005056c00008" name="103-105" r="9.3218399999999999" x="28.314" g1="0" b1="0.0001170799" g2="0" b2="0.0001170799" node1="42" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="43.756892420286327" q1="12.56646147622237" p2="-42.640208234687776" q2="-13.156508968836899">
+    <iidm:line id="_04488a45-c766-11e1-8775-005056c00008" name="103-105" r="9.3218399999999999" x="28.314" g1="0" b1="0.0001170799" g2="0" b2="0.0001170799" node1="42" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="43.796526849368604" q1="12.535361114721866" p2="-42.678500030207935" q2="-13.12146513231191">
         <iidm:alias>_044f8f24-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04611b58-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10219,7 +10342,7 @@
             <iidm:temporaryLimit name="_22b6919a-a7a0-49fc-9e90-329069c55055" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046009e6-c766-11e1-8775-005056c00008" name="45-49" r="11.918016400000001" x="32.408639999999998" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="32" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="118" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-43.104364796228126" q1="-8.237361637189375" p2="44.453023328742631" q2="7.4384944795638717">
+    <iidm:line id="_046009e6-c766-11e1-8775-005056c00008" name="45-49" r="11.918016400000001" x="32.408639999999998" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="32" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="118" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-40.732385604715901" q1="-8.0719150101323738" p2="41.932093905754556" q2="6.8574519960227924">
         <iidm:alias>_044ca8f9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047dcb1b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10227,7 +10350,7 @@
             <iidm:temporaryLimit name="_8b91f4fd-4038-45b7-870c-fbc08592b95a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046a6a27-c766-11e1-8775-005056c00008" name="88-89" r="2.4219360000000001" x="12.4058876" g1="0" b1="5.549815e-05" g2="0" b2="5.549815e-05" node1="22" voltageLevelId1="_0470f9d2-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-104.89865841627788" q1="-7.1552417884510113" p2="106.48759863807928" q2="13.383468880306626">
+    <iidm:line id="_046a6a27-c766-11e1-8775-005056c00008" name="88-89" r="2.4219360000000001" x="12.4058876" g1="0" b1="5.549815e-05" g2="0" b2="5.549815e-05" node1="22" voltageLevelId1="_0470f9d2-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-111.83792093979419" q1="-8.1171861763884667" p2="113.65295807793503" q2="15.507573351450739">
         <iidm:alias>_045ef879-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04649dc1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10235,7 +10358,7 @@
             <iidm:temporaryLimit name="_970bc323-73bf-440d-a3c5-00aebc3a1992" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048a7540-c766-11e1-8775-005056c00008" name="80-98" r="4.1469120000000004" x="18.817920000000001" g1="0" b1="8.20707e-05" g2="0" b2="8.20707e-05" node1="79" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04773b62-c766-11e1-8775-005056c00008" p1="21.438556988854536" q1="9.7705246150065221" p2="-21.309238884109398" q2="-12.228479636209745">
+    <iidm:line id="_048a7540-c766-11e1-8775-005056c00008" name="80-98" r="4.1469120000000004" x="18.817920000000001" g1="0" b1="8.20707e-05" g2="0" b2="8.20707e-05" node1="79" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04773b62-c766-11e1-8775-005056c00008" p1="11.399408569856444" q1="11.978224667259587" p2="-11.330563334962177" q2="-14.710164285796512">
         <iidm:alias>_045338a2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04887972-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10243,7 +10366,7 @@
             <iidm:temporaryLimit name="_cb084dc7-1b26-415f-9495-4695df661912" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04640183-c766-11e1-8775-005056c00008" name="91-92" r="6.7430880000000002" x="22.163329999999998" g1="0" b1="9.3778700000000004e-05" g2="0" b2="9.3778700000000004e-05" node1="22" voltageLevelId1="_044f8f29-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="-8.1834493633185232" q1="-14.181675904413057" p2="8.2765877558680909" q2="11.344694051786931">
+    <iidm:line id="_04640183-c766-11e1-8775-005056c00008" name="91-92" r="6.7430880000000002" x="22.163329999999998" g1="0" b1="9.3778700000000004e-05" g2="0" b2="9.3778700000000004e-05" node1="22" voltageLevelId1="_044f8f29-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="-5.6713944878859364" q1="-14.584397502255575" p2="5.7546346040203682" q2="11.720986539878441">
         <iidm:alias>_04492680-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_044c5ad5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10251,7 +10374,7 @@
             <iidm:temporaryLimit name="_3a165a76-f6ba-461b-84d6-159a5e0b5077" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0474a358-c766-11e1-8775-005056c00008" name="7-12" r="1.501949" x="5.9241599999999996" g1="0" b1="2.5080350000000001e-05" g2="0" b2="2.5080350000000001e-05" node1="22" voltageLevelId1="_047eb571-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="21.253846776695912" q1="-7.3442530052230097" p2="-21.209860656996241" q2="6.6616220586724628">
+    <iidm:line id="_0474a358-c766-11e1-8775-005056c00008" name="7-12" r="1.501949" x="5.9241599999999996" g1="0" b1="2.5080350000000001e-05" g2="0" b2="2.5080350000000001e-05" node1="22" voltageLevelId1="_047eb571-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="19.471941159712816" q1="-7.8188291705068069" p2="-19.433722244844958" q2="7.1137223067675199">
         <iidm:alias>_046ab848-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0477feb7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10259,7 +10382,7 @@
             <iidm:temporaryLimit name="_b19bc945-cc51-4d77-8eaa-3f6afe2d9316" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04765108-c766-11e1-8775-005056c00008" name="99-100" r="3.13632" x="14.165711399999999" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_04644fa4-c766-11e1-8775-005056c00008" node2="80" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-30.006146054023009" q1="9.9118461039973873" p2="30.182930697598291" q2="-11.35441175760546">
+    <iidm:line id="_04765108-c766-11e1-8775-005056c00008" name="99-100" r="3.13632" x="14.165711399999999" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_04644fa4-c766-11e1-8775-005056c00008" node2="80" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-40.046240275934672" q1="12.290303740948568" p2="40.354800009011939" q2="-13.137409716861987">
         <iidm:alias>_0471e436-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047e4040-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10267,7 +10390,7 @@
             <iidm:temporaryLimit name="_a9e283ed-fcad-4f4c-ab57-8531875bb098" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047b8128-c766-11e1-8775-005056c00008" name="114-115" r="0.400752" x="1.8120959999999999" g1="0" b1="7.9201000000000006e-06" g2="0" b2="7.9201000000000006e-06" node1="22" voltageLevelId1="_04791027-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="-0.38039365644237777" q1="2.5449354159675868" p2="0.38057460048925645" q2="-2.7997418830574299">
+    <iidm:line id="_047b8128-c766-11e1-8775-005056c00008" name="114-115" r="0.400752" x="1.8120959999999999" g1="0" b1="7.9201000000000006e-06" g2="0" b2="7.9201000000000006e-06" node1="22" voltageLevelId1="_04791027-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="-0.5876851168818481" q1="2.2299325905322083" p2="0.58783170996903078" q2="-2.4848901853322869">
         <iidm:alias>_046c17d3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d0233-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10275,7 +10398,7 @@
             <iidm:temporaryLimit name="_c59e4022-b1c0-4811-a32e-f54656bff32d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046931a5-c766-11e1-8775-005056c00008" name="83-84" r="10.890000000000001" x="22.999680000000001" g1="0" b1="7.4035799999999993e-05" g2="0" b2="7.4035799999999993e-05" node1="33" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b0bf4-c766-11e1-8775-005056c00008" p1="-27.325040023856516" q1="18.00874113703351" p2="28.055519741102341" q2="-18.913204745743073">
+    <iidm:line id="_046931a5-c766-11e1-8775-005056c00008" name="83-84" r="10.890000000000001" x="22.999680000000001" g1="0" b1="7.4035799999999993e-05" g2="0" b2="7.4035799999999993e-05" node1="33" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b0bf4-c766-11e1-8775-005056c00008" p1="-32.321221917025369" q1="21.058883728826316" p2="33.337140105451667" q2="-21.340132848893905">
         <iidm:alias>_0465d645-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479102b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10283,7 +10406,7 @@
             <iidm:temporaryLimit name="_1268eb09-e233-44ce-b8af-22dc30eb16ad" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047ae4ea-c766-11e1-8775-005056c00008" name="14-15" r="10.367279999999999" x="33.976799999999997" g1="0" b1="0.0001440542" g2="0" b2="0.0001440542" node1="21" voltageLevelId1="_047b8129-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="15.135917740852953" q1="7.1761305288067065" p2="-14.93639244548798" q2="-11.189515244536965">
+    <iidm:line id="_047ae4ea-c766-11e1-8775-005056c00008" name="14-15" r="10.367279999999999" x="33.976799999999997" g1="0" b1="0.0001440542" g2="0" b2="0.0001440542" node1="21" voltageLevelId1="_047b8129-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="16.496146697636124" q1="7.3526261348043729" p2="-16.267556198928286" q2="-11.26105849593079">
         <iidm:alias>_0449e9d9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046ed6fa-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10291,7 +10414,7 @@
             <iidm:temporaryLimit name="_9c0c454b-ecc3-40f6-b505-f32fec412522" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046e3ab2-c766-11e1-8775-005056c00008" name="80-96" r="6.2029439999999996" x="31.711680000000001" g1="0" b1="0.0001417585" g2="0" b2="0.0001417585" node1="80" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="12.945136496084537" q1="23.563429742747669" p2="-12.663440034412728" q2="-27.21448279577973">
+    <iidm:line id="_046e3ab2-c766-11e1-8775-005056c00008" name="80-96" r="6.2029439999999996" x="31.711680000000001" g1="0" b1="0.0001417585" g2="0" b2="0.0001417585" node1="80" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="4.7137760599054488" q1="26.394634361420255" p2="-4.4283892401395173" q2="-30.015930200306702">
         <iidm:alias>_045338a4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04865695-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10299,7 +10422,7 @@
             <iidm:temporaryLimit name="_1432f4d6-9299-4b0d-bd7f-16e059f9de66" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04893cc4-c766-11e1-8775-005056c00008" name="56-59" r="13.9914722" x="41.643360000000001" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="59" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-33.887015618691564" q1="-1.9903682509349478" p2="34.900587265799707" q2="-0.031691169003159221">
+    <iidm:line id="_04893cc4-c766-11e1-8775-005056c00008" name="56-59" r="13.9914722" x="41.643360000000001" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="59" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-20.13285366167759" q1="-7.6764863369718803" p2="20.514808996880067" q2="3.7747680149056126">
         <iidm:alias>_046b5484-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04798557-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10307,7 +10430,7 @@
             <iidm:temporaryLimit name="_193f6952-4267-4cc8-a541-726c095028ba" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c1243-c766-11e1-8775-005056c00008" name="92-100" r="11.290752400000001" x="51.400799999999997" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="71" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="33.68115384465424" q1="-16.595877634572304" p2="-32.797331329577176" q2="15.862793938548528">
+    <iidm:line id="_045c1243-c766-11e1-8775-005056c00008" name="92-100" r="11.290752400000001" x="51.400799999999997" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="71" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="36.862237091769742" q1="-17.294930738380849" p2="-35.81409630844832" q2="17.315441381311508">
         <iidm:alias>_045e8348-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045ed164-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10315,7 +10438,7 @@
             <iidm:temporaryLimit name="_579249ce-1c81-4d29-8d3f-5fc627a18f99" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0474a356-c766-11e1-8775-005056c00008" name="43-44" r="10.593792000000001" x="42.7584953" g1="0" b1="0.00017412765" g2="0" b2="0.00017412765" node1="22" voltageLevelId1="_045e8349-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04544a15-c766-11e1-8775-005056c00008" p1="-7.3332689568804605" q1="-12.760948179459236" p2="7.4405722753191323" q2="7.6659054185217208">
+    <iidm:line id="_0474a356-c766-11e1-8775-005056c00008" name="43-44" r="10.593792000000001" x="42.7584953" g1="0" b1="0.00017412765" g2="0" b2="0.00017412765" node1="22" voltageLevelId1="_045e8349-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04544a15-c766-11e1-8775-005056c00008" p1="-5.2458054764662077" q1="-11.303397655464712" p2="5.3139656794954391" q2="5.9638526557808298">
         <iidm:alias>_04642899-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047b0bf2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10323,7 +10446,7 @@
             <iidm:temporaryLimit name="_3d2cb4b5-ee82-4866-9855-4a5f4803cd3b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04627ae6-c766-11e1-8775-005056c00008" name="109-110" r="4.8438720000000002" x="13.2770882" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="22" voltageLevelId1="_046b7b99-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="13.793524668535085" q1="-3.3596928894193412" p2="-13.733971740244513" q2="1.6768008943089898">
+    <iidm:line id="_04627ae6-c766-11e1-8775-005056c00008" name="109-110" r="4.8438720000000002" x="13.2770882" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="22" voltageLevelId1="_046b7b99-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="12.737628311938865" q1="-2.969515222513718" p2="-12.687116536984783" q2="1.2616205637563038">
         <iidm:alias>_0466e7b5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a6fbb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10331,7 +10454,7 @@
             <iidm:temporaryLimit name="_6fc48d8d-05f8-4104-a6a2-3686d430a091" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0478c207-c766-11e1-8775-005056c00008" name="68-81" r="0.84699999999999998" x="9.7767990000000005" g1="0" b1="0.00083471078000000004" g2="0" b2="0.00083471078000000004" node1="38" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_048a272b-c766-11e1-8775-005056c00008" p1="-92.192308765273836" q1="-9.3913670592925307" p2="92.358164779624772" q2="-68.944281075850398">
+    <iidm:line id="_0478c207-c766-11e1-8775-005056c00008" name="68-81" r="0.84699999999999998" x="9.7767990000000005" g1="0" b1="0.00083471078000000004" g2="0" b2="0.00083471078000000004" node1="38" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_048a272b-c766-11e1-8775-005056c00008" p1="-150.09428750608711" q1="-3.9111411514496623" p2="150.51280843893912" q2="-71.501290058435401">
         <iidm:alias>_044a37f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045b4ef6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10339,7 +10462,7 @@
             <iidm:temporaryLimit name="_191836a1-39cd-402b-8dcf-4f3867c45bd0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0467d215-c766-11e1-8775-005056c00008" name="85-89" r="4.1643359999999996" x="30.143518400000001" g1="0" b1="0.00013487144999999999" g2="0" b2="0.00013487144999999999" node1="52" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-76.800774689829794" q1="-3.5141701445386309" p2="78.285191577617397" q2="9.6532040738862239">
+    <iidm:line id="_0467d215-c766-11e1-8775-005056c00008" name="85-89" r="4.1643359999999996" x="30.143518400000001" g1="0" b1="0.00013487144999999999" g2="0" b2="0.00013487144999999999" node1="52" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-83.603737548457076" q1="-3.7803693979714432" p2="85.377720801927978" q2="12.034069436568601">
         <iidm:alias>_047629f9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0478e915-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10347,7 +10470,7 @@
             <iidm:temporaryLimit name="_66cbdeeb-a4e4-4bfc-aec1-9fb7a2d2b6bc" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044a37f2-c766-11e1-8775-005056c00008" name="89-90" r="4.1469120000000004" x="17.371727" g1="0" b1="0.00030417815" g2="0" b2="0.00030417815" node1="62" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="111.00142742930639" q1="21.072578637262126" p2="-107.93351022216773" q2="-18.439580748707655">
+    <iidm:line id="_044a37f2-c766-11e1-8775-005056c00008" name="89-90" r="4.1469120000000004" x="17.371727" g1="0" b1="0.00030417815" g2="0" b2="0.00030417815" node1="62" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="112.75020663639449" q1="21.245332442096405" p2="-109.58792770873357" q2="-18.213016297103714">
         <iidm:alias>_045386c2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048719e9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10355,7 +10478,7 @@
             <iidm:temporaryLimit name="_8489e809-6588-4ed2-a9a4-43c44a0d47da" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04658820-c766-11e1-8775-005056c00008" name="98-100" r="6.9173280000000004" x="31.188960999999999" g1="0" b1="0.0001365932" g2="0" b2="0.0001365932" node1="22" voltageLevelId1="_04773b62-c766-11e1-8775-005056c00008" node2="82" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-12.690760178823124" q1="4.2284800843565025" p2="12.768915346392095" q2="-8.8310228615257156">
+    <iidm:line id="_04658820-c766-11e1-8775-005056c00008" name="98-100" r="6.9173280000000004" x="31.188960999999999" g1="0" b1="0.0001365932" g2="0" b2="0.0001365932" node1="22" voltageLevelId1="_04773b62-c766-11e1-8775-005056c00008" node2="82" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-22.669419981770083" q1="6.710170859640745" p2="22.89632589418682" q2="-10.641308008760744">
         <iidm:alias>_046f4c22-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046fe865-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10363,7 +10486,7 @@
             <iidm:temporaryLimit name="_620beaaf-63c8-4020-bea5-c3609c0eaadf" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c5ada-c766-11e1-8775-005056c00008" name="28-29" r="4.1294880000000003" x="16.430831900000001" g1="0" b1="6.8296599999999999e-05" g2="0" b2="6.8296599999999999e-05" node1="22" voltageLevelId1="_04819ba0-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04588fd5-c766-11e1-8775-005056c00008" p1="15.976590384764251" q1="-6.3180074526294181" p2="-15.904254363537037" q2="4.4001837644565018">
+    <iidm:line id="_044c5ada-c766-11e1-8775-005056c00008" name="28-29" r="4.1294880000000003" x="16.430831900000001" g1="0" b1="6.8296599999999999e-05" g2="0" b2="6.8296599999999999e-05" node1="22" voltageLevelId1="_04819ba0-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04588fd5-c766-11e1-8775-005056c00008" p1="15.431848222375336" q1="-5.166538269224823" p2="-15.366821199211325" q2="3.215721055141592">
         <iidm:alias>_0461697a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04697fc1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10371,7 +10494,13 @@
             <iidm:temporaryLimit name="_6748d0d0-aec8-4b7b-a9ab-be6aecda7c5d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0468e382-c766-11e1-8775-005056c00008" name="3-5" r="4.1991839999999998" x="18.817920000000001" g1="0" b1="8.1496799999999995e-05" g2="0" b2="8.1496799999999995e-05" node1="31" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-71.155231519384216" q1="-16.975675894500174" p2="72.505530178269723" q2="20.230212567791696">
+    <iidm:line id="_044c5ada-c766-11e1-8775-005056c00008-1" name="28-29-open-ended" r="4.1294880000000003" x="16.430831900000001" g1="0" b1="6.8296599999999999e-05" g2="0" b2="6.8296599999999999e-05" node1="25" voltageLevelId1="_04819ba0-c766-11e1-8775-005056c00008" node2="25" voltageLevelId2="_04588fd5-c766-11e1-8775-005056c00008" p1="0.00031217871380281783" q1="-2.2100730937254358" p2="0" q2="0">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_accb8136-1faf-4399-9787-3cd567284fd2-1" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_6748d0d0-aec8-4b7b-a9ab-be6aecda7c5d-1" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0468e382-c766-11e1-8775-005056c00008" name="3-5" r="4.1991839999999998" x="18.817920000000001" g1="0" b1="8.1496799999999995e-05" g2="0" b2="8.1496799999999995e-05" node1="31" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-70.181525222705886" q1="-16.755650243630839" p2="71.496386868039266" q2="19.85564176256073">
         <iidm:alias>_046b0668-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04742e24-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10379,7 +10508,7 @@
             <iidm:temporaryLimit name="_828ca44c-560b-4f94-b825-21e237285fae" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0447c6f1-c766-11e1-8775-005056c00008" name="82-96" r="2.8226879999999999" x="9.2347199999999994" g1="0" b1="0.00015610649999999999" g2="0" b2="0.00015610649999999999" node1="33" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="-12.813934930295339" q1="-9.5915623605012943" p2="12.849517280218558" q2="4.4104401819793759">
+    <iidm:line id="_0447c6f1-c766-11e1-8775-005056c00008" name="82-96" r="2.8226879999999999" x="9.2347199999999994" g1="0" b1="0.00015610649999999999" g2="0" b2="0.00015610649999999999" node1="33" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="-15.791401207596135" q1="-9.5673038677800086" p2="15.841493905147869" q2="4.4603110800238976">
         <iidm:alias>_0478e91a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0480d856-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10387,7 +10516,7 @@
             <iidm:temporaryLimit name="_233b7735-85f4-4a6f-9d87-15129fe42ef5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0483e594-c766-11e1-8775-005056c00008" name="38-65" r="4.3608399999999996" x="47.7224" g1="0" b1="0.0010805785" g2="0" b2="0.0010805785" node1="29" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-138.39573098344138" q1="-120.8588408895135" p2="141.2660288968892" q2="57.720146686442497">
+    <iidm:line id="_0483e594-c766-11e1-8775-005056c00008" name="38-65" r="4.3608399999999996" x="47.7224" g1="0" b1="0.0010805785" g2="0" b2="0.0010805785" node1="29" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-160.69857461268083" q1="-97.986391406754876" p2="163.77727351007499" q2="34.864666438513531">
         <iidm:alias>_04638c56-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d5054-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10395,7 +10524,7 @@
             <iidm:temporaryLimit name="_990ce3c5-c90c-41b9-abee-fb803d9df3a5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04784cd4-c766-11e1-8775-005056c00008" name="106-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_04479fe8-c766-11e1-8775-005056c00008" node2="24" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="23.925723867261212" q1="-0.71942965354472366" p2="-23.595312266383601" q2="-2.4227098010115422">
+    <iidm:line id="_04784cd4-c766-11e1-8775-005056c00008" name="106-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_04479fe8-c766-11e1-8775-005056c00008" node2="24" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="23.85286931913522" q1="-0.6945727503031176" p2="-23.524462011323202" q2="-2.4550160576366613">
         <iidm:alias>_04483c21-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f0395-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10403,7 +10532,7 @@
             <iidm:temporaryLimit name="_1372c3b0-62d7-47d7-a8c0-ed8e10bc1f1a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046f9a43-c766-11e1-8775-005056c00008" name="27-115" r="2.8575360000000001" x="12.9111843" g1="0" b1="5.6588600000000002e-05" g2="0" b2="5.6588600000000002e-05" node1="43" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="22.470825091953042" q1="2.7713046886444213" p2="-22.380194917340308" q2="-4.2000567913599056">
+    <iidm:line id="_046f9a43-c766-11e1-8775-005056c00008" name="27-115" r="2.8575360000000001" x="12.9111843" g1="0" b1="5.6588600000000002e-05" g2="0" b2="5.6588600000000002e-05" node1="43" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="22.680181437448681" q1="3.0948000609312474" p2="-22.587517998049677" q2="-4.514943458355777">
         <iidm:alias>_046d0238-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048c22f4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10411,7 +10540,7 @@
             <iidm:temporaryLimit name="_64cfd0fb-1d8e-45d2-a52f-469238dfc0c6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04529c61-c766-11e1-8775-005056c00008" name="12-14" r="3.7461600000000002" x="12.3187675" g1="0" b1="5.2112050000000002e-05" g2="0" b2="5.2112050000000002e-05" node1="71" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b8129-c766-11e1-8775-005056c00008" p1="29.338272201039956" q1="7.0842080895029973" p2="-29.135508181873831" q2="-8.1760817769111878">
+    <iidm:line id="_04529c61-c766-11e1-8775-005056c00008" name="12-14" r="3.7461600000000002" x="12.3187675" g1="0" b1="5.2112050000000002e-05" g2="0" b2="5.2112050000000002e-05" node1="71" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b8129-c766-11e1-8775-005056c00008" p1="30.717579683629086" q1="7.3240676326595979" p2="-30.495792660402405" q2="-8.3525839821382366">
         <iidm:alias>_045fbbc1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047bf65b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10419,7 +10548,7 @@
             <iidm:temporaryLimit name="_efe2501d-bcee-42ff-a037-3d8a280487b0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0463da77-c766-11e1-8775-005056c00008" name="76-118" r="2.8575360000000001" x="9.4786560000000009" g1="0" b1="3.8911849999999999e-05" g2="0" b2="3.8911849999999999e-05" node1="22" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="-7.9445009181151747" q1="-13.593448642462333" p2="7.9877153836198342" q2="12.53138090271422">
+    <iidm:line id="_0463da77-c766-11e1-8775-005056c00008" name="76-118" r="2.8575360000000001" x="9.4786560000000009" g1="0" b1="3.8911849999999999e-05" g2="0" b2="3.8911849999999999e-05" node1="22" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="-5.5186542569291275" q1="-14.811380718992176" p2="5.5619859368673783" q2="13.750050071593082">
         <iidm:alias>_046931a0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04806320-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10427,7 +10556,7 @@
             <iidm:temporaryLimit name="_2ae204bf-78cc-49cb-b886-a933b33057e4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046931a3-c766-11e1-8775-005056c00008" name="74-75" r="2.1431520000000002" x="7.0741440000000004" g1="0" b1="2.9671699999999999e-05" g2="0" b2="2.9671699999999999e-05" node1="23" voltageLevelId1="_047dcb11-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="-45.898174224430015" q1="-4.0241669550352883" p2="46.18110330238332" q2="3.997888633595402">
+    <iidm:line id="_046931a3-c766-11e1-8775-005056c00008" name="74-75" r="2.1431520000000002" x="7.0741440000000004" g1="0" b1="2.9671699999999999e-05" g2="0" b2="2.9671699999999999e-05" node1="23" voltageLevelId1="_047dcb11-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="-45.272856383262635" q1="-4.1369678092930311" p2="45.548128498931867" q2="4.0849204652137914">
         <iidm:alias>_044f4103-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04638c58-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10435,7 +10564,7 @@
             <iidm:temporaryLimit name="_e822432e-79af-4bba-8f40-5250468f81a0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045ed162-c766-11e1-8775-005056c00008" name="3-12" r="8.4332159999999998" x="27.878398900000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="32" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-8.1055199566855975" q1="-9.6195140141089741" p2="8.1693563596446985" q2="5.918010402145601">
+    <iidm:line id="_045ed162-c766-11e1-8775-005056c00008" name="3-12" r="8.4332159999999998" x="27.878398900000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="32" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-8.6505671748795727" q1="-9.7359411711147104" p2="8.7200767733862623" q2="6.0550981453104393">
         <iidm:alias>_047a48a1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047b5a14-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10443,7 +10572,7 @@
             <iidm:temporaryLimit name="_c437e52c-43d7-4ae9-87ad-dc19396dc6ff" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04499bb6-c766-11e1-8775-005056c00008" name="49-51" r="8.468064" x="23.8708782" g1="0" b1="9.81405e-05" g2="0" b2="9.81405e-05" node1="119" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04542300-c766-11e1-8775-005056c00008" p1="60.266581656782193" q1="21.754979847722485" p2="-58.329873655890175" q2="-19.692554193536811">
+    <iidm:line id="_04499bb6-c766-11e1-8775-005056c00008" name="49-51" r="8.468064" x="23.8708782" g1="0" b1="9.81405e-05" g2="0" b2="9.81405e-05" node1="119" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04542300-c766-11e1-8775-005056c00008" p1="76.842377433063717" q1="18.665329841513348" p2="-73.917269075135408" q2="-13.810946940732292">
         <iidm:alias>_0487dd38-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b1180-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10451,7 +10580,7 @@
             <iidm:temporaryLimit name="_90dcdbe1-437b-443f-b0b5-c2353f7c6954" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04839779-c766-11e1-8775-005056c00008" name="40-42" r="9.6703209999999995" x="31.885919999999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="42" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="-2.4997837715077673" q1="-10.771227003791385" p2="2.5609496981369517" q2="7.2403893581028695">
+    <iidm:line id="_04839779-c766-11e1-8775-005056c00008" name="40-42" r="9.6703209999999995" x="31.885919999999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="42" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="-0.55167115652679788" q1="-9.7107995963478739" p2="0.59422752325695316" q2="6.0322350125328246">
         <iidm:alias>_044974a9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04616975-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10459,7 +10588,7 @@
             <iidm:temporaryLimit name="_9b8510fa-bd0e-4e63-8f4c-0e5443a3eb63" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0484a8e1-c766-11e1-8775-005056c00008" name="32-113" r="10.71576" x="35.370719999999999" g1="0" b1="0.00014864555000000001" g2="0" b2="0.00014864555000000001" node1="52" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="2.6980468122720218" q1="-9.8371581682090738" p2="-2.6570476575561752" q2="5.0621108679543472">
+    <iidm:line id="_0484a8e1-c766-11e1-8775-005056c00008" name="32-113" r="10.71576" x="35.370719999999999" g1="0" b1="0.00014864555000000001" g2="0" b2="0.00014864555000000001" node1="52" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="0.83200100576871217" q1="-8.3179302269999003" p2="-0.80862877654284493" q2="3.497623956452995">
         <iidm:alias>_04723258-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0482860a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10467,7 +10596,7 @@
             <iidm:temporaryLimit name="_336bfd86-a922-4154-9e06-cd87382cdc5f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04898ae4-c766-11e1-8775-005056c00008" name="51-58" r="4.4431200000000004" x="12.5278568" g1="0" b1="5.1308550000000002e-05" g2="0" b2="5.1308550000000002e-05" node1="31" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="14.752164053817085" q1="4.8791172349960572" p2="-14.683969396042936" q2="-6.3463526263654684">
+    <iidm:line id="_04898ae4-c766-11e1-8775-005056c00008" name="51-58" r="4.4431200000000004" x="12.5278568" g1="0" b1="5.1308550000000002e-05" g2="0" b2="5.1308550000000002e-05" node1="31" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="25.304248589371625" q1="0.49083225769374211" p2="-25.128688344791271" q2="-1.6504048508689404">
         <iidm:alias>_044778d4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04789af1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10475,7 +10604,7 @@
             <iidm:temporaryLimit name="_2be10dec-f0ac-470d-83f7-a2a4e70f3491" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046efe04-c766-11e1-8775-005056c00008" name="29-31" r="1.8817919999999999" x="5.7673439999999996" g1="0" b1="2.3817700000000001e-05" g2="0" b2="2.3817700000000001e-05" node1="22" voltageLevelId1="_04588fd5-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="-8.0956900830739578" q1="-8.4001683343529674" p2="8.1107936330308927" q2="7.6732694897151426">
+    <iidm:line id="_046efe04-c766-11e1-8775-005056c00008" name="29-31" r="1.8817919999999999" x="5.7673439999999996" g1="0" b1="2.3817700000000001e-05" g2="0" b2="2.3817700000000001e-05" node1="22" voltageLevelId1="_04588fd5-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="-8.633146470827997" q1="-7.2157120747143821" p2="8.6472393888040351" q2="6.4854380554260942">
         <iidm:alias>_04492688-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047cb9a5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10483,7 +10612,7 @@
             <iidm:temporaryLimit name="_f0e21213-6535-44a7-89b6-3063f8738d6b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044a10e4-c766-11e1-8775-005056c00008" name="65-68" r="0.66791999999999996" x="7.7439999999999998" g1="0" b1="0.00065909092999999995" g2="0" b2="0.00065909092999999995" node1="41" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0449e9d2-c766-11e1-8775-005056c00008" p1="-68.624588264241694" q1="12.970648008204744" p2="68.716834342936664" q2="-75.945340793729926">
+    <iidm:line id="_044a10e4-c766-11e1-8775-005056c00008" name="65-68" r="0.66791999999999996" x="7.7439999999999998" g1="0" b1="0.00065909092999999995" g2="0" b2="0.00065909092999999995" node1="41" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0449e9d2-c766-11e1-8775-005056c00008" p1="-162.13664122143805" q1="23.747607873049763" p2="162.53861626686506" q2="-83.12202563706613">
         <iidm:alias>_0461dea7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047629f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10491,7 +10620,7 @@
             <iidm:temporaryLimit name="_ab31cd46-6d0c-4d9c-95f1-396a45a237e1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046b7b92-c766-11e1-8775-005056c00008" name="49-54" r="12.719519999999999" x="50.355361899999998" g1="0" b1="0.00021177684999999999" g2="0" b2="0.00021177684999999999" node1="120" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="32.067690233116359" q1="13.973053106667471" p2="-31.131793422759003" q2="-17.510105428812238">
+    <iidm:line id="_046b7b92-c766-11e1-8775-005056c00008" name="49-54" r="12.719519999999999" x="50.355361899999998" g1="0" b1="0.00021177684999999999" g2="0" b2="0.00021177684999999999" node1="120" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="46.776154586510785" q1="11.850224472651414" p2="-45.084015019391735" q2="-12.393384113041437">
         <iidm:alias>_0462f017-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047120e1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10499,7 +10628,7 @@
             <iidm:temporaryLimit name="_1bf78539-b6fa-4d8b-ba8e-9b5970019be6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04607f15-c766-11e1-8775-005056c00008" name="70-71" r="1.536797" x="6.1855200000000004" g1="0" b1="2.5195149999999999e-05" g2="0" b2="2.5195149999999999e-05" node1="52" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04664b78-c766-11e1-8775-005056c00008" p1="-0.44579021522148099" q1="-6.7487411250285509" p2="0.44945337849415018" q2="5.9118407554901919">
+    <iidm:line id="_04607f15-c766-11e1-8775-005056c00008" name="70-71" r="1.536797" x="6.1855200000000004" g1="0" b1="2.5195149999999999e-05" g2="0" b2="2.5195149999999999e-05" node1="52" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04664b78-c766-11e1-8775-005056c00008" p1="-5.0468787013244034" q1="-4.8700358171037079" p2="5.050997782594024" q2="4.0345390649599491">
         <iidm:alias>_04486336-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f51b4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10507,7 +10636,7 @@
             <iidm:temporaryLimit name="_08ff3ae4-d1dd-49f7-9eda-32ffc8eb0010" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c5ad7-c766-11e1-8775-005056c00008" name="55-56" r="0.85029100000000002" x="2.631024" g1="0" b1="1.0732300000000001e-05" g2="0" b2="1.0732300000000001e-05" node1="31" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="-17.738660925915202" q1="-10.54462290639181" p2="17.761431796683851" q2="10.275684115984204">
+    <iidm:line id="_044c5ad7-c766-11e1-8775-005056c00008" name="55-56" r="0.85029100000000002" x="2.631024" g1="0" b1="1.0732300000000001e-05" g2="0" b2="1.0732300000000001e-05" node1="31" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="-28.68638771268116" q1="-7.0046258904494563" p2="28.733283583364411" q2="6.8103726275342948">
         <iidm:alias>_04558294-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045868c2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10515,7 +10644,7 @@
             <iidm:temporaryLimit name="_94316214-afd8-4c0d-bca4-916acb92af85" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048a2725-c766-11e1-8775-005056c00008" name="35-37" r="1.9166399999999999" x="8.6597279999999994" g1="0" b1="3.7821399999999997e-05" g2="0" b2="3.7821399999999997e-05" node1="21" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-31.179511705060641" q1="-12.960008370500169" p2="31.324665720256572" q2="12.478457217455752">
+    <iidm:line id="_048a2725-c766-11e1-8775-005056c00008" name="35-37" r="1.9166399999999999" x="8.6597279999999994" g1="0" b1="3.7821399999999997e-05" g2="0" b2="3.7821399999999997e-05" node1="21" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-29.558758188869511" q1="-14.434797305957384" p2="29.691973396745897" q2="13.863326907145119">
         <iidm:alias>_0471bd29-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04808a30-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10523,7 +10652,7 @@
             <iidm:temporaryLimit name="_4ea6b532-d914-4b0c-97ee-9f02a14a40b3" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04614263-c766-11e1-8775-005056c00008" name="4-5" r="0.30666199999999999" x="1.3904350000000001" g1="0" b1="6.0261499999999999e-06" g2="0" b2="6.0261499999999999e-06" node1="22" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-110.07941259198704" q1="-20.394802824596386" p2="110.29666962729362" q2="21.165966421549921">
+    <iidm:line id="_04614263-c766-11e1-8775-005056c00008" name="4-5" r="0.30666199999999999" x="1.3904350000000001" g1="0" b1="6.0261499999999999e-06" g2="0" b2="6.0261499999999999e-06" node1="22" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-108.54958445277506" q1="-19.947670070906913" p2="108.76113377961316" q2="20.693373759118906">
         <iidm:alias>_04529c66-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04753f92-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10531,7 +10660,7 @@
             <iidm:temporaryLimit name="_2a95fb2b-6661-46e7-a9f6-fe63c1b7433c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0451b208-c766-11e1-8775-005056c00008" name="20-21" r="3.1885919999999999" x="14.7929754" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_046b2d70-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0460f448-c766-11e1-8775-005056c00008" p1="-29.888159624537558" q1="0.23013406952015791" p2="30.072806589547767" q2="-1.2992943727767867">
+    <iidm:line id="_0451b208-c766-11e1-8775-005056c00008" name="20-21" r="3.1885919999999999" x="14.7929754" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_046b2d70-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0460f448-c766-11e1-8775-005056c00008" p1="-30.859113185253857" q1="0.58023509308024224" p2="31.056677028916308" q2="-1.5839510776543715">
         <iidm:alias>_046c65f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048c22f6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10539,7 +10668,7 @@
             <iidm:temporaryLimit name="_4b67f5f5-f0e1-4bfb-9d57-4d3474720a45" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047d55e4-c766-11e1-8775-005056c00008" name="104-105" r="1.731946" x="6.5862720000000001" g1="0" b1="2.8294300000000001e-05" g2="0" b2="2.8294300000000001e-05" node1="32" voltageLevelId1="_0483977a-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="48.572981818768575" q1="0.72338974926115895" p2="-48.323863943243339" q2="-0.69979445654391947">
+    <iidm:line id="_047d55e4-c766-11e1-8775-005056c00008" name="104-105" r="1.731946" x="6.5862720000000001" g1="0" b1="2.8294300000000001e-05" g2="0" b2="2.8294300000000001e-05" node1="32" voltageLevelId1="_0483977a-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="48.030945744057476" q1="0.86547899740017697" p2="-47.787334877710698" q2="-0.86289494405268441">
         <iidm:alias>_0451d910-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046c65f2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10547,7 +10676,7 @@
             <iidm:temporaryLimit name="_1ca40dc7-6736-4fa8-b4cb-ca696949e421" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046dc589-c766-11e1-8775-005056c00008" name="44-45" r="3.9029759999999998" x="15.699023199999999" g1="0" b1="6.4279149999999996e-05" g2="0" b2="6.4279149999999996e-05" node1="23" voltageLevelId1="_04544a15-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_045d23b4-c766-11e1-8775-005056c00008" p1="-23.438710765738701" q1="-6.2549788258733923" p2="23.575953971703502" q2="4.6767556428857553">
+    <iidm:line id="_046dc589-c766-11e1-8775-005056c00008" name="44-45" r="3.9029759999999998" x="15.699023199999999" g1="0" b1="6.4279149999999996e-05" g2="0" b2="6.4279149999999996e-05" node1="23" voltageLevelId1="_04544a15-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_045d23b4-c766-11e1-8775-005056c00008" p1="-21.312608178706611" q1="-4.4627263875888969" p2="21.422449277869614" q2="2.7588096922631138">
         <iidm:alias>_04518afa-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04667287-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10555,7 +10684,7 @@
             <iidm:temporaryLimit name="_ba738481-ddba-4ebe-a218-8aad0b537f5b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04642896-c766-11e1-8775-005056c00008" name="4-11" r="3.641616" x="11.9877129" g1="0" b1="5.0160700000000002e-05" g2="0" b2="5.0160700000000002e-05" node1="23" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="71.079935477041559" q1="8.3950709469489482" p2="-70.021836674660449" q2="-6.6512944095429436">
+    <iidm:line id="_04642896-c766-11e1-8775-005056c00008" name="4-11" r="3.641616" x="11.9877129" g1="0" b1="5.0160700000000002e-05" g2="0" b2="5.0160700000000002e-05" node1="23" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="69.550120992611667" q1="7.9479452158625428" p2="-68.536064894586374" q2="-6.346775155471021">
         <iidm:alias>_0455f7c5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04803c17-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10563,7 +10692,7 @@
             <iidm:temporaryLimit name="_b1d87c24-e527-4174-aa04-cd0b9de271ea" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047d07c0-c766-11e1-8775-005056c00008" name="92-93" r="4.4953919999999998" x="14.775551800000001" g1="0" b1="6.2557400000000005e-05" g2="0" b2="6.2557400000000005e-05" node1="72" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04789af0-c766-11e1-8775-005056c00008" p1="63.114155345319503" q1="-11.655705080428779" p2="-62.03732946862732" q2="13.068280019653702">
+    <iidm:line id="_047d07c0-c766-11e1-8775-005056c00008" name="92-93" r="4.4953919999999998" x="14.775551800000001" g1="0" b1="6.2557400000000005e-05" g2="0" b2="6.2557400000000005e-05" node1="72" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04789af0-c766-11e1-8775-005056c00008" p1="70.618301639493524" q1="-12.723979030710723" p2="-69.268118453065" q2="15.041482305314915">
         <iidm:alias>_044a5f07-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047602e5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10571,7 +10700,7 @@
             <iidm:temporaryLimit name="_4e1daf8e-7708-4b96-8d3f-67f58f2505f9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044f4109-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="43" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="121" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-55.54670422818775" q1="-20.137290323546541" p2="58.481613504760418" q2="25.356598926816542">
+    <iidm:line id="_044f4109-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="43" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="121" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-53.574726106195392" q1="-18.911263454974495" p2="56.235824252758214" q2="22.82759669880004">
         <iidm:alias>_046958b0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04758db0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10579,7 +10708,7 @@
             <iidm:temporaryLimit name="_c58940cb-bd36-4dfc-9615-11716dd652a7" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046e61c8-c766-11e1-8775-005056c00008" name="69-75" r="7.0567200000000003" x="21.257280000000002" g1="0" b1="0.00035583104999999999" g2="0" b2="0.00035583104999999999" node1="61" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="97.673146697954351" q1="22.983134047412307" p2="-93.73451982013286" q2="-23.562774492013723">
+    <iidm:line id="_046e61c8-c766-11e1-8775-005056c00008" name="69-75" r="7.0567200000000003" x="21.257280000000002" g1="0" b1="0.00035583104999999999" g2="0" b2="0.00035583104999999999" node1="61" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="90.106455970797612" q1="24.472929913836637" p2="-86.670808690866579" q2="-26.570457439030861">
         <iidm:alias>_046d294a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048ac362-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10587,7 +10716,7 @@
             <iidm:temporaryLimit name="_3c9a454c-10ee-4c72-a059-77f723f5b7c7" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0463da71-c766-11e1-8775-005056c00008" name="79-80" r="2.7181440000000001" x="12.2664957" g1="0" b1="5.3661600000000001e-05" g2="0" b2="5.3661600000000001e-05" node1="23" voltageLevelId1="_04481510-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-64.837863019072103" q1="-32.201823561432199" p2="65.634335255441684" q2="33.836108933885079">
+    <iidm:line id="_0463da71-c766-11e1-8775-005056c00008" name="79-80" r="2.7181440000000001" x="12.2664957" g1="0" b1="5.3661600000000001e-05" g2="0" b2="5.3661600000000001e-05" node1="23" voltageLevelId1="_04481510-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-66.525737436394266" q1="-32.366489146304588" p2="67.358614927356101" q2="34.165888611521545">
         <iidm:alias>_0464ebe9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04662468-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10595,7 +10724,7 @@
             <iidm:temporaryLimit name="_270a7d04-9ff9-4178-8b72-b610735a72ac" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044fdd41-c766-11e1-8775-005056c00008" name="51-52" r="3.5370720000000002" x="10.2453117" g1="0" b1="4.0059699999999999e-05" g2="0" b2="4.0059699999999999e-05" node1="32" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04806326-c766-11e1-8775-005056c00008" p1="26.577677259235788" q1="6.8134116088165806" p2="-26.412376024162516" q2="-7.6277332697915288">
+    <iidm:line id="_044fdd41-c766-11e1-8775-005056c00008" name="51-52" r="3.5370720000000002" x="10.2453117" g1="0" b1="4.0059699999999999e-05" g2="0" b2="4.0059699999999999e-05" node1="32" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04806326-c766-11e1-8775-005056c00008" p1="31.61303927281412" q1="5.3201294195698097" p2="-31.387738298317636" q2="-5.9558647255119306">
         <iidm:alias>_045115c2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0464ebe5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10603,7 +10732,7 @@
             <iidm:temporaryLimit name="_9d1eb182-ceb5-426e-9440-5f4d426a31cb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c3958-c766-11e1-8775-005056c00008" name="53-54" r="4.5825120000000004" x="21.257280000000002" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="22" voltageLevelId1="_04876804-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="-14.627851477618131" q1="-4.8575920987581158" p2="14.694231256692877" q2="2.3638937907233508">
+    <iidm:line id="_045c3958-c766-11e1-8775-005056c00008" name="53-54" r="4.5825120000000004" x="21.257280000000002" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="22" voltageLevelId1="_04876804-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="-9.6952142953328853" q1="-6.7130060908113975" p2="9.7312286792537623" q2="4.0811764700390256">
         <iidm:alias>_044f6817-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0455f7c6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10611,7 +10740,7 @@
             <iidm:temporaryLimit name="_735ac8df-6a6a-43f0-86f2-49d3280c9a3b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044ef2e1-c766-11e1-8775-005056c00008" name="54-55" r="2.9446560000000002" x="12.3187675" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="63" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04767817-c766-11e1-8775-005056c00008" p1="5.6676935990278174" q1="2.6791314685318852" p2="-5.6593393092691198" q2="-4.4794214634820708">
+    <iidm:line id="_044ef2e1-c766-11e1-8775-005056c00008" name="54-55" r="2.9446560000000002" x="12.3187675" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="63" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04767817-c766-11e1-8775-005056c00008" p1="10.156572049265128" q1="1.7058292751681365" p2="-10.136178283352205" q2="-3.4556485578065024">
         <iidm:alias>_04640181-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047dcb17-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10619,7 +10748,7 @@
             <iidm:temporaryLimit name="_52aadf8d-53f2-4827-8c70-421bdf1ba822" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0456e226-c766-11e1-8775-005056c00008" name="80-97" r="3.1885919999999999" x="16.2740154" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="82" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="20.427572108756404" q1="28.216567580535322" p2="-20.208827286012831" q2="-29.769076961600298">
+    <iidm:line id="_0456e226-c766-11e1-8775-005056c00008" name="80-97" r="3.1885919999999999" x="16.2740154" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="82" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="12.226243366528495" q1="30.998409965231406" p2="-12.023645633793123" q2="-32.630442350153807">
         <iidm:alias>_04479fe9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047df222-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10627,7 +10756,7 @@
             <iidm:temporaryLimit name="_fece5807-6af8-4161-8de8-8f8473d92f11" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0487b624-c766-11e1-8775-005056c00008" name="103-110" r="6.8058139999999998" x="31.5897121" g1="0" b1="0.00013228879999999999" g2="0" b2="0.00013228879999999999" node1="43" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="58.864777195096707" q1="18.397126574192246" p2="-57.373152868090571" q2="-15.92716355114703">
+    <iidm:line id="_0487b624-c766-11e1-8775-005056c00008" name="103-110" r="6.8058139999999998" x="31.5897121" g1="0" b1="0.00013228879999999999" g2="0" b2="0.00013228879999999999" node1="43" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="57.719546522888145" q1="18.497456049564349" p2="-56.277447900560261" q2="-16.257588753185896">
         <iidm:alias>_046a9139-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b3895-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10635,7 +10764,7 @@
             <iidm:temporaryLimit name="_3eacc034-737e-41de-a7b6-b610d3bd0921" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045338a8-c766-11e1-8775-005056c00008" name="56-58" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="61" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="-2.6738570301804439" q1="-5.5325333914127679" p2="2.6839549060978016" q2="3.346346595835803">
+    <iidm:line id="_045338a8-c766-11e1-8775-005056c00008" name="56-58" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="61" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="-13.06428685378572" q1="-0.68089735394419593" p2="13.128696972851618" q2="-1.349591553227028">
         <iidm:alias>_0451d915-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04817494-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10643,7 +10772,7 @@
             <iidm:temporaryLimit name="_0d0c3ec5-798a-48a4-9bc8-d19c57128a13" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04854529-c766-11e1-8775-005056c00008" name="15-33" r="6.6211200000000003" x="21.675455100000001" g1="0" b1="9.1655200000000003e-05" g2="0" b2="9.1655200000000003e-05" node1="52" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456bb11-c766-11e1-8775-005056c00008" p1="43.947307381089402" q1="0.31326474433868901" p2="-43.133033121151328" q2="-0.47646200061237032">
+    <iidm:line id="_04854529-c766-11e1-8775-005056c00008" name="15-33" r="6.6211200000000003" x="21.675455100000001" g1="0" b1="9.1655200000000003e-05" g2="0" b2="9.1655200000000003e-05" node1="52" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456bb11-c766-11e1-8775-005056c00008" p1="64.512418372488895" q1="-8.2883293066680608" p2="-62.734927352467508" q2="11.271830493019081">
         <iidm:alias>_0448d862-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047d2ed5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10651,7 +10780,7 @@
             <iidm:temporaryLimit name="_5b0395f4-534d-4975-a1af-e0b6ef439193" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04649dc2-c766-11e1-8775-005056c00008" name="35-36" r="0.39029799999999998" x="1.7772479999999999" g1="0" b1="7.6905500000000004e-06" g2="0" b2="7.6905500000000004e-06" node1="22" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="-1.8089078753034324" q1="3.9652748152495421" p2="1.8094307350546739" q2="-4.1914509188811522">
+    <iidm:line id="_04649dc2-c766-11e1-8775-005056c00008" name="35-36" r="0.39029799999999998" x="1.7772479999999999" g1="0" b1="7.6905500000000004e-06" g2="0" b2="7.6905500000000004e-06" node1="22" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="-3.4327053489467558" q1="5.4386792651684326" p2="3.4337912648728124" q2="-5.6694339488417365">
         <iidm:alias>_044c0cb5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0456e225-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10659,7 +10788,7 @@
             <iidm:temporaryLimit name="_74c4b341-7b99-4a81-b88a-2ed3b0c4b1de" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0470d2c9-c766-11e1-8775-005056c00008" name="37-40" r="10.3324327" x="29.272320000000001" g1="0" b1="0.0001205234" g2="0" b2="0.0001205234" node1="61" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="54.25272352629753" q1="9.03214645556627" p2="-52.172555530635734" q2="-6.6159594320470205">
+    <iidm:line id="_0470d2c9-c766-11e1-8775-005056c00008" name="37-40" r="10.3324327" x="29.272320000000001" g1="0" b1="0.0001205234" g2="0" b2="0.0001205234" node1="61" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="56.310133961842965" q1="10.235520155568379" p2="-54.125356538109855" q2="-7.6269989622195942">
         <iidm:alias>_045b9d10-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046a4317-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10667,7 +10796,7 @@
             <iidm:temporaryLimit name="_e98d56fe-a54b-45e4-acff-0ac310beb3dd" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044e56a2-c766-11e1-8775-005056c00008" name="48-49" r="3.1188959999999999" x="8.7991200000000003" g1="0" b1="3.6099649999999999e-05" g2="0" b2="3.6099649999999999e-05" node1="23" voltageLevelId1="_044778d3-c766-11e1-8775-005056c00008" node2="122" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-30.945334927453978" q1="1.9810107483695356" p2="31.111041609793517" q2="-2.8297405124811301">
+    <iidm:line id="_044e56a2-c766-11e1-8775-005056c00008" name="48-49" r="3.1188959999999999" x="8.7991200000000003" g1="0" b1="3.6099649999999999e-05" g2="0" b2="3.6099649999999999e-05" node1="23" voltageLevelId1="_044778d3-c766-11e1-8775-005056c00008" node2="122" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-28.845916939314414" q1="1.3185288385120306" p2="28.989517908385977" q2="-2.2296981106692528">
         <iidm:alias>_0454bf49-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0460a623-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10675,7 +10804,7 @@
             <iidm:temporaryLimit name="_f2e58700-2366-46e0-8408-9472d85acd23" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047eb573-c766-11e1-8775-005056c00008" name="56-59" r="14.3748007" x="43.734237700000001" g1="0" b1="0.0001632805" g2="0" b2="0.0001632805" node1="62" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-32.339585313659605" q1="-2.3735328358624561" p2="33.287869208558888" q2="-0.09040003335413857">
+    <iidm:line id="_047eb573-c766-11e1-8775-005056c00008" name="56-59" r="14.3748007" x="43.734237700000001" g1="0" b1="0.0001632805" g2="0" b2="0.0001632805" node1="62" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-19.178977685164259" q1="-7.7132401028675854" p2="19.536329919687372" q2="3.4517028629632129">
         <iidm:alias>_0468bc78-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048915b0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10683,7 +10812,7 @@
             <iidm:temporaryLimit name="_89654167-95a6-4c76-aad7-63a881116e17" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046f9a4b-c766-11e1-8775-005056c00008" name="94-100" r="3.1014719999999998" x="10.105919999999999" g1="0" b1="0.00017332415000000001" g2="0" b2="0.00017332415000000001" node1="52" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-0.38385766112730424" q1="-51.143208011312211" p2="0.80684532581151436" q2="46.446256718613611">
+    <iidm:line id="_046f9a4b-c766-11e1-8775-005056c00008" name="94-100" r="3.1014719999999998" x="10.105919999999999" g1="0" b1="0.00017332415000000001" g2="0" b2="0.00017332415000000001" node1="52" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-6.1271056067196188" q1="-52.23255028890501" p2="6.5779825189884429" q2="47.636674912047908">
         <iidm:alias>_04812676-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048a2722-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10691,7 +10820,7 @@
             <iidm:temporaryLimit name="_216c0f3b-03e8-4b7d-96fc-a5f891331f7f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046735d0-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="123" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-84.836607800458694" q1="-4.0884776849363513" p2="86.071017630276401" q2="7.7335982153874969">
+    <iidm:line id="_046735d0-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="123" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-92.394649110057614" q1="-2.4976571423204668" p2="93.857469627832103" q2="7.3078129485038721">
         <iidm:alias>_04570934-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b3894-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10699,7 +10828,7 @@
             <iidm:temporaryLimit name="_32655e4f-e7da-46b0-a908-b601224ddb73" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046d294b-c766-11e1-8775-005056c00008" name="21-22" r="3.641616" x="16.901281399999998" g1="0" b1="7.0592299999999998e-05" g2="0" b2="7.0592299999999998e-05" node1="22" voltageLevelId1="_0460f448-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04773b6a-c766-11e1-8775-005056c00008" p1="-44.07148462317295" q1="-6.6994466301659061" p2="44.531635699778889" q2="6.5912124790049349">
+    <iidm:line id="_046d294b-c766-11e1-8775-005056c00008" name="21-22" r="3.641616" x="16.901281399999998" g1="0" b1="7.0592299999999998e-05" g2="0" b2="7.0592299999999998e-05" node1="22" voltageLevelId1="_0460f448-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04773b6a-c766-11e1-8775-005056c00008" p1="-45.055512898272845" q1="-6.4149401777318262" p2="45.536816964728779" q2="6.4114308040343602">
         <iidm:alias>_044a37f0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_044be5a2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10707,7 +10836,7 @@
             <iidm:temporaryLimit name="_bafaeace-e459-4dc2-87a0-467a9ea25f8d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_6a131803-f462-47e2-bc21-bda919364fe9" name="reactor1" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="36" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="37" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="-153.50000064643433" q1="35.572604863715625" p2="153.50000064643433" q2="2.1255219806448622e-11">
+    <iidm:line id="_6a131803-f462-47e2-bc21-bda919364fe9" name="reactor1" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="36" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="37" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="7.4940054162198066e-14" q1="-83.151381910630136" p2="-7.7715611723760958e-14" q2="92.151021072741386">
         <iidm:alias>_04531196-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_ca0adad2-ffe3-4efa-b56b-7d333b8ae18f</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10715,7 +10844,7 @@
             <iidm:temporaryLimit name="_ae4eadea-f3fc-4ac6-8899-c1698ece7a89" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_9803b364-2a93-4f21-94b7-8bdbe27a16f2" name="reactor2" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="38" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="0" q1="0" p2="0" q2="0">
+    <iidm:line id="_9803b364-2a93-4f21-94b7-8bdbe27a16f2" name="reactor2" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="38" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="-2.8846681987548806e-10" q1="27.473605921984966" p2="2.8846681987548806e-10" q2="-26.58845395914382">
         <iidm:alias>_0461b792-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_afe0e60b-3870-44fb-ba93-a056228f9636</iidm:alias>
     </iidm:line>

--- a/tests/main_sa/reference/launch/three_windings_transformer_contingency/outputIIDM.xml
+++ b/tests/main_sa/reference/launch/three_windings_transformer_contingency/outputIIDM.xml
@@ -31,7 +31,7 @@
                     <iidm:alias>_bea273f1-1e21-476d-b0d0-92dd6cb9a2d4</iidm:alias>
                     <iidm:alias>_c94e6b68-da6c-43d1-94fd-09ad60c74134</iidm:alias>
                 </iidm:switch>
-                <iidm:switch id="_047abdd7-c766-11e1-8775-005056c00008-BREAKER" name="BREAKER-Jay LD" kind="BREAKER" retained="true" open="true" node1="0" node2="8"/>
+                <iidm:switch id="_047abdd7-c766-11e1-8775-005056c00008-BREAKER" name="BREAKER-Jay LD" kind="BREAKER" retained="true" open="false" node1="0" node2="8"/>
                 <iidm:internalConnection node1="7" node2="0"/>
                 <iidm:internalConnection node1="9" node2="1"/>
                 <iidm:internalConnection node1="10" node2="2"/>
@@ -47,9 +47,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.00460477378802" angle="-2.8865023170678468" nodes="0,1,2,3,4,5,6,7,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.70059148708255" angle="-8.1340485017638393" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047abdd7-c766-11e1-8775-005056c00008" name="Jay LD" loadType="UNDEFINED" p0="14" q0="8" node="8" p="0" q="0">
+            <iidm:load id="_047abdd7-c766-11e1-8775-005056c00008" name="Jay LD" loadType="UNDEFINED" p0="14" q0="8" node="8" p="13.995014171327153" q="7.995252155446976">
                 <iidm:alias>_04590500-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -139,12 +139,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="128.00466666497914" angle="-0.58466591852371985" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="127.81055450560758" angle="-4.7244390992870811" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045b00d5-c766-11e1-8775-005056c00008" name="Madison LD" loadType="UNDEFINED" p0="62" q0="13" node="14" p="62.017064759771444" q="13.005964038427845">
+            <iidm:load id="_045b00d5-c766-11e1-8775-005056c00008" name="Madison LD" loadType="UNDEFINED" p0="62" q0="13" node="14" p="61.980751729429983" q="12.993274149955894">
                 <iidm:alias>_045b27e3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_04689566-c766-11e1-8775-005056c00008" name="Madison NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="15" p="9.0024771425474679" q="0">
+            <iidm:load id="_04689566-c766-11e1-8775-005056c00008" name="Madison NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="15" p="8.9972058962075767" q="0">
                 <iidm:alias>_04765100-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -272,16 +272,16 @@
                 <iidm:internalConnection node1="61" node2="12"/>
                 <iidm:internalConnection node1="62" node2="15"/>
                 <iidm:internalConnection node1="63" node2="18"/>
-                <iidm:bus v="126.06004191903422" angle="-19.453196159616766" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63"/>
+                <iidm:bus v="126.06000571304631" angle="-23.010834986147607" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_046c3ee7-c766-11e1-8775-005056c00008" name="Torrey SM" energySource="THERMAL" minP="20" maxP="80" ratedS="100" voltageRegulatorOn="true" targetP="48" targetV="126.06" targetQ="0" node="21" p="-52.972604726432827" q="-7.3968276989235786">
+            <iidm:generator id="_046c3ee7-c766-11e1-8775-005056c00008" name="Torrey SM" energySource="THERMAL" minP="20" maxP="80" ratedS="100" voltageRegulatorOn="true" targetP="48" targetV="126.06" targetQ="0" node="21" p="-53.153221252589788" q="-7.2676585506595446">
                 <iidm:alias>_047147f3-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_b97aee41-3115-4cfd-9071-b52fb44d0b66"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_5005c073-28d1-4a7d-b257-649dec43ec73"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-30" maxQ="85"/>
             </iidm:generator>
-            <iidm:load id="_044afb44-c766-11e1-8775-005056c00008" name="Torrey LD" loadType="UNDEFINED" p0="113" q0="32" node="20" p="113.0000563642463" q="32.000026602598552">
+            <iidm:load id="_044afb44-c766-11e1-8775-005056c00008" name="Torrey LD" loadType="UNDEFINED" p0="113" q0="32" node="20" p="113.00000768174958" q="32.000003625604613">
                 <iidm:alias>_04522737-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -332,9 +332,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="123.87514365157477" angle="-3.7246511201894776" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="123.82642529052771" angle="-7.2316107222629125" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04481515-c766-11e1-8775-005056c00008" name="Darrah LD" loadType="UNDEFINED" p0="68" q0="36" node="8" p="68.010591029794995" q="36.009345511445289">
+            <iidm:load id="_04481515-c766-11e1-8775-005056c00008" name="Darrah LD" loadType="UNDEFINED" p0="68" q0="36" node="8" p="67.999651355658258" q="35.999692373165374">
                 <iidm:alias>_044e7db8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -385,9 +385,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.46784025344323" angle="10.508519079584536" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.45801401482848" angle="7.1930601287753966" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044c0cb3-c766-11e1-8775-005056c00008" name="Smythe LD" loadType="UNDEFINED" p0="5" q0="3" node="8" p="5.0001148338470278" q="3.0001148347261459">
+            <iidm:load id="_044c0cb3-c766-11e1-8775-005056c00008" name="Smythe LD" loadType="UNDEFINED" p0="5" q0="3" node="8" p="4.999963897806377" q="2.9999638978932675">
                 <iidm:alias>_045163e8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -514,9 +514,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="125.90792597604587" angle="-19.625773035683189" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="125.90822341789224" angle="-23.183190951171159" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0450a093-c766-11e1-8775-005056c00008" name="Sunnysde LD" loadType="UNDEFINED" p0="84" q0="18" node="20" p="83.999963706621131" q="17.999987038080839">
+            <iidm:load id="_0450a093-c766-11e1-8775-005056c00008" name="Sunnysde LD" loadType="UNDEFINED" p0="84" q0="18" node="20" p="84.000014972919175" q="18.000005347471454">
                 <iidm:alias>_045f4695-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -568,12 +568,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="126.80626361901399" angle="-3.8161785274804121" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="126.72840006916663" angle="-7.3724838643496815" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044b2251-c766-11e1-8775-005056c00008" name="Bellefnt LD" loadType="UNDEFINED" p0="68" q0="27" node="8" p="68.015353144195984" q="27.010160933593554">
+            <iidm:load id="_044b2251-c766-11e1-8775-005056c00008" name="Bellefnt LD" loadType="UNDEFINED" p0="68" q0="27" node="8" p="67.998682298360478" q="26.999127997194673">
                 <iidm:alias>_04622cc1-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0449e9d5-c766-11e1-8775-005056c00008" name="Bellefnt SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.40300000000001" targetDeadband="1" node="9" q="-11.079001831687245">
+            <iidm:shunt id="_0449e9d5-c766-11e1-8775-005056c00008" name="Bellefnt SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.40300000000001" targetDeadband="1" node="9" q="-11.065400207638525">
                 <iidm:alias>_047bcf48-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_6cc38790-c6a6-4309-99f4-a3258e24e785"/>
                 <iidm:shuntLinearModel bPerSection="0.00013779999999999999" gPerSection="0" maximumSectionCount="10"/>
@@ -665,12 +665,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="126.06561768013582" angle="-3.8254249805384455" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="126.06593785813475" angle="-7.1540461786993852" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04682035-c766-11e1-8775-005056c00008" name="Fieldale LD" loadType="UNDEFINED" p0="39" q0="30" node="14" p="38.999989128154127" q="29.999986061737349">
+            <iidm:load id="_04682035-c766-11e1-8775-005056c00008" name="Fieldale LD" loadType="UNDEFINED" p0="39" q0="30" node="14" p="39.000010508710062" q="30.000013472706417">
                 <iidm:alias>_0478c20a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_045c6067-c766-11e1-8775-005056c00008" name="Fieldale SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.066" targetDeadband="1" node="15" q="-5.4670337466095154">
+            <iidm:shunt id="_045c6067-c766-11e1-8775-005056c00008" name="Fieldale SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.066" targetDeadband="1" node="15" q="-5.4670615166895757">
                 <iidm:alias>_0451b209-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_2d222dd9-7306-4afd-baa5-fd303b0eeb40"/>
                 <iidm:shuntLinearModel bPerSection="6.8800000000000005e-05" gPerSection="0" maximumSectionCount="10"/>
@@ -780,7 +780,7 @@
                 <iidm:internalConnection node1="51" node2="9"/>
                 <iidm:internalConnection node1="52" node2="12"/>
                 <iidm:internalConnection node1="53" node2="15"/>
-                <iidm:bus v="138.01517582243704" angle="-7.6471172903115052" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
+                <iidm:bus v="138.01487629483324" angle="-11.216588418944017" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="_047f0391-c766-11e1-8775-005056c00008" name="Muskngum SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="392" targetV="138.59999099999999" targetQ="0" node="18" p="-0" q="-0">
                 <iidm:alias>_047eb572-c766-11e1-8775-005056c00008</iidm:alias>
@@ -789,7 +789,7 @@
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
-            <iidm:load id="_047e1936-c766-11e1-8775-005056c00008" name="Muskngum LD" loadType="UNDEFINED" p0="39" q0="18" node="17" p="38.999801030837027" q="17.999846947057993">
+            <iidm:load id="_047e1936-c766-11e1-8775-005056c00008" name="Muskngum LD" loadType="UNDEFINED" p0="39" q0="18" node="17" p="38.999755754290796" q="17.99981211907744">
                 <iidm:alias>_046e88d5-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -876,9 +876,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="221.10006999226573" angle="-2.4917620988581559" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="221.10001000665366" angle="-6.0537544082572623" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0458ddf1-c766-11e1-8775-005056c00008" name="Muskngum SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="391" targetV="221.09999999999999" targetQ="0" node="14" p="-431.50600933406747" q="-158.32202649372789">
+            <iidm:generator id="_0458ddf1-c766-11e1-8775-005056c00008" name="Muskngum SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="391" targetV="221.09999999999999" targetQ="0" node="14" p="-432.97728145338777" q="-159.71767599989391">
                 <iidm:alias>_04522732-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_5036c3a5-56f9-489c-9ecb-8c15aa7c70c5"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_12b01822-ca11-4cf8-a6b4-2f8ff805ca20"/>
@@ -886,7 +886,7 @@
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045cae83-c766-11e1-8775-005056c00008" name="65-66" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="42" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="272.93269781532786" q1="97.396749748301261" p2="-272.93269781532786" q2="-70.502461043569156">
+        <iidm:twoWindingsTransformer id="_045cae83-c766-11e1-8775-005056c00008" name="65-66" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="42" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="273.32689962939287" q1="97.43809306877742" p2="-273.32689962939287" q2="-70.472247996678121">
             <iidm:alias>_044b2254-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_044b4964-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_045645e1-c766-11e1-8775-005056c00008</iidm:alias>
@@ -961,9 +961,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="125.57774163466446" angle="-4.9293514568909407" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.08966686145024" angle="-9.9628874451384295" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0453d4e2-c766-11e1-8775-005056c00008" name="Adams LD" loadType="UNDEFINED" p0="18" q0="3" node="8" p="18.077647772669192" q="3.0215998251803287">
+            <iidm:load id="_0453d4e2-c766-11e1-8775-005056c00008" name="Adams LD" loadType="UNDEFINED" p0="18" q0="3" node="8" p="17.996334292955023" q="2.9989818171670959">
                 <iidm:alias>_0448ff77-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1053,16 +1053,16 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="133.32005735690669" angle="1.9236922683418012" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="133.32000155519688" angle="-1.4127968484968196" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_046bf0c4-c766-11e1-8775-005056c00008" name="Claytor SM" energySource="THERMAL" minP="0" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="40" targetV="133.31999200000001" targetQ="0" node="15" p="-44.143837272027362" q="-83.146696831248192">
+            <iidm:generator id="_046bf0c4-c766-11e1-8775-005056c00008" name="Claytor SM" energySource="THERMAL" minP="0" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="40" targetV="133.31999200000001" targetQ="0" node="15" p="-44.294351043824832" q="-83.069481229852798">
                 <iidm:alias>_0460a627-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e56da2eb-bb6a-4133-953c-40073c5bc5f4"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_d41be6b4-155e-4c8f-b46b-16b50c49f0f4"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-60" maxQ="170"/>
             </iidm:generator>
-            <iidm:load id="_048433b6-c766-11e1-8775-005056c00008" name="Claytor LD" loadType="UNDEFINED" p0="23" q0="16" node="14" p="23.000016912793971" q="16.000019609041296">
+            <iidm:load id="_048433b6-c766-11e1-8775-005056c00008" name="Claytor LD" loadType="UNDEFINED" p0="23" q0="16" node="14" p="23.000002472654657" q="16.000002866846078">
                 <iidm:alias>_0480ff6b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1133,12 +1133,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="129.7592447702105" angle="-16.201640914301979" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="129.73825938111665" angle="-19.852235350795311" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0449e9d7-c766-11e1-8775-005056c00008" name="N.Newark LD" loadType="UNDEFINED" p0="53" q0="22" node="11" p="53.001942485322175" q="22.001343874187747">
+            <iidm:load id="_0449e9d7-c766-11e1-8775-005056c00008" name="N.Newark LD" loadType="UNDEFINED" p0="53" q0="22" node="11" p="52.998527363000761" q="21.998981203964895">
                 <iidm:alias>_04531191-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_04684741-c766-11e1-8775-005056c00008" name="N.Newark SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.32300000000001" targetDeadband="1" node="12" q="-9.6647029603145178">
+            <iidm:shunt id="_04684741-c766-11e1-8775-005056c00008" name="N.Newark SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.32300000000001" targetDeadband="1" node="12" q="-9.6615771537168555">
                 <iidm:alias>_04607f19-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_eae61817-d3cb-488f-a1f3-13bc8e31431b"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -1191,9 +1191,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="131.20488698654398" angle="-0.6741940524460146" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.95790740150755" angle="-4.4458030416985812" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0448d86a-c766-11e1-8775-005056c00008" name="Hillsbro NegG LD" loadType="UNDEFINED" p0="12" q0="0" node="8" p="12.005756503069735" q="0">
+            <iidm:load id="_0448d86a-c766-11e1-8775-005056c00008" name="Hillsbro NegG LD" loadType="UNDEFINED" p0="12" q0="0" node="8" p="11.997137496358617" q="0">
                 <iidm:alias>_044ef2e8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1244,9 +1244,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="125.33681302748006" angle="-17.611548320015409" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="125.31854542071596" angle="-21.489470394037248" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047dcb12-c766-11e1-8775-005056c00008" name="S.Kenton LD" loadType="UNDEFINED" p0="18" q0="7" node="8" p="18.000177541131524" q="7.000115073333955">
+            <iidm:load id="_047dcb12-c766-11e1-8775-005056c00008" name="S.Kenton LD" loadType="UNDEFINED" p0="18" q0="7" node="8" p="17.999083701011774" q="6.9994061125852376">
                 <iidm:alias>_0451b205-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1300,9 +1300,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="124.19456593530134" angle="9.1251049783605787" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25"/>
+                <iidm:bus v="124.17824936356857" angle="5.7958152938513914" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044afb49-c766-11e1-8775-005056c00008" name="Hazard LD" loadType="UNDEFINED" p0="21" q0="10" node="8" p="20.998987672139442" q="9.9991965781002534">
+            <iidm:load id="_044afb49-c766-11e1-8775-005056c00008" name="Hazard LD" loadType="UNDEFINED" p0="21" q0="10" node="8" p="20.997856858724987" q="9.9982991520884461">
                 <iidm:alias>_045e5c31-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1335,14 +1335,14 @@
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="3"/>
-                <iidm:bus v="31.048641483825328" angle="9.1251049783605804" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13"/>
+                <iidm:bus v="31.044562340892139" angle="5.7958152938513923" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13"/>
             </iidm:nodeBreakerTopology>
             <iidm:staticVarCompensator id="_047fc6e6-c766-11e1-8775-005056c00008" name="Pinevlle SVC" bMin="-10" bMax="10" voltageSetpoint="33.494999999999997" regulationMode="VOLTAGE" node="5" p="0" q="0">
                 <iidm:alias>_046ab846-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_98f667da-02d1-4a31-b826-44314a1fbbfe"/>
             </iidm:staticVarCompensator>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045e3525-c766-11e1-8775-005056c00008" name="86-87" r="0.30796918750000002" x="2.2585859312499998" g="0" b="-0.0040863184000000004" ratedU1="132" ratedU2="33" node1="22" voltageLevelId1="_0484f70a-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_04555b88-c766-11e1-8775-005056c00008" p1="-2.0383000842727483e-14" q1="3.9392850552069043" p2="7.6617565888779289e-15" q2="-4.770010142681741e-14">
+        <iidm:twoWindingsTransformer id="_045e3525-c766-11e1-8775-005056c00008" name="86-87" r="0.30796918750000002" x="2.2585859312499998" g="0" b="-0.0040863184000000004" ratedU1="132" ratedU2="33" node1="22" voltageLevelId1="_0484f70a-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_04555b88-c766-11e1-8775-005056c00008" p1="-1.1969591984239969e-14" q1="3.9382500436593233" p2="-4.3385332485231365e-15" q2="-8.9700172765216554e-15">
             <iidm:alias>_0452755a-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04682034-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_048c7110-c766-11e1-8775-005056c00008</iidm:alias>
@@ -1418,7 +1418,7 @@
                 <iidm:temporaryLimit name="_257d56c1-d70a-4a96-b85c-d928ade03ad4" acceptableDuration="60" value="12246"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_045e3525-c766-11e1-8775-005056c00008-1" name="86-87-open-ended" r="0.30796918750000002" x="2.2585859312499998" g="0" b="-0.0040863184000000004" ratedU1="132" ratedU2="33" node1="25" voltageLevelId1="_0484f70a-c766-11e1-8775-005056c00008" node2="15" voltageLevelId2="_04555b88-c766-11e1-8775-005056c00008" p1="0" q1="3.939285055206851" p2="0" q2="0">
+        <iidm:twoWindingsTransformer id="_045e3525-c766-11e1-8775-005056c00008-1" name="86-87-open-ended" r="0.30796918750000002" x="2.2585859312499998" g="0" b="-0.0040863184000000004" ratedU1="132" ratedU2="33" node1="25" voltageLevelId1="_0484f70a-c766-11e1-8775-005056c00008" node2="15" voltageLevelId2="_04555b88-c766-11e1-8775-005056c00008" p1="8.6736173798840355e-17" q1="3.9382500436593215" p2="0" q2="0">
             <iidm:alias>_0452755a-c766-11e1-8775-005056c00008-1</iidm:alias>
             <iidm:alias>_04682034-c766-11e1-8775-005056c00008-1</iidm:alias>
             <iidm:alias>_048c7110-c766-11e1-8775-005056c00008-1</iidm:alias>
@@ -1542,12 +1542,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="132.89895200873292" angle="0.10841572358231059" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="132.74077812197436" angle="-3.3316228644774557" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0447ee05-c766-11e1-8775-005056c00008" name="NwCarlsl NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="8" p="9.0009599009513295" q="0">
+            <iidm:load id="_0447ee05-c766-11e1-8775-005056c00008" name="NwCarlsl NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="8" p="8.9968763458000449" q="0">
                 <iidm:alias>_04731cb7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_047a48a8-c766-11e1-8775-005056c00008" name="NwCarlsl LD" loadType="UNDEFINED" p0="30" q0="12" node="9" p="30.00319966983777" q="12.002133189060483">
+            <iidm:load id="_047a48a8-c766-11e1-8775-005056c00008" name="NwCarlsl LD" loadType="UNDEFINED" p0="30" q0="12" node="9" p="29.98958781933348" q="11.993059349316301">
                 <iidm:alias>_044c0cb9-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1598,9 +1598,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.62149483698715" angle="-2.8019211753095714" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.62192713335308" angle="-6.1354496724452856" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044ecbd1-c766-11e1-8775-005056c00008" name="Blaine LD" loadType="UNDEFINED" p0="2" q0="1" node="8" p="1.9999989627506074" q="0.99999913562565557">
+            <iidm:load id="_044ecbd1-c766-11e1-8775-005056c00008" name="Blaine LD" loadType="UNDEFINED" p0="2" q0="1" node="8" p="2.0000007649202205" q="1.0000006374335983">
                 <iidm:alias>_04700f74-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1651,9 +1651,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="133.16949499792705" angle="3.2941239740545489" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="133.15977980124597" angle="-0.12332262364229496" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046b7b95-c766-11e1-8775-005056c00008" name="Sundial LD" loadType="UNDEFINED" p0="15" q0="9" node="8" p="15.000311357708068" q="9.0003113598623656">
+            <iidm:load id="_046b7b95-c766-11e1-8775-005056c00008" name="Sundial LD" loadType="UNDEFINED" p0="15" q0="9" node="8" p="14.999868122659752" q="8.9998681230462338">
                 <iidm:alias>_046efe07-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1704,9 +1704,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.7639827190831" angle="-4.5216785942785247" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.70141827495009" angle="-8.1378177654603974" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045645e2-c766-11e1-8775-005056c00008" name="Riversde LD" loadType="UNDEFINED" p0="51" q0="27" node="8" p="51.002204568424567" q="27.001945235461694">
+            <iidm:load id="_045645e2-c766-11e1-8775-005056c00008" name="Riversde LD" loadType="UNDEFINED" p0="51" q0="27" node="8" p="50.992423724572731" q="26.993315382125289">
                 <iidm:alias>_0476ed4b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1757,9 +1757,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.54523580849983" angle="-0.57889245491198116" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.83732540311286" angle="-5.3104730649709326" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04887973-c766-11e1-8775-005056c00008" name="Randolph LD" loadType="UNDEFINED" p0="10" q0="5" node="8" p="10.046189321006166" q="5.0385503330645145">
+            <iidm:load id="_04887973-c766-11e1-8775-005056c00008" name="Randolph LD" loadType="UNDEFINED" p0="10" q0="5" node="8" p="9.995576631497471" q="4.996314403113189">
                 <iidm:alias>_0462f018-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1810,9 +1810,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.48264994279926" angle="-18.818579210606423" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.48473736369431" angle="-22.383941931186161" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0477627b-c766-11e1-8775-005056c00008" name="WNwPhil2 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="11.999926804255503" q="2.9999695018351358">
+            <iidm:load id="_0477627b-c766-11e1-8775-005056c00008" name="WNwPhil2 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="12.000000925427992" q="3.000000385595007">
                 <iidm:alias>_045841b6-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1882,9 +1882,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="126.73013547423734" angle="-2.0673831748110851" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="126.73058975090724" angle="-5.4053237150336777" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0476781a-c766-11e1-8775-005056c00008" name="Cloverdl LD" loadType="UNDEFINED" p0="43" q0="16" node="11" p="42.999975806089793" q="15.999984996027495">
+            <iidm:load id="_0476781a-c766-11e1-8775-005056c00008" name="Cloverdl LD" loadType="UNDEFINED" p0="43" q0="16" node="11" p="43.000017924581712" q="16.000011116021213">
                 <iidm:alias>_0481749a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1954,9 +1954,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="128.11668253625842" angle="-0.69842948401275695" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="128.11691744564945" angle="-4.036049051448841" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046b0665-c766-11e1-8775-005056c00008" name="Hancock LD" loadType="UNDEFINED" p0="38" q0="25" node="11" p="37.999999800166151" q="24.999999780883936">
+            <iidm:load id="_046b0665-c766-11e1-8775-005056c00008" name="Hancock LD" loadType="UNDEFINED" p0="38" q0="25" node="11" p="38.000010534851221" q="25.000011551373014">
                 <iidm:alias>_0464c4d5-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2008,12 +2008,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="128.68602305991223" angle="-17.260662291872272" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="128.66276778278794" angle="-20.97093993164766" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044bbe92-c766-11e1-8775-005056c00008" name="WMVernon LD" loadType="UNDEFINED" p0="16" q0="8" node="8" p="16.000545367076924" q="8.0004544777277182">
+            <iidm:load id="_044bbe92-c766-11e1-8775-005056c00008" name="WMVernon LD" loadType="UNDEFINED" p0="16" q0="8" node="8" p="15.999382219259498" q="7.999485189342197">
                 <iidm:alias>_04500452-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_047825c8-c766-11e1-8775-005056c00008" name="WMVernon SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.21199999999999" targetDeadband="1" node="9" q="-9.5054931127803748">
+            <iidm:shunt id="_047825c8-c766-11e1-8775-005056c00008" name="WMVernon SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.21199999999999" targetDeadband="1" node="9" q="-9.5020578849648505">
                 <iidm:alias>_047084aa-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_2a6c1dcd-201b-4911-83b2-c16acc50a0f4"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -2047,9 +2047,9 @@
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="3"/>
-                <iidm:bus v="230.99998646418615" angle="22.331569732169982" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="230.99998499999268" angle="19.274161694610228" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_045868c0-c766-11e1-8775-005056c00008" name="Breed SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="450" targetV="230.99998500000001" targetQ="0" node="5" p="-496.61816931030779" q="28.502009987292219">
+            <iidm:generator id="_045868c0-c766-11e1-8775-005056c00008" name="Breed SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="450" targetV="230.99998500000001" targetQ="0" node="5" p="-498.31144924302936" q="23.590562571543668">
                 <iidm:alias>_045b7606-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_f26d4eb3-ebdb-4025-8080-f856ce656b42"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_7566f2a7-61eb-42fe-a59a-8276257fdbc6"/>
@@ -2123,9 +2123,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="127.47047443094633" angle="-17.707724300545351" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="127.47345531178125" angle="-21.2789567332042" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044d1e22-c766-11e1-8775-005056c00008" name="Newcmrst LD" loadType="UNDEFINED" p0="17" q0="8" node="11" p="16.999848854412246" q="7.9998814547923045">
+            <iidm:load id="_044d1e22-c766-11e1-8775-005056c00008" name="Newcmrst LD" loadType="UNDEFINED" p0="17" q0="8" node="11" p="16.999999905369723" q="7.9999999257801742">
                 <iidm:alias>_048a754b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2195,9 +2195,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="138.59999143103315" angle="12.475248772064775" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="138.59999105466056" angle="8.8870402529982879" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_045ab2b0-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="220" targetV="138.59999099999999" targetQ="0" node="11" p="-242.79110499615052" q="-41.74084076940126">
+            <iidm:generator id="_045ab2b0-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="220" targetV="138.59999099999999" targetQ="0" node="11" p="-243.61893074103656" q="-47.845630565396988">
                 <iidm:alias>_046ba2a5-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_56975783-9739-40fc-8ec1-e1de8cb06c9a"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b8449cd9-5a17-497e-bf04-70f728b0f9f2"/>
@@ -2250,9 +2250,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="223.300000793457" angle="14.610780978989476" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="223.30000008556303" angle="11.296751095559602" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0483224a-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="314" targetV="223.30000000000001" targetQ="0" node="8" p="-346.52912258541477" q="-17.240885598751788">
+            <iidm:generator id="_0483224a-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="314" targetV="223.30000000000001" targetQ="0" node="8" p="-347.71065569402492" q="-23.057171081134051">
                 <iidm:alias>_045cd594-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_05df66ba-3f64-40cb-8b18-c66d26c4e2c1"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_c1d29442-5f57-41d1-bb60-4b74b4994c20"/>
@@ -2260,7 +2260,7 @@
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045b7604-c766-11e1-8775-005056c00008" name="26-25" r="0" x="6.6559680000000006" g="0" b="0" ratedU1="220" ratedU2="132" node1="22" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="108.29381751186271" q1="22.200376049018583" p2="-108.29381751186271" q2="-18.024386383599126">
+        <iidm:twoWindingsTransformer id="_045b7604-c766-11e1-8775-005056c00008" name="26-25" r="0" x="6.6559680000000006" g="0" b="0" ratedU1="220" ratedU2="132" node1="22" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="122.18980919365225" q1="22.751844585079493" p2="-122.18980919365221" q2="-17.472914968338689">
             <iidm:alias>_0447c6f3-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0463b364-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04803c1c-c766-11e1-8775-005056c00008</iidm:alias>
@@ -2403,9 +2403,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="136.6200429399974" angle="2.7951505216534032" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="136.62000641475373" angle="-0.72522661531736032" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_048aea70-c766-11e1-8775-005056c00008" name="Sporn SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="513.43743900000004" targetV="136.62" targetQ="-62.132553100000003" node="20" p="-566.62746891456186" q="51.627636282073432">
+            <iidm:generator id="_048aea70-c766-11e1-8775-005056c00008" name="Sporn SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="513.43743900000004" targetV="136.62" targetQ="-62.132553100000003" node="20" p="-568.55945405270995" q="50.287132800313159">
                 <iidm:alias>_04555b84-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_27799004-aa1e-4889-ba95-ee6fdae64895"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_827a9c80-183d-4e33-9e73-ef0aab3dfb13"/>
@@ -2495,9 +2495,9 @@
                 <iidm:internalConnection node1="39" node2="9"/>
                 <iidm:internalConnection node1="40" node2="12"/>
                 <iidm:internalConnection node1="41" node2="3"/>
-                <iidm:bus v="219.70986543410694" angle="-0.98397715551021436" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41"/>
+                <iidm:bus v="219.70665850608182" angle="-4.5149886623014908" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41"/>
             </iidm:nodeBreakerTopology>
-            <iidm:danglingLine id="_0482fb33-c766-11e1-8775-005056c00008" name="68-116" p0="184" q0="0" r="0.16456000000000001" x="1.9601999999999999" g="0" b="0.00033884300000000002" ucteXnodeCode="XWE_BR21" node="41" p="184.11568647210419" q="-14.980175199335873">
+            <iidm:danglingLine id="_0482fb33-c766-11e1-8775-005056c00008" name="68-116" p0="184" q0="0" r="0.16456000000000001" x="1.9601999999999999" g="0" b="0.00033884300000000002" ucteXnodeCode="XWE_BR21" node="41" p="184.11558699753249" q="-14.979659070827802">
                 <iidm:alias>_0459c855-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_04684742-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_5631ccc0-d9d2-11e2-bb49-005056c00008</iidm:alias>
@@ -2510,7 +2510,7 @@
                 </iidm:currentLimits>
             </iidm:danglingLine>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_044f6815-c766-11e1-8775-005056c00008" name="68-69" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-196.92824771186682" q1="102.0721144952773" p2="196.92824771186682" q2="-86.115841772640607">
+        <iidm:twoWindingsTransformer id="_044f6815-c766-11e1-8775-005056c00008" name="68-69" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-197.47865631343981" q1="102.06301816094565" p2="197.47865631343984" q2="-86.036475228878544">
             <iidm:alias>_047e8e67-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04840ca7-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0487dd39-c766-11e1-8775-005056c00008</iidm:alias>
@@ -2617,9 +2617,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="131.60566408168276" angle="-9.0003936578583517" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="131.60565455510948" angle="-12.551440549249598" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04547126-c766-11e1-8775-005056c00008" name="Natrium LD" loadType="UNDEFINED" p0="77" q0="14" node="14" p="76.999937419677025" q="13.999981036270903">
+            <iidm:load id="_04547126-c766-11e1-8775-005056c00008" name="Natrium LD" loadType="UNDEFINED" p0="77" q0="14" node="14" p="76.999910993958281" q="13.999973028482604">
                 <iidm:alias>_047b3307-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2670,9 +2670,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="123.83408022094392" angle="-16.528989866483592" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="123.81648222115005" angle="-20.519492755932639" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045d4ac9-c766-11e1-8775-005056c00008" name="Sterling LD" loadType="UNDEFINED" p0="31" q0="17" node="8" p="31.000094218841845" q="17.000086114082478">
+            <iidm:load id="_045d4ac9-c766-11e1-8775-005056c00008" name="Sterling LD" loadType="UNDEFINED" p0="31" q0="17" node="8" p="30.998232358033029" q="16.998384443963495">
                 <iidm:alias>_0477b094-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2780,9 +2780,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="130.28629568274323" angle="5.7801498864101548" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="130.2717431577457" angle="2.4252827450997065" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0466246a-c766-11e1-8775-005056c00008" name="Switchbk LD" loadType="UNDEFINED" p0="30" q0="16" node="17" p="30.000975288885574" q="16.000866932848261">
+            <iidm:load id="_0466246a-c766-11e1-8775-005056c00008" name="Switchbk LD" loadType="UNDEFINED" p0="30" q0="16" node="17" p="29.999629506989216" q="15.999670674235011">
                 <iidm:alias>_04882b59-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2833,9 +2833,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="135.0884829880909" angle="3.0939646589830416" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="135.08649731197733" angle="-0.3124434635647434" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046adf5a-c766-11e1-8775-005056c00008" name="Bradley LD" loadType="UNDEFINED" p0="34" q0="8" node="8" p="34.000181309510616" q="8.0000711018952533">
+            <iidm:load id="_046adf5a-c766-11e1-8775-005056c00008" name="Bradley LD" loadType="UNDEFINED" p0="34" q0="8" node="8" p="33.999972539186523" q="7.9999892310564373">
                 <iidm:alias>_04555b85-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2889,9 +2889,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.22155443479527" angle="-2.2945094818701235" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25"/>
+                <iidm:bus v="127.10287500276944" angle="-6.5536173198433207" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047a48a2-c766-11e1-8775-005056c00008" name="Mullin LD" loadType="UNDEFINED" p0="17" q0="7" node="8" p="17.002887338519567" q="7.0019816190070179">
+            <iidm:load id="_047a48a2-c766-11e1-8775-005056c00008" name="Mullin LD" loadType="UNDEFINED" p0="17" q0="7" node="8" p="16.996746582927429" q="6.9977674052282319">
                 <iidm:alias>_0474553a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3057,16 +3057,16 @@
                 <iidm:internalConnection node1="81" node2="18"/>
                 <iidm:internalConnection node1="82" node2="21"/>
                 <iidm:internalConnection node1="83" node2="24"/>
-                <iidm:bus v="134.24405275832822" angle="5.4709418522786244" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
+                <iidm:bus v="134.24399746765354" angle="2.1276529585819484" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_044cd00a-c766-11e1-8775-005056c00008" name="Glen Lyn SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="252" targetV="134.243988" targetQ="0" node="27" p="-278.10617481377233" q="-84.220548557188451">
+            <iidm:generator id="_044cd00a-c766-11e1-8775-005056c00008" name="Glen Lyn SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="252" targetV="134.243988" targetQ="0" node="27" p="-279.05441157609641" q="-84.330823372822493">
                 <iidm:alias>_045e5c30-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e54b499b-436c-4b89-9803-b1d75e2fa364"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_32c8ab65-80f7-4c17-b3f5-ff075cce0ba5"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
-            <iidm:load id="_04566cf5-c766-11e1-8775-005056c00008" name="Glen Lyn LD" loadType="UNDEFINED" p0="37" q0="18" node="26" p="37.000026772801547" q="18.000021707682162">
+            <iidm:load id="_04566cf5-c766-11e1-8775-005056c00008" name="Glen Lyn LD" loadType="UNDEFINED" p0="37" q0="18" node="26" p="37.000003914177377" q="18.000003173657444">
                 <iidm:alias>_04577e64-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3117,9 +3117,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.65833703178512" angle="-2.1149669950380527" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.56442675721431" angle="-5.6862678401368871" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044ea4c0-c766-11e1-8775-005056c00008" name="Kankakee LD" loadType="UNDEFINED" p0="52" q0="22" node="8" p="52.003045166288416" q="22.002147274553622">
+            <iidm:load id="_044ea4c0-c766-11e1-8775-005056c00008" name="Kankakee LD" loadType="UNDEFINED" p0="52" q0="22" node="8" p="51.988758256850211" q="21.992073701073728">
                 <iidm:alias>_047e6758-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3228,12 +3228,12 @@
                 <iidm:internalConnection node1="51" node2="9"/>
                 <iidm:internalConnection node1="52" node2="12"/>
                 <iidm:internalConnection node1="53" node2="15"/>
-                <iidm:bus v="127.42262394859442" angle="-1.8014750209015951" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
+                <iidm:bus v="127.42282071659578" angle="-5.1382577596017747" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0484cffb-c766-11e1-8775-005056c00008" name="Roanoke LD" loadType="UNDEFINED" p0="31" q0="26" node="17" p="31.000001602332155" q="26.000002239819175">
+            <iidm:load id="_0484cffb-c766-11e1-8775-005056c00008" name="Roanoke LD" loadType="UNDEFINED" p0="31" q0="26" node="17" p="31.00000700836857" q="26.000009796644974">
                 <iidm:alias>_0454983a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0489d903-c766-11e1-8775-005056c00008" name="Roanoke SC" sectionCount="5" voltageRegulatorOn="true" targetV="127.423" targetDeadband="1" node="18" q="-18.639530807848754">
+            <iidm:shunt id="_0489d903-c766-11e1-8775-005056c00008" name="Roanoke SC" sectionCount="5" voltageRegulatorOn="true" targetV="127.423" targetDeadband="1" node="18" q="-18.639588374801022">
                 <iidm:alias>_0476c638-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_5be38d1a-9d01-42d8-b8bb-e9a26cfbcf1a"/>
                 <iidm:shuntLinearModel bPerSection="0.0002296" gPerSection="0" maximumSectionCount="10"/>
@@ -3325,12 +3325,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="120.61298212356724" angle="-22.004925084917712" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="120.59660672284326" angle="-25.766736346653822" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047a219a-c766-11e1-8775-005056c00008" name="Howard LD" loadType="UNDEFINED" p0="37" q0="23" node="14" p="36.997706614682699" q="22.997624019258563">
+            <iidm:load id="_047a219a-c766-11e1-8775-005056c00008" name="Howard LD" loadType="UNDEFINED" p0="37" q0="23" node="14" p="36.995621941644252" q="22.995464352679839">
                 <iidm:alias>_04882b51-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_04488a49-c766-11e1-8775-005056c00008" name="Howard NegG LD" loadType="UNDEFINED" p0="59" q0="0" node="15" p="58.996342980169715" q="0">
+            <iidm:load id="_04488a49-c766-11e1-8775-005056c00008" name="Howard NegG LD" loadType="UNDEFINED" p0="59" q0="0" node="15" p="58.993018771811101" q="0">
                 <iidm:alias>_046d9e74-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3380,7 +3380,7 @@
                 <iidm:internalConnection node1="19" node2="6"/>
                 <iidm:internalConnection node1="20" node2="3"/>
                 <iidm:internalConnection node1="21" node2="6"/>
-                <iidm:bus v="218.7745998265824" angle="0.7756748972747558" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
+                <iidm:bus v="218.77300884607479" angle="-2.7222033927816045" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_046efe09-c766-11e1-8775-005056c00008" name="CRI132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -3543,20 +3543,20 @@
                 <iidm:internalConnection node1="81" node2="18"/>
                 <iidm:internalConnection node1="82" node2="21"/>
                 <iidm:internalConnection node1="83" node2="24"/>
-                <iidm:bus v="137.28005266633096" angle="3.618052304529392" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
+                <iidm:bus v="137.28000781361254" angle="0.17446345498603327" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_045868c1-c766-11e1-8775-005056c00008" name="CabinCrk SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="477" targetV="137.28" targetQ="0" node="27" p="-526.41525946892625" q="-139.97770042459163">
+            <iidm:generator id="_045868c1-c766-11e1-8775-005056c00008" name="CabinCrk SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="477" targetV="137.28" targetQ="0" node="27" p="-528.21013619761118" q="-140.9777525463835">
                 <iidm:alias>_0487dd36-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_a6ec9760-88da-48df-a23f-7877e7c85ccd"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_e6131af8-c298-413b-84e3-4e21c3b6b06f"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-225" maxQ="640"/>
             </iidm:generator>
-            <iidm:load id="_04747c44-c766-11e1-8775-005056c00008" name="CabinCrk LD" loadType="UNDEFINED" p0="130" q0="26" node="26" p="130.0000748101364" q="26.000024936716908">
+            <iidm:load id="_04747c44-c766-11e1-8775-005056c00008" name="CabinCrk LD" loadType="UNDEFINED" p0="130" q0="26" node="26" p="130.00001109888157" q="26.000003699627293">
                 <iidm:alias>_046a9138-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_0488c79b-c766-11e1-8775-005056c00008" name="81-80" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="21" voltageLevelId1="_048a272b-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-148.24339345515386" q1="71.403997675019724" p2="148.24339345515386" q2="-62.547966940119274">
+        <iidm:twoWindingsTransformer id="_0488c79b-c766-11e1-8775-005056c00008" name="81-80" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="21" voltageLevelId1="_048a272b-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-151.0713058272718" q1="71.524025661255081" p2="151.07130582727177" q2="-62.385383983114529">
             <iidm:alias>_044974a0-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_045a3d83-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_046adf57-c766-11e1-8775-005056c00008</iidm:alias>
@@ -3636,12 +3636,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="134.74792733744391" angle="-12.980705710713785" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="134.74737154589593" angle="-16.572192909267468" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04524e4a-c766-11e1-8775-005056c00008" name="Zanesvll LD" loadType="UNDEFINED" p0="20" q0="11" node="8" p="20.000036695403281" q="11.000033637473578">
+            <iidm:load id="_04524e4a-c766-11e1-8775-005056c00008" name="Zanesvll LD" loadType="UNDEFINED" p0="20" q0="11" node="8" p="19.99999871204836" q="10.999998819377691">
                 <iidm:alias>_045c1240-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_048b5fa9-c766-11e1-8775-005056c00008" name="Zanesvll SC" sectionCount="5" voltageRegulatorOn="true" targetV="134.72300000000001" targetDeadband="1" node="9" q="-15.633180376615611">
+            <iidm:shunt id="_048b5fa9-c766-11e1-8775-005056c00008" name="Zanesvll SC" sectionCount="5" voltageRegulatorOn="true" targetV="134.72300000000001" targetDeadband="1" node="9" q="-15.633051413272367">
                 <iidm:alias>_04736ad5-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_99c6c4ad-5247-4058-96d4-ee8495103e85"/>
                 <iidm:shuntLinearModel bPerSection="0.00017220000000000001" gPerSection="0" maximumSectionCount="10"/>
@@ -3694,9 +3694,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.77395053237214" angle="8.5151765190353768" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.75851142922207" angle="5.1817353072748285" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044ca8f2-c766-11e1-8775-005056c00008" name="Tazewell LD" loadType="UNDEFINED" p0="12" q0="7" node="8" p="12.000424094833242" q="7.0004123192784249">
+            <iidm:load id="_044ca8f2-c766-11e1-8775-005056c00008" name="Tazewell LD" loadType="UNDEFINED" p0="12" q0="7" node="8" p="11.999853330454274" q="6.9998574051892799">
                 <iidm:alias>_04542305-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3747,9 +3747,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="119.8276787853918" angle="-20.084281808582503" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="119.82596407415662" angle="-23.999282550252758" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04778989-c766-11e1-8775-005056c00008" name="NwLibrty LD" loadType="UNDEFINED" p0="27" q0="11" node="8" p="26.997560218048118" q="10.998343407833731">
+            <iidm:load id="_04778989-c766-11e1-8775-005056c00008" name="NwLibrty LD" loadType="UNDEFINED" p0="27" q0="11" node="8" p="26.997278793683304" q="10.998152329391354">
                 <iidm:alias>_0483e592-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3782,12 +3782,12 @@
                 <iidm:internalConnection node1="11" node2="2"/>
                 <iidm:internalConnection node1="12" node2="3"/>
                 <iidm:internalConnection node1="13" node2="3"/>
-                <iidm:bus v="122.60498159135881" angle="-6.4725949582195685" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13"/>
+                <iidm:bus v="122.60531049155998" angle="-9.8012034312222145" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0463da70-c766-11e1-8775-005056c00008" name="Danville LD" loadType="UNDEFINED" p0="25" q0="13" node="5" p="24.999991589170907" q="12.999992710615608">
+            <iidm:load id="_0463da70-c766-11e1-8775-005056c00008" name="Danville LD" loadType="UNDEFINED" p0="25" q0="13" node="5" p="25.000007076272716" q="13.00000613277027">
                 <iidm:alias>_0488eeab-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_0448b150-c766-11e1-8775-005056c00008" name="Danville NegG LD" loadType="UNDEFINED" p0="43" q0="0" node="6" p="42.999985533373966" q="0">
+            <iidm:load id="_0448b150-c766-11e1-8775-005056c00008" name="Danville NegG LD" loadType="UNDEFINED" p0="43" q0="0" node="6" p="43.00001217118907" q="0">
                 <iidm:alias>_0457cc88-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3838,9 +3838,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.46624585322255" angle="14.282214510987078" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.45566590063848" angle="10.981542662630828" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045cae82-c766-11e1-8775-005056c00008" name="Fremont LD" loadType="UNDEFINED" p0="48" q0="10" node="8" p="48.00059278192753" q="10.000205827905464">
+            <iidm:load id="_045cae82-c766-11e1-8775-005056c00008" name="Fremont LD" loadType="UNDEFINED" p0="48" q0="10" node="8" p="47.999001245262271" q="9.9996532125657804">
                 <iidm:alias>_045f4693-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3986,9 +3986,9 @@
                 <iidm:internalConnection node1="70" node2="15"/>
                 <iidm:internalConnection node1="71" node2="18"/>
                 <iidm:internalConnection node1="72" node2="21"/>
-                <iidm:bus v="132.34939545548423" angle="1.3249585304774061" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
+                <iidm:bus v="132.3330896337246" angle="-2.1340764121568472" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0448d863-c766-11e1-8775-005056c00008" name="Turner LD" loadType="UNDEFINED" p0="61" q0="28" node="23" p="61.002833584906092" q="28.002167803439242">
+            <iidm:load id="_0448d863-c766-11e1-8775-005056c00008" name="Turner LD" loadType="UNDEFINED" p0="61" q0="28" node="23" p="60.999777804226966" q="27.999830014369103">
                 <iidm:alias>_046e3ab3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4042,9 +4042,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.22099623193147" angle="-3.2435943229995261" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="127.19376300308384" angle="-7.6336180057064373" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047d7cf6-c766-11e1-8775-005056c00008" name="Grant LD" loadType="UNDEFINED" p0="24" q0="4" node="8" p="24.001058991736908" q="4.0002941686979767">
+            <iidm:load id="_047d7cf6-c766-11e1-8775-005056c00008" name="Grant LD" loadType="UNDEFINED" p0="24" q0="4" node="8" p="23.999058760713375" q="3.9997385480605643">
                 <iidm:alias>_0481e9c0-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4114,9 +4114,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="221.60904710000011" angle="5.8276057247881123" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="221.03364852956227" angle="2.6804061829378925" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04867dab-c766-11e1-8775-005056c00008" name="Olive NegG LD" loadType="UNDEFINED" p0="28" q0="0" node="11" p="28.005275362278027" q="0">
+            <iidm:load id="_04867dab-c766-11e1-8775-005056c00008" name="Olive NegG LD" loadType="UNDEFINED" p0="28" q0="0" node="11" p="27.977710278689472" q="0">
                 <iidm:alias>_048433b8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4222,15 +4222,15 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="133.36335965585442" angle="0.57565070857297151" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="133.19548006632519" angle="-2.8403656358454321" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:shunt id="_0447c6f6-c766-11e1-8775-005056c00008" name="Olive SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.67599999999999" targetDeadband="1" node="17" q="-40.83616396420782">
+            <iidm:shunt id="_0447c6f6-c766-11e1-8775-005056c00008" name="Olive SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.67599999999999" targetDeadband="1" node="17" q="-40.733418449586914">
                 <iidm:alias>_045e8340-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_c701959a-91c1-4a35-9a37-71fb790426ca"/>
                 <iidm:shuntLinearModel bPerSection="0.00045919999999999999" gPerSection="0" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_04575750-c766-11e1-8775-005056c00008" name="8-5" r="0" x="4.6522079999999999" g="0" b="0" ratedU1="220" ratedU2="132" node1="32" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="354.21742670053584" q1="63.453241140798475" p2="-354.21742670053578" q2="-30.392584336121782">
+        <iidm:twoWindingsTransformer id="_04575750-c766-11e1-8775-005056c00008" name="8-5" r="0" x="4.6522079999999999" g="0" b="0" ratedU1="220" ratedU2="132" node1="32" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="370.85889558219191" q1="59.68069886322327" p2="-370.85889558219191" q2="-23.470284653760455">
             <iidm:alias>_045eaa55-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_046b2d74-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04745533-c766-11e1-8775-005056c00008</iidm:alias>
@@ -4301,9 +4301,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.78017694943702" angle="7.439662247888104" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.77349016277222" angle="4.1107728601574669" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047b0bf0-c766-11e1-8775-005056c00008" name="Wythe LD" loadType="UNDEFINED" p0="22" q0="15" node="8" p="22.000345627599248" q="15.000392760692296">
+            <iidm:load id="_047b0bf0-c766-11e1-8775-005056c00008" name="Wythe LD" loadType="UNDEFINED" p0="22" q0="15" node="8" p="21.999890501381977" q="14.999875569958684">
                 <iidm:alias>_0479d376-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4354,9 +4354,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="123.90262772712643" angle="-16.561424020848236" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="123.88511358728211" angle="-20.549825118245355" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0458ddf5-c766-11e1-8775-005056c00008" name="WestLima LD" loadType="UNDEFINED" p0="33" q0="9" node="8" p="33.000066925733286" q="9.0000304208084199">
+            <iidm:load id="_0458ddf5-c766-11e1-8775-005056c00008" name="WestLima LD" loadType="UNDEFINED" p0="33" q0="9" node="8" p="32.998095065016329" q="8.9991341371231286">
                 <iidm:alias>_04492686-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4464,9 +4464,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="128.13066784473045" angle="10.379863870456695" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="128.11436322328126" angle="7.0508688856322062" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044b2257-c766-11e1-8775-005056c00008" name="BeaverCk LD" loadType="UNDEFINED" p0="24" q0="15" node="17" p="24.000224735269228" q="15.000234099969475">
+            <iidm:load id="_044b2257-c766-11e1-8775-005056c00008" name="BeaverCk LD" loadType="UNDEFINED" p0="24" q0="15" node="17" p="23.998984307179668" q="14.998942001570789">
                 <iidm:alias>_045868c4-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4557,7 +4557,7 @@
                 <iidm:internalConnection node1="39" node2="9"/>
                 <iidm:internalConnection node1="40" node2="12"/>
                 <iidm:internalConnection node1="41" node2="3"/>
-                <iidm:bus v="215.846798692297" angle="2.9343943009065652" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="214.61511303116581" angle="0.22271762803047135" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_047bcf46-c766-11e1-8775-005056c00008" name="STN132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -4638,7 +4638,7 @@
                     <iidm:alias>_e9315b98-af75-40bb-bf8e-05bd03d43db5</iidm:alias>
                 </iidm:switch>
                 <iidm:switch id="_b8b0b9a9-af8b-41d2-a4f8-940637e63f70-1" name="DISCONNECTOR701-1" kind="DISCONNECTOR" retained="false" open="false" node1="64" node2="65"/>
-                <iidm:switch id="_0b78ffaa-9859-4658-af17-c8d355633556-1" name="BREAKER351-1" kind="BREAKER" retained="true" open="false" node1="63" node2="64"/>
+                <iidm:switch id="_0b78ffaa-9859-4658-af17-c8d355633556-1" name="BREAKER351-1" kind="BREAKER" retained="true" open="true" node1="63" node2="64"/>
                 <iidm:switch id="_9dfeeaef-5c49-4c2c-97b1-03876970bee4-1" name="DISCONNECTOR702-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="63"/>
                 <iidm:internalConnection node1="19" node2="0"/>
                 <iidm:internalConnection node1="20" node2="0"/>
@@ -4684,9 +4684,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="129.51005828811179" angle="-1.6000391124252757" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65"/>
+                <iidm:bus v="129.39004345300216" angle="-6.4618090898439089" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045dbff4-c766-11e1-8775-005056c00008" name="Sorenson LD" loadType="UNDEFINED" p0="11" q0="3" node="20" p="11.005645150132171" q="3.0025664162570909">
+            <iidm:load id="_045dbff4-c766-11e1-8775-005056c00008" name="Sorenson LD" loadType="UNDEFINED" p0="11" q0="3" node="20" p="11.00161882831868" q="3.0007358671498445">
                 <iidm:alias>_044d4536-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4708,7 +4708,7 @@
                     <iidm:alias>_90c04b95-703a-4bae-82b8-7edf3075aa24</iidm:alias>
                 </iidm:switch>
                 <iidm:switch id="_4d08a684-cdcb-484a-a767-03b10f4ada7f-1" name="DISCONNECTOR735-1" kind="DISCONNECTOR" retained="false" open="false" node1="14" node2="15"/>
-                <iidm:switch id="_f468d841-1bf6-470e-85d4-55d34fab8bff-1" name="BREAKER368-1" kind="BREAKER" retained="true" open="false" node1="13" node2="14"/>
+                <iidm:switch id="_f468d841-1bf6-470e-85d4-55d34fab8bff-1" name="BREAKER368-1" kind="BREAKER" retained="true" open="true" node1="13" node2="14"/>
                 <iidm:switch id="_f193bd8f-badf-4600-82ac-f212d1f33534-1" name="DISCONNECTOR736-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="13"/>
                 <iidm:internalConnection node1="4" node2="0"/>
                 <iidm:internalConnection node1="5" node2="1"/>
@@ -4719,13 +4719,13 @@
                 <iidm:internalConnection node1="10" node2="3"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="0"/>
-                <iidm:bus v="389.72480943846506" angle="0" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15"/>
+                <iidm:bus v="384.3748597503706" angle="0" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13"/>
             </iidm:nodeBreakerTopology>
             <iidm:lccConverterStation id="_7393a68e-c4e6-48dd-9347-543858363fdb" name="Conv1" lossFactor="0" powerFactor="0.80000000000000004" node="12" p="10" q="6">
                 <iidm:alias>_739658a7-e08b-4395-8d79-93e87b7855e3</iidm:alias>
             </iidm:lccConverterStation>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_047120e9-c766-11e1-8775-005056c00008" name="30-17" r="0" x="6.7605125399999997" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_047b8123-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="204.3132188104068" q1="115.7286959721221" p2="-204.31321881040674" q2="-95.246729280507509">
+        <iidm:twoWindingsTransformer id="_047120e9-c766-11e1-8775-005056c00008" name="30-17" r="0" x="6.7605125399999997" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_047b8123-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="298.82982245785689" q1="111.58470985362479" p2="-298.82982245785701" q2="-73.351995145159904">
             <iidm:alias>_044f6811-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0463b36a-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_047d2ed8-c766-11e1-8775-005056c00008</iidm:alias>
@@ -4744,7 +4744,7 @@
                 <iidm:temporaryLimit name="_f62f2fc6-4b6c-4571-a8c5-40d6a89ac703" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_b08e9e50-4e0c-4ac0-9f21-4a27429caeb2" name="PowTrans1" r="0.4840000000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_3bbfa58a-a1ad-4b23-a526-3d76b096c1f4" node2="41" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="-131.57604436580453" q1="21.425420451515041" p2="131.75860090030025" q2="-14.579550407926668">
+        <iidm:twoWindingsTransformer id="_b08e9e50-4e0c-4ac0-9f21-4a27429caeb2" name="PowTrans1" r="0.4840000000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_3bbfa58a-a1ad-4b23-a526-3d76b096c1f4" node2="41" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="-9.9999999999482654" q1="-5.9999999999690061" p2="10.001436227158012" q2="6.053858520334984">
             <iidm:alias>_046ba2aa-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_a5bf9702-545a-437d-9663-773550202828</iidm:alias>
             <iidm:alias>_ee9505e1-96d7-49b3-9d1a-924397ffb27e</iidm:alias>
@@ -4764,7 +4764,7 @@
                 <iidm:temporaryLimit name="_611bb05e-9b9a-469c-b1d1-80a944c3ce2f" acceptableDuration="60" value="1400"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:threeWindingsTransformer id="_86d83c7d-7826-4c16-b161-4ce17174e77f-1" name="T422" r1="-1.5199999809265099" x1="23.199999999999999" g1="0" b1="0" ratedU1="400" r2="2.0000000630528461" x2="19.999999999999996" g2="0" b2="0" ratedU2="220" r3="1.2000000564689806" x3="12" g3="0" b3="0" ratedU3="132" ratedU0="400" node1="15" voltageLevelId1="_3bbfa58a-a1ad-4b23-a526-3d76b096c1f4" node2="44" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" node3="65" voltageLevelId3="_047bcf46-c766-11e1-8775-005056c00008" p1="121.57604446886674" q1="-27.425420389679061" p2="0" q2="0" p3="-121.60876994601699" q3="31.025223725996483">
+        <iidm:threeWindingsTransformer id="_86d83c7d-7826-4c16-b161-4ce17174e77f-1" name="T422" r1="-1.5199999809265099" x1="23.199999999999999" g1="0" b1="0" ratedU1="400" r2="2.0000000630528461" x2="19.999999999999996" g2="0" b2="0" ratedU2="220" r3="1.2000000564689806" x3="12" g3="0" b3="0" ratedU3="132" ratedU0="400" node1="15" voltageLevelId1="_3bbfa58a-a1ad-4b23-a526-3d76b096c1f4" node2="44" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" node3="65" voltageLevelId3="_047bcf46-c766-11e1-8775-005056c00008" p1="0" q1="0" p2="0" q2="0" p3="0" q3="0">
             <iidm:alias>_1b2d419c-ac88-4dae-8dfe-2eb92d18c40a-1</iidm:alias>
             <iidm:alias>_206474da-93c8-46b1-863f-9a308bfc2117-1</iidm:alias>
             <iidm:alias>_9ac069ea-557b-4b8c-b12e-f9f2aecc3bf5-1</iidm:alias>
@@ -5028,16 +5028,16 @@
                 <iidm:internalConnection node1="121" node2="30"/>
                 <iidm:internalConnection node1="122" node2="33"/>
                 <iidm:internalConnection node1="123" node2="36"/>
-                <iidm:bus v="135.3000418094442" angle="-12.167339923097924" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123"/>
+                <iidm:bus v="135.30000559788303" angle="-15.75419916819337" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04859346-c766-11e1-8775-005056c00008" name="Philo SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="204" targetV="135.30000000000001" targetQ="0" node="39" p="-225.13357008733954" q="-174.75074628083078">
+            <iidm:generator id="_04859346-c766-11e1-8775-005056c00008" name="Philo SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="204" targetV="135.30000000000001" targetQ="0" node="39" p="-225.90119032350663" q="-175.20100089229095">
                 <iidm:alias>_048719e2-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e3753d6d-b894-4cce-b6fa-307c50dc107f"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_dff93c01-9c84-4c1f-8529-66c054ed9e37"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
-            <iidm:load id="_045163e2-c766-11e1-8775-005056c00008" name="Philo LD" loadType="UNDEFINED" p0="87" q0="30" node="38" p="87.000040326185399" q="30.000023175972203">
+            <iidm:load id="_045163e2-c766-11e1-8775-005056c00008" name="Philo LD" loadType="UNDEFINED" p0="87" q0="30" node="38" p="87.000005399288554" q="30.000003103039468">
                 <iidm:alias>_04513cd3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5088,9 +5088,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.53403308608084" angle="8.3828392799385494" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.51198757511339" angle="5.0376179752927319" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04524e46-c766-11e1-8775-005056c00008" name="BetsyLne LD" loadType="UNDEFINED" p0="11" q0="7" node="8" p="11.000300666642723" q="7.0003188917689183">
+            <iidm:load id="_04524e46-c766-11e1-8775-005056c00008" name="BetsyLne LD" loadType="UNDEFINED" p0="11" q0="7" node="8" p="10.999533043028373" q="6.9995047496138811">
                 <iidm:alias>_04549830-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5143,15 +5143,15 @@
                 <iidm:internalConnection node1="22" node2="6"/>
                 <iidm:internalConnection node1="23" node2="3"/>
                 <iidm:internalConnection node1="24" node2="6"/>
-                <iidm:bus v="124.75883271835093" angle="-4.7755817334349624" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24"/>
+                <iidm:bus v="124.75916584536186" angle="-8.1129289413187937" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04566cf3-c766-11e1-8775-005056c00008" name="Reusens NegG LD" loadType="UNDEFINED" p0="22" q0="0" node="8" p="21.999991320443076" q="0">
+            <iidm:load id="_04566cf3-c766-11e1-8775-005056c00008" name="Reusens NegG LD" loadType="UNDEFINED" p0="22" q0="0" node="8" p="22.000005263038787" q="0">
                 <iidm:alias>_0483be81-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_0482fb36-c766-11e1-8775-005056c00008" name="Reusens LD" loadType="UNDEFINED" p0="28" q0="12" node="9" p="27.999988953291194" q="11.999992109494745">
+            <iidm:load id="_0482fb36-c766-11e1-8775-005056c00008" name="Reusens LD" loadType="UNDEFINED" p0="28" q0="12" node="9" p="28.000006698413003" q="12.000004784581096">
                 <iidm:alias>_0486cbc1-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_04558293-c766-11e1-8775-005056c00008" name="Reusens SC" sectionCount="5" voltageRegulatorOn="true" targetV="124.76300000000001" targetDeadband="1" node="10" q="-5.3542796213884438">
+            <iidm:shunt id="_04558293-c766-11e1-8775-005056c00008" name="Reusens SC" sectionCount="5" voltageRegulatorOn="true" targetV="124.76300000000001" targetDeadband="1" node="10" q="-5.3543082150760934">
                 <iidm:alias>_04893ccc-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_99303cd3-6b53-4ee2-a5ce-fe8d5feeb304"/>
                 <iidm:shuntLinearModel bPerSection="6.8800000000000005e-05" gPerSection="0" maximumSectionCount="10"/>
@@ -5224,12 +5224,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="126.42567550768095" angle="12.518433314444202" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="126.42235176208214" angle="9.2302916711487519" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045c8777-c766-11e1-8775-005056c00008" name="Holston NegG LD" loadType="UNDEFINED" p0="85" q0="0" node="11" p="85.000688467057486" q="0">
+            <iidm:load id="_045c8777-c766-11e1-8775-005056c00008" name="Holston NegG LD" loadType="UNDEFINED" p0="85" q0="0" node="11" p="84.999747011643308" q="0">
                 <iidm:alias>_0487dd31-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_0451d918-c766-11e1-8775-005056c00008" name="Holston LD" loadType="UNDEFINED" p0="78" q0="42" node="12" p="78.000631769770408" q="42.000566974401629">
+            <iidm:load id="_0451d918-c766-11e1-8775-005056c00008" name="Holston LD" loadType="UNDEFINED" p0="78" q0="42" node="12" p="77.999767845978567" q="41.999791656854143">
                 <iidm:alias>_0485ba54-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5337,9 +5337,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="127.78850064428582" angle="-2.7354164054360042" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="127.72515037905841" angle="-6.2747635443883452" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04742e27-c766-11e1-8775-005056c00008" name="SthPoint LD" loadType="UNDEFINED" p0="47" q0="11" node="17" p="47.008823724393181" q="11.003442093696291">
+            <iidm:load id="_04742e27-c766-11e1-8775-005056c00008" name="SthPoint LD" loadType="UNDEFINED" p0="47" q0="11" node="17" p="46.999500821251594" q="10.99980528557472">
                 <iidm:alias>_047b3303-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5391,12 +5391,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="132.92085244873445" angle="1.3358914770338133" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="132.9098788680482" angle="-2.1177560301203093" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04716f06-c766-11e1-8775-005056c00008" name="CapitlHl LD" loadType="UNDEFINED" p0="39" q0="32" node="8" p="39.001224733558274" q="32.0016748668424">
+            <iidm:load id="_04716f06-c766-11e1-8775-005056c00008" name="CapitlHl LD" loadType="UNDEFINED" p0="39" q0="32" node="8" p="38.999902868563019" q="31.999867170794744">
                 <iidm:alias>_04700f70-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0466c0a0-c766-11e1-8775-005056c00008" name="CapitlHl SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.00200000000001" targetDeadband="1" node="9" q="-20.282810062021579">
+            <iidm:shunt id="_0466c0a0-c766-11e1-8775-005056c00008" name="CapitlHl SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.00200000000001" targetDeadband="1" node="9" q="-20.279461214025694">
                 <iidm:alias>_045e8346-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_99931a87-ee15-4fd0-b251-9556df7fe598"/>
                 <iidm:shuntLinearModel bPerSection="0.0002296" gPerSection="0" maximumSectionCount="10"/>
@@ -5449,9 +5449,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="132.05821466379913" angle="1.0236051971696025" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="132.04391068995039" angle="-2.4336779035863527" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046efe03-c766-11e1-8775-005056c00008" name="Chemical LD" loadType="UNDEFINED" p0="71" q0="26" node="8" p="71.002896250730515" q="26.001767688800676">
+            <iidm:load id="_046efe03-c766-11e1-8775-005056c00008" name="Chemical LD" loadType="UNDEFINED" p0="71" q0="26" node="8" p="70.999755572034303" q="25.999850818783681">
                 <iidm:alias>_045d71d5-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5502,9 +5502,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.5786422673259" angle="-2.5965811357712076" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.52136053391777" angle="-6.2274749542394785" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046a4319-c766-11e1-8775-005056c00008" name="JacksnRd LD" loadType="UNDEFINED" p0="19" q0="2" node="8" p="19.000689813326908" q="2.0001210213464891">
+            <iidm:load id="_046a4319-c766-11e1-8775-005056c00008" name="JacksnRd LD" loadType="UNDEFINED" p0="19" q0="2" node="8" p="18.997501976396553" q="1.9995617694515748">
                 <iidm:alias>_046c8d06-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5650,9 +5650,9 @@
                 <iidm:internalConnection node1="70" node2="15"/>
                 <iidm:internalConnection node1="71" node2="18"/>
                 <iidm:internalConnection node1="72" node2="21"/>
-                <iidm:bus v="130.60925273521102" angle="12.199494421129051" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
+                <iidm:bus v="130.59915416034096" angle="8.8907996034405627" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0458ddf4-c766-11e1-8775-005056c00008" name="Saltvlle LD" loadType="UNDEFINED" p0="65" q0="10" node="23" p="65.001531863694424" q="10.000392788648272">
+            <iidm:load id="_0458ddf4-c766-11e1-8775-005056c00008" name="Saltvlle LD" loadType="UNDEFINED" p0="65" q0="10" node="23" p="64.999518273069654" q="9.9998764805794114">
                 <iidm:alias>_045645e4-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5722,9 +5722,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="132.00363202787977" angle="2.2797082359095242" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="131.62033305004712" angle="-1.6322327266695196" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0476ed42-c766-11e1-8775-005056c00008" name="Trenton NegG LD" loadType="UNDEFINED" p0="13" q0="0" node="11" p="13.009564869561229" q="0">
+            <iidm:load id="_0476ed42-c766-11e1-8775-005056c00008" name="Trenton NegG LD" loadType="UNDEFINED" p0="13" q0="0" node="11" p="12.995237624032757" q="0">
                 <iidm:alias>_0471e432-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5794,9 +5794,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="128.42780206515133" angle="-3.6219953920205135" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="128.34936128426625" angle="-7.2071710070084665" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044a5f08-c766-11e1-8775-005056c00008" name="HickryCk LD" loadType="UNDEFINED" p0="39" q0="10" node="11" p="39.00208764791207" q="10.000892173146175">
+            <iidm:load id="_044a5f08-c766-11e1-8775-005056c00008" name="HickryCk LD" loadType="UNDEFINED" p0="39" q0="10" node="11" p="38.992904427453261" q="9.9969678879399488">
                 <iidm:alias>_047d7cf3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5925,9 +5925,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="125.34039727161067" angle="-15.722224390227712" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="125.32372247141181" angle="-19.700286627971554" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:shunt id="_0450eeb7-c766-11e1-8775-005056c00008" name="EastLima SC" sectionCount="5" voltageRegulatorOn="true" targetV="131.565" targetDeadband="1" node="20" q="-22.544158795074445">
+            <iidm:shunt id="_0450eeb7-c766-11e1-8775-005056c00008" name="EastLima SC" sectionCount="5" voltageRegulatorOn="true" targetV="131.565" targetDeadband="1" node="20" q="-22.538160819221229">
                 <iidm:alias>_044aad27-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_6c36f421-303e-4932-93a9-5b0ff86cb7d4"/>
                 <iidm:shuntLinearModel bPerSection="0.00028699999999999998" gPerSection="0" maximumSectionCount="10"/>
@@ -6015,16 +6015,16 @@
                 <iidm:internalConnection node1="41" node2="7"/>
                 <iidm:internalConnection node1="42" node2="12"/>
                 <iidm:internalConnection node1="43" node2="11"/>
-                <iidm:bus v="218.90473505433636" angle="-5.2015393175667182" nodes="0,1,2,3,8,9,10,13,17,18,21,22,23,24,25,26,31,32,33,34,35,39,40"/>
-                <iidm:bus v="237.9377651463725" angle="-16.961599306812289" nodes="11,15,37,43"/>
-                <iidm:bus v="226.19474576907345" angle="-5.2015392762801618" nodes="12,16,38,42"/>
-                <iidm:bus v="214.7003229083077" angle="-16.961599306812285" nodes="4,5,6,7,14,19,20,27,28,29,30,36,41"/>
+                <iidm:bus v="218.90696148375409" angle="-8.7555174570296188" nodes="0,1,2,3,8,9,10,13,17,18,21,22,23,24,25,26,31,32,33,34,35,39,40"/>
+                <iidm:bus v="237.93769436383769" angle="-20.50203312726029" nodes="11,15,37,43"/>
+                <iidm:bus v="226.19468245119592" angle="-8.7555174529621045" nodes="12,16,38,42"/>
+                <iidm:bus v="214.70025903852618" angle="-20.50203312726029" nodes="4,5,6,7,14,19,20,27,28,29,30,36,41"/>
             </iidm:nodeBreakerTopology>
-            <iidm:vscConverterStation id="_b46bfb8e-7af6-459e-acf3-53a42c943a7c" name="VSC2" voltageRegulatorOn="true" lossFactor="0.32362458" voltageSetpoint="218.47" reactivePowerSetpoint="0" node="42" p="-0" q="-27.482684079051793">
+            <iidm:vscConverterStation id="_b46bfb8e-7af6-459e-acf3-53a42c943a7c" name="VSC2" voltageRegulatorOn="true" lossFactor="0.32362458" voltageSetpoint="218.47" reactivePowerSetpoint="0" node="42" p="-0" q="-27.474059628214238">
                 <iidm:alias>_a168e701-bd48-4f66-8f0b-0f69b2545530</iidm:alias>
                 <iidm:minMaxReactiveLimits minQ="-1.7976931348623157e+308" maxQ="1.7976931348623157e+308"/>
             </iidm:vscConverterStation>
-            <iidm:vscConverterStation id="_b48ce7cf-abf5-413f-bc51-9e1d3103c9bd" name="VSC1" voltageRegulatorOn="true" lossFactor="0.32467531999999999" voltageSetpoint="213.53999999999999" reactivePowerSetpoint="0" node="43" p="-0" q="-92.151020935015353">
+            <iidm:vscConverterStation id="_b48ce7cf-abf5-413f-bc51-9e1d3103c9bd" name="VSC1" voltageRegulatorOn="true" lossFactor="0.32467531999999999" voltageSetpoint="213.53999999999999" reactivePowerSetpoint="0" node="43" p="-0" q="-92.151020935008347">
                 <iidm:alias>_071bb138-ff00-4874-8acc-a884aa5cf4a9</iidm:alias>
                 <iidm:minMaxReactiveLimits minQ="-1.7976931348623157e+308" maxQ="1.7976931348623157e+308"/>
             </iidm:vscConverterStation>
@@ -6092,7 +6092,7 @@
                 <iidm:internalConnection node1="29" node2="6"/>
                 <iidm:internalConnection node1="30" node2="9"/>
                 <iidm:internalConnection node1="31" node2="3"/>
-                <iidm:bus v="201.92328378368711" angle="-11.863111626447182" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
+                <iidm:bus v="201.8080310855444" angle="-15.729061436959242" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_0448d867-c766-11e1-8775-005056c00008" name="EDO132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -6178,9 +6178,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="131.34004395247288" angle="-7.6143615097689539" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="131.34000617861446" angle="-11.161304647298328" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0472a789-c766-11e1-8775-005056c00008" name="W.Kammer SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="160" targetV="131.34" targetQ="0" node="14" p="-176.57534908810945" q="93.992680593075789">
+            <iidm:generator id="_0472a789-c766-11e1-8775-005056c00008" name="W.Kammer SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="160" targetV="131.34" targetQ="0" node="14" p="-177.17740417529933" q="94.097617622899008">
                 <iidm:alias>_04697fc0-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_17852426-f663-4add-9a2b-0a635d51f101"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b512ea0a-96d0-4a48-9de1-a5cf499bf0dd"/>
@@ -6329,16 +6329,16 @@
                 <iidm:internalConnection node1="71" node2="15"/>
                 <iidm:internalConnection node1="72" node2="18"/>
                 <iidm:internalConnection node1="73" node2="21"/>
-                <iidm:bus v="130.02004488852387" angle="-16.961599306812285" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
+                <iidm:bus v="130.02000620971913" angle="-20.502033127260294" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04839777-c766-11e1-8775-005056c00008" name="Tidd SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="155" targetV="130.02000000000001" targetQ="0" node="24" p="-171.05736942910602" q="-95.019216188652223">
+            <iidm:generator id="_04839777-c766-11e1-8775-005056c00008" name="Tidd SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="155" targetV="130.02000000000001" targetQ="0" node="24" p="-171.64061029482122" q="-94.862968935718399">
                 <iidm:alias>_045fe2d8-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_d2a96d8d-65be-4fd6-a012-ceeeabd2bee6"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_29df1e0b-36ca-4536-97b4-6f98b84d49d8"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-90" maxQ="255"/>
             </iidm:generator>
-            <iidm:load id="_04798556-c766-11e1-8775-005056c00008" name="Tidd LD" loadType="UNDEFINED" p0="277" q0="113" node="23" p="277.00014344857158" q="113.00009753123577">
+            <iidm:load id="_04798556-c766-11e1-8775-005056c00008" name="Tidd LD" loadType="UNDEFINED" p0="277" q0="113" node="23" p="277.00001984416497" q="113.00001349212212">
                 <iidm:alias>_04502b62-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6368,13 +6368,13 @@
                 <iidm:internalConnection node1="10" node2="3"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="0"/>
-                <iidm:bus v="361.17890731901053" angle="-11.602314054031041" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="360.97118676094289" angle="-15.467964838021924" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
             </iidm:nodeBreakerTopology>
             <iidm:lccConverterStation id="_9793118d-5ba1-4a9c-b2e0-db1d15be5913" name="Conv2" lossFactor="0" powerFactor="-0.75741000000000003" node="12" p="-10" q="8.6206896551724146">
                 <iidm:alias>_453bdc57-5855-4eb5-8712-d6a0255e0da8</iidm:alias>
             </iidm:lccConverterStation>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045c1248-c766-11e1-8775-005056c00008" name="38-37" r="0" x="6.5340005399999992" g="0" b="0" ratedU1="220" ratedU2="132" node1="30" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="167.29168599769037" q1="89.641408096700133" p2="-167.29168599769037" q2="-75.623087232900374">
+        <iidm:twoWindingsTransformer id="_045c1248-c766-11e1-8775-005056c00008" name="38-37" r="0" x="6.5340005399999992" g="0" b="0" ratedU1="220" ratedU2="132" node1="30" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="172.02291624444058" q1="88.785992811540225" p2="-172.02291624444049" q2="-74.185660520285637">
             <iidm:alias>_0453d4e8-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0477d7aa-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_047df228-c766-11e1-8775-005056c00008</iidm:alias>
@@ -6398,7 +6398,7 @@
                 <iidm:temporaryLimit name="_c97df399-5a91-4c8b-b72c-496cade334b5" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_0485ba57-c766-11e1-8775-005056c00008" name="64-61" r="0" x="4.669632" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="157.89158635775999" q1="60.519703259203169" p2="-157.89158635775996" q2="-53.010519444912063">
+        <iidm:twoWindingsTransformer id="_0485ba57-c766-11e1-8775-005056c00008" name="64-61" r="0" x="4.669632" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="157.43305292764384" q1="60.540765174365639" p2="-157.43305292764401" q2="-53.069036383469438">
             <iidm:alias>_04549831-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0472ce92-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0489d905-c766-11e1-8775-005056c00008</iidm:alias>
@@ -6424,7 +6424,7 @@
                 <iidm:temporaryLimit name="_f6b1a81c-eda7-4a08-b290-bd29a5ed9fa4" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_044cd007-c766-11e1-8775-005056c00008" name="63-59" r="0" x="6.7256646120000001" g="0" b="0" ratedU1="220" ratedU2="132" node1="41" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="73" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-1.4155343563970746e-13" q1="83.151439201261084" p2="-4.4408920985006262e-14" q2="-80.568885865152623">
+        <iidm:twoWindingsTransformer id="_044cd007-c766-11e1-8775-005056c00008" name="63-59" r="0" x="6.7256646120000001" g="0" b="0" ratedU1="220" ratedU2="132" node1="41" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="73" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="1.0547118733938987e-13" q1="83.151389728923391" p2="2.2204460492503131e-14" q2="-80.568837929348078">
             <iidm:alias>_044e7db4-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_046eafe5-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0488797a-c766-11e1-8775-005056c00008</iidm:alias>
@@ -6470,7 +6470,7 @@
                 <iidm:temporaryLimit name="_f2daef4d-6f1a-44d1-9c9b-228acff12575" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_ffd940c8-03c8-4dcf-ad46-62018a0d813d" name="PowTrans2" r="0.3932500000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_04f97116-552a-4a34-afd9-4862f62ac7aa" node2="31" voltageLevelId2="_04742e21-c766-11e1-8775-005056c00008" p1="10.000003534423998" q1="-8.6206919901176509" p2="-9.99830954360508" q2="8.6988761817665274">
+        <iidm:twoWindingsTransformer id="_ffd940c8-03c8-4dcf-ad46-62018a0d813d" name="PowTrans2" r="0.3932500000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_04f97116-552a-4a34-afd9-4862f62ac7aa" node2="31" voltageLevelId2="_04742e21-c766-11e1-8775-005056c00008" p1="10.000000509281589" q1="-8.6206899725182637" p2="-9.9983045692174759" q2="8.6989641293211246">
             <iidm:alias>_04479fea-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_c089eb25-9f67-4d82-88a8-635dd4808bae</iidm:alias>
             <iidm:alias>_ea8cd467-31f0-40dc-95d7-4064463724c4</iidm:alias>
@@ -6537,9 +6537,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="124.78661210135063" angle="-20.110735263632094" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.78818295656103" angle="-23.673115320287501" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0481c2b3-c766-11e1-8775-005056c00008" name="Wooster LD" loadType="UNDEFINED" p0="23" q0="11" node="8" p="22.999891122723419" q="10.999913213901987">
+            <iidm:load id="_0481c2b3-c766-11e1-8775-005056c00008" name="Wooster LD" loadType="UNDEFINED" p0="23" q0="11" node="8" p="22.999998358546115" q="10.999998691594758">
                 <iidm:alias>_04614268-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6609,9 +6609,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="125.569240580746" angle="-19.879044716207179" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="125.5695327680115" angle="-23.43552203385439" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044974a8-c766-11e1-8775-005056c00008" name="Wagenhls LD" loadType="UNDEFINED" p0="63" q0="22" node="11" p="62.999973180441316" q="21.999984390735257">
+            <iidm:load id="_044974a8-c766-11e1-8775-005056c00008" name="Wagenhls LD" loadType="UNDEFINED" p0="63" q0="22" node="11" p="63.000010719930287" q="22.000006239113219">
                 <iidm:alias>_048481d4-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6662,9 +6662,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.41115729229784" angle="-4.2975169699729667" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.27635896059513" angle="-8.1622982545574807" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047fedf2-c766-11e1-8775-005056c00008" name="Concord LD" loadType="UNDEFINED" p0="34" q0="16" node="8" p="34.007579313294151" q="16.005945001157791">
+            <iidm:load id="_047fedf2-c766-11e1-8775-005056c00008" name="Concord LD" loadType="UNDEFINED" p0="34" q0="16" node="8" p="33.993658792541979" q="15.99502681315669">
                 <iidm:alias>_046d9e75-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6772,9 +6772,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="127.70028465049954" angle="-1.3339863888821777" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="127.48660976092212" angle="-5.5852636962347599" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045f94ba-c766-11e1-8775-005056c00008" name="Delaware LD" loadType="UNDEFINED" p0="59" q0="23" node="17" p="59.023657936663376" q="23.015373030201474">
+            <iidm:load id="_045f94ba-c766-11e1-8775-005056c00008" name="Delaware LD" loadType="UNDEFINED" p0="59" q0="23" node="17" p="58.985579220632253" q="22.990631330457092">
                 <iidm:alias>_0463654a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6882,9 +6882,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="125.47558498741709" angle="-5.7960315876172537" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="125.27225951159171" angle="-10.388580460389514" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04697fc9-c766-11e1-8775-005056c00008" name="FtWayne LD" loadType="UNDEFINED" p0="90" q0="30" node="17" p="90.065886076477369" q="30.036612307141869">
+            <iidm:load id="_04697fc9-c766-11e1-8775-005056c00008" name="FtWayne LD" loadType="UNDEFINED" p0="90" q0="30" node="17" p="90.008913122074389" q="30.004951897948466">
                 <iidm:alias>_044d1e25-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6935,9 +6935,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.01280773058832" angle="-17.866480547623347" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.01478748023186" angle="-21.433612470346272" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0474f170-c766-11e1-8775-005056c00008" name="WNwPhil1 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="11.999933747771195" q="2.9999723949554675">
+            <iidm:load id="_0474f170-c766-11e1-8775-005056c00008" name="WNwPhil1 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="12.000002570542916" q="3.0000010710596254">
                 <iidm:alias>_0466c0a7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7008,12 +7008,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="129.53159473851238" angle="3.2495317719974453" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="129.50880719267639" angle="-0.14986799122162903" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044a5f05-c766-11e1-8775-005056c00008" name="Logan LD" loadType="UNDEFINED" p0="54" q0="27" node="11" p="54.002565378434596" q="27.002137849215718">
+            <iidm:load id="_044a5f05-c766-11e1-8775-005056c00008" name="Logan LD" loadType="UNDEFINED" p0="54" q0="27" node="11" p="53.998731886572429" q="26.998943247082558">
                 <iidm:alias>_04767811-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0475dbd6-c766-11e1-8775-005056c00008" name="Logan SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.41900000000001" targetDeadband="1" node="12" q="-19.261642272756532">
+            <iidm:shunt id="_0475dbd6-c766-11e1-8775-005056c00008" name="Logan SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.41900000000001" targetDeadband="1" node="12" q="-19.254865749259366">
                 <iidm:alias>_04577e67-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_a7768441-642e-48a2-b4a8-0ae06bebf676"/>
                 <iidm:shuntLinearModel bPerSection="0.0002296" gPerSection="0" maximumSectionCount="10"/>
@@ -7087,19 +7087,19 @@
                 <iidm:internalConnection node1="32" node2="3"/>
                 <iidm:internalConnection node1="33" node2="6"/>
                 <iidm:internalConnection node1="34" node2="9"/>
-                <iidm:bus v="132.66003880086433" angle="-13.706712494333804" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34"/>
+                <iidm:bus v="132.66000519992798" angle="-17.315678656450785" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04633e31-c766-11e1-8775-005056c00008" name="W.Lancst SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="19" targetV="132.66" targetQ="0" node="13" p="-20.968322704212994" q="1.6590815259004281">
+            <iidm:generator id="_04633e31-c766-11e1-8775-005056c00008" name="W.Lancst SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="19" targetV="132.66" targetQ="0" node="13" p="-21.039816745816793" q="1.4821277740999419">
                 <iidm:alias>_047bcf42-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_83fae784-1da1-4055-8108-ba978276d1b6"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_5f711f63-f631-45d3-b26c-33821ab2ee56"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-15" maxQ="45"/>
             </iidm:generator>
-            <iidm:load id="_048a9c51-c766-11e1-8775-005056c00008" name="W.Lancst LD" loadType="UNDEFINED" p0="28" q0="10" node="11" p="28.00001228430893" q="10.000007312089716">
+            <iidm:load id="_048a9c51-c766-11e1-8775-005056c00008" name="W.Lancst LD" loadType="UNDEFINED" p0="28" q0="10" node="11" p="28.000001646291107" q="10.0000009799352">
                 <iidm:alias>_044e7db6-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_045b00d9-c766-11e1-8775-005056c00008" name="W.Lancst SC" sectionCount="5" voltageRegulatorOn="true" targetV="132.66" targetDeadband="1" node="12" q="-10.101645703527282">
+            <iidm:shunt id="_045b00d9-c766-11e1-8775-005056c00008" name="W.Lancst SC" sectionCount="5" voltageRegulatorOn="true" targetV="132.66" targetDeadband="1" node="12" q="-10.101640586316181">
                 <iidm:alias>_04758db6-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_be267a3c-f7a7-4bdf-bb17-71b773247fbf"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -7209,9 +7209,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="130.00688298897975" angle="-2.1657711656431569" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="129.88464216409503" angle="-5.7714723650527571" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045dbff2-c766-11e1-8775-005056c00008" name="Portsmth LD" loadType="UNDEFINED" p0="66" q0="20" node="17" p="66.021217822329774" q="20.010717220184677">
+            <iidm:load id="_045dbff2-c766-11e1-8775-005056c00008" name="Portsmth LD" loadType="UNDEFINED" p0="66" q0="20" node="17" p="65.996995279109598" q="19.998482487226031">
                 <iidm:alias>_0454bf45-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7282,16 +7282,16 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="127.64400014027794" angle="-3.1099511625260816" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="127.64400002135224" angle="-7.5472338850936307" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04856c34-c766-11e1-8775-005056c00008" name="DeerCrk SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="7" targetV="127.64400000000001" targetQ="0" node="12" p="-7.7251715226047883" q="-34.922503849408848">
+            <iidm:generator id="_04856c34-c766-11e1-8775-005056c00008" name="DeerCrk SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="7" targetV="127.64400000000001" targetQ="0" node="12" p="-7.7515114326693464" q="-37.704747020095979">
                 <iidm:alias>_0477d7a5-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e5a479a8-ab8d-4a54-bb52-376874ae2784"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b55d80d5-720f-46f9-897f-ff8c5eaf8b44"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-15" maxQ="45"/>
             </iidm:generator>
-            <iidm:load id="_04791028-c766-11e1-8775-005056c00008" name="DeerCrk LD" loadType="UNDEFINED" p0="43" q0="27" node="11" p="43.000000070884063" q="27.000000074181003">
+            <iidm:load id="_04791028-c766-11e1-8775-005056c00008" name="DeerCrk LD" loadType="UNDEFINED" p0="43" q0="27" node="11" p="43.000000010789527" q="27.00000001129137">
                 <iidm:alias>_04486337-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7342,9 +7342,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.13369949908704" angle="-1.5720836991082232" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.92792370800798" angle="-5.770033482574628" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0462c904-c766-11e1-8775-005056c00008" name="Medford LD" loadType="UNDEFINED" p0="22" q0="7" node="8" p="22.007550494992845" q="7.0040045084266538">
+            <iidm:load id="_0462c904-c766-11e1-8775-005056c00008" name="Medford LD" loadType="UNDEFINED" p0="22" q0="7" node="8" p="21.993766893649131" q="6.9966948769923833">
                 <iidm:alias>_0489b1f7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7433,9 +7433,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="132.53653541190019" angle="3.9463977935578356" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="132.05061128772732" angle="-0.027176372124770299" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046205b5-c766-11e1-8775-005056c00008" name="CollCrnr LD" loadType="UNDEFINED" p0="7" q0="3" node="14" p="7.0072164769755769" q="3.005156397553189">
+            <iidm:load id="_046205b5-c766-11e1-8775-005056c00008" name="CollCrnr LD" loadType="UNDEFINED" p0="7" q0="3" node="14" p="6.9974613613540075" q="2.9981869058972799">
                 <iidm:alias>_04486334-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7486,9 +7486,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.90976274684002" angle="4.3749151008138565" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.89266670445812" angle="1.0038656035160602" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0483be82-c766-11e1-8775-005056c00008" name="Caldwell LD" loadType="UNDEFINED" p0="42" q0="31" node="8" p="42.001575859288366" q="31.001938581306167">
+            <iidm:load id="_0483be82-c766-11e1-8775-005056c00008" name="Caldwell LD" loadType="UNDEFINED" p0="42" q0="31" node="8" p="41.999330016262675" q="30.99917581803895">
                 <iidm:alias>_045841b9-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7539,9 +7539,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.3310726837484" angle="-3.1780055230897664" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.33151260734823" angle="-6.5101917044773074" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045f94b4-c766-11e1-8775-005056c00008" name="Franklin LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="7.9999956446859688" q="2.9999972779292245">
+            <iidm:load id="_045f94b4-c766-11e1-8775-005056c00008" name="Franklin LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="8.0000030497746994" q="3.000001906109429">
                 <iidm:alias>_047da403-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7592,9 +7592,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="125.17244773251397" angle="-4.8284337372772992" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.92209034069475" angle="-9.5995529037238683" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045f6da2-c766-11e1-8775-005056c00008" name="McKinley LD" loadType="UNDEFINED" p0="60" q0="34" node="8" p="60.055911262466353" q="34.052821481735783">
+            <iidm:load id="_045f6da2-c766-11e1-8775-005056c00008" name="McKinley LD" loadType="UNDEFINED" p0="60" q0="34" node="8" p="60.008945438329128" q="34.008448889388688">
                 <iidm:alias>_0465d641-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7741,19 +7741,19 @@
                 <iidm:internalConnection node1="71" node2="18"/>
                 <iidm:internalConnection node1="72" node2="21"/>
                 <iidm:internalConnection node1="73" node2="12"/>
-                <iidm:bus v="130.68000801247155" angle="-3.0160753681959518" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
+                <iidm:bus v="130.68000813751976" angle="-6.745147591129526" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_044ca8f0-c766-11e1-8775-005056c00008" name="TwinBrch SM" energySource="THERMAL" minP="50" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="85" targetV="130.68000799999999" targetQ="0" node="24" p="-93.805654203058126" q="-84.26243040869366">
+            <iidm:generator id="_044ca8f0-c766-11e1-8775-005056c00008" name="TwinBrch SM" energySource="THERMAL" minP="50" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="85" targetV="130.68000799999999" targetQ="0" node="24" p="-94.125495968127765" q="-90.636435119262956">
                 <iidm:alias>_04633e38-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_0f6ab5a4-6b72-42f4-92bc-1993e1ae58a3"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_668eb671-5c36-4351-a95d-53ca850581db"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-60" maxQ="170"/>
             </iidm:generator>
-            <iidm:load id="_048740f1-c766-11e1-8775-005056c00008" name="TwinBrch LD" loadType="UNDEFINED" p0="47" q0="10" node="23" p="47.000000006728229" q="10.000000002385899">
+            <iidm:load id="_048740f1-c766-11e1-8775-005056c00008" name="TwinBrch LD" loadType="UNDEFINED" p0="47" q0="10" node="23" p="47.000000074189956" q="10.000000026308497">
                 <iidm:alias>_044ecbda-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:danglingLine id="_045338a1-c766-11e1-8775-005056c00008" name="12-117" p0="20" q0="8" r="5.7324960000000003" x="24.393599999999999" g="0" b="0.00020546369999999999" ucteXnodeCode="XMO_TE32" node="73" p="20.1617936197859" q="5.1797255248887408">
+            <iidm:danglingLine id="_045338a1-c766-11e1-8775-005056c00008" name="12-117" p0="20" q0="8" r="5.7324960000000003" x="24.393599999999999" g="0" b="0.00020546369999999999" ucteXnodeCode="XMO_TE32" node="73" p="20.161793658503356" q="5.1797255347627233">
                 <iidm:alias>_044afb42-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_0457f391-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_5631f3d0-d9d2-11e2-bb49-005056c00008</iidm:alias>
@@ -7851,9 +7851,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="124.51304530616135" angle="-6.4613884588492398" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="124.11879535725819" angle="-11.141725223147253" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0479fa87-c766-11e1-8775-005056c00008" name="Lincoln LD" loadType="UNDEFINED" p0="45" q0="25" node="14" p="45.058187463280703" q="25.053900499571618">
+            <iidm:load id="_0479fa87-c766-11e1-8775-005056c00008" name="Lincoln LD" loadType="UNDEFINED" p0="45" q0="25" node="14" p="45.003134853206902" q="25.002902709260361">
                 <iidm:alias>_047fc6e2-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7904,9 +7904,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="134.64774364240952" angle="3.5659031072079936" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="134.64602536001001" angle="0.19374811059241961" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044c81e4-c766-11e1-8775-005056c00008" name="Hinton NegG LD" loadType="UNDEFINED" p0="42" q0="0" node="8" p="42.00019913586334" q="0">
+            <iidm:load id="_044c81e4-c766-11e1-8775-005056c00008" name="Hinton NegG LD" loadType="UNDEFINED" p0="42" q0="0" node="8" p="41.999972232201223" q="0">
                 <iidm:alias>_04494d96-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7957,9 +7957,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.28520142870607" angle="-3.3572194918721174" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.25413956323865" angle="-7.4430425883011511" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_048bfbe0-c766-11e1-8775-005056c00008" name="N. E. LD" loadType="UNDEFINED" p0="25" q0="10" node="8" p="25.004079731558228" q="10.002719968984666">
+            <iidm:load id="_048bfbe0-c766-11e1-8775-005056c00008" name="N. E. LD" loadType="UNDEFINED" p0="25" q0="10" node="8" p="25.001669625437856" q="10.001113108404157">
                 <iidm:alias>_0480b140-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8010,9 +8010,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.13562503202759" angle="-18.788749574985587" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.1387381038721" angle="-22.357604578588433" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04854525-c766-11e1-8775-005056c00008" name="SCoshoct LD" loadType="UNDEFINED" p0="18" q0="5" node="8" p="17.99982935168698" q="4.9999209964010447">
+            <iidm:load id="_04854525-c766-11e1-8775-005056c00008" name="SCoshoct LD" loadType="UNDEFINED" p0="18" q0="5" node="8" p="17.999998675685365" q="4.9999993868913899">
                 <iidm:alias>_04747c42-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8063,9 +8063,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="125.09674678981388" angle="-3.6582960067001782" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="125.04036935037469" angle="-7.18305808655803" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044aad24-c766-11e1-8775-005056c00008" name="WHuntngd LD" loadType="UNDEFINED" p0="33" q0="15" node="8" p="33.005750828395165" q="15.004356941249677">
+            <iidm:load id="_044aad24-c766-11e1-8775-005056c00008" name="WHuntngd LD" loadType="UNDEFINED" p0="33" q0="15" node="8" p="32.99972780722085" q="14.999793793916078">
                 <iidm:alias>_04784cd2-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8097,9 +8097,9 @@
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="3"/>
-                <iidm:bus v="129.36006562212361" angle="-2.2754720753438944" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="129.36000959337184" angle="-5.5973069667966255" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0452ea80-c766-11e1-8775-005056c00008" name="DanRiver SM" energySource="THERMAL" minP="20" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="36" targetV="129.36000000000001" targetQ="0" node="5" p="-39.729453544824622" q="-20.31207879692678">
+            <iidm:generator id="_0452ea80-c766-11e1-8775-005056c00008" name="DanRiver SM" energySource="THERMAL" minP="20" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="36" targetV="129.36000000000001" targetQ="0" node="5" p="-39.864915939442348" q="-20.27291083115297">
                 <iidm:alias>_046a4316-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_fec62959-21c5-4921-90b2-7c85e9f3bfab"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_9db08c95-4586-4a2b-87e3-5a17c944b43a"/>
@@ -8172,9 +8172,9 @@
                 <iidm:internalConnection node1="29" node2="3"/>
                 <iidm:internalConnection node1="30" node2="9"/>
                 <iidm:internalConnection node1="31" node2="6"/>
-                <iidm:bus v="130.28668380762028" angle="-2.0390955070488674" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
+                <iidm:bus v="130.14492101067614" angle="-5.6727328498659855" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
             </iidm:nodeBreakerTopology>
-            <iidm:danglingLine id="_044ef2e7-c766-11e1-8775-005056c00008" name="71-73" p0="6" q0="0" r="1.508918" x="7.9104960000000002" g="0" b="6.76079e-05" ucteXnodeCode="XMO_TE31" node="31" p="6.0032055067465704" q="-1.1308231993979825">
+            <iidm:danglingLine id="_044ef2e7-c766-11e1-8775-005056c00008" name="71-73" p0="6" q0="0" r="1.508918" x="7.9104960000000002" g="0" b="6.76079e-05" ucteXnodeCode="XMO_TE31" node="31" p="6.0032108888266542" q="-1.1282909432608037">
                 <iidm:alias>_04670ec2-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_046b2d7a-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_26a070b9-db0c-47cd-9991-0a461576aec2</iidm:alias>
@@ -8234,9 +8234,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="134.29653376002443" angle="-9.0710441588305173" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="134.29662399007981" angle="-12.632173611112087" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0453add4-c766-11e1-8775-005056c00008" name="Summerfl LD" loadType="UNDEFINED" p0="28" q0="7" node="8" p="27.999911305670494" q="6.9999630440683909">
+            <iidm:load id="_0453add4-c766-11e1-8775-005056c00008" name="Summerfl LD" loadType="UNDEFINED" p0="28" q0="7" node="8" p="27.999909843293263" q="6.9999624347458447">
                 <iidm:alias>_04851e16-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8363,9 +8363,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="132.66007299148242" angle="18.839953986362428" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="132.6600104947407" angle="15.558150135570814" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0489b1fa-c766-11e1-8775-005056c00008" name="ClinchRv SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="607" targetV="132.66" targetQ="0" node="20" p="-669.88273060301515" q="-48.801286803473225">
+            <iidm:generator id="_0489b1fa-c766-11e1-8775-005056c00008" name="ClinchRv SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="607" targetV="132.66" targetQ="0" node="20" p="-672.16677709004182" q="-49.03956578297089">
                 <iidm:alias>_04840caa-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_2621b09a-22e3-4630-b3bd-32c102e36741"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b0d662e5-64c9-4d59-b8e0-9b1ed175769b"/>
@@ -8420,9 +8420,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.49434997634478" angle="-3.9888233676622185" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.47193056999063" angle="-7.6755788404035261" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0485e168-c766-11e1-8775-005056c00008" name="Pokagon LD" loadType="UNDEFINED" p0="20" q0="9" node="8" p="20.000322074596038" q="9.000241557243676">
+            <iidm:load id="_0485e168-c766-11e1-8775-005056c00008" name="Pokagon LD" loadType="UNDEFINED" p0="20" q0="9" node="8" p="19.998959181560515" q="8.9992193997117536">
                 <iidm:alias>_0462c902-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8473,9 +8473,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.12389236324981" angle="-4.1901246378669557" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.04903736227061" angle="-8.1412855013062302" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04812679-c766-11e1-8775-005056c00008" name="GoshenJt LD" loadType="UNDEFINED" p0="14" q0="1" node="8" p="14.002675200810973" q="1.0003184965720189">
+            <iidm:load id="_04812679-c766-11e1-8775-005056c00008" name="GoshenJt LD" loadType="UNDEFINED" p0="14" q0="1" node="8" p="13.999538375020611" q="0.99994504524933114">
                 <iidm:alias>_045b9d17-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8526,9 +8526,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="118.00350663049247" angle="-22.649882898976649" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="117.99819214543388" angle="-26.495795982827655" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0489b1f2-c766-11e1-8775-005056c00008" name="S.Tiffin LD" loadType="UNDEFINED" p0="37" q0="10" node="8" p="36.996074846568419" q="9.9982319753920361">
+            <iidm:load id="_0489b1f2-c766-11e1-8775-005056c00008" name="S.Tiffin LD" loadType="UNDEFINED" p0="37" q0="10" node="8" p="36.995259697513347" q="9.9978648197985915">
                 <iidm:alias>_046476b8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8579,9 +8579,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="123.65928362730065" angle="-11.345711170390333" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="123.60343185236691" angle="-15.65544099803709" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045cfca7-c766-11e1-8775-005056c00008" name="Haviland LD" loadType="UNDEFINED" p0="23" q0="9" node="8" p="23.00576602874423" q="9.003760767764776">
+            <iidm:load id="_045cfca7-c766-11e1-8775-005056c00008" name="Haviland LD" loadType="UNDEFINED" p0="23" q0="9" node="8" p="23.001586212825224" q="9.0010345104063525">
                 <iidm:alias>_0482ad17-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8651,9 +8651,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="131.00711594429839" angle="-8.9658054263066482" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="131.00723206346473" angle="-12.513042789556701" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04555b82-c766-11e1-8775-005056c00008" name="SWKammer LD" loadType="UNDEFINED" p0="78" q0="3" node="11" p="77.999918499038245" q="2.999994775581194">
+            <iidm:load id="_04555b82-c766-11e1-8775-005056c00008" name="SWKammer LD" loadType="UNDEFINED" p0="78" q0="3" node="11" p="77.999921209750937" q="2.9999949493447091">
                 <iidm:alias>_0474ca6b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8761,9 +8761,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="130.37072823252646" angle="3.6690455773781601" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="130.35196652930685" angle="0.27776560400703698" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04817492-c766-11e1-8775-005056c00008" name="Baileysv LD" loadType="UNDEFINED" p0="38" q0="15" node="17" p="38.001540555737691" q="15.001013537207974">
+            <iidm:load id="_04817492-c766-11e1-8775-005056c00008" name="Baileysv LD" loadType="UNDEFINED" p0="38" q0="15" node="17" p="37.999343900962316" q="14.999568358380488">
                 <iidm:alias>_0474f17b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8814,9 +8814,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.04814330991073" angle="12.058815665738399" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.04205932604802" angle="8.7623436691671515" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0461b790-c766-11e1-8775-005056c00008" name="HolstonT NegG LD" loadType="UNDEFINED" p0="10" q0="0" node="8" p="10.000145325044603" q="0">
+            <iidm:load id="_0461b790-c766-11e1-8775-005056c00008" name="HolstonT NegG LD" loadType="UNDEFINED" p0="10" q0="0" node="8" p="9.9999516927202485" q="0">
                 <iidm:alias>_0464ebe7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8867,9 +8867,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.16852341325355" angle="-1.5787128932882759" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.96158634988065" angle="-5.7845472924317329" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044c81e5-c766-11e1-8775-005056c00008" name="WMedford LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="8.0028152925999656" q="3.0017597642698366">
+            <iidm:load id="_044c81e5-c766-11e1-8775-005056c00008" name="WMedford LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="7.9977776760744721" q="2.9986111761631093">
                 <iidm:alias>_04570939-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8959,12 +8959,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="124.68118222276054" angle="-15.990586133907891" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="124.66209677588046" angle="-19.986577975654725" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04854520-c766-11e1-8775-005056c00008" name="Rockhill LD" loadType="UNDEFINED" p0="59" q0="26" node="14" p="59.001010777133921" q="26.000742382925356">
+            <iidm:load id="_04854520-c766-11e1-8775-005056c00008" name="Rockhill LD" loadType="UNDEFINED" p0="59" q0="26" node="14" p="58.997230433403772" q="25.997965886871299">
                 <iidm:alias>_0461b799-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0460cd38-c766-11e1-8775-005056c00008" name="Rockhill SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.81399999999999" targetDeadband="1" node="15" q="-12.482953951973574">
+            <iidm:shunt id="_0460cd38-c766-11e1-8775-005056c00008" name="Rockhill SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.81399999999999" targetDeadband="1" node="15" q="-12.479132613164868">
                 <iidm:alias>_048b86b4-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_069d84c6-bd26-4c26-ac6c-e801a0202a00"/>
                 <iidm:shuntLinearModel bPerSection="0.0001606" gPerSection="0" maximumSectionCount="10"/>
@@ -9037,12 +9037,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="128.55634146392575" angle="4.9655247645164584" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="128.52959492948378" angle="1.5868103907449804" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047a48a5-c766-11e1-8775-005056c00008" name="Sprigg LD" loadType="UNDEFINED" p0="20" q0="10" node="11" p="20.001000898176489" q="10.000834095727514">
+            <iidm:load id="_047a48a5-c766-11e1-8775-005056c00008" name="Sprigg LD" loadType="UNDEFINED" p0="20" q0="10" node="11" p="19.999328603208067" q="9.9994405089341569">
                 <iidm:alias>_0472ce97-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_04553478-c766-11e1-8775-005056c00008" name="Sprigg SC" sectionCount="5" voltageRegulatorOn="true" targetV="129.935" targetDeadband="1" node="12" q="-9.4863447021583589">
+            <iidm:shunt id="_04553478-c766-11e1-8775-005056c00008" name="Sprigg SC" sectionCount="5" voltageRegulatorOn="true" targetV="129.935" targetDeadband="1" node="12" q="-9.4823977875511449">
                 <iidm:alias>_045bc428-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_f4cdc674-4a66-4ab8-8d4f-552cb066e259"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -9134,12 +9134,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="118.46299631682518" angle="-21.686345942072137" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="118.46175586307818" angle="-25.563013207481738" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04819ba4-c766-11e1-8775-005056c00008" name="West End NegG LD" loadType="UNDEFINED" p0="46" q0="0" node="14" p="45.994990283087709" q="0">
+            <iidm:load id="_04819ba4-c766-11e1-8775-005056c00008" name="West End NegG LD" loadType="UNDEFINED" p0="46" q0="0" node="14" p="45.994584729343138" q="0">
                 <iidm:alias>_04627ae0-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_04555b89-c766-11e1-8775-005056c00008" name="West End LD" loadType="UNDEFINED" p0="20" q0="23" node="15" p="19.997821862212049" q="22.995825387461778">
+            <iidm:load id="_04555b89-c766-11e1-8775-005056c00008" name="West End LD" loadType="UNDEFINED" p0="20" q0="23" node="15" p="19.997645534497018" q="22.995487451539205">
                 <iidm:alias>_04592c18-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9190,9 +9190,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.31248925083676" angle="-1.6735918971456067" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.1787593881235" angle="-6.4577139728549051" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046d0232-c766-11e1-8775-005056c00008" name="Deer Crk NegG LD" loadType="UNDEFINED" p0="6" q0="0" node="8" p="6.0029955674491795" q="0">
+            <iidm:load id="_046d0232-c766-11e1-8775-005056c00008" name="Deer Crk NegG LD" loadType="UNDEFINED" p0="6" q0="0" node="8" p="6.0005576751733667" q="0">
                 <iidm:alias>_0480150a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9262,9 +9262,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="133.92747668312646" angle="-11.353944414454475" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="133.92172720360008" angle="-14.938486817822353" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046c3ee3-c766-11e1-8775-005056c00008" name="Crooksvl LD" loadType="UNDEFINED" p0="34" q0="0" node="11" p="34.000086884542377" q="0">
+            <iidm:load id="_046c3ee3-c766-11e1-8775-005056c00008" name="Crooksvl LD" loadType="UNDEFINED" p0="34" q0="0" node="11" p="33.999521227971705" q="0">
                 <iidm:alias>_047e4047-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9315,9 +9315,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="132.05135837777328" angle="-14.596394308482802" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="132.05309159416313" angle="-18.176427979985171" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046dc585-c766-11e1-8775-005056c00008" name="WCambrdg LD" loadType="UNDEFINED" p0="17" q0="4" node="8" p="16.999920271434359" q="3.9999687339447054">
+            <iidm:load id="_046dc585-c766-11e1-8775-005056c00008" name="WCambrdg LD" loadType="UNDEFINED" p0="17" q0="4" node="8" p="17.000002356399381" q="4.0000009240782317">
                 <iidm:alias>_045dbff8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9406,9 +9406,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="130.32016072358471" angle="-2.5344425813765787" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="130.23853240092299" angle="-6.1886087795450573" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_048b5fa5-c766-11e1-8775-005056c00008" name="SouthBnd LD" loadType="UNDEFINED" p0="70" q0="23" node="14" p="70.004742145095534" q="23.002596947622468">
+            <iidm:load id="_048b5fa5-c766-11e1-8775-005056c00008" name="SouthBnd LD" loadType="UNDEFINED" p0="70" q0="23" node="14" p="69.987969892627049" q="22.993412461461713">
                 <iidm:alias>_04522734-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9458,11 +9458,11 @@
                 <iidm:internalConnection node1="19" node2="6"/>
                 <iidm:internalConnection node1="20" node2="3"/>
                 <iidm:internalConnection node1="21" node2="6"/>
-                <iidm:bus v="228.10650946395356" angle="13.939127893842091" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
+                <iidm:bus v="227.78248230570824" angle="10.847397494019608" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:line id="_044cd006-c766-11e1-8775-005056c00008" name="31-32" r="5.1923519999999996" x="17.16264" g1="0" b1="7.20271e-05" g2="0" b2="7.20271e-05" node1="31" voltageLevelId1="_04636548-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="-26.9554789049877" q1="7.019128095377436" p2="27.208425784881239" q2="-8.5311542072121398">
+    <iidm:line id="_044cd006-c766-11e1-8775-005056c00008" name="31-32" r="5.1923519999999996" x="17.16264" g1="0" b1="7.20271e-05" g2="0" b2="7.20271e-05" node1="31" voltageLevelId1="_04636548-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="-29.260771467814369" q1="9.4053594912842211" p2="29.569293466115305" q2="-10.729761896340596">
         <iidm:alias>_04682030-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0471bd25-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9470,7 +9470,7 @@
             <iidm:temporaryLimit name="_de6da3cb-8cb5-4900-9c33-8ad45632b535" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045a3d89-c766-11e1-8775-005056c00008" name="2-12" r="3.2582879999999999" x="10.7331839" g1="0" b1="4.5110200000000001e-05" g2="0" b2="4.5110200000000001e-05" node1="21" voltageLevelId1="_045d4ac5-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-31.528847131816327" q1="-17.114103271026764" p2="31.777898178091629" q2="16.419342494303738">
+    <iidm:line id="_045a3d89-c766-11e1-8775-005056c00008" name="2-12" r="3.2582879999999999" x="10.7331839" g1="0" b1="4.5110200000000001e-05" g2="0" b2="4.5110200000000001e-05" node1="21" voltageLevelId1="_045d4ac5-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-30.545638529221371" q1="-17.695330282885539" p2="30.786552929833782" q2="16.974026318153353">
         <iidm:alias>_046adf51-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046fe868-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9478,7 +9478,7 @@
             <iidm:temporaryLimit name="_6bd63dd1-1344-4183-b7bd-af326919f4eb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04513cd7-c766-11e1-8775-005056c00008" name="32-114" r="2.3522400000000001" x="10.6634884" g1="0" b1="4.6717149999999997e-05" g2="0" b2="4.6717149999999997e-05" node1="49" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04791027-c766-11e1-8775-005056c00008" p1="7.5453684581076024" q1="3.9557295376696944" p2="-7.5339460624538539" q2="-5.4212834823674294">
+    <iidm:line id="_04513cd7-c766-11e1-8775-005056c00008" name="32-114" r="2.3522400000000001" x="10.6634884" g1="0" b1="4.6717149999999997e-05" g2="0" b2="4.6717149999999997e-05" node1="49" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04791027-c766-11e1-8775-005056c00008" p1="6.356731450012111" q1="4.1245566909190758" p2="-6.3474312367219596" q2="-5.5947270431825205">
         <iidm:alias>_046d0237-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0470d2c7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9486,7 +9486,7 @@
             <iidm:temporaryLimit name="_5f05650a-c63d-46e5-a426-2db4f036929f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045d71d4-c766-11e1-8775-005056c00008" name="24-72" r="8.5029120000000002" x="34.151040000000002" g1="0" b1="0.00014003675" g2="0" b2="0.00014003675" node1="30" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="25.490706095664901" q1="-5.0255862166601375" p2="-25.170370923435598" q2="1.4613499202793121">
+    <iidm:line id="_045d71d4-c766-11e1-8775-005056c00008" name="24-72" r="8.5029120000000002" x="34.151040000000002" g1="0" b1="0.00014003675" g2="0" b2="0.00014003675" node1="30" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="24.069892944112617" q1="-5.2574444258949953" p2="-23.781596964698824" q2="1.5877436102056868">
         <iidm:alias>_04667281-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d0234-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9494,7 +9494,7 @@
             <iidm:temporaryLimit name="_d2074163-ab09-4251-a1d7-6983091dc4f1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045f94b8-c766-11e1-8775-005056c00008" name="17-18" r="2.1431520000000002" x="8.7991200000000003" g1="0" b1="3.7247499999999999e-05" g2="0" b2="3.7247499999999999e-05" node1="57" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04689563-c766-11e1-8775-005056c00008" p1="113.29553395743046" q1="38.547580617768872" p2="-111.45936221484236" q2="-32.2171727461564">
+    <iidm:line id="_045f94b8-c766-11e1-8775-005056c00008" name="17-18" r="2.1431520000000002" x="8.7991200000000003" g1="0" b1="3.7247499999999999e-05" g2="0" b2="3.7247499999999999e-05" node1="57" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04689563-c766-11e1-8775-005056c00008" p1="110.65769950643698" q1="40.87879804970548" p2="-108.86967998035357" q2="-34.742598775598225">
         <iidm:alias>_045e0e17-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0485ba59-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9502,7 +9502,7 @@
             <iidm:temporaryLimit name="_2b6693c7-4e29-4c2c-91d0-3485bbe8fe87" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048963d8-c766-11e1-8775-005056c00008" name="17-113" r="1.590811" x="5.244624" g1="0" b1="2.2038549999999999e-05" g2="0" b2="2.2038549999999999e-05" node1="58" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="5.109772974426023" q1="2.9618180320082503" p2="-5.1062439616816766" q2="-3.6883553653375971">
+    <iidm:line id="_048963d8-c766-11e1-8775-005056c00008" name="17-113" r="1.590811" x="5.244624" g1="0" b1="2.2038549999999999e-05" g2="0" b2="2.2038549999999999e-05" node1="58" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="1.2392923683370476" q1="4.4677247303024954" p2="-1.2369235657969972" q2="-5.1966404653979756">
         <iidm:alias>_045841b5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046958b4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9510,7 +9510,7 @@
             <iidm:temporaryLimit name="_786432da-fa4d-4751-a275-87d0e20529f1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0458ddf0-c766-11e1-8775-005056c00008" name="49-50" r="4.6522079999999999" x="13.102848099999999" g1="0" b1="5.3776400000000002e-05" g2="0" b2="5.3776400000000002e-05" node1="112" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044d1e26-c766-11e1-8775-005056c00008" p1="62.28473038277739" q1="11.672291194180168" p2="-61.258134502252538" q2="-10.703070517177077">
+    <iidm:line id="_0458ddf0-c766-11e1-8775-005056c00008" name="49-50" r="4.6522079999999999" x="13.102848099999999" g1="0" b1="5.3776400000000002e-05" g2="0" b2="5.3776400000000002e-05" node1="112" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044d1e26-c766-11e1-8775-005056c00008" p1="62.133336719320596" q1="11.700905206323323" p2="-61.111342913258291" q2="-10.744670266552442">
         <iidm:alias>_0464ebe8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f9fd8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9518,7 +9518,7 @@
             <iidm:temporaryLimit name="_1f0844a5-ea5c-42b2-abcb-6fac2c426092" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04535fb7-c766-11e1-8775-005056c00008" name="1-3" r="2.2476959999999999" x="7.3877759999999997" g1="0" b1="3.1049149999999997e-05" g2="0" b2="3.1049149999999997e-05" node1="21" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_047eb579-c766-11e1-8775-005056c00008" p1="-39.543936275908621" q1="-16.745040215734885" p2="39.799583436209907" q2="16.574259351746406">
+    <iidm:line id="_04535fb7-c766-11e1-8775-005056c00008" name="1-3" r="2.2476959999999999" x="7.3877759999999997" g1="0" b1="3.1049149999999997e-05" g2="0" b2="3.1049149999999997e-05" node1="21" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_047eb579-c766-11e1-8775-005056c00008" p1="-40.51266581887235" q1="-16.144744874172705" p2="40.776745757566331" q2="16.002798810045977">
         <iidm:alias>_044ef2e9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047c4474-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9526,7 +9526,7 @@
             <iidm:temporaryLimit name="_4ea43e34-67a3-42b8-9601-2189db7790d4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0478e912-c766-11e1-8775-005056c00008" name="92-102" r="2.1431520000000002" x="9.7400160000000007" g1="0" b1="4.2011000000000001e-05" g2="0" b2="4.2011000000000001e-05" node1="66" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="49.799893324445968" q1="-9.0162583648579471" p2="-49.479664768040109" q2="9.0398445066998772">
+    <iidm:line id="_0478e912-c766-11e1-8775-005056c00008" name="92-102" r="2.1431520000000002" x="9.7400160000000007" g1="0" b1="4.2011000000000001e-05" g2="0" b2="4.2011000000000001e-05" node1="66" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="49.989724743049493" q1="-9.055725732441342" p2="-49.666983647770671" q2="9.0909491793297974">
         <iidm:alias>_045a1673-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0468bc79-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9534,7 +9534,7 @@
             <iidm:temporaryLimit name="_23cc194e-9273-46e9-a793-84a9c2911737" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04547127-c766-11e1-8775-005056c00008" name="93-94" r="3.8855520000000001" x="12.7543688" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="21" voltageLevelId1="_04789af0-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="56.851535438925069" q1="-21.929140878593696" p2="-56.003874999988156" q2="22.891163090030211">
+    <iidm:line id="_04547127-c766-11e1-8775-005056c00008" name="93-94" r="3.8855520000000001" x="12.7543688" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="21" voltageLevelId1="_04789af0-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="57.295367462484002" q1="-22.049142273499189" p2="-56.434644196572656" q2="23.054463198659906">
         <iidm:alias>_04500450-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047b0bfb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9542,7 +9542,7 @@
             <iidm:temporaryLimit name="_1a9fe09e-3f63-4904-8e36-aa38c5e16c59" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04791021-c766-11e1-8775-005056c00008" name="46-48" r="10.4718237" x="32.931359999999998" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044778d3-c766-11e1-8775-005056c00008" p1="-8.6626927831010416" q1="-7.9962479185796518" p2="8.7260897649444775" q2="3.3526742150723514">
+    <iidm:line id="_04791021-c766-11e1-8775-005056c00008" name="46-48" r="10.4718237" x="32.931359999999998" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044778d3-c766-11e1-8775-005056c00008" p1="-8.8118187272336836" q1="-7.9445972468978123" p2="8.8764229454720454" q2="3.3048415056327101">
         <iidm:alias>_0459ef69-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04640186-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9550,7 +9550,7 @@
             <iidm:temporaryLimit name="_467ba04d-dbad-4fe1-81c8-3bc87b41fcd1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046958b6-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="113" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-92.154562716893992" q1="-2.5673526451535702" p2="93.609820606518738" q2="7.3388894454456581">
+    <iidm:line id="_046958b6-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="113" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-92.488424762870707" q1="-2.4717924733726528" p2="93.954205064726253" q2="7.2970586128091428">
         <iidm:alias>_04776270-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a96c8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9558,7 +9558,7 @@
             <iidm:temporaryLimit name="_d0737ab4-5a3a-46c8-8aeb-789313f0f332" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046f4c26-c766-11e1-8775-005056c00008" name="75-118" r="2.5264799999999998" x="8.3809430000000003" g1="0" b1="3.4377849999999998e-05" g2="0" b2="3.4377849999999998e-05" node1="48" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="39.572821711103416" q1="28.799143751993405" p2="-39.197166205347798" q2="-28.652376510852882">
+    <iidm:line id="_046f4c26-c766-11e1-8775-005056c00008" name="75-118" r="2.5264799999999998" x="8.3809430000000003" g1="0" b1="3.4377849999999998e-05" g2="0" b2="3.4377849999999998e-05" node1="48" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="39.064359677730046" q1="28.818381270764448" p2="-38.694353761654412" q2="-28.689313811150463">
         <iidm:alias>_04619088-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04814d8a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9566,7 +9566,7 @@
             <iidm:temporaryLimit name="_173dc7ff-ae18-4410-b2e1-a4c2abac8ff6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c3954-c766-11e1-8775-005056c00008" name="94-96" r="4.6870560000000001" x="15.1414566" g1="0" b1="6.60009e-05" g2="0" b2="6.60009e-05" node1="49" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="37.720151080699956" q1="-12.761772144133857" p2="-37.289859442193304" q2="11.909702554191687">
+    <iidm:line id="_045c3954-c766-11e1-8775-005056c00008" name="94-96" r="4.6870560000000001" x="15.1414566" g1="0" b1="6.60009e-05" g2="0" b2="6.60009e-05" node1="49" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="38.378159269655676" q1="-12.902626422907021" p2="-37.933029151776751" q2="12.099065405091061">
         <iidm:alias>_046ba2a0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0472ce94-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9574,7 +9574,7 @@
             <iidm:temporaryLimit name="_efde58bf-c92e-496d-b558-d0095a271083" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04518af7-c766-11e1-8775-005056c00008" name="62-67" r="4.4953919999999998" x="20.38608" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="39" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="-2.6333597532592505" q1="-18.330752095706764" p2="2.7083273744425616" q2="15.525566043070004">
+    <iidm:line id="_04518af7-c766-11e1-8775-005056c00008" name="62-67" r="4.4953919999999998" x="20.38608" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="39" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="-2.4879619062525316" q1="-18.363255150514128" p2="2.5630198319174067" q2="15.558476685355519">
         <iidm:alias>_04544a10-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04814d86-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9582,7 +9582,7 @@
             <iidm:temporaryLimit name="_8a81d4ae-2bc8-4038-8650-27a6150946b1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0452c375-c766-11e1-8775-005056c00008" name="47-49" r="3.3279839999999998" x="10.890000000000001" g1="0" b1="4.6028449999999998e-05" g2="0" b2="4.6028449999999998e-05" node1="30" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="114" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="16.932648633718809" q1="-22.712628177092789" p2="-16.790568686203571" q2="21.509355532427207">
+    <iidm:line id="_0452c375-c766-11e1-8775-005056c00008" name="47-49" r="3.3279839999999998" x="10.890000000000001" g1="0" b1="4.6028449999999998e-05" g2="0" b2="4.6028449999999998e-05" node1="30" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="114" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="16.974074129601842" q1="-22.793802963167579" p2="-16.831060194940779" q2="21.593657893702662">
         <iidm:alias>_0465fd54-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0471e431-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9590,7 +9590,7 @@
             <iidm:temporaryLimit name="_8d6a074c-900d-4a37-830c-5da4c1de1ab5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046c17d9-c766-11e1-8775-005056c00008" name="100-106" r="10.54152" x="39.900959999999998" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="76" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="59.439459369581385" q1="10.055342100706916" p2="-57.269954427820544" q2="-7.9072117638625814">
+    <iidm:line id="_046c17d9-c766-11e1-8775-005056c00008" name="100-106" r="10.54152" x="39.900959999999998" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="76" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="59.40103056951174" q1="10.058564621635242" p2="-57.234145253723092" q2="-7.920367738128375">
         <iidm:alias>_045d98e5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0480d851-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9598,7 +9598,7 @@
             <iidm:temporaryLimit name="_3154dc30-b0e5-4570-8e52-9333bae20ef2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046b2d77-c766-11e1-8775-005056c00008" name="77-78" r="0.655142" x="2.1605759999999998" g1="0" b1="3.6271800000000001e-05" g2="0" b2="3.6271800000000001e-05" node1="66" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044fb634-c766-11e1-8775-005056c00008" p1="43.948615933627252" q1="3.9869200539332379" p2="-43.875576135449187" q2="-5.0139513887048945">
+    <iidm:line id="_046b2d77-c766-11e1-8775-005056c00008" name="77-78" r="0.655142" x="2.1605759999999998" g1="0" b1="3.6271800000000001e-05" g2="0" b2="3.6271800000000001e-05" node1="66" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044fb634-c766-11e1-8775-005056c00008" p1="43.678114361396219" q1="3.9429682005494184" p2="-43.605958502074735" q2="-4.9726210860619391">
         <iidm:alias>_046ed6fb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04893cc3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9606,7 +9606,7 @@
             <iidm:temporaryLimit name="_cce754c5-b9d5-4105-a431-32da96e4a6cf" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c8776-c766-11e1-8775-005056c00008" name="6-7" r="0.79976199999999997" x="3.6241919999999999" g1="0" b1="1.5782850000000001e-05" g2="0" b2="1.5782850000000001e-05" node1="21" voltageLevelId1="_044f6818-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047eb571-c766-11e1-8775-005056c00008" p1="38.372434220643811" q1="-5.6977628117137646" p2="-38.302073457589749" q2="5.4780603614160679">
+    <iidm:line id="_045c8776-c766-11e1-8775-005056c00008" name="6-7" r="0.79976199999999997" x="3.6241919999999999" g1="0" b1="1.5782850000000001e-05" g2="0" b2="1.5782850000000001e-05" node1="21" voltageLevelId1="_044f6818-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047eb571-c766-11e1-8775-005056c00008" p1="42.723187772271544" q1="-7.9356478983820864" p2="-42.634797824978385" q2="7.7982695151192551">
         <iidm:alias>_046efe08-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04720b4a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9614,7 +9614,7 @@
             <iidm:temporaryLimit name="_361a9cc3-fb33-4037-9b9a-c20adb90b66b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047ba839-c766-11e1-8775-005056c00008" name="77-80" r="5.1226560000000001" x="18.295200000000001" g1="0" b1="6.5426999999999995e-05" g2="0" b2="6.5426999999999995e-05" node1="67" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="76" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-45.901174550184159" q1="-23.167357431284831" p2="46.659162247785382" q2="23.495388305482273">
+    <iidm:line id="_047ba839-c766-11e1-8775-005056c00008" name="77-80" r="5.1226560000000001" x="18.295200000000001" g1="0" b1="6.5426999999999995e-05" g2="0" b2="6.5426999999999995e-05" node1="67" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="76" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-46.171286312057241" q1="-23.194019800817923" p2="46.937083145266243" q2="23.550223624888204">
         <iidm:alias>_047c6b85-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0480b148-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9622,7 +9622,7 @@
             <iidm:temporaryLimit name="_da00c66f-a882-4938-923b-f2455f7f9a81" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04592c16-c766-11e1-8775-005056c00008" name="78-79" r="0.95135000000000003" x="4.2514560000000001" g1="0" b1="1.8595050000000001e-05" g2="0" b2="1.8595050000000001e-05" node1="22" voltageLevelId1="_044fb634-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04481510-c766-11e1-8775-005056c00008" p1="-27.12732965776723" q1="-20.987816914420613" p2="27.190766559257863" q2="20.618485483549769">
+    <iidm:line id="_04592c16-c766-11e1-8775-005056c00008" name="78-79" r="0.95135000000000003" x="4.2514560000000001" g1="0" b1="1.8595050000000001e-05" g2="0" b2="1.8595050000000001e-05" node1="22" voltageLevelId1="_044fb634-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04481510-c766-11e1-8775-005056c00008" p1="-27.393798912939722" q1="-21.027229223127954" p2="27.458131387715738" q2="20.662024480177703">
         <iidm:alias>_0453add6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045b7605-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9630,7 +9630,7 @@
             <iidm:temporaryLimit name="_ba4abe9d-8490-4c19-b19b-c9d2c3597fc9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047b3301-c766-11e1-8775-005056c00008" name="103-104" r="8.1195839999999997" x="27.599615100000001" g1="0" b1="0.00011679295" g2="0" b2="0.00011679295" node1="40" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="33.038111559518377" q1="13.987439502531293" p2="-32.421614385008091" q2="-15.884809987403123">
+    <iidm:line id="_047b3301-c766-11e1-8775-005056c00008" name="103-104" r="8.1195839999999997" x="27.599615100000001" g1="0" b1="0.00011679295" g2="0" b2="0.00011679295" node1="40" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="33.049142844912637" q1="13.983340768366665" p2="-32.432372292586841" q2="-15.879787295559847">
         <iidm:alias>_0459a142-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045d98e6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9638,7 +9638,7 @@
             <iidm:temporaryLimit name="_2320da74-eda7-4f7f-ade9-1ed0e994f3af" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045e5c32-c766-11e1-8775-005056c00008" name="95-96" r="2.9795039999999999" x="9.5309279999999994" g1="0" b1="4.2298000000000001e-05" g2="0" b2="4.2298000000000001e-05" node1="21" voltageLevelId1="_044f4108-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="14.199886653737162" q1="-24.768335954945933" p2="-14.059894971745479" q2="23.794329900876644">
+    <iidm:line id="_045e5c32-c766-11e1-8775-005056c00008" name="95-96" r="2.9795039999999999" x="9.5309279999999994" g1="0" b1="4.2298000000000001e-05" g2="0" b2="4.2298000000000001e-05" node1="21" voltageLevelId1="_044f4108-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="14.770757617033381" q1="-24.913724641984849" p2="-14.626502305928271" q2="23.953750543610226">
         <iidm:alias>_04597a34-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04801509-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9646,7 +9646,7 @@
             <iidm:temporaryLimit name="_3bc03415-e95f-47a7-8e92-01089d304a9c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045ed169-c766-11e1-8775-005056c00008" name="77-80" r="2.9620799999999998" x="8.4506409999999992" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="68" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="77" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-100.18020278525397" q1="-42.757434855003936" p2="102.15313708724334" q2="43.461013464335068">
+    <iidm:line id="_045ed169-c766-11e1-8775-005056c00008" name="77-80" r="2.9620799999999998" x="8.4506409999999992" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="68" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="77" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-100.7557718155152" q1="-42.777176275684219" p2="102.74903218817599" q2="43.539330207731879">
         <iidm:alias>_0464289a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04828605-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9654,7 +9654,7 @@
             <iidm:temporaryLimit name="_f93b6d4c-39fa-4f6f-a42d-c63a4cf21a67" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047f78c2-c766-11e1-8775-005056c00008" name="5-11" r="3.5370720000000002" x="11.8831682" g1="0" b1="4.987375e-05" g2="0" b2="4.987375e-05" node1="48" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="82.820561520627606" q1="10.768716380126552" p2="-81.429440521274671" q2="-7.8291648654903803">
+    <iidm:line id="_047f78c2-c766-11e1-8775-005056c00008" name="5-11" r="3.5370720000000002" x="11.8831682" g1="0" b1="4.987375e-05" g2="0" b2="4.987375e-05" node1="48" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="88.064467698500138" q1="8.5380499011448556" p2="-86.500562923234881" q2="-5.0147203787862926">
         <iidm:alias>_045bc426-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0476c633-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9662,7 +9662,7 @@
             <iidm:temporaryLimit name="_3bc4ab96-7a0d-4e18-b9f5-d89f63a82f0a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04845ac7-c766-11e1-8775-005056c00008" name="71-72" r="7.7711040000000002" x="31.363201100000001" g1="0" b1="0.00012752525" g2="0" b2="0.00012752525" node1="29" voltageLevelId1="_04664b78-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="-13.086146831962262" q1="-2.5819227281348622" p2="13.164624754063423" q2="-1.4613546509897515">
+    <iidm:line id="_04845ac7-c766-11e1-8775-005056c00008" name="71-72" r="7.7711040000000002" x="31.363201100000001" g1="0" b1="0.00012752525" g2="0" b2="0.00012752525" node1="29" voltageLevelId1="_04664b78-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="-11.721372190706399" q1="-2.5046712225803569" p2="11.784462198476648" q2="-1.5877445644335391">
         <iidm:alias>_04642891-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046b0661-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9670,7 +9670,7 @@
             <iidm:temporaryLimit name="_bcb69c6e-125e-449c-acb3-a4deb151668d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047343c2-c766-11e1-8775-005056c00008" name="66-67" r="3.9029759999999998" x="17.685359999999999" g1="0" b1="7.6962800000000001e-05" g2="0" b2="7.6962800000000001e-05" node1="50" voltageLevelId1="_047147f4-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="31.008999740499355" q1="21.034261438850084" p2="-30.708243275842456" q2="-22.525527768726295">
+    <iidm:line id="_047343c2-c766-11e1-8775-005056c00008" name="66-67" r="3.9029759999999998" x="17.685359999999999" g1="0" b1="7.6962800000000001e-05" g2="0" b2="7.6962800000000001e-05" node1="50" voltageLevelId1="_047147f4-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="30.862060890464061" q1="21.059810043438436" p2="-30.56293027933113" q2="-22.558439024123832">
         <iidm:alias>_0465af34-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04860874-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9678,7 +9678,7 @@
             <iidm:temporaryLimit name="_b4b8a31d-dc3c-4b51-88ad-a22e070eb96c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04569409-c766-11e1-8775-005056c00008" name="34-43" r="7.1961120000000003" x="29.289743399999999" g1="0" b1="0.0001212695" g2="0" b2="0.0001212695" node1="40" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_045e8349-c766-11e1-8775-005056c00008" p1="13.635998686072584" q1="-7.8127703991237691" p2="-13.533660155244917" q2="4.4390669850957121">
+    <iidm:line id="_04569409-c766-11e1-8775-005056c00008" name="34-43" r="7.1961120000000003" x="29.289743399999999" g1="0" b1="0.0001212695" g2="0" b2="0.0001212695" node1="40" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_045e8349-c766-11e1-8775-005056c00008" p1="12.587903301733409" q1="-7.5877667355326155" p2="-12.499469145371989" q2="4.1586018669605274">
         <iidm:alias>_04500454-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04505274-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9686,7 +9686,7 @@
             <iidm:temporaryLimit name="_5585c67a-0839-48e6-8847-4393e1e9b9c7" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04817498-c766-11e1-8775-005056c00008" name="52-53" r="7.0567200000000003" x="28.488240000000001" g1="0" b1="0.00011644859999999999" g2="0" b2="0.00011644859999999999" node1="21" voltageLevelId1="_04806326-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04876804-c766-11e1-8775-005056c00008" p1="13.438341583667802" q1="0.93851943063347421" p2="-13.354788545086516" q2="-4.2672352547660779">
+    <iidm:line id="_04817498-c766-11e1-8775-005056c00008" name="52-53" r="7.0567200000000003" x="28.488240000000001" g1="0" b1="0.00011644859999999999" g2="0" b2="0.00011644859999999999" node1="21" voltageLevelId1="_04806326-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04876804-c766-11e1-8775-005056c00008" p1="13.381267538102302" q1="0.95810998032374239" p2="-13.29834860740341" q2="-4.289522827355837">
         <iidm:alias>_045115c7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0472a784-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9694,7 +9694,7 @@
             <iidm:temporaryLimit name="_e7c9dfab-fb45-4470-964f-4ba9e391f60b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044b7078-c766-11e1-8775-005056c00008" name="105-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="49" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="23" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="26.889711053786076" q1="1.3296797944122811" p2="-26.471381253948977" q2="-4.1925950816020414">
+    <iidm:line id="_044b7078-c766-11e1-8775-005056c00008" name="105-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="49" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="23" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="26.894264840027997" q1="1.3280833652327118" p2="-26.475803410547822" q2="-4.1905622079602542">
         <iidm:alias>_0452c378-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0481c2b7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9702,7 +9702,7 @@
             <iidm:temporaryLimit name="_fff133bf-25fd-46b2-b144-a227c31ee882" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048ac367-c766-11e1-8775-005056c00008" name="100-101" r="4.8264480000000001" x="21.9890881" g1="0" b1="9.4123049999999997e-05" g2="0" b2="9.4123049999999997e-05" node1="77" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046ed6f7-c766-11e1-8775-005056c00008" p1="-21.641053333542903" q1="24.672169784343399" p2="21.952692243244137" q2="-26.558421043430773">
+    <iidm:line id="_048ac367-c766-11e1-8775-005056c00008" name="100-101" r="4.8264480000000001" x="21.9890881" g1="0" b1="9.4123049999999997e-05" g2="0" b2="9.4123049999999997e-05" node1="77" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046ed6f7-c766-11e1-8775-005056c00008" p1="-21.82109570021878" q1="24.759059863025783" p2="22.136059761721288" q2="-26.62999586039707">
         <iidm:alias>_044afb45-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b5fa2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9710,7 +9710,7 @@
             <iidm:temporaryLimit name="_217e3c95-24b5-438f-a721-d2257e1a43b4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0481c2b1-c766-11e1-8775-005056c00008" name="56-57" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="57" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="-30.929734166232315" q1="-5.4126817551286646" p2="31.297394986829907" q2="4.2092397792371354">
+    <iidm:line id="_0481c2b1-c766-11e1-8775-005056c00008" name="56-57" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="57" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="-30.791634433012689" q1="-5.479306610250263" p2="31.156298391816083" q2="4.2673840917469814">
         <iidm:alias>_045e0e12-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0487dd35-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9718,7 +9718,7 @@
             <iidm:temporaryLimit name="_f5547027-3d48-4a53-937b-bd5ba63ef70d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047a6fb7-c766-11e1-8775-005056c00008" name="47-69" r="14.705855400000001" x="48.403869999999998" g1="0" b1="0.00020351240000000001" g2="0" b2="0.00020351240000000001" node1="31" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="57" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-83.477242331490814" q1="25.72912826991141" p2="89.89822513015946" q2="-12.043541708482417">
+    <iidm:line id="_047a6fb7-c766-11e1-8775-005056c00008" name="47-69" r="14.705855400000001" x="48.403869999999998" g1="0" b1="0.00020351240000000001" g2="0" b2="0.00020351240000000001" node1="31" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="57" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-83.824920248609629" q1="25.922797008095422" p2="90.303495135260221" q2="-12.04733242447392">
         <iidm:alias>_04758db9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0485ba56-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9726,7 +9726,7 @@
             <iidm:temporaryLimit name="_e9fec217-cf6f-4d39-9495-26ed10c05100" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0453fbf0-c766-11e1-8775-005056c00008" name="110-111" r="3.8332799999999998" x="13.1551189" g1="0" b1="5.7392100000000002e-05" g2="0" b2="5.7392100000000002e-05" node1="40" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_046a1c00-c766-11e1-8775-005056c00008" p1="-39.264264319166593" q1="-20.588022960459917" p2="39.729496626932274" q2="20.312108350062548">
+    <iidm:line id="_0453fbf0-c766-11e1-8775-005056c00008" name="110-111" r="3.8332799999999998" x="13.1551189" g1="0" b1="5.7392100000000002e-05" g2="0" b2="5.7392100000000002e-05" node1="40" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_046a1c00-c766-11e1-8775-005056c00008" p1="-39.397601945562002" q1="-20.541668055013997" p2="39.864922215582389" q2="20.272915149697663">
         <iidm:alias>_0447c6f5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04812675-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9734,7 +9734,7 @@
             <iidm:temporaryLimit name="_ea48fee0-31b6-4990-a332-25d08b7d731f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04778984-c766-11e1-8775-005056c00008" name="41-42" r="7.14384" x="23.522401800000001" g1="0" b1="9.8714400000000005e-05" g2="0" b2="9.8714400000000005e-05" node1="21" voltageLevelId1="_048c4a08-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="-9.8651035935645872" q1="-11.430986757877283" p2="9.9669149966285708" q2="8.9555915621222582">
+    <iidm:line id="_04778984-c766-11e1-8775-005056c00008" name="41-42" r="7.14384" x="23.522401800000001" g1="0" b1="9.8714400000000005e-05" g2="0" b2="9.8714400000000005e-05" node1="21" voltageLevelId1="_048c4a08-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="-10.658375290403798" q1="-11.123227274932534" p2="10.7654230316551" q2="8.6655874045322019">
         <iidm:alias>_044d1e2a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046512f1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9742,7 +9742,7 @@
             <iidm:temporaryLimit name="_063af52c-fe10-4c1e-85d4-dd80dcc1d2f9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04653a08-c766-11e1-8775-005056c00008" name="80-99" r="7.9104960000000002" x="35.893439999999998" g1="0" b1="0.00015668044999999999" g2="0" b2="0.00015668044999999999" node1="78" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04644fa4-c766-11e1-8775-005056c00008" p1="2.5630773124582484" q1="6.5502464082000724" p2="-2.5224134944437466" q2="-12.159125900711729">
+    <iidm:line id="_04653a08-c766-11e1-8775-005056c00008" name="80-99" r="7.9104960000000002" x="35.893439999999998" g1="0" b1="0.00015668044999999999" g2="0" b2="0.00015668044999999999" node1="78" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04644fa4-c766-11e1-8775-005056c00008" p1="1.952070180126203" q1="6.6911200519359655" p2="-1.9114321626357449" q2="-12.300042183814071">
         <iidm:alias>_04773b69-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0477b092-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9750,7 +9750,7 @@
             <iidm:temporaryLimit name="_c05229ce-6abb-4209-ad4f-0dcd4a070f28" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04581aa5-c766-11e1-8775-005056c00008" name="54-59" r="8.7642720000000001" x="39.953229999999998" g1="0" b1="0.0001716024" g2="0" b2="0.0001716024" node1="58" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-19.549275234181998" q1="-10.545290561610541" p2="19.793764152810382" q2="6.0318977267028648">
+    <iidm:line id="_04581aa5-c766-11e1-8775-005056c00008" name="54-59" r="8.7642720000000001" x="39.953229999999998" g1="0" b1="0.0001716024" g2="0" b2="0.0001716024" node1="58" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-19.665558524544085" q1="-10.51439574004098" p2="19.912296635919976" q2="6.0112594753043531">
         <iidm:alias>_0457cc82-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045cae81-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9758,7 +9758,7 @@
             <iidm:temporaryLimit name="_ac528cbe-6fc1-41dd-ba9d-d8b7a4c77576" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04690a93-c766-11e1-8775-005056c00008" name="92-94" r="8.3809430000000003" x="27.529920000000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="67" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="64.752849213002079" q1="-16.292560650360553" p2="-62.592332990140441" q2="19.424394041102751">
+    <iidm:line id="_04690a93-c766-11e1-8775-005056c00008" name="92-94" r="8.3809430000000003" x="27.529920000000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="67" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="65.215012621497493" q1="-16.356791763094908" p2="-63.023737852068983" q2="19.590410643687417">
         <iidm:alias>_044c33c1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0483706b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9766,7 +9766,7 @@
             <iidm:temporaryLimit name="_6ac84228-6b04-4b10-b560-29655c8e93b4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046009e3-c766-11e1-8775-005056c00008" name="37-39" r="5.5931040000000003" x="18.469439999999999" g1="0" b1="7.7479350000000006e-05" g2="0" b2="7.7479350000000006e-05" node1="57" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046bf0c7-c766-11e1-8775-005056c00008" p1="67.685952172017068" q1="18.05231295548688" p2="-65.922705637226215" q2="-14.559472186068239">
+    <iidm:line id="_046009e3-c766-11e1-8775-005056c00008" name="37-39" r="5.5931040000000003" x="18.469439999999999" g1="0" b1="7.7479350000000006e-05" g2="0" b2="7.7479350000000006e-05" node1="57" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046bf0c7-c766-11e1-8775-005056c00008" p1="66.811843556660023" q1="18.142934465481272" p2="-65.088752131873548" q2="-14.782337439440546">
         <iidm:alias>_044c33c9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04789afa-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9774,7 +9774,7 @@
             <iidm:temporaryLimit name="_2ccdc288-c132-40d1-a928-3887bec4ff67" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0458b6e8-c766-11e1-8775-005056c00008" name="46-47" r="6.6211200000000003" x="22.12848" g1="0" b1="9.0679499999999998e-05" g2="0" b2="9.0679499999999998e-05" node1="33" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_0457f396-c766-11e1-8775-005056c00008" p1="-32.15281487804225" q1="1.103239425896295" p2="32.544501630054604" q2="-3.0165002176769122">
+    <iidm:line id="_0458b6e8-c766-11e1-8775-005056c00008" name="46-47" r="6.6211200000000003" x="22.12848" g1="0" b1="9.0679499999999998e-05" g2="0" b2="9.0679499999999998e-05" node1="33" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_0457f396-c766-11e1-8775-005056c00008" p1="-32.452076134342157" q1="1.2411447771579294" p2="32.851324215712587" q2="-3.1289943560446765">
         <iidm:alias>_04507980-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0464c4da-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9782,7 +9782,7 @@
             <iidm:temporaryLimit name="_06ca3245-2668-448f-a5c6-961924217a5c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044f8f22-c766-11e1-8775-005056c00008" name="82-83" r="1.9514879999999999" x="6.3858959999999998" g1="0" b1="0.0001089302" g2="0" b2="0.0001089302" node1="31" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728074-c766-11e1-8775-005056c00008" p1="-65.561169866400206" q1="39.158856111103439" p2="66.256485848010243" q2="-40.511497223502381">
+    <iidm:line id="_044f8f22-c766-11e1-8775-005056c00008" name="82-83" r="1.9514879999999999" x="6.3858959999999998" g1="0" b1="0.0001089302" g2="0" b2="0.0001089302" node1="31" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728074-c766-11e1-8775-005056c00008" p1="-66.364785151748379" q1="39.509789992789109" p2="67.076036233966647" q2="-40.808894309214821">
         <iidm:alias>_047a48a6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b3891-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9790,7 +9790,7 @@
             <iidm:temporaryLimit name="_dfbd2f07-76ab-41e3-910f-dc706979ea4b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045cfca6-c766-11e1-8775-005056c00008" name="108-109" r="1.82952" x="5.0181120000000004" g1="0" b1="2.1809000000000001e-05" g2="0" b2="2.1809000000000001e-05" node1="21" voltageLevelId1="_046c65f4-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b7b99-c766-11e1-8775-005056c00008" p1="20.849106321009572" q1="-0.5540380276309721" p2="-20.799499784468249" q2="-0.0076236969579897632">
+    <iidm:line id="_045cfca6-c766-11e1-8775-005056c00008" name="108-109" r="1.82952" x="5.0181120000000004" g1="0" b1="2.1809000000000001e-05" g2="0" b2="2.1809000000000001e-05" node1="21" voltageLevelId1="_046c65f4-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b7b99-c766-11e1-8775-005056c00008" p1="20.783104589317105" q1="-0.53063357259926047" p2="-20.733812968783546" q2="-0.031896733296232424">
         <iidm:alias>_04481514-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04716f00-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9798,7 +9798,7 @@
             <iidm:temporaryLimit name="_11451cec-81c7-4f83-a7db-df7dcaffa94e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04784cd5-c766-11e1-8775-005056c00008" name="70-74" r="6.9870239999999999" x="23.051952400000001" g1="0" b1="9.6648299999999994e-05" g2="0" b2="9.6648299999999994e-05" node1="48" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047dcb11-c766-11e1-8775-005056c00008" p1="23.957300868651409" q1="9.4523507343044226" p2="-23.669230741602515" q2="-11.689552134670203">
+    <iidm:line id="_04784cd5-c766-11e1-8775-005056c00008" name="70-74" r="6.9870239999999999" x="23.051952400000001" g1="0" b1="9.6648299999999994e-05" g2="0" b2="9.6648299999999994e-05" node1="48" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047dcb11-c766-11e1-8775-005056c00008" p1="23.285324968796576" q1="9.3741579801299189" p2="-23.010603985392709" q2="-11.650423169683959">
         <iidm:alias>_045e5c33-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046ab84b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9806,7 +9806,7 @@
             <iidm:temporaryLimit name="_37a5cc00-bd7f-4ec7-a77c-e140e23450d2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04747c40-c766-11e1-8775-005056c00008" name="77-82" r="5.1923519999999996" x="14.8626719" g1="0" b1="0.0002345615" g2="0" b2="0.0002345615" node1="69" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_046512f8-c766-11e1-8775-005056c00008" p1="-26.508739796607237" q1="30.894965454339957" p2="27.080244598877425" q2="-37.303319826150528">
+    <iidm:line id="_04747c40-c766-11e1-8775-005056c00008" name="77-82" r="5.1923519999999996" x="14.8626719" g1="0" b1="0.0002345615" g2="0" b2="0.0002345615" node1="69" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_046512f8-c766-11e1-8775-005056c00008" p1="-27.537744700641809" q1="31.350822746442187" p2="28.135382709155472" q2="-37.681976080486258">
         <iidm:alias>_0451b202-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0452ea84-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9814,7 +9814,7 @@
             <iidm:temporaryLimit name="_e9798d58-b518-4fab-984c-c72076dfc2ae" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045e3524-c766-11e1-8775-005056c00008" name="23-24" r="2.3522400000000001" x="8.5726080000000007" g1="0" b1="0.00014290635" g2="0" b2="0.00014290635" node1="39" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_048c22fa-c766-11e1-8775-005056c00008" p1="57.52458007824616" q1="-9.1921309525794381" p2="-57.07548553917222" q2="5.8284103790633619">
+    <iidm:line id="_045e3524-c766-11e1-8775-005056c00008" name="23-24" r="2.3522400000000001" x="8.5726080000000007" g1="0" b1="0.00014290635" g2="0" b2="0.00014290635" node1="39" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_048c22fa-c766-11e1-8775-005056c00008" p1="54.706657295520024" q1="-10.079493088023792" p2="-54.295170280944717" q2="6.6115275757978793">
         <iidm:alias>_046cb413-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f9fd3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9822,7 +9822,7 @@
             <iidm:temporaryLimit name="_e8ec73b8-1ecf-4d18-9ef9-80eabf3a4969" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0474f177-c766-11e1-8775-005056c00008" name="15-17" r="2.2999679999999998" x="7.6142880000000002" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="48" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-159.91868496764286" q1="-14.464459299606144" p2="163.67731531516463" q2="22.764800955756183">
+    <iidm:line id="_0474f177-c766-11e1-8775-005056c00008" name="15-17" r="2.2999679999999998" x="7.6142880000000002" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="48" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-150.96087365565245" q1="-19.149667942195865" p2="154.34393711153515" q2="26.217110270594311">
         <iidm:alias>_044c5ad2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046931a7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9830,7 +9830,7 @@
             <iidm:temporaryLimit name="_2ceac3d1-f73d-43db-8d37-9e329f1787bb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0483be84-c766-11e1-8775-005056c00008" name="8-30" r="2.0860400000000001" x="24.393599999999999" g1="0" b1="0.00053099175999999997" g2="0" b2="0.00053099175999999997" node1="30" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="38" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="102.91382030696595" q1="19.969827239127746" p2="-102.37387764854675" q2="-64.47200988492402">
+    <iidm:line id="_0483be84-c766-11e1-8775-005056c00008" name="8-30" r="2.0860400000000001" x="24.393599999999999" g1="0" b1="0.00053099175999999997" g2="0" b2="0.00053099175999999997" node1="30" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="38" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="87.873855602129922" q1="26.491297064912661" p2="-87.426763501237147" q2="-71.662479587631239">
         <iidm:alias>_0454e651-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04801506-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9838,7 +9838,7 @@
             <iidm:temporaryLimit name="_ca795ad3-97e5-4416-aaba-53cce27f6434" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0488eea6-c766-11e1-8775-005056c00008" name="49-69" r="17.16264" x="56.453762099999999" g1="0" b1="0.00023760329999999999" g2="0" b2="0.00023760329999999999" node1="115" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-75.176899132016715" q1="26.443050833125785" p2="81.364409029983079" q2="-14.874689902136391">
+    <iidm:line id="_0488eea6-c766-11e1-8775-005056c00008" name="49-69" r="17.16264" x="56.453762099999999" g1="0" b1="0.00023760329999999999" g2="0" b2="0.00023760329999999999" node1="115" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-75.485442213095126" q1="26.635154996549204" p2="81.727663874206272" q2="-14.886823762770259">
         <iidm:alias>_04492681-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046735d6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9846,7 +9846,7 @@
             <iidm:temporaryLimit name="_c42dc3ef-3a2e-4070-8efb-78e5c0cd5554" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047566a0-c766-11e1-8775-005056c00008" name="13-15" r="12.9634562" x="42.584255200000001" g1="0" b1="0.00017986685000000001" g2="0" b2="0.00017986685000000001" node1="21" voltageLevelId1="_04851e1b-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="10.634179774122545" q1="-0.23755101266677267" p2="-10.538128782618038" q2="-5.1986593984165017">
+    <iidm:line id="_047566a0-c766-11e1-8775-005056c00008" name="13-15" r="12.9634562" x="42.584255200000001" g1="0" b1="0.00017986685000000001" g2="0" b2="0.00017986685000000001" node1="21" voltageLevelId1="_04851e1b-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="15.058575349863601" q1="-1.2253428361181131" p2="-14.874829075492652" q2="-3.9074479772047352">
         <iidm:alias>_04662461-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04865694-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9854,7 +9854,7 @@
             <iidm:temporaryLimit name="_ad988fd9-9270-4230-95a2-1858f32259df" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0476c63a-c766-11e1-8775-005056c00008" name="69-70" r="5.2271999999999998" x="22.12848" g1="0" b1="0.00035009184999999998" g2="0" b2="0.00035009184999999998" node1="59" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="75.549946676144558" q1="19.455191274468344" p2="-73.762296101670103" q2="-24.339126337241765">
+    <iidm:line id="_0476c63a-c766-11e1-8775-005056c00008" name="69-70" r="5.2271999999999998" x="22.12848" g1="0" b1="0.00035009184999999998" g2="0" b2="0.00035009184999999998" node1="59" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="76.806341819700748" q1="20.014206101560937" p2="-74.956857561753267" q2="-24.625252884932252">
         <iidm:alias>_047e193a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b1184-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9862,7 +9862,7 @@
             <iidm:temporaryLimit name="_519e3ecb-3561-4d11-ac6b-172a0b4b09b2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04520028-c766-11e1-8775-005056c00008" name="19-20" r="4.3908480000000001" x="20.38608" g1="0" b1="8.5514249999999999e-05" g2="0" b2="8.5514249999999999e-05" node1="39" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b2d70-c766-11e1-8775-005056c00008" p1="-20.879331476211561" q1="-3.0574033492840118" p2="21.003647993737943" q2="0.96027715290440829">
+    <iidm:line id="_04520028-c766-11e1-8775-005056c00008" name="19-20" r="4.3908480000000001" x="20.38608" g1="0" b1="8.5514249999999999e-05" g2="0" b2="8.5514249999999999e-05" node1="39" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b2d70-c766-11e1-8775-005056c00008" p1="-14.78468452445369" q1="2.2042552446643313" p2="14.850520662160054" q2="-4.5327445424000956">
         <iidm:alias>_0472f5a9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04745537-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9870,7 +9870,7 @@
             <iidm:temporaryLimit name="_b88528bf-cb1c-4c00-ad79-d5937197d40c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04862f83-c766-11e1-8775-005056c00008" name="94-95" r="2.2999679999999998" x="7.5620159999999998" g1="0" b1="3.1852600000000001e-05" g2="0" b2="3.1852600000000001e-05" node1="51" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f4108-c766-11e1-8775-005056c00008" p1="56.643136787981831" q1="6.6157512948779225" p2="-56.201468155784731" q2="-6.2335987355525004">
+    <iidm:line id="_04862f83-c766-11e1-8775-005056c00008" name="94-95" r="2.2999679999999998" x="7.5620159999999998" g1="0" b1="3.1852600000000001e-05" g2="0" b2="3.1852600000000001e-05" node1="51" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f4108-c766-11e1-8775-005056c00008" p1="57.220536614056329" q1="6.496730689709997" p2="-56.770088369152937" q2="-6.0854506628441438">
         <iidm:alias>_044ca8f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04837060-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9878,7 +9878,7 @@
             <iidm:temporaryLimit name="_b70e76a1-6e79-4fb6-b487-dffa9bfeab7b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047b0bf6-c766-11e1-8775-005056c00008" name="12-16" r="3.6938879999999998" x="14.5316162" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="68" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046f7338-c766-11e1-8775-005056c00008" p1="9.50209823886515" q1="9.0997250587540588" p2="-9.4602907999364252" q2="-11.010403249374143">
+    <iidm:line id="_047b0bf6-c766-11e1-8775-005056c00008" name="12-16" r="3.6938879999999998" x="14.5316162" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="68" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046f7338-c766-11e1-8775-005056c00008" p1="16.380734309694279" q1="7.6961512020423175" p2="-16.306152324493404" q2="-9.4774024020887637">
         <iidm:alias>_0450798a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045c8772-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9886,7 +9886,7 @@
             <iidm:temporaryLimit name="_af73f526-c58b-40e7-8e1c-14f05a39f6a2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04524e47-c766-11e1-8775-005056c00008" name="100-103" r="2.7878400000000001" x="9.1476000000000006" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="78" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0475b4c0-c766-11e1-8775-005056c00008" p1="115.59165790191206" q1="-20.691432888435575" p2="-113.47503009054788" q2="22.130850328998186">
+    <iidm:line id="_04524e47-c766-11e1-8775-005056c00008" name="100-103" r="2.7878400000000001" x="9.1476000000000006" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="78" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0475b4c0-c766-11e1-8775-005056c00008" p1="115.37550680038163" q1="-20.639909787862081" p2="-113.26688546954746" q2="22.053060536037531">
         <iidm:alias>_04684744-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048aea71-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9894,7 +9894,7 @@
             <iidm:temporaryLimit name="_1631e50b-21a3-470b-803b-f9665b6fcd60" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04682038-c766-11e1-8775-005056c00008" name="27-32" r="3.9900959999999999" x="13.1551189" g1="0" b1="5.5268600000000001e-05" g2="0" b2="5.5268600000000001e-05" node1="40" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="15.733223883372061" q1="-2.6096284189358689" p2="-15.672237606005568" q2="1.0038248192521544">
+    <iidm:line id="_04682038-c766-11e1-8775-005056c00008" name="27-32" r="3.9900959999999999" x="13.1551189" g1="0" b1="5.5268600000000001e-05" g2="0" b2="5.5268600000000001e-05" node1="40" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="17.953845534025415" q1="-3.0613198705299562" p2="-17.873973062854823" q2="1.5235410714645614">
         <iidm:alias>_0455347a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479ac63-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9902,7 +9902,7 @@
             <iidm:temporaryLimit name="_52eb4b09-42bb-4106-ac26-fe1059639d3a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0482fb31-c766-11e1-8775-005056c00008" name="59-61" r="5.7150720000000002" x="26.1360016" g1="0" b1="0.0001113407" g2="0" b2="0.0001113407" node1="68" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-100.83815123386731" q1="22.27657294925514" p2="104.47302695792446" q2="-9.4565529415317897">
+    <iidm:line id="_0482fb31-c766-11e1-8775-005056c00008" name="59-61" r="5.7150720000000002" x="26.1360016" g1="0" b1="0.0001113407" g2="0" b2="0.0001113407" node1="68" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-100.77070581206829" q1="22.249766259429592" p2="104.40054916576422" q2="-9.4527579173219802">
         <iidm:alias>_044a10e9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0473b8f5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9910,7 +9910,7 @@
             <iidm:temporaryLimit name="_b5a7dea0-bfce-4548-a04d-7bb7b6d9f80a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047d55e3-c766-11e1-8775-005056c00008" name="100-104" r="7.8582239999999999" x="35.544960000000003" g1="0" b1="0.00015524565000000001" g2="0" b2="0.00015524565000000001" node1="79" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="55.04501506016031" q1="10.976728854244636" p2="-53.641075660188122" q2="-9.9722539045417182">
+    <iidm:line id="_047d55e3-c766-11e1-8775-005056c00008" name="100-104" r="7.8582239999999999" x="35.544960000000003" g1="0" b1="0.00015524565000000001" g2="0" b2="0.00015524565000000001" node1="79" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="54.998386896323012" q1="10.980795136076701" p2="-53.596634930622301" q2="-9.9862216074496999">
         <iidm:alias>_04636547-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048aea76-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9918,7 +9918,7 @@
             <iidm:temporaryLimit name="_17a10cd0-b653-4dcf-bdc3-4d5005ea9591" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04653a02-c766-11e1-8775-005056c00008" name="75-77" r="10.4718237" x="34.830577900000002" g1="0" b1="0.00014284895" g2="0" b2="0.00014284895" node1="49" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-35.809721687529922" q1="-7.081000018001343" p2="36.646499502319443" q2="5.0293231079805132">
+    <iidm:line id="_04653a02-c766-11e1-8775-005056c00008" name="75-77" r="10.4718237" x="34.830577900000002" g1="0" b1="0.00014284895" g2="0" b2="0.00014284895" node1="49" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-36.444508701792564" q1="-7.0041720435039423" p2="37.311107670742501" q2="5.054612764746313">
         <iidm:alias>_04642894-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04720b47-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9926,7 +9926,7 @@
             <iidm:temporaryLimit name="_6f81df11-7e71-4b6e-a6ee-a8c5f72f4ba5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04483c2a-c766-11e1-8775-005056c00008" name="23-32" r="5.5234079999999999" x="20.089872400000001" g1="0" b1="0.00033660465000000001" g2="0" b2="0.00033660465000000001" node1="40" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="81.152192430230173" q1="7.2564620045780499" p2="-79.02686803367294" q2="-10.928089918453384">
+    <iidm:line id="_04483c2a-c766-11e1-8775-005056c00008" name="23-32" r="5.5234079999999999" x="20.089872400000001" g1="0" b1="0.00033660465000000001" g2="0" b2="0.00033660465000000001" node1="40" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="84.13278015287689" q1="4.9383112869022234" p2="-81.853670896482527" q2="-7.9889581414739324">
         <iidm:alias>_044b978a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0461dea6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9934,7 +9934,7 @@
             <iidm:temporaryLimit name="_a8f6a7d2-e58d-4671-a776-97be7291355e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048719e5-c766-11e1-8775-005056c00008" name="96-97" r="3.0143520000000001" x="15.42024" g1="0" b1="6.8870549999999994e-05" g2="0" b2="6.8870549999999994e-05" node1="50" voltageLevelId1="_045a1672-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="2.6454270333590788" q1="-25.325814067246395" p2="-2.5407057427961059" q2="23.46960866786727">
+    <iidm:line id="_048719e5-c766-11e1-8775-005056c00008" name="96-97" r="3.0143520000000001" x="15.42024" g1="0" b1="6.8870549999999994e-05" g2="0" b2="6.8870549999999994e-05" node1="50" voltageLevelId1="_045a1672-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="3.1259255346866777" q1="-25.488996730712799" p2="-3.0192759689944988" q2="23.643170714772467">
         <iidm:alias>_0451b207-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04828601-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9942,7 +9942,7 @@
             <iidm:temporaryLimit name="_ea6d39aa-df95-4d3e-b7b6-a800e552e72a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048481d0-c766-11e1-8775-005056c00008" name="25-27" r="5.5408330000000001" x="28.401121100000001" g1="0" b1="0.000506198385" g2="0" b2="0.000506198385" node1="30" voltageLevelId1="_04728079-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0476c639-c766-11e1-8775-005056c00008" p1="148.73615959814802" q1="29.12246746077583" p2="-141.91999783067914" q2="-12.202493351669114">
+    <iidm:line id="_048481d0-c766-11e1-8775-005056c00008" name="25-27" r="5.5408330000000001" x="28.401121100000001" g1="0" b1="0.000506198385" g2="0" b2="0.000506198385" node1="30" voltageLevelId1="_04728079-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0476c639-c766-11e1-8775-005056c00008" p1="154.59189731506245" q1="30.287781208389497" p2="-147.23690799375942" q2="-10.580756403263784">
         <iidm:alias>_046d2947-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04725960-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9950,7 +9950,7 @@
             <iidm:temporaryLimit name="_d9d53af2-5ffa-4f2a-a4e6-ed22371332d6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04885268-c766-11e1-8775-005056c00008" name="110-112" r="4.3037280000000004" x="11.1513615" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="41" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="13" voltageLevelId2="_04784cd1-c766-11e1-8775-005056c00008" p1="69.35439222764451" q1="11.007409586584336" p2="-67.999994151833818" q2="-12.999989282032251">
+    <iidm:line id="_04885268-c766-11e1-8775-005056c00008" name="110-112" r="4.3037280000000004" x="11.1513615" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="41" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="13" voltageLevelId2="_04784cd1-c766-11e1-8775-005056c00008" p1="69.354413629089535" q1="11.00738122861458" p2="-68.000021733956757" q2="-13.000005650191476">
         <iidm:alias>_04611b55-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0481c2ba-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9958,7 +9958,7 @@
             <iidm:temporaryLimit name="_d50299b9-a055-408a-aa1e-2e93a715120f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0484a8e4-c766-11e1-8775-005056c00008" name="89-92" r="1.7249760000000001" x="8.7991200000000003" g1="0" b1="0.00015725434999999999" g2="0" b2="0.00015725434999999999" node1="57" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="68" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="227.6113771184356" q1="-3.2588800250804573" p2="-222.53337882814685" q2="23.711762385800402">
+    <iidm:line id="_0484a8e4-c766-11e1-8775-005056c00008" name="89-92" r="1.7249760000000001" x="8.7991200000000003" g1="0" b1="0.00015725434999999999" g2="0" b2="0.00015725434999999999" node1="57" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="68" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="228.52681978058399" q1="-3.1809951088357491" p2="-223.40789466495821" q2="23.843063037195549">
         <iidm:alias>_04481517-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04808a3c-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9966,7 +9966,7 @@
             <iidm:temporaryLimit name="_eee9ca2b-764f-4ab8-a745-405338044743" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04689568-c766-11e1-8775-005056c00008" name="49-54" r="15.1414566" x="50.703842199999997" g1="0" b1="0.00020948120000000001" g2="0" b2="0.00020948120000000001" node1="116" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="46.672066269105848" q1="9.6001474234145867" p2="-44.721058155554637" q2="-10.230530030397823">
+    <iidm:line id="_04689568-c766-11e1-8775-005056c00008" name="49-54" r="15.1414566" x="50.703842199999997" g1="0" b1="0.00020948120000000001" g2="0" b2="0.00020948120000000001" node1="116" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="46.50984894184915" q1="9.6268706710394927" p2="-44.570747936927788" q2="-10.297122369816494">
         <iidm:alias>_046030f0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04605808-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9974,7 +9974,7 @@
             <iidm:temporaryLimit name="_690202a4-aad2-4ad3-8842-961b39e37709" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046c8d04-c766-11e1-8775-005056c00008" name="40-41" r="2.5264799999999998" x="8.4854880000000001" g1="0" b1="3.5066600000000001e-05" g2="0" b2="3.5066600000000001e-05" node1="40" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048c4a08-c766-11e1-8775-005056c00008" p1="27.265198917840312" q1="-1.9623588476822578" p2="-27.130975345345103" q2="1.4327620743490921">
+    <iidm:line id="_046c8d04-c766-11e1-8775-005056c00008" name="40-41" r="2.5264799999999998" x="8.4854880000000001" g1="0" b1="3.5066600000000001e-05" g2="0" b2="3.5066600000000001e-05" node1="40" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048c4a08-c766-11e1-8775-005056c00008" p1="26.463216084771744" q1="-1.6814014765914778" p2="-26.336881845663306" q2="1.1253617122825854">
         <iidm:alias>_045cae80-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a2194-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9982,7 +9982,7 @@
             <iidm:temporaryLimit name="_34f2ef7c-32da-4444-b989-d02f5f931c50" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046735d5-c766-11e1-8775-005056c00008" name="39-40" r="3.206016" x="10.54152" g1="0" b1="4.4536249999999999e-05" g2="0" b2="4.4536249999999999e-05" node1="22" voltageLevelId1="_046bf0c7-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="38.925142354446201" q1="3.5611334044162097" p2="-38.582894883283657" q2="-3.7002889119208433">
+    <iidm:line id="_046735d5-c766-11e1-8775-005056c00008" name="39-40" r="3.206016" x="10.54152" g1="0" b1="4.4536249999999999e-05" g2="0" b2="4.4536249999999999e-05" node1="22" voltageLevelId1="_046bf0c7-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="38.091474741376167" q1="3.7841848934370983" p2="-37.763124418467065" q2="-3.9690034380938712">
         <iidm:alias>_045115c1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048badc2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9990,7 +9990,7 @@
             <iidm:temporaryLimit name="_38d58455-5205-46bb-8e44-c66873f62938" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0470d2c4-c766-11e1-8775-005056c00008" name="89-92" r="6.8476319999999999" x="27.5473423" g1="0" b1="0.00011880164999999999" g2="0" b2="0.00011880164999999999" node1="58" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="71.801212392058588" q1="-5.843133435978304" p2="-69.789768037561288" q2="9.8176091232481753">
+    <iidm:line id="_0470d2c4-c766-11e1-8775-005056c00008" name="89-92" r="6.8476319999999999" x="27.5473423" g1="0" b1="0.00011880164999999999" g2="0" b2="0.00011880164999999999" node1="58" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="72.091255768977689" q1="-5.8330287821128701" p2="-70.063599902174701" q2="9.8730371193858186">
         <iidm:alias>_04690a97-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04690a98-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9998,7 +9998,7 @@
             <iidm:temporaryLimit name="_0cce41c7-b99f-4fec-93d2-73ea24433fa1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0479ac60-c766-11e1-8775-005056c00008" name="33-37" r="7.2309599999999996" x="24.742080000000001" g1="0" b1="0.00010502754999999999" g2="0" b2="0.00010502754999999999" node1="21" voltageLevelId1="_0456bb11-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="42.271832805341717" q1="-20.535593845609036" p2="-41.257413408441046" q2="20.750572621736048">
+    <iidm:line id="_0479ac60-c766-11e1-8775-005056c00008" name="33-37" r="7.2309599999999996" x="24.742080000000001" g1="0" b1="0.00010502754999999999" g2="0" b2="0.00010502754999999999" node1="21" voltageLevelId1="_0456bb11-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="38.792512536399045" q1="-19.976389005900273" p2="-37.920516356080228" q2="19.705929577748805">
         <iidm:alias>_04716f08-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0483be89-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10006,7 +10006,7 @@
             <iidm:temporaryLimit name="_343677c6-7477-4bf6-a12c-2c7e4a684d6f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048c4a00-c766-11e1-8775-005056c00008" name="105-108" r="4.5476640000000002" x="12.249072099999999" g1="0" b1="5.2915499999999998e-05" g2="0" b2="5.2915499999999998e-05" node1="50" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_046c65f4-c766-11e1-8775-005056c00008" p1="22.997237006271778" q1="-0.86260788588862336" p2="-22.849105781575826" q2="-0.44596085503065541">
+    <iidm:line id="_048c4a00-c766-11e1-8775-005056c00008" name="105-108" r="4.5476640000000002" x="12.249072099999999" g1="0" b1="5.2915499999999998e-05" g2="0" b2="5.2915499999999998e-05" node1="50" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_046c65f4-c766-11e1-8775-005056c00008" p1="22.930376196645295" q1="-0.84152778269001327" p2="-22.783105426807904" q2="-0.4693670283299714">
         <iidm:alias>_046adf53-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04795e46-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10014,7 +10014,7 @@
             <iidm:temporaryLimit name="_74cf84b9-e14f-4f81-9e8b-3a791cd474a0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04631724-c766-11e1-8775-005056c00008" name="34-37" r="0.44605400000000001" x="1.637856" g1="0" b1="2.8236900000000001e-05" g2="0" b2="2.8236900000000001e-05" node1="41" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-54.300985135197379" q1="-35.72845529995282" p2="54.421324700714159" q2="35.287765936876362">
+    <iidm:line id="_04631724-c766-11e1-8775-005056c00008" name="34-37" r="0.44605400000000001" x="1.637856" g1="0" b1="2.8236900000000001e-05" g2="0" b2="2.8236900000000001e-05" node1="41" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-57.108830550020748" q1="-35.125013617147403" p2="57.236973976452134" q2="34.713231479971981">
         <iidm:alias>_04592c19-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04719611-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10022,7 +10022,7 @@
             <iidm:temporaryLimit name="_8e90bf2e-3be4-41be-a84e-c1d4e709f8a1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04814d85-c766-11e1-8775-005056c00008" name="61-62" r="1.435738" x="6.5514239999999999" g1="0" b1="2.812215e-05" g2="0" b2="2.812215e-05" node1="40" voltageLevelId1="_0448d867-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="59.941592561283194" q1="-18.17434269406774" p2="-59.616503485889979" q2="18.685568470057074">
+    <iidm:line id="_04814d85-c766-11e1-8775-005056c00008" name="61-62" r="1.435738" x="6.5514239999999999" g1="0" b1="2.812215e-05" g2="0" b2="2.812215e-05" node1="40" voltageLevelId1="_0448d867-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="60.122667859253632" q1="-18.210012242856706" p2="-59.795663977851824" q2="18.72997583027977">
         <iidm:alias>_045a3d85-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047abdd8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10030,7 +10030,7 @@
             <iidm:temporaryLimit name="_39a23399-348e-44d9-8032-8fc62e6c7d63" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046a4318-c766-11e1-8775-005056c00008" name="101-102" r="4.2863040000000003" x="19.5148811" g1="0" b1="8.4366399999999999e-05" g2="0" b2="8.4366399999999999e-05" node1="22" voltageLevelId1="_046ed6f7-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="-43.953042552277857" q1="11.55803128559697" p2="44.479548896566463" q2="-12.039958819465857">
+    <iidm:line id="_046a4318-c766-11e1-8775-005056c00008" name="101-102" r="4.2863040000000003" x="19.5148811" g1="0" b1="8.4366399999999999e-05" g2="0" b2="8.4366399999999999e-05" node1="22" voltageLevelId1="_046ed6f7-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="-44.135950958106548" q1="11.630120737433474" p2="44.667019594486881" q2="-12.090912997389754">
         <iidm:alias>_04878f1b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04885261-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10038,7 +10038,7 @@
             <iidm:temporaryLimit name="_0501dacc-29fc-44a2-8cad-31a20b011d25" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c81e3-c766-11e1-8775-005056c00008" name="26-30" r="3.8671600000000002" x="41.624000000000002" g1="0" b1="0.00093801650000000002" g2="0" b2="0.00093801650000000002" node1="21" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="238.23529894586537" q1="-4.9594837957776079" p2="-233.69794206216042" q2="-36.677135679271935">
+    <iidm:line id="_044c81e3-c766-11e1-8775-005056c00008" name="26-30" r="3.8671600000000002" x="41.624000000000002" g1="0" b1="0.00093801650000000002" g2="0" b2="0.00093801650000000002" node1="21" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="225.52084663345502" q1="0.30532735022712476" p2="-221.4044951837777" q2="-45.976088786328972">
         <iidm:alias>_0463654b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04747c4a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10046,7 +10046,7 @@
             <iidm:temporaryLimit name="_c95a66fd-913c-48c7-b8ef-cf3007c60af6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048915b9-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="41" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="117" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-52.969956729242064" q1="-19.076899676789218" p2="55.578191893760376" q2="22.751748443656979">
+    <iidm:line id="_048915b9-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="41" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="117" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-53.769234508348461" q1="-18.777727292025521" p2="56.443423501128187" q2="22.751498534429444">
         <iidm:alias>_044bbe98-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0456e224-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10054,7 +10054,7 @@
             <iidm:temporaryLimit name="_6cd83bc2-204f-44d5-afd4-fbfef8d2146f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c5ad6-c766-11e1-8775-005056c00008" name="105-106" r="2.4393600000000002" x="9.5309279999999994" g1="0" b1="4.1150150000000001e-05" g2="0" b2="4.1150150000000001e-05" node1="51" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="9.6080188245320812" q1="6.1491637029425199" p2="-9.5871672087740052" q2="-7.3967220093629464">
+    <iidm:line id="_044c5ad6-c766-11e1-8775-005056c00008" name="105-106" r="2.4393600000000002" x="9.5309279999999994" g1="0" b1="4.1150150000000001e-05" g2="0" b2="4.1150150000000001e-05" node1="51" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="9.6394039011626997" q1="6.137859790514705" p2="-9.6184847254056365" q2="-7.3851609319412868">
         <iidm:alias>_04505270-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04531190-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10062,7 +10062,7 @@
             <iidm:temporaryLimit name="_487e1317-48f9-4747-b931-f3f79e95f55a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048badc5-c766-11e1-8775-005056c00008" name="60-61" r="0.45999400000000001" x="2.3522400000000001" g1="0" b1="4.1781450000000003e-05" g2="0" b2="4.1781450000000003e-05" node1="30" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-169.27706333569105" q1="15.878460330038251" p2="170.05244026871424" q2="-13.351296126967634">
+    <iidm:line id="_048badc5-c766-11e1-8775-005056c00008" name="60-61" r="0.45999400000000001" x="2.3522400000000001" g1="0" b1="4.1781450000000003e-05" g2="0" b2="4.1781450000000003e-05" node1="30" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-169.31155449190129" q1="15.894645841833505" p2="170.08725745492902" q2="-13.365815297946915">
         <iidm:alias>_04793734-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048a4e31-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10070,7 +10070,7 @@
             <iidm:temporaryLimit name="_3c55a929-a755-409b-af5f-bae188892af1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044cd003-c766-11e1-8775-005056c00008" name="23-25" r="2.7181440000000001" x="13.9391994" g1="0" b1="0.00024793390000000002" g2="0" b2="0.00024793390000000002" node1="41" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="-196.3777974040307" q1="-9.1404731016745711" p2="202.34875249014976" q2="30.642764233725156">
+    <iidm:line id="_044cd003-c766-11e1-8775-005056c00008" name="23-25" r="2.7181440000000001" x="13.9391994" g1="0" b1="0.00024793390000000002" g2="0" b2="0.00024793390000000002" node1="41" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="-204.6802524072402" q1="-10.595908863575094" p2="211.21684172671581" q2="35.030764955219922">
         <iidm:alias>_045ed161-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0473b8f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10078,7 +10078,7 @@
             <iidm:temporaryLimit name="_9658628a-596f-41a9-96a7-c5a8aaf5400c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0457a574-c766-11e1-8775-005056c00008" name="19-34" r="13.102848099999999" x="43.037277199999998" g1="0" b1="0.00018135905000000001" g2="0" b2="0.00018135905000000001" node1="40" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0483be8b-c766-11e1-8775-005056c00008" p1="55.902923080441106" q1="-15.340530679031311" p2="-53.129035101361467" q2="18.820573431172491">
+    <iidm:line id="_0457a574-c766-11e1-8775-005056c00008" name="19-34" r="13.102848099999999" x="43.037277199999998" g1="0" b1="0.00018135905000000001" g2="0" b2="0.00018135905000000001" node1="40" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0483be8b-c766-11e1-8775-005056c00008" p1="51.345405089790411" q1="-15.717742503882537" p2="-48.961044609781837" q2="17.93699370203732">
         <iidm:alias>_04502b61-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04686e5b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10086,7 +10086,7 @@
             <iidm:temporaryLimit name="_b69ab61b-751d-487a-a538-2d47eea7572e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04595326-c766-11e1-8775-005056c00008" name="59-60" r="5.5234079999999999" x="25.264800000000001" g1="0" b1="0.00010789715" g2="0" b2="0.00010789715" node1="69" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_045cfca4-c766-11e1-8775-005056c00008" p1="-89.196104957655947" q1="19.150724157591352" p2="91.939276668688692" q2="-10.278941663133999">
+    <iidm:line id="_04595326-c766-11e1-8775-005056c00008" name="59-60" r="5.5234079999999999" x="25.264800000000001" g1="0" b1="0.00010789715" g2="0" b2="0.00010789715" node1="69" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_045cfca4-c766-11e1-8775-005056c00008" p1="-89.122981757350487" q1="19.122816408835522" p2="91.861512537967727" q2="-10.272264342510354">
         <iidm:alias>_04611b57-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0463b366-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10094,7 +10094,7 @@
             <iidm:temporaryLimit name="_a38d4859-b54a-482f-a2ad-0b4ce4c4da2a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045a8ba1-c766-11e1-8775-005056c00008" name="15-19" r="2.0908799999999998" x="6.865056" g1="0" b1="2.8983e-05" g2="0" b2="2.8983e-05" node1="50" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="29.130040419157865" q1="8.417794113274887" p2="-29.006890216493765" q2="-8.9191007438074141">
+    <iidm:line id="_045a8ba1-c766-11e1-8775-005056c00008" name="15-19" r="2.0908799999999998" x="6.865056" g1="0" b1="2.8983e-05" g2="0" b2="2.8983e-05" node1="50" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="33.164674412556003" q1="10.68811790432685" p2="-33.001586282939293" q2="-11.05397635219939">
         <iidm:alias>_047629f1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0481e9c1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10102,7 +10102,7 @@
             <iidm:temporaryLimit name="_15d16bd2-d87c-4584-93d2-b294dc1be116" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04513cd6-c766-11e1-8775-005056c00008" name="90-91" r="4.4256960000000003" x="14.566463499999999" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="31" voltageLevelId1="_047d07c3-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044f8f29-c766-11e1-8775-005056c00008" p1="4.2547238029305472" q1="-16.320251956488125" p2="-4.1845651245677322" q2="14.562740290916048">
+    <iidm:line id="_04513cd6-c766-11e1-8775-005056c00008" name="90-91" r="4.4256960000000003" x="14.566463499999999" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="31" voltageLevelId1="_047d07c3-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044f8f29-c766-11e1-8775-005056c00008" p1="4.4091625902640956" q1="-16.341491628212481" p2="-4.3384487196356787" q2="14.585954576109769">
         <iidm:alias>_045f94b9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04627ae1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10110,7 +10110,7 @@
             <iidm:temporaryLimit name="_7d2a67fb-9d8c-4745-a67e-ce6ade5e520e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0487b623-c766-11e1-8775-005056c00008" name="22-23" r="5.9590079999999999" x="27.704158799999998" g1="0" b1="0.00011593205" g2="0" b2="0.00011593205" node1="21" voltageLevelId1="_04773b6a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_047f9fdb-c766-11e1-8775-005056c00008" p1="-49.787389838520923" q1="-7.8089218073316538" p2="50.693839012558172" q2="8.0710134951678736">
+    <iidm:line id="_0487b623-c766-11e1-8775-005056c00008" name="22-23" r="5.9590079999999999" x="27.704158799999998" g1="0" b1="0.00011593205" g2="0" b2="0.00011593205" node1="21" voltageLevelId1="_04773b6a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_047f9fdb-c766-11e1-8775-005056c00008" p1="-57.585621331043093" q1="-10.778167804614625" p2="58.843357502728402" q2="12.738907258310547">
         <iidm:alias>_045e0e18-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0477b095-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10118,7 +10118,7 @@
             <iidm:temporaryLimit name="_6477d99a-dd64-4083-8f56-1396610879f0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048b1189-c766-11e1-8775-005056c00008" name="83-85" r="7.4923200000000003" x="25.787520000000001" g1="0" b1="9.9862250000000004e-05" g2="0" b2="9.9862250000000004e-05" node1="32" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-54.247849981284055" q1="19.082776499086439" p2="55.776845492272031" q2="-17.110069332085107">
+    <iidm:line id="_048b1189-c766-11e1-8775-005056c00008" name="83-85" r="7.4923200000000003" x="25.787520000000001" g1="0" b1="9.9862250000000004e-05" g2="0" b2="9.9862250000000004e-05" node1="32" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-54.738135280865194" q1="19.224993139023809" p2="56.294672218522969" q2="-17.156388333514027">
         <iidm:alias>_0455d0b1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0462c906-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10126,7 +10126,7 @@
             <iidm:temporaryLimit name="_38cb3e5b-af1a-4684-aa2f-242826ed460c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045868c5-c766-11e1-8775-005056c00008" name="17-31" r="8.2589760000000005" x="27.233711199999998" g1="0" b1="0.00011449725" g2="0" b2="0.00011449725" node1="60" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="17.170622802839421" q1="1.9571553863936311" p2="-17.018044337563698" q2="-5.2399811728016585">
+    <iidm:line id="_045868c5-c766-11e1-8775-005056c00008" name="17-31" r="8.2589760000000005" x="27.233711199999998" g1="0" b1="0.00011449725" g2="0" b2="0.00011449725" node1="60" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="12.854571825508481" q1="2.5892397845516593" p2="-12.763039557402955" q2="-6.0698058231741809">
         <iidm:alias>_04544a16-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0467f924-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10134,7 +10134,7 @@
             <iidm:temporaryLimit name="_9066b19a-f404-42c3-88ce-51d375f6fdb5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0488c796-c766-11e1-8775-005056c00008" name="89-90" r="9.0256319999999999" x="32.75712" g1="0" b1="0.00015151515000000001" g2="0" b2="0.00015151515000000001" node1="59" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="59.660243932132275" q1="9.2564763011569333" p2="-57.761899259255912" q2="-7.4549351045146235">
+    <iidm:line id="_0488c796-c766-11e1-8775-005056c00008" name="89-90" r="9.0256319999999999" x="32.75712" g1="0" b1="0.00015151515000000001" g2="0" b2="0.00015151515000000001" node1="59" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="59.716114379653028" q1="9.2604358413338765" p2="-57.814298950822838" q2="-7.4461682325985805">
         <iidm:alias>_0459ef61-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04837069-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10142,7 +10142,7 @@
             <iidm:temporaryLimit name="_924b4a0b-bef5-432a-ad87-ab5c10d9c019" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0462c907-c766-11e1-8775-005056c00008" name="70-75" r="7.4574720000000001" x="24.56784" g1="0" b1="0.0001033058" g2="0" b2="0.0001033058" node1="50" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="9.4278670391285608" q1="7.1647021638913415" p2="-9.3536151465089112" q2="-10.353113658667775">
+    <iidm:line id="_0462c907-c766-11e1-8775-005056c00008" name="70-75" r="7.4574720000000001" x="24.56784" g1="0" b1="0.0001033058" g2="0" b2="0.0001033058" node1="50" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="8.6113779761090008" q1="7.0860772404073913" p2="-8.5441395129886697" q2="-10.292639570046363">
         <iidm:alias>_04649dc9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04784cdb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10150,7 +10150,7 @@
             <iidm:temporaryLimit name="_d432d118-553c-4f4c-a734-e98e0762ec40" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045fbbc3-c766-11e1-8775-005056c00008" name="50-57" r="8.2589760000000005" x="23.34816" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="22" voltageLevelId1="_044d1e26-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="44.258211501604976" q1="6.7031025723908968" p2="-43.297330733156784" q2="-7.2092115531327829">
+    <iidm:line id="_045fbbc3-c766-11e1-8775-005056c00008" name="50-57" r="8.2589760000000005" x="23.34816" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="22" voltageLevelId1="_044d1e26-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="44.11134019749769" q1="6.7446694279738679" p2="-43.156301226658556" q2="-7.2673850954877581">
         <iidm:alias>_04500455-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0468e383-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10158,7 +10158,7 @@
             <iidm:temporaryLimit name="_2f32bda4-7275-4485-9901-12f8cff9e4a1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044b9789-c766-11e1-8775-005056c00008" name="5-6" r="2.0734560000000002" x="9.4089600000000004" g1="0" b1="4.0920549999999999e-05" g2="0" b2="4.0920549999999999e-05" node1="49" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f6818-c766-11e1-8775-005056c00008" p1="91.39708152675216" q1="19.513844892838332" p2="-90.375478767578414" q2="-16.304383876187686">
+    <iidm:line id="_044b9789-c766-11e1-8775-005056c00008" name="5-6" r="2.0734560000000002" x="9.4089600000000004" g1="0" b1="4.0920549999999999e-05" g2="0" b2="4.0920549999999999e-05" node1="49" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f6818-c766-11e1-8775-005056c00008" p1="95.824718136980877" q1="17.682460853397121" p2="-94.711937186380439" q2="-14.056415032029962">
         <iidm:alias>_044a5f01-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0455d0b2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10166,7 +10166,7 @@
             <iidm:temporaryLimit name="_b3b0e81b-a434-4e9c-ad94-1161ff47b077" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04720b41-c766-11e1-8775-005056c00008" name="55-59" r="8.2572340000000004" x="37.600994100000001" g1="0" b1="0.00016201790000000001" g2="0" b2="0.00016201790000000001" node1="30" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-24.078982370758791" q1="-11.567635484027596" p2="24.42515299460154" q2="7.8504078754296325">
+    <iidm:line id="_04720b41-c766-11e1-8775-005056c00008" name="55-59" r="8.2572340000000004" x="37.600994100000001" g1="0" b1="0.00016201790000000001" g2="0" b2="0.00016201790000000001" node1="30" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-24.193338622972494" q1="-11.535257883440041" p2="24.542093273670215" q2="7.8297869073610293">
         <iidm:alias>_04656113-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04675ce4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10174,7 +10174,7 @@
             <iidm:temporaryLimit name="_6db0d250-4a2e-4169-abf0-f842aeca485d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048963d9-c766-11e1-8775-005056c00008" name="1-2" r="5.2794720000000002" x="17.4065762" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="22" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_045d4ac5-c766-11e1-8775-005056c00008" p1="-11.458268006758127" q1="-10.256904626532309" p2="11.52852506791878" q2="8.1138617388545278">
+    <iidm:line id="_048963d9-c766-11e1-8775-005056c00008" name="1-2" r="5.2794720000000002" x="17.4065762" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="22" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_045d4ac5-c766-11e1-8775-005056c00008" p1="-10.479754509187398" q1="-10.848564431264823" p2="10.546679451907174" q2="8.696111211180714">
         <iidm:alias>_044b9786-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04845acb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10182,7 +10182,7 @@
             <iidm:temporaryLimit name="_9f39cb45-314c-445e-b177-909854a9ce45" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0484f709-c766-11e1-8775-005056c00008" name="11-12" r="1.0367280000000001" x="3.4151039999999999" g1="0" b1="1.4405399999999999e-05" g2="0" b2="1.4405399999999999e-05" node1="40" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="34.613527952049175" q1="-24.307894754130356" p2="-34.505044805618915" q2="24.17459430740114">
+    <iidm:line id="_0484f709-c766-11e1-8775-005056c00008" name="11-12" r="1.0367280000000001" x="3.4151039999999999" g1="0" b1="1.4405399999999999e-05" g2="0" b2="1.4405399999999999e-05" node1="40" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="39.708337634205215" q1="-28.899694934740978" p2="-39.561778297507715" q2="28.892128325839888">
         <iidm:alias>_0456e227-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04880440-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10190,7 +10190,7 @@
             <iidm:temporaryLimit name="_70fad3e1-4529-4a7f-9e6c-8ab249d65460" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044bbe91-c766-11e1-8775-005056c00008" name="8-9" r="1.18096" x="14.762" g1="0" b1="0.001200413215" g2="0" b2="0.001200413215" node1="31" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_045c8779-c766-11e1-8775-005056c00008" p1="-485.13651874939569" q1="-83.423068826996442" p2="490.81054915630989" q2="32.934875747259355">
+    <iidm:line id="_044bbe91-c766-11e1-8775-005056c00008" name="8-9" r="1.18096" x="14.762" g1="0" b1="0.001200413215" g2="0" b2="0.001200413215" node1="31" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_045c8779-c766-11e1-8775-005056c00008" p1="-486.71038834262771" q1="-86.171994522653378" p2="492.45481090890007" q2="37.046769385892297">
         <iidm:alias>_04745535-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048a7548-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="2000">
@@ -10198,7 +10198,7 @@
             <iidm:temporaryLimit name="_205e5d8a-f05a-479d-adaa-3514f48f6857" acceptableDuration="60" value="2400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04566cf8-c766-11e1-8775-005056c00008" name="64-65" r="1.30196" x="14.6168" g1="0" b1="0.000392562" g2="0" b2="0.000392562" node1="35" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-157.89158576309489" q1="-33.92273885832288" p2="158.57512794492001" q2="3.5949293050304711">
+    <iidm:line id="_04566cf8-c766-11e1-8775-005056c00008" name="64-65" r="1.30196" x="14.6168" g1="0" b1="0.000392562" g2="0" b2="0.000392562" node1="35" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-157.43305286905743" q1="-33.951884288963441" p2="158.11267646702876" q2="3.5797094729451389">
         <iidm:alias>_044a10e2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04793738-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10206,7 +10206,7 @@
             <iidm:temporaryLimit name="_8cee2b62-2953-439b-ba4b-4a48d55116c0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046783f3-c766-11e1-8775-005056c00008" name="54-56" r="0.47915999999999997" x="1.6639919999999999" g1="0" b1="2.1005500000000001e-05" g2="0" b2="2.1005500000000001e-05" node1="60" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="29.60613101447586" q1="2.7080802106002415" p2="-29.579422508900262" q2="-3.2821261863811664">
+    <iidm:line id="_046783f3-c766-11e1-8775-005056c00008" name="54-56" r="0.47915999999999997" x="1.6639919999999999" g1="0" b1="2.1005500000000001e-05" g2="0" b2="2.1005500000000001e-05" node1="60" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="29.565473863230523" q1="2.6943976845324418" p2="-29.53884038642456" q2="-3.2687055963508587">
         <iidm:alias>_0460f444-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d2949-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10214,7 +10214,7 @@
             <iidm:temporaryLimit name="_640627c7-0672-413e-8dc8-c9965709a5cb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04670ec6-c766-11e1-8775-005056c00008" name="84-85" r="5.2620480000000001" x="11.1687832" g1="0" b1="3.541095e-05" g2="0" b2="3.541095e-05" node1="21" voltageLevelId1="_047b0bf4-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-44.008026632797211" q1="14.233716314203631" p2="44.705548753814483" q2="-13.910528918633732">
+    <iidm:line id="_04670ec6-c766-11e1-8775-005056c00008" name="84-85" r="5.2620480000000001" x="11.1687832" g1="0" b1="3.541095e-05" g2="0" b2="3.541095e-05" node1="21" voltageLevelId1="_047b0bf4-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-44.353613313286758" q1="14.346596537416206" p2="45.0623435443093" q2="-13.999272696010992">
         <iidm:alias>_0453fbf5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046512f7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10222,7 +10222,7 @@
             <iidm:temporaryLimit name="_8b888209-5038-4b98-80fc-062b5ea55747" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0460cd36-c766-11e1-8775-005056c00008" name="34-36" r="1.51763" x="4.669632" g1="0" b1="1.6299349999999998e-05" g2="0" b2="1.6299349999999998e-05" node1="43" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="34.793008078238955" q1="11.202864089027237" p2="-34.662014042244707" q2="-11.303133847305229">
+    <iidm:line id="_0460cd36-c766-11e1-8775-005056c00008" name="34-36" r="1.51763" x="4.669632" g1="0" b1="1.6299349999999998e-05" g2="0" b2="1.6299349999999998e-05" node1="43" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="34.484742164058076" q1="11.256952896365483" p2="-34.355672407983562" q2="-11.362994916607468">
         <iidm:alias>_046a6a26-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0487b620-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10230,7 +10230,7 @@
             <iidm:temporaryLimit name="_c0a08025-3a61-4d24-9944-f3ef0b079f64" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04549836-c766-11e1-8775-005056c00008" name="24-70" r="0.38507000000000002" x="71.699759999999998" g1="0" b1="0.00029264234999999998" g2="0" b2="0.00029264234999999998" node1="32" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="18.575242535702884" q1="-0.8028277135123042" p2="-18.567209654996855" q2="-7.746915961761272">
+    <iidm:line id="_04549836-c766-11e1-8775-005056c00008" name="24-70" r="0.38507000000000002" x="71.699759999999998" g1="0" b1="0.00029264234999999998" g2="0" b2="0.00029264234999999998" node1="32" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="17.230046890406932" q1="-1.3540839170254511" p2="-17.223141192697316" q2="-7.3666727996471169">
         <iidm:alias>_04549834-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04854522-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10238,7 +10238,7 @@
             <iidm:temporaryLimit name="_32793450-bbfd-4dcd-a911-89e199600780" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0452273a-c766-11e1-8775-005056c00008" name="85-86" r="6.0983999999999998" x="21.431519999999999" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="50" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0484f70a-c766-11e1-8775-005056c00008" p1="21.283026953872" q1="16.354030319297546" p2="-20.99899457227048" q2="-17.877761657590145">
+    <iidm:line id="_0452273a-c766-11e1-8775-005056c00008" name="85-86" r="6.0983999999999998" x="21.431519999999999" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="50" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0484f70a-c766-11e1-8775-005056c00008" p1="21.281908716905576" q1="16.351793929463561" p2="-20.997855398188822" q2="-17.874799818467444">
         <iidm:alias>_044afb43-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479fa85-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10246,7 +10246,7 @@
             <iidm:temporaryLimit name="_2ec4bef5-7abb-4f52-bb62-49ee474d672b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0450eeb5-c766-11e1-8775-005056c00008" name="16-17" r="7.9104960000000002" x="31.380622899999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="22" voltageLevelId1="_046f7338-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-15.543786632852536" q1="1.0076855276918202" p2="15.663109156063515" q2="-5.0124093552778248">
+    <iidm:line id="_0450eeb5-c766-11e1-8775-005056c00008" name="16-17" r="7.9104960000000002" x="31.380622899999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="22" voltageLevelId1="_046f7338-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-8.6955167886143219" q1="-0.52371038740491682" p2="8.7327037774675365" q2="-3.8016129010203987">
         <iidm:alias>_044ef2ea-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04837066-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10254,7 +10254,7 @@
             <iidm:temporaryLimit name="_9280074c-8555-49ff-9e62-8ed8f7d95060" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048a4e33-c766-11e1-8775-005056c00008" name="62-66" r="8.3983679999999996" x="37.984317799999999" g1="0" b1="0.00016586315" g2="0" b2="0.00016586315" node1="41" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-15.420033600304794" q1="-21.537270612223995" p2="15.70424937630669" q2="16.790577005953171">
+    <iidm:line id="_048a4e33-c766-11e1-8775-005056c00008" name="62-66" r="8.3983679999999996" x="37.984317799999999" g1="0" b1="0.00016586315" g2="0" b2="0.00016586315" node1="41" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-15.273997702640985" q1="-21.57215957114915" p2="15.556672129324866" q2="16.818508846567816">
         <iidm:alias>_046e13a9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a96c7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10262,7 +10262,7 @@
             <iidm:temporaryLimit name="_ace48562-0a49-4b76-ae82-c896a00b04f9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0478e913-c766-11e1-8775-005056c00008" name="76-77" r="7.736256" x="25.787520000000001" g1="0" b1="0.00010560145" g2="0" b2="0.00010560145" node1="21" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-61.863276089836759" q1="-21.301627723547028" p2="63.987985858534749" q2="24.913780684268112">
+    <iidm:line id="_0478e913-c766-11e1-8775-005056c00008" name="76-77" r="7.736256" x="25.787520000000001" g1="0" b1="0.00010560145" g2="0" b2="0.00010560145" node1="21" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-62.348316821202708" q1="-21.248740429076481" p2="64.504073075526151" q2="24.96611179444843">
         <iidm:alias>_044b9785-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04725965-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10270,7 +10270,7 @@
             <iidm:temporaryLimit name="_3f744dba-88dc-4d89-90d4-a6f196054b28" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048badc1-c766-11e1-8775-005056c00008" name="60-62" r="2.1431520000000002" x="9.7748640000000009" g1="0" b1="4.2125800000000002e-05" g2="0" b2="4.2125800000000002e-05" node1="32" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="-0.66214490180276364" q1="-8.5995127107044897" p2="0.66994660835297171" q2="7.1824757129068066">
+    <iidm:line id="_048badc1-c766-11e1-8775-005056c00008" name="60-62" r="2.1431520000000002" x="9.7748640000000009" g1="0" b1="4.2125800000000002e-05" g2="0" b2="4.2125800000000002e-05" node1="32" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="-0.54988108399109692" q1="-8.6223764370100007" p2="0.55771082388172499" q2="7.205466122552223">
         <iidm:alias>_045b7600-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04720b44-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10278,7 +10278,7 @@
             <iidm:temporaryLimit name="_43f91aaf-c5f4-4995-85a2-37afac616331" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0472a780-c766-11e1-8775-005056c00008" name="27-28" r="3.3332109999999999" x="14.89752" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="42" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04819ba0-c766-11e1-8775-005056c00008" p1="32.599300772070769" q1="-1.0939757955529756" p2="-32.383113421203689" q2="0.041373131563141215">
+    <iidm:line id="_0472a780-c766-11e1-8775-005056c00008" name="27-28" r="3.3332109999999999" x="14.89752" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="42" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04819ba0-c766-11e1-8775-005056c00008" p1="34.559759774462421" q1="-2.1179612367864005" p2="-34.315801867378546" q2="1.1944256108506845">
         <iidm:alias>_04531198-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0475188b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10286,7 +10286,7 @@
             <iidm:temporaryLimit name="_2c20e8bd-84e6-4a1e-b88e-071f631327cb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c81e1-c766-11e1-8775-005056c00008" name="45-46" r="6.9695999999999998" x="23.626943600000001" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="31" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="34" voltageLevelId2="_048a7544-c766-11e1-8775-005056c00008" p1="-33.312338209177916" q1="-7.0180145831912952" p2="33.783818342333319" q2="5.3355694428633678">
+    <iidm:line id="_044c81e1-c766-11e1-8775-005056c00008" name="45-46" r="6.9695999999999998" x="23.626943600000001" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="31" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="34" voltageLevelId2="_048a7544-c766-11e1-8775-005056c00008" p1="-33.818280124982266" q1="-6.9576032997241066" p2="34.303709244249639" q2="5.3229648834127046">
         <iidm:alias>_04561ed6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045c877a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10294,7 +10294,7 @@
             <iidm:temporaryLimit name="_6ad31f7e-233f-4801-898f-9ffc883ec724" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c1249-c766-11e1-8775-005056c00008" name="18-19" r="1.949746" x="8.5900320000000008" g1="0" b1="3.2770900000000002e-05" g2="0" b2="3.2770900000000002e-05" node1="22" voltageLevelId1="_04689563-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="51.403637116534384" q1="-1.8354043336665029" p2="-51.074607207624524" q2="2.2634947853077869">
+    <iidm:line id="_045c1249-c766-11e1-8775-005056c00008" name="18-19" r="1.949746" x="8.5900320000000008" g1="0" b1="3.2770900000000002e-05" g2="0" b2="3.2770900000000002e-05" node1="22" voltageLevelId1="_04689563-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="48.860739282688549" q1="0.73415727399002573" p2="-48.562268548307088" q2="-0.4354377527699127">
         <iidm:alias>_046b066b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047ae4e0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10302,7 +10302,7 @@
             <iidm:temporaryLimit name="_a025c9d8-58f9-4320-a1fe-73ecc68d4147" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044a5f09-c766-11e1-8775-005056c00008" name="9-10" r="1.2487200000000001" x="15.584800700000001" g1="0" b1="0.0012706611300000001" g2="0" b2="0.0012706611300000001" node1="21" voltageLevelId1="_045c8779-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_044f4102-c766-11e1-8775-005056c00008" p1="-490.81054915631012" q1="-32.934875747258886" p2="496.61816442941495" q2="-28.50199784608747">
+    <iidm:line id="_044a5f09-c766-11e1-8775-005056c00008" name="9-10" r="1.2487200000000001" x="15.584800700000001" g1="0" b1="0.0012706611300000001" g2="0" b2="0.0012706611300000001" node1="21" voltageLevelId1="_045c8779-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_044f4102-c766-11e1-8775-005056c00008" p1="-492.45481090889996" q1="-37.046769385892176" p2="498.31144923992906" q2="-23.590562566847218">
         <iidm:alias>_04614262-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04834957-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="2000">
@@ -10310,7 +10310,7 @@
             <iidm:temporaryLimit name="_b7fac0a3-c5af-48b9-af49-261fd8d46e00" acceptableDuration="60" value="2400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0480b14b-c766-11e1-8775-005056c00008" name="85-88" r="3.4847999999999999" x="17.772480000000002" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="51" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0470f9d2-c766-11e1-8775-005056c00008" p1="-62.580440343980662" q1="3.5056140795532307" p2="63.416625891752822" q2="-1.8688792499167495">
+    <iidm:line id="_0480b14b-c766-11e1-8775-005056c00008" name="85-88" r="3.4847999999999999" x="17.772480000000002" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="51" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0470f9d2-c766-11e1-8775-005056c00008" p1="-63.012544620362434" q1="3.5816861675483311" p2="63.860621023491234" q2="-1.8837601130896582">
         <iidm:alias>_047602e2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04765105-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10318,7 +10318,7 @@
             <iidm:temporaryLimit name="_51646744-d343-42b5-8ba7-fcedc7cc3a98" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04486330-c766-11e1-8775-005056c00008" name="69-77" r="5.3840159999999999" x="17.598240000000001" g1="0" b1="0.00029786500000000002" g2="0" b2="0.00029786500000000002" node1="60" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="33.47500242122824" q1="17.69143696708424" p2="-32.995824672031588" q2="-26.902364841218358">
+    <iidm:line id="_04486330-c766-11e1-8775-005056c00008" name="69-77" r="5.3840159999999999" x="17.598240000000001" g1="0" b1="0.00029786500000000002" g2="0" b2="0.00029786500000000002" node1="60" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="32.494179291282535" q1="18.090134771103848" p2="-32.028271635464591" q2="-27.343148866118376">
         <iidm:alias>_046205b9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479d379-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10326,7 +10326,7 @@
             <iidm:temporaryLimit name="_76311a15-b79a-4439-a7ce-47afa8fa6fe2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04553477-c766-11e1-8775-005056c00008" name="11-13" r="3.8768400000000001" x="12.7369442" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="41" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04851e1b-c766-11e1-8775-005056c00008" p1="45.170666016450987" q1="15.717879495875744" p2="-44.641753285103086" q2="-15.768387643936755">
+    <iidm:line id="_04553477-c766-11e1-8775-005056c00008" name="11-13" r="3.8768400000000001" x="12.7369442" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="41" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04851e1b-c766-11e1-8775-005056c00008" p1="49.674290730155569" q1="15.028191835823041" p2="-49.052229808013543" q2="-14.769678359044875">
         <iidm:alias>_0479fa89-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0485452a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10334,7 +10334,7 @@
             <iidm:temporaryLimit name="_efbf8de7-4b84-4834-bb7c-6250b6072211" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04488a45-c766-11e1-8775-005056c00008" name="103-105" r="9.3218399999999999" x="28.314" g1="0" b1="0.0001170799" g2="0" b2="0.0001170799" node1="42" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="43.794170222232637" q1="12.537082176292468" p2="-42.67622632785924" q2="-13.123434904150718">
+    <iidm:line id="_04488a45-c766-11e1-8775-005056c00008" name="103-105" r="9.3218399999999999" x="28.314" g1="0" b1="0.0001170799" g2="0" b2="0.0001170799" node1="42" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="43.796681054926921" q1="12.53525759820695" p2="-42.678648884198374" q2="-13.121346325942355">
         <iidm:alias>_044f8f24-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04611b58-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10342,7 +10342,7 @@
             <iidm:temporaryLimit name="_22b6919a-a7a0-49fc-9e90-329069c55055" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046009e6-c766-11e1-8775-005056c00008" name="45-49" r="11.918016400000001" x="32.408639999999998" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="32" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="118" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-40.323472693920223" q1="-8.1588173433326965" p2="41.499984596173597" q2="6.8804468218429946">
+    <iidm:line id="_046009e6-c766-11e1-8775-005056c00008" name="45-49" r="11.918016400000001" x="32.408639999999998" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="32" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="118" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-40.859666742662334" q1="-7.9987130394524648" p2="42.066041391753146" q2="6.8022433122908437">
         <iidm:alias>_044ca8f9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047dcb1b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10350,7 +10350,7 @@
             <iidm:temporaryLimit name="_8b91f4fd-4038-45b7-870c-fbc08592b95a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046a6a27-c766-11e1-8775-005056c00008" name="88-89" r="2.4219360000000001" x="12.4058876" g1="0" b1="5.549815e-05" g2="0" b2="5.549815e-05" node1="22" voltageLevelId1="_0470f9d2-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-111.41723095302207" q1="-8.1313252534394564" p2="113.21844223721193" q2="15.450745660976573">
+    <iidm:line id="_046a6a27-c766-11e1-8775-005056c00008" name="88-89" r="2.4219360000000001" x="12.4058876" g1="0" b1="5.549815e-05" g2="0" b2="5.549815e-05" node1="22" voltageLevelId1="_0470f9d2-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-111.85962371853466" q1="-8.115893580090658" p2="113.67537253233368" q2="15.509932555378439">
         <iidm:alias>_045ef879-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04649dc1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10358,7 +10358,7 @@
             <iidm:temporaryLimit name="_970bc323-73bf-440d-a3c5-00aebc3a1992" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048a7540-c766-11e1-8775-005056c00008" name="80-98" r="4.1469120000000004" x="18.817920000000001" g1="0" b1="8.20707e-05" g2="0" b2="8.20707e-05" node1="79" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04773b62-c766-11e1-8775-005056c00008" p1="11.965505461485652" q1="11.845583448817177" p2="-11.894535420223622" q2="-14.567923428036419">
+    <iidm:line id="_048a7540-c766-11e1-8775-005056c00008" name="80-98" r="4.1469120000000004" x="18.817920000000001" g1="0" b1="8.20707e-05" g2="0" b2="8.20707e-05" node1="79" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04773b62-c766-11e1-8775-005056c00008" p1="11.357303221305697" q1="11.988125010115539" p2="-11.288609884821055" q2="-14.720751214739716">
         <iidm:alias>_045338a2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04887972-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10366,7 +10366,7 @@
             <iidm:temporaryLimit name="_cb084dc7-1b26-415f-9495-4695df661912" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04640183-c766-11e1-8775-005056c00008" name="91-92" r="6.7430880000000002" x="22.163329999999998" g1="0" b1="9.3778700000000004e-05" g2="0" b2="9.3778700000000004e-05" node1="22" voltageLevelId1="_044f8f29-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="-5.8155828550810282" q1="-14.562740614256317" p2="5.8992630104811079" q2="11.700406237566794">
+    <iidm:line id="_04640183-c766-11e1-8775-005056c00008" name="91-92" r="6.7430880000000002" x="22.163329999999998" g1="0" b1="9.3778700000000004e-05" g2="0" b2="9.3778700000000004e-05" node1="22" voltageLevelId1="_044f8f29-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="-5.6615033560304591" q1="-14.585954620987089" p2="5.7447146487856218" q2="11.722472660535251">
         <iidm:alias>_04492680-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_044c5ad5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10374,7 +10374,7 @@
             <iidm:temporaryLimit name="_3a165a76-f6ba-461b-84d6-159a5e0b5077" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0474a358-c766-11e1-8775-005056c00008" name="7-12" r="1.501949" x="5.9241599999999996" g1="0" b1="2.5080350000000001e-05" g2="0" b2="2.5080350000000001e-05" node1="22" voltageLevelId1="_047eb571-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="19.301383730833361" q1="-7.4781813517982787" p2="-19.264188761775884" q2="6.7689466806371179">
+    <iidm:line id="_0474a358-c766-11e1-8775-005056c00008" name="7-12" r="1.501949" x="5.9241599999999996" g1="0" b1="2.5080350000000001e-05" g2="0" b2="2.5080350000000001e-05" node1="22" voltageLevelId1="_047eb571-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="23.637297106999632" q1="-9.797830685288714" p2="-23.580296401566439" q2="9.1670911850312198">
         <iidm:alias>_046ab848-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0477feb7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10382,7 +10382,7 @@
             <iidm:temporaryLimit name="_b19bc945-cc51-4d77-8eaa-3f6afe2d9316" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04765108-c766-11e1-8775-005056c00008" name="99-100" r="3.13632" x="14.165711399999999" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_04644fa4-c766-11e1-8775-005056c00008" node2="80" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-39.477795144575111" q1="12.159125537711084" p2="39.77792176352029" q2="-13.044348995405342">
+    <iidm:line id="_04765108-c766-11e1-8775-005056c00008" name="99-100" r="3.13632" x="14.165711399999999" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_04644fa4-c766-11e1-8775-005056c00008" node2="80" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-40.088541464990527" q1="12.300042155927216" p2="40.397733323351815" q2="-13.144291349346258">
         <iidm:alias>_0471e436-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047e4040-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10390,7 +10390,7 @@
             <iidm:temporaryLimit name="_a9e283ed-fcad-4f4c-ab57-8531875bb098" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047b8128-c766-11e1-8775-005056c00008" name="114-115" r="0.400752" x="1.8120959999999999" g1="0" b1="7.9201000000000006e-06" g2="0" b2="7.9201000000000006e-06" node1="22" voltageLevelId1="_04791027-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="-0.46886568114174171" q1="2.4195268709542472" p2="0.46903196442333783" q2="-2.6748699171045458">
+    <iidm:line id="_047b8128-c766-11e1-8775-005056c00008" name="114-115" r="0.400752" x="1.8120959999999999" g1="0" b1="7.9201000000000006e-06" g2="0" b2="7.9201000000000006e-06" node1="22" voltageLevelId1="_04791027-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="-1.6503441229525802" q1="2.5961180061380715" p2="1.6505962862198347" q2="-2.8502421550421526">
         <iidm:alias>_046c17d3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d0233-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10398,7 +10398,7 @@
             <iidm:temporaryLimit name="_c59e4022-b1c0-4811-a32e-f54656bff32d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046931a5-c766-11e1-8775-005056c00008" name="83-84" r="10.890000000000001" x="22.999680000000001" g1="0" b1="7.4035799999999993e-05" g2="0" b2="7.4035799999999993e-05" node1="33" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b0bf4-c766-11e1-8775-005056c00008" p1="-32.009639485404229" q1="20.914231556112803" p2="33.00772393152733" q2="-21.234034174327803">
+    <iidm:line id="_046931a5-c766-11e1-8775-005056c00008" name="83-84" r="10.890000000000001" x="22.999680000000001" g1="0" b1="7.4035799999999993e-05" g2="0" b2="7.4035799999999993e-05" node1="33" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b0bf4-c766-11e1-8775-005056c00008" p1="-32.337229701884389" q1="21.066858300489795" p2="33.35408034878882" q2="-21.346101345648734">
         <iidm:alias>_0465d645-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479102b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10406,7 +10406,7 @@
             <iidm:temporaryLimit name="_1268eb09-e233-44ce-b8af-22dc30eb16ad" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047ae4ea-c766-11e1-8775-005056c00008" name="14-15" r="10.367279999999999" x="33.976799999999997" g1="0" b1="0.0001440542" g2="0" b2="0.0001440542" node1="21" voltageLevelId1="_047b8129-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="16.147910199215143" q1="6.7231590949304785" p2="-15.933998052451843" q2="-10.691922175420357">
+    <iidm:line id="_047ae4ea-c766-11e1-8775-005056c00008" name="14-15" r="10.367279999999999" x="33.976799999999997" g1="0" b1="0.0001440542" g2="0" b2="0.0001440542" node1="21" voltageLevelId1="_047b8129-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="21.174714710299934" q1="5.850688851297142" p2="-20.853227491102373" q2="-9.4567666707656013">
         <iidm:alias>_0449e9d9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046ed6fa-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10414,7 +10414,7 @@
             <iidm:temporaryLimit name="_9c0c454b-ecc3-40f6-b505-f32fec412522" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046e3ab2-c766-11e1-8775-005056c00008" name="80-96" r="6.2029439999999996" x="31.711680000000001" g1="0" b1="0.0001417585" g2="0" b2="0.0001417585" node1="80" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="5.15128216089128" q1="26.231562784576688" p2="-4.867586361310031" q2="-29.862164157983241">
+    <iidm:line id="_046e3ab2-c766-11e1-8775-005056c00008" name="80-96" r="6.2029439999999996" x="31.711680000000001" g1="0" b1="0.0001417585" g2="0" b2="0.0001417585" node1="80" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="4.6705517574459048" q1="26.407306716215988" p2="-4.3850559500987565" q2="-30.028010630869911">
         <iidm:alias>_045338a4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04865695-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10422,7 +10422,7 @@
             <iidm:temporaryLimit name="_1432f4d6-9299-4b0d-bd7f-16e059f9de66" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04893cc4-c766-11e1-8775-005056c00008" name="56-59" r="13.9914722" x="41.643360000000001" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="59" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-20.044411080590368" q1="-7.7117595879629661" p2="20.423559148210259" q2="3.8016940728431572">
+    <iidm:line id="_04893cc4-c766-11e1-8775-005056c00008" name="56-59" r="13.9914722" x="41.643360000000001" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="59" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-20.147102383670916" q1="-7.6708469963404484" p2="20.529511896047254" q2="3.7704786719267358">
         <iidm:alias>_046b5484-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04798557-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10430,7 +10430,7 @@
             <iidm:temporaryLimit name="_193f6952-4267-4cc8-a541-726c095028ba" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c1243-c766-11e1-8775-005056c00008" name="92-100" r="11.290752400000001" x="51.400799999999997" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="71" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="36.684057695022318" q1="-17.255144206460727" p2="-35.64553745072665" q2="17.231519660847379">
+    <iidm:line id="_045c1243-c766-11e1-8775-005056c00008" name="92-100" r="11.290752400000001" x="51.400799999999997" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="71" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="36.876029526245489" q1="-17.297751090479604" p2="-35.827149291304416" q2="17.321649373693589">
         <iidm:alias>_045e8348-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045ed164-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10438,7 +10438,7 @@
             <iidm:temporaryLimit name="_579249ce-1c81-4d29-8d3f-5fc627a18f99" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0474a356-c766-11e1-8775-005056c00008" name="43-44" r="10.593792000000001" x="42.7584953" g1="0" b1="0.00017412765" g2="0" b2="0.00017412765" node1="22" voltageLevelId1="_045e8349-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04544a15-c766-11e1-8775-005056c00008" p1="-4.4665187138473383" q1="-11.439181769785371" p2="4.5310587851670414" q2="6.0806809860693196">
+    <iidm:line id="_0474a356-c766-11e1-8775-005056c00008" name="43-44" r="10.593792000000001" x="42.7584953" g1="0" b1="0.00017412765" g2="0" b2="0.00017412765" node1="22" voltageLevelId1="_045e8349-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04544a15-c766-11e1-8775-005056c00008" p1="-5.4996143267318232" q1="-11.158008196804127" p2="5.5678791997220936" q2="5.8163808118031373">
         <iidm:alias>_04642899-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047b0bf2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10446,7 +10446,7 @@
             <iidm:temporaryLimit name="_3d2cb4b5-ee82-4866-9855-4a5f4803cd3b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04627ae6-c766-11e1-8775-005056c00008" name="109-110" r="4.8438720000000002" x="13.2770882" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="22" voltageLevelId1="_046b7b99-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="12.799502146039815" q1="-2.9923728131255816" p2="-12.748481947645313" q2="1.285881883382423">
+    <iidm:line id="_04627ae6-c766-11e1-8775-005056c00008" name="109-110" r="4.8438720000000002" x="13.2770882" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="22" voltageLevelId1="_046b7b99-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="12.733809628204368" q1="-2.9681050625594985" p2="-12.683329154357281" q2="1.260123621456362">
         <iidm:alias>_0466e7b5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a6fbb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10454,7 +10454,7 @@
             <iidm:temporaryLimit name="_6fc48d8d-05f8-4104-a6a2-3686d430a091" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0478c207-c766-11e1-8775-005056c00008" name="68-81" r="0.84699999999999998" x="9.7767990000000005" g1="0" b1="0.00083471078000000004" g2="0" b2="0.00083471078000000004" node1="38" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_048a272b-c766-11e1-8775-005056c00008" p1="-147.83698447805969" q1="-4.149594614215486" p2="148.24339345515389" q2="-71.40399767501934">
+    <iidm:line id="_0478c207-c766-11e1-8775-005056c00008" name="68-81" r="0.84699999999999998" x="9.7767990000000005" g1="0" b1="0.00083471078000000004" g2="0" b2="0.00083471078000000004" node1="38" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_048a272b-c766-11e1-8775-005056c00008" p1="-150.64977717096687" q1="-3.8532850263062661" p2="151.07130582727171" q2="-71.524025661255678">
         <iidm:alias>_044a37f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045b4ef6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10462,7 +10462,7 @@
             <iidm:temporaryLimit name="_191836a1-39cd-402b-8dcf-4f3867c45bd0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0467d215-c766-11e1-8775-005056c00008" name="85-89" r="4.1643359999999996" x="30.143518400000001" g1="0" b1="0.00013487144999999999" g2="0" b2="0.00013487144999999999" node1="52" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-83.18521122517906" q1="-3.8392770256338498" p2="84.941102151863618" q2="11.961472575179616">
+    <iidm:line id="_0467d215-c766-11e1-8775-005056c00008" name="85-89" r="4.1643359999999996" x="30.143518400000001" g1="0" b1="0.00013487144999999999" g2="0" b2="0.00013487144999999999" node1="52" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-83.625364018348918" q1="-3.7767611984669101" p2="85.400280261444479" q2="12.037237100509875">
         <iidm:alias>_047629f9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0478e915-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10470,7 +10470,7 @@
             <iidm:temporaryLimit name="_66cbdeeb-a4e4-4bfc-aec1-9fb7a2d2b6bc" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044a37f2-c766-11e1-8775-005056c00008" name="89-90" r="4.1469120000000004" x="17.371727" g1="0" b1="0.00030417815" g2="0" b2="0.00030417815" node1="62" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="112.65106593855879" q1="21.234816569794216" p2="-109.4941878317871" q2="-18.225371349358969">
+    <iidm:line id="_044a37f2-c766-11e1-8775-005056c00008" name="89-90" r="4.1469120000000004" x="17.371727" g1="0" b1="0.00030417815" g2="0" b2="0.00030417815" node1="62" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="112.75703452364128" q1="21.246014774535968" p2="-109.59438467602567" q2="-18.212130620723084">
         <iidm:alias>_045386c2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048719e9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10478,7 +10478,7 @@
             <iidm:temporaryLimit name="_8489e809-6588-4ed2-a9a4-43c44a0d47da" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04658820-c766-11e1-8775-005056c00008" name="98-100" r="6.9173280000000004" x="31.188960999999999" g1="0" b1="0.0001365932" g2="0" b2="0.0001365932" node1="22" voltageLevelId1="_04773b62-c766-11e1-8775-005056c00008" node2="82" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-22.105652883755262" q1="6.5678536737422579" p2="22.321999437229724" q2="-10.546671889778041">
+    <iidm:line id="_04658820-c766-11e1-8775-005056c00008" name="98-100" r="6.9173280000000004" x="31.188960999999999" g1="0" b1="0.0001365932" g2="0" b2="0.0001365932" node1="22" voltageLevelId1="_04773b62-c766-11e1-8775-005056c00008" node2="82" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-22.711363696333052" q1="6.7207622052518827" p2="22.939065475769677" q2="-10.648306486540424">
         <iidm:alias>_046f4c22-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046fe865-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10486,7 +10486,7 @@
             <iidm:temporaryLimit name="_620beaaf-63c8-4020-bea5-c3609c0eaadf" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c5ada-c766-11e1-8775-005056c00008" name="28-29" r="4.1294880000000003" x="16.430831900000001" g1="0" b1="6.8296599999999999e-05" g2="0" b2="6.8296599999999999e-05" node1="22" voltageLevelId1="_04819ba0-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04588fd5-c766-11e1-8775-005056c00008" p1="15.37991525140621" q1="-4.8313060139859569" p2="-15.316022583851263" q2="2.8747332500035592">
+    <iidm:line id="_044c5ada-c766-11e1-8775-005056c00008" name="28-29" r="4.1294880000000003" x="16.430831900000001" g1="0" b1="6.8296599999999999e-05" g2="0" b2="6.8296599999999999e-05" node1="22" voltageLevelId1="_04819ba0-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04588fd5-c766-11e1-8775-005056c00008" p1="17.318745698574798" q1="-5.9842687675426616" p2="-17.235987337843568" q2="4.1052953624739681">
         <iidm:alias>_0461697a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04697fc1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10494,13 +10494,13 @@
             <iidm:temporaryLimit name="_6748d0d0-aec8-4b7b-a9ab-be6aecda7c5d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c5ada-c766-11e1-8775-005056c00008-1" name="28-29-open-ended" r="4.1294880000000003" x="16.430831900000001" g1="0" b1="6.8296599999999999e-05" g2="0" b2="6.8296599999999999e-05" node1="25" voltageLevelId1="_04819ba0-c766-11e1-8775-005056c00008" node2="25" voltageLevelId2="_04588fd5-c766-11e1-8775-005056c00008" p1="0.00031245752501864264" q1="-2.2120469412013315" p2="0" q2="0">
+    <iidm:line id="_044c5ada-c766-11e1-8775-005056c00008-1" name="28-29-open-ended" r="4.1294880000000003" x="16.430831900000001" g1="0" b1="6.8296599999999999e-05" g2="0" b2="6.8296599999999999e-05" node1="25" voltageLevelId1="_04819ba0-c766-11e1-8775-005056c00008" node2="25" voltageLevelId2="_04588fd5-c766-11e1-8775-005056c00008" p1="0.00031187484096722139" q1="-2.2079218222000212" p2="0" q2="0">
         <iidm:currentLimits1 permanentLimit="1000">
             <iidm:temporaryLimit name="_accb8136-1faf-4399-9787-3cd567284fd2-1" acceptableDuration="900" value="1150"/>
             <iidm:temporaryLimit name="_6748d0d0-aec8-4b7b-a9ab-be6aecda7c5d-1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0468e382-c766-11e1-8775-005056c00008" name="3-5" r="4.1991839999999998" x="18.817920000000001" g1="0" b1="8.1496799999999995e-05" g2="0" b2="8.1496799999999995e-05" node1="31" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-70.1030452023832" q1="-16.943266309004244" p2="71.416177959857166" q2="20.034176223186318">
+    <iidm:line id="_0468e382-c766-11e1-8775-005056c00008" name="3-5" r="4.1991839999999998" x="18.817920000000001" g1="0" b1="8.1496799999999995e-05" g2="0" b2="8.1496799999999995e-05" node1="31" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-72.356605958826378" q1="-15.612435481970058" p2="73.743059067503211" q2="19.037206381280207">
         <iidm:alias>_046b0668-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04742e24-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10508,7 +10508,7 @@
             <iidm:temporaryLimit name="_828ca44c-560b-4f94-b825-21e237285fae" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0447c6f1-c766-11e1-8775-005056c00008" name="82-96" r="2.8226879999999999" x="9.2347199999999994" g1="0" b1="0.00015610649999999999" g2="0" b2="0.00015610649999999999" node1="33" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="-15.521647217953809" q1="-9.5960311548428407" p2="15.570367085091972" q2="4.4829323922376876">
+    <iidm:line id="_0447c6f1-c766-11e1-8775-005056c00008" name="82-96" r="2.8226879999999999" x="9.2347199999999994" g1="0" b1="0.00015610649999999999" g2="0" b2="0.00015610649999999999" node1="33" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="-15.769330240880249" q1="-9.5718915009595573" p2="15.819317128646007" q2="4.4646230204195856">
         <iidm:alias>_0478e91a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0480d856-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10516,7 +10516,7 @@
             <iidm:temporaryLimit name="_233b7735-85f4-4a6f-9d87-15129fe42ef5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0483e594-c766-11e1-8775-005056c00008" name="38-65" r="4.3608399999999996" x="47.7224" g1="0" b1="0.0010805785" g2="0" b2="0.0010805785" node1="29" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-157.29337645408546" q1="-98.340284278466868" p2="160.25469155891702" q2="33.86434775892743">
+    <iidm:line id="_0483e594-c766-11e1-8775-005056c00008" name="38-65" r="4.3608399999999996" x="47.7224" g1="0" b1="0.0010805785" g2="0" b2="0.0010805785" node1="29" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-162.02461167522318" q1="-97.484956940861395" p2="165.14178868415453" q2="34.764988189016066">
         <iidm:alias>_04638c56-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d5054-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10524,7 +10524,7 @@
             <iidm:temporaryLimit name="_990ce3c5-c90c-41b9-abee-fb803d9df3a5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04784cd4-c766-11e1-8775-005056c00008" name="106-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_04479fe8-c766-11e1-8775-005056c00008" node2="24" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="23.857135257742858" q1="-0.69604717950810624" p2="-23.528611298150093" q2="-2.4531143327069325">
+    <iidm:line id="_04784cd4-c766-11e1-8775-005056c00008" name="106-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_04479fe8-c766-11e1-8775-005056c00008" node2="24" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="23.852610511532394" q1="-0.69448186434744474" p2="-23.524210342216886" q2="-2.4551339284048623">
         <iidm:alias>_04483c21-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f0395-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10532,7 +10532,7 @@
             <iidm:temporaryLimit name="_1372c3b0-62d7-47d7-a8c0-ed8e10bc1f1a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046f9a43-c766-11e1-8775-005056c00008" name="27-115" r="2.8575360000000001" x="12.9111843" g1="0" b1="5.6588600000000002e-05" g2="0" b2="5.6588600000000002e-05" node1="43" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="22.567950642045581" q1="2.9001421857855068" p2="-22.476573174594776" q2="-4.329127533037858">
+    <iidm:line id="_046f9a43-c766-11e1-8775-005056c00008" name="27-115" r="2.8575360000000001" x="12.9111843" g1="0" b1="5.6588600000000002e-05" g2="0" b2="5.6588600000000002e-05" node1="43" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="23.745371512795348" q1="2.7667756973804192" p2="-23.644356526783589" q2="-4.1464474658738011">
         <iidm:alias>_046d0238-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048c22f4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10540,7 +10540,7 @@
             <iidm:temporaryLimit name="_64cfd0fb-1d8e-45d2-a52f-469238dfc0c6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04529c61-c766-11e1-8775-005056c00008" name="12-14" r="3.7461600000000002" x="12.3187675" g1="0" b1="5.2112050000000002e-05" g2="0" b2="5.2112050000000002e-05" node1="71" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b8129-c766-11e1-8775-005056c00008" p1="30.365391666202363" q1="6.6710518265456713" p2="-30.150583532760646" q2="-7.7234771905054895">
+    <iidm:line id="_04529c61-c766-11e1-8775-005056c00008" name="12-14" r="3.7461600000000002" x="12.3187675" g1="0" b1="5.2112050000000002e-05" g2="0" b2="5.2112050000000002e-05" node1="71" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b8129-c766-11e1-8775-005056c00008" p1="35.460613182133358" q1="6.0345052541494502" p2="-35.17425302466242" q2="-6.8506338571041683">
         <iidm:alias>_045fbbc1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047bf65b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10548,7 +10548,7 @@
             <iidm:temporaryLimit name="_efe2501d-bcee-42ff-a037-3d8a280487b0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0463da77-c766-11e1-8775-005056c00008" name="76-118" r="2.8575360000000001" x="9.4786560000000009" g1="0" b1="3.8911849999999999e-05" g2="0" b2="3.8911849999999999e-05" node1="22" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="-6.1473055581771305" q1="-14.707725624954589" p2="6.1914205896825196" q2="13.648014911672174">
+    <iidm:line id="_0463da77-c766-11e1-8775-005056c00008" name="76-118" r="2.8575360000000001" x="9.4786560000000009" g1="0" b1="3.8911849999999999e-05" g2="0" b2="3.8911849999999999e-05" node1="22" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="-5.6513359844100703" q1="-14.750951381404642" p2="5.6946253393970911" q2="13.689520150314868">
         <iidm:alias>_046931a0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04806320-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10556,7 +10556,7 @@
             <iidm:temporaryLimit name="_2ae204bf-78cc-49cb-b886-a933b33057e4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046931a3-c766-11e1-8775-005056c00008" name="74-75" r="2.1431520000000002" x="7.0741440000000004" g1="0" b1="2.9671699999999999e-05" g2="0" b2="2.9671699999999999e-05" node1="23" voltageLevelId1="_047dcb11-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="-44.346104389081511" q1="-4.2416180718888388" p2="44.610102540998859" q2="4.1513748383208373">
+    <iidm:line id="_046931a3-c766-11e1-8775-005056c00008" name="74-75" r="2.1431520000000002" x="7.0741440000000004" g1="0" b1="2.9671699999999999e-05" g2="0" b2="2.9671699999999999e-05" node1="23" voltageLevelId1="_047dcb11-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="-44.988079079524027" q1="-4.2833048981701642" p2="45.260097606572415" q2="4.2206014670080245">
         <iidm:alias>_044f4103-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04638c58-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10564,7 +10564,7 @@
             <iidm:temporaryLimit name="_e822432e-79af-4bba-8f40-5250468f81a0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045ed162-c766-11e1-8775-005056c00008" name="3-12" r="8.4332159999999998" x="27.878398900000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="32" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-8.6986255056748938" q1="-9.6318849828020436" p2="8.7677093719801569" q2="5.9490442405282895">
+    <iidm:line id="_045ed162-c766-11e1-8775-005056c00008" name="3-12" r="8.4332159999999998" x="27.878398900000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="32" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-7.4130395779623575" q1="-10.387327378698142" p2="7.4778805284862457" q2="6.6928071049819318">
         <iidm:alias>_047a48a1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047b5a14-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10572,7 +10572,7 @@
             <iidm:temporaryLimit name="_c437e52c-43d7-4ae9-87ad-dc19396dc6ff" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04499bb6-c766-11e1-8775-005056c00008" name="49-51" r="8.468064" x="23.8708782" g1="0" b1="9.81405e-05" g2="0" b2="9.81405e-05" node1="119" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04542300-c766-11e1-8775-005056c00008" p1="77.005214918751903" q1="18.639450523185541" p2="-74.069009283886118" q2="-13.753720499044467">
+    <iidm:line id="_04499bb6-c766-11e1-8775-005056c00008" name="49-51" r="8.468064" x="23.8708782" g1="0" b1="9.81405e-05" g2="0" b2="9.81405e-05" node1="119" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04542300-c766-11e1-8775-005056c00008" p1="76.821076171551297" q1="18.668740187498681" p2="-73.897417620952538" q2="-13.818453134402242">
         <iidm:alias>_0487dd38-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b1180-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10580,7 +10580,7 @@
             <iidm:temporaryLimit name="_90dcdbe1-437b-443f-b0b5-c2353f7c6954" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04839779-c766-11e1-8775-005056c00008" name="40-42" r="9.6703209999999995" x="31.885919999999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="42" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="0.065173997515429599" q1="-9.8771027131922828" p2="-0.021063901323111617" q2="6.2005962043192362">
+    <iidm:line id="_04839779-c766-11e1-8775-005056c00008" name="40-42" r="9.6703209999999995" x="31.885919999999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="42" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="-0.74313996411637351" q1="-9.5797010652679404" p2="0.78441073429253649" q2="5.8943999512929945">
         <iidm:alias>_044974a9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04616975-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10588,7 +10588,7 @@
             <iidm:temporaryLimit name="_9b8510fa-bd0e-4e63-8f4c-0e5443a3eb63" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0484a8e1-c766-11e1-8775-005056c00008" name="32-113" r="10.71576" x="35.370719999999999" g1="0" b1="0.00014864555000000001" g2="0" b2="0.00014864555000000001" node1="52" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="0.92168842393959027" q1="-8.5156516364878065" p2="-0.89674608851548676" q2="3.6883554761939483">
+    <iidm:line id="_0484a8e1-c766-11e1-8775-005056c00008" name="32-113" r="10.71576" x="35.370719999999999" g1="0" b1="0.00014864555000000001" g2="0" b2="0.00014864555000000001" node1="52" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="4.816053272280902" q1="-9.9199964744161271" p2="-4.7636338938130836" q2="5.1966404750633028">
         <iidm:alias>_04723258-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0482860a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10596,7 +10596,7 @@
             <iidm:temporaryLimit name="_336bfd86-a922-4154-9e06-cd87382cdc5f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04898ae4-c766-11e1-8775-005056c00008" name="51-58" r="4.4431200000000004" x="12.5278568" g1="0" b1="5.1308550000000002e-05" g2="0" b2="5.1308550000000002e-05" node1="31" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="25.405009349971188" q1="0.44913213187575546" p2="-25.228074453903883" q2="-1.6047704743979221">
+    <iidm:line id="_04898ae4-c766-11e1-8775-005056c00008" name="51-58" r="4.4431200000000004" x="12.5278568" g1="0" b1="5.1308550000000002e-05" g2="0" b2="5.1308550000000002e-05" node1="31" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="25.290936079727633" q1="0.49633672605891854" p2="-25.115556973966115" q2="-1.6564278731752244">
         <iidm:alias>_044778d4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04789af1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10604,7 +10604,7 @@
             <iidm:temporaryLimit name="_2be10dec-f0ac-470d-83f7-a2a4e70f3491" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046efe04-c766-11e1-8775-005056c00008" name="29-31" r="1.8817919999999999" x="5.7673439999999996" g1="0" b1="2.3817700000000001e-05" g2="0" b2="2.3817700000000001e-05" node1="22" voltageLevelId1="_04588fd5-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="-8.6850362781336088" q1="-6.8750272512135" p2="8.6987026781348362" q2="6.1433568635796947">
+    <iidm:line id="_046efe04-c766-11e1-8775-005056c00008" name="29-31" r="1.8817919999999999" x="5.7673439999999996" g1="0" b1="2.3817700000000001e-05" g2="0" b2="2.3817700000000001e-05" node1="22" voltageLevelId1="_04588fd5-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="-6.7630712972243447" q1="-8.1050338145923426" p2="6.7753232228921849" q2="7.3691933475663944">
         <iidm:alias>_04492688-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047cb9a5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10612,7 +10612,7 @@
             <iidm:temporaryLimit name="_f0e21213-6535-44a7-89b6-3063f8738d6b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044a10e4-c766-11e1-8775-005056c00008" name="65-68" r="0.66791999999999996" x="7.7439999999999998" g1="0" b1="0.00065909092999999995" g2="0" b2="0.00065909092999999995" node1="41" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0449e9d2-c766-11e1-8775-005056c00008" p1="-160.25628294124982" q1="23.466176718134513" p2="160.6495457178217" q2="-82.942344681730091">
+    <iidm:line id="_044a10e4-c766-11e1-8775-005056c00008" name="65-68" r="0.66791999999999996" x="7.7439999999999998" g1="0" b1="0.00065909092999999995" g2="0" b2="0.00065909092999999995" node1="41" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0449e9d2-c766-11e1-8775-005056c00008" p1="-163.60405366667288" q1="23.934910835778183" p2="164.01284648687437" q2="-83.230074063809269">
         <iidm:alias>_0461dea7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047629f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10620,7 +10620,7 @@
             <iidm:temporaryLimit name="_ab31cd46-6d0c-4d9c-95f1-396a45a237e1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046b7b92-c766-11e1-8775-005056c00008" name="49-54" r="12.719519999999999" x="50.355361899999998" g1="0" b1="0.00021177684999999999" g2="0" b2="0.00021177684999999999" node1="120" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="46.923351100987695" q1="11.832406587502639" p2="-45.222018535872579" q2="-12.339176658693821">
+    <iidm:line id="_046b7b92-c766-11e1-8775-005056c00008" name="49-54" r="12.719519999999999" x="50.355361899999998" g1="0" b1="0.00021177684999999999" g2="0" b2="0.00021177684999999999" node1="120" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="46.757061696279713" q1="11.852541216633432" p2="-45.066112456342807" q2="-12.400413869771999">
         <iidm:alias>_0462f017-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047120e1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10628,7 +10628,7 @@
             <iidm:temporaryLimit name="_1bf78539-b6fa-4d8b-ba8e-9b5970019be6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04607f15-c766-11e1-8775-005056c00008" name="70-71" r="1.536797" x="6.1855200000000004" g1="0" b1="2.5195149999999999e-05" g2="0" b2="2.5195149999999999e-05" node1="52" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04664b78-c766-11e1-8775-005056c00008" p1="-7.0768473094091515" q1="-4.5417390839546616" p2="7.0829413252158666" q2="3.7127459275323473">
+    <iidm:line id="_04607f15-c766-11e1-8775-005056c00008" name="70-71" r="1.536797" x="6.1855200000000004" g1="0" b1="2.5195149999999999e-05" g2="0" b2="2.5195149999999999e-05" node1="52" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04664b78-c766-11e1-8775-005056c00008" p1="-5.7136992116792547" q1="-4.4667931031488362" p2="5.7181613018798885" q2="3.6329621658409641">
         <iidm:alias>_04486336-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f51b4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10636,7 +10636,7 @@
             <iidm:temporaryLimit name="_08ff3ae4-d1dd-49f7-9eda-32ffc8eb0010" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c5ad7-c766-11e1-8775-005056c00008" name="55-56" r="0.85029100000000002" x="2.631024" g1="0" b1="1.0732300000000001e-05" g2="0" b2="1.0732300000000001e-05" node1="31" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="-28.763579080484586" q1="-6.9789629152809747" p2="28.810695399677826" q2="6.7853931512846968">
+    <iidm:line id="_044c5ad7-c766-11e1-8775-005056c00008" name="55-56" r="0.85029100000000002" x="2.631024" g1="0" b1="1.0732300000000001e-05" g2="0" b2="1.0732300000000001e-05" node1="31" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="-28.674583931198651" q1="-7.0084484238077778" p2="28.72144607790344" q2="6.8140905918921577">
         <iidm:alias>_04558294-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045868c2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10644,7 +10644,7 @@
             <iidm:temporaryLimit name="_94316214-afd8-4c0d-bca4-916acb92af85" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048a2725-c766-11e1-8775-005056c00008" name="35-37" r="1.9166399999999999" x="8.6597279999999994" g1="0" b1="3.7821399999999997e-05" g2="0" b2="3.7821399999999997e-05" node1="21" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-29.339284293694579" q1="-14.466145041828321" p2="29.470823662778734" q2="13.885652613290722">
+    <iidm:line id="_048a2725-c766-11e1-8775-005056c00008" name="35-37" r="1.9166399999999999" x="8.6597279999999994" g1="0" b1="3.7821399999999997e-05" g2="0" b2="3.7821399999999997e-05" node1="21" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-29.641715871886802" q1="-14.403429238855059" p2="29.775303610311816" q2="13.832513937240407">
         <iidm:alias>_0471bd29-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04808a30-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10652,7 +10652,7 @@
             <iidm:temporaryLimit name="_4ea6b532-d914-4b0c-97ee-9f02a14a40b3" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04614263-c766-11e1-8775-005056c00008" name="4-5" r="0.30666199999999999" x="1.3904350000000001" g1="0" b1="6.0261499999999999e-06" g2="0" b2="6.0261499999999999e-06" node1="22" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-108.37269835648262" q1="-20.169351121773115" p2="108.58360569329906" q2="20.912010804178934">
+    <iidm:line id="_04614263-c766-11e1-8775-005056c00008" name="4-5" r="0.30666199999999999" x="1.3904350000000001" g1="0" b1="6.0261499999999999e-06" g2="0" b2="6.0261499999999999e-06" node1="22" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-112.99877146952828" q1="-18.125851310055648" p2="113.22665067920848" q2="18.945985967529118">
         <iidm:alias>_04529c66-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04753f92-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10660,7 +10660,7 @@
             <iidm:temporaryLimit name="_2a95fb2b-6661-46e7-a9f6-fe63c1b7433c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0451b208-c766-11e1-8775-005056c00008" name="20-21" r="3.1885919999999999" x="14.7929754" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_046b2d70-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0460f448-c766-11e1-8775-005056c00008" p1="-39.079938411873677" q1="-3.9813154247976295" p2="39.390565744100073" q2="3.4451526394896841">
+    <iidm:line id="_0451b208-c766-11e1-8775-005056c00008" name="20-21" r="3.1885919999999999" x="14.7929754" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_046b2d70-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0460f448-c766-11e1-8775-005056c00008" p1="-32.846851925616811" q1="1.5337636929329983" p2="33.071550444573724" q2="-2.4096052427962076">
         <iidm:alias>_046c65f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048c22f6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10668,7 +10668,7 @@
             <iidm:temporaryLimit name="_4b67f5f5-f0e1-4bfb-9d57-4d3474720a45" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047d55e4-c766-11e1-8775-005056c00008" name="104-105" r="1.731946" x="6.5862720000000001" g1="0" b1="2.8294300000000001e-05" g2="0" b2="2.8294300000000001e-05" node1="32" voltageLevelId1="_0483977a-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="48.062680897376815" q1="0.85707029374534205" p2="-47.818749807348496" q2="-0.85326571580869226">
+    <iidm:line id="_047d55e4-c766-11e1-8775-005056c00008" name="104-105" r="1.731946" x="6.5862720000000001" g1="0" b1="2.8294300000000001e-05" g2="0" b2="2.8294300000000001e-05" node1="32" voltageLevelId1="_0483977a-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="48.028995323770104" q1="0.86599824966158079" p2="-47.785404177051632" q2="-0.86348953550165752">
         <iidm:alias>_0451d910-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046c65f2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10676,7 +10676,7 @@
             <iidm:temporaryLimit name="_1ca40dc7-6736-4fa8-b4cb-ca696949e421" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046dc589-c766-11e1-8775-005056c00008" name="44-45" r="3.9029759999999998" x="15.699023199999999" g1="0" b1="6.4279149999999996e-05" g2="0" b2="6.4279149999999996e-05" node1="23" voltageLevelId1="_04544a15-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_045d23b4-c766-11e1-8775-005056c00008" p1="-20.531605375804702" q1="-4.5756422161839483" p2="20.633863520152264" q2="2.840190928646591">
+    <iidm:line id="_046dc589-c766-11e1-8775-005056c00008" name="44-45" r="3.9029759999999998" x="15.699023199999999" g1="0" b1="6.4279149999999996e-05" g2="0" b2="6.4279149999999996e-05" node1="23" voltageLevelId1="_04544a15-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_045d23b4-c766-11e1-8775-005056c00008" p1="-21.567261317565041" q1="-4.3138082544555854" p2="21.679419269772488" q2="2.6189119088778359">
         <iidm:alias>_04518afa-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04667287-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10684,7 +10684,7 @@
             <iidm:temporaryLimit name="_ba738481-ddba-4ebe-a218-8aad0b537f5b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04642896-c766-11e1-8775-005056c00008" name="4-11" r="3.641616" x="11.9877129" g1="0" b1="5.0160700000000002e-05" g2="0" b2="5.0160700000000002e-05" node1="23" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="69.368540421300111" q1="8.1672188918170132" p2="-68.359494492712784" q2="-6.5834159434684274">
+    <iidm:line id="_04642896-c766-11e1-8775-005056c00008" name="4-11" r="3.641616" x="11.9877129" g1="0" b1="5.0160700000000002e-05" g2="0" b2="5.0160700000000002e-05" node1="23" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="74.012325695349631" q1="6.1328068926621935" p2="-72.870027673345433" q2="-4.1071813898262022">
         <iidm:alias>_0455f7c5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04803c17-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10692,7 +10692,7 @@
             <iidm:temporaryLimit name="_b1d87c24-e527-4174-aa04-cd0b9de271ea" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047d07c0-c766-11e1-8775-005056c00008" name="92-93" r="4.4953919999999998" x="14.775551800000001" g1="0" b1="6.2557400000000005e-05" g2="0" b2="6.2557400000000005e-05" node1="72" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04789af0-c766-11e1-8775-005056c00008" p1="70.185535815653026" q1="-12.666208121764596" p2="-68.851961610011131" q2="14.928729398117957">
+    <iidm:line id="_047d07c0-c766-11e1-8775-005056c00008" name="92-93" r="4.4953919999999998" x="14.775551800000001" g1="0" b1="6.2557400000000005e-05" g2="0" b2="6.2557400000000005e-05" node1="72" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04789af0-c766-11e1-8775-005056c00008" p1="70.646492427994943" q1="-12.728180768847771" p2="-69.295221104076404" q2="15.049284997118425">
         <iidm:alias>_044a5f07-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047602e5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10700,7 +10700,7 @@
             <iidm:temporaryLimit name="_4e1daf8e-7708-4b96-8d3f-67f58f2505f9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044f4109-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="43" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="121" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-52.969956729242064" q1="-19.076899676789218" p2="55.578191893760376" q2="22.751748443656979">
+    <iidm:line id="_044f4109-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="43" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="121" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-53.769234508348461" q1="-18.777727292025521" p2="56.443423501128187" q2="22.751498534429444">
         <iidm:alias>_046958b0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04758db0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10708,7 +10708,7 @@
             <iidm:temporaryLimit name="_c58940cb-bd36-4dfc-9615-11716dd652a7" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046e61c8-c766-11e1-8775-005056c00008" name="69-75" r="7.0567200000000003" x="21.257280000000002" g1="0" b1="0.00035583104999999999" g2="0" b2="0.00035583104999999999" node1="61" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="89.411917523337507" q1="24.259876901992154" p2="-86.028406518592007" q2="-26.519857334968666">
+    <iidm:line id="_046e61c8-c766-11e1-8775-005056c00008" name="69-75" r="7.0567200000000003" x="21.257280000000002" g1="0" b1="0.00035583104999999999" g2="0" b2="0.00035583104999999999" node1="61" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="89.749166367282768" q1="24.579167885547658" p2="-86.335310751338099" q2="-26.741976522324073">
         <iidm:alias>_046d294a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048ac362-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10716,7 +10716,7 @@
             <iidm:temporaryLimit name="_3c9a454c-10ee-4c72-a059-77f723f5b7c7" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0463da71-c766-11e1-8775-005056c00008" name="79-80" r="2.7181440000000001" x="12.2664957" g1="0" b1="5.3661600000000001e-05" g2="0" b2="5.3661600000000001e-05" node1="23" voltageLevelId1="_04481510-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-66.191995544586774" q1="-32.337346580955071" p2="67.017635620731497" q2="34.103924862743263">
+    <iidm:line id="_0463da71-c766-11e1-8775-005056c00008" name="79-80" r="2.7181440000000001" x="12.2664957" g1="0" b1="5.3661600000000001e-05" g2="0" b2="5.3661600000000001e-05" node1="23" voltageLevelId1="_04481510-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-66.458035253092277" q1="-32.382429636038992" p2="67.289679141533426" q2="34.176259242337956">
         <iidm:alias>_0464ebe9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04662468-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10724,7 +10724,7 @@
             <iidm:temporaryLimit name="_270a7d04-9ff9-4178-8b72-b610735a72ac" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044fdd41-c766-11e1-8775-005056c00008" name="51-52" r="3.5370720000000002" x="10.2453117" g1="0" b1="4.0059699999999999e-05" g2="0" b2="4.0059699999999999e-05" node1="32" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04806326-c766-11e1-8775-005056c00008" p1="31.664148139112125" q1="5.3047084973888881" p2="-31.438173983284141" q2="-5.9384392834258755">
+    <iidm:line id="_044fdd41-c766-11e1-8775-005056c00008" name="51-52" r="3.5370720000000002" x="10.2453117" g1="0" b1="4.0059699999999999e-05" g2="0" b2="4.0059699999999999e-05" node1="32" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04806326-c766-11e1-8775-005056c00008" p1="31.606481268351512" q1="5.3221166559090056" p2="-31.381266606207259" q2="-5.9581092591026188">
         <iidm:alias>_045115c2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0464ebe5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10732,7 +10732,7 @@
             <iidm:temporaryLimit name="_9d1eb182-ceb5-426e-9440-5f4d426a31cb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c3958-c766-11e1-8775-005056c00008" name="53-54" r="4.5825120000000004" x="21.257280000000002" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="22" voltageLevelId1="_04876804-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="-9.6451065201296231" q1="-6.7326759231088582" p2="9.6808984002278464" q2="4.0998438895674854">
+    <iidm:line id="_045c3958-c766-11e1-8775-005056c00008" name="53-54" r="4.5825120000000004" x="21.257280000000002" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="22" voltageLevelId1="_04876804-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="-9.7016502622502081" q1="-6.7104756206967489" p2="9.737693327762047" q2="4.0787747183606431">
         <iidm:alias>_044f6817-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0455f7c6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10740,7 +10740,7 @@
             <iidm:temporaryLimit name="_735ac8df-6a6a-43f0-86f2-49d3280c9a3b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044ef2e1-c766-11e1-8775-005056c00008" name="54-55" r="2.9446560000000002" x="12.3187675" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="63" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04767817-c766-11e1-8775-005056c00008" p1="10.177894498268206" q1="1.7038941507760106" p2="-10.157422285305161" q2="-3.4533822104988849">
+    <iidm:line id="_044ef2e1-c766-11e1-8775-005056c00008" name="54-55" r="2.9446560000000002" x="12.3187675" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="63" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04767817-c766-11e1-8775-005056c00008" p1="10.152468494740557" q1="1.7064172491161114" p2="-10.132089601004781" q2="-3.4562994278509978">
         <iidm:alias>_04640181-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047dcb17-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10748,7 +10748,7 @@
             <iidm:temporaryLimit name="_52aadf8d-53f2-4827-8c70-421bdf1ba822" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0456e226-c766-11e1-8775-005056c00008" name="80-97" r="3.1885919999999999" x="16.2740154" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="82" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="12.662290559111794" q1="30.838138714231139" p2="-12.459608093856964" q2="-32.469918800441896">
+    <iidm:line id="_0456e226-c766-11e1-8775-005056c00008" name="80-97" r="3.1885919999999999" x="16.2740154" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="82" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="12.18314798701134" q1="31.010799973148778" p2="-11.980592505193812" q2="-32.643038669705973">
         <iidm:alias>_04479fe9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047df222-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10756,7 +10756,7 @@
             <iidm:temporaryLimit name="_fece5807-6af8-4161-8de8-8f8473d92f11" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0487b624-c766-11e1-8775-005056c00008" name="103-110" r="6.8058139999999998" x="31.5897121" g1="0" b1="0.00013228879999999999" g2="0" b2="0.00013228879999999999" node1="43" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="57.786611650762453" q1="18.491400429894611" p2="-56.341644927594423" q2="-16.238213234218776">
+    <iidm:line id="_0487b624-c766-11e1-8775-005056c00008" name="103-110" r="6.8058139999999998" x="31.5897121" g1="0" b1="0.00013228879999999999" g2="0" b2="0.00013228879999999999" node1="43" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="57.715416372764651" q1="18.497833373377524" p2="-56.273494468600703" q2="-16.258787651574767">
         <iidm:alias>_046a9139-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b3895-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10764,7 +10764,7 @@
             <iidm:temporaryLimit name="_3eacc034-737e-41de-a7b6-b610d3bd0921" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045338a8-c766-11e1-8775-005056c00008" name="56-58" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="61" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="-13.162745528116332" q1="-0.63246555859964237" p2="13.228145637285893" q2="-1.3951983903947789">
+    <iidm:line id="_045338a8-c766-11e1-8775-005056c00008" name="56-58" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="61" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="-13.051275811957105" q1="-0.68728804881584349" p2="13.115555783269889" q2="-1.3435724458472333">
         <iidm:alias>_0451d915-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04817494-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10772,7 +10772,7 @@
             <iidm:temporaryLimit name="_0d0c3ec5-798a-48a4-9bc8-d19c57128a13" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04854529-c766-11e1-8775-005056c00008" name="15-33" r="6.6211200000000003" x="21.675455100000001" g1="0" b1="9.1655200000000003e-05" g2="0" b2="9.1655200000000003e-05" node1="52" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456bb11-c766-11e1-8775-005056c00008" p1="67.195061955707857" q1="-8.0992325870253676" p2="-65.277592534383587" q2="11.53183465991534">
+    <iidm:line id="_04854529-c766-11e1-8775-005056c00008" name="15-33" r="6.6211200000000003" x="21.675455100000001" g1="0" b1="9.1655200000000003e-05" g2="0" b2="9.1655200000000003e-05" node1="52" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456bb11-c766-11e1-8775-005056c00008" p1="63.515345841183226" q1="-8.1791839894293776" p2="-61.794098609845349" q2="10.975355263826557">
         <iidm:alias>_0448d862-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047d2ed5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10780,7 +10780,7 @@
             <iidm:temporaryLimit name="_5b0395f4-534d-4975-a1af-e0b6ef439193" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04649dc2-c766-11e1-8775-005056c00008" name="35-36" r="0.39029799999999998" x="1.7772479999999999" g1="0" b1="7.6905500000000004e-06" g2="0" b2="7.6905500000000004e-06" node1="22" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="-3.6607845268845036" q1="5.4661149967765503" p2="3.6619180182879503" q2="-5.696951480778381">
+    <iidm:line id="_04649dc2-c766-11e1-8775-005056c00008" name="35-36" r="0.39029799999999998" x="1.7772479999999999" g1="0" b1="7.6905500000000004e-06" g2="0" b2="7.6905500000000004e-06" node1="22" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="-3.3563787385806907" q1="5.4042946389012219" p2="3.3574407585558936" q2="-5.6353896808521222">
         <iidm:alias>_044c0cb5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0456e225-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10788,7 +10788,7 @@
             <iidm:temporaryLimit name="_74c4b341-7b99-4a81-b88a-2ed3b0c4b1de" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0470d2c9-c766-11e1-8775-005056c00008" name="37-40" r="10.3324327" x="29.272320000000001" g1="0" b1="0.0001205234" g2="0" b2="0.0001205234" node1="61" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="56.97099887062209" q1="10.190941900585671" p2="-54.740297848316445" q2="-7.4560611721563506">
+    <iidm:line id="_0470d2c9-c766-11e1-8775-005056c00008" name="37-40" r="10.3324327" x="29.272320000000001" g1="0" b1="0.0001205234" g2="0" b2="0.0001205234" node1="61" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="56.119311457098142" q1="10.329211879065209" p2="-53.949177713771412" q2="-7.7653822248920674">
         <iidm:alias>_045b9d10-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046a4317-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10796,7 +10796,7 @@
             <iidm:temporaryLimit name="_e98d56fe-a54b-45e4-acff-0ac310beb3dd" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044e56a2-c766-11e1-8775-005056c00008" name="48-49" r="3.1188959999999999" x="8.7991200000000003" g1="0" b1="3.6099649999999999e-05" g2="0" b2="3.6099649999999999e-05" node1="23" voltageLevelId1="_044778d3-c766-11e1-8775-005056c00008" node2="122" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-28.726129472415508" q1="1.2804741572286351" p2="28.868519293467266" q2="-2.1950651945235378">
+    <iidm:line id="_044e56a2-c766-11e1-8775-005056c00008" name="48-49" r="3.1188959999999999" x="8.7991200000000003" g1="0" b1="3.6099649999999999e-05" g2="0" b2="3.6099649999999999e-05" node1="23" voltageLevelId1="_044778d3-c766-11e1-8775-005056c00008" node2="122" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-28.87642206557593" q1="1.3282113113541036" p2="29.020332296575997" q2="-2.238507163078495">
         <iidm:alias>_0454bf49-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0460a623-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10804,7 +10804,7 @@
             <iidm:temporaryLimit name="_f2e58700-2366-46e0-8408-9472d85acd23" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047eb573-c766-11e1-8775-005056c00008" name="56-59" r="14.3748007" x="43.734237700000001" g1="0" b1="0.0001632805" g2="0" b2="0.0001632805" node1="62" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-19.094359838382385" q1="-7.7463439548334154" p2="19.449085631405435" q2="3.4768246564949679">
+    <iidm:line id="_047eb573-c766-11e1-8775-005056c00008" name="56-59" r="14.3748007" x="43.734237700000001" g1="0" b1="0.0001632805" g2="0" b2="0.0001632805" node1="62" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-19.192609942788451" q1="-7.7079482740313701" p2="19.550387099319451" q2="3.4477019295259361">
         <iidm:alias>_0468bc78-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048915b0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10812,7 +10812,7 @@
             <iidm:temporaryLimit name="_89654167-95a6-4c76-aad7-63a881116e17" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046f9a4b-c766-11e1-8775-005056c00008" name="94-100" r="3.1014719999999998" x="10.105919999999999" g1="0" b1="0.00017332415000000001" g2="0" b2="0.00017332415000000001" node1="52" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-5.7680604186933184" q1="-52.170401470900984" p2="6.216931831369763" q2="47.567366911911442">
+    <iidm:line id="_046f9a4b-c766-11e1-8775-005056c00008" name="94-100" r="3.1014719999999998" x="10.105919999999999" g1="0" b1="0.00017332415000000001" g2="0" b2="0.00017332415000000001" node1="52" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-6.1399441013521852" q1="-52.238648537205748" p2="6.590965800209597" q2="47.643280308261176">
         <iidm:alias>_04812676-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048a2722-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10820,7 +10820,7 @@
             <iidm:temporaryLimit name="_216c0f3b-03e8-4b7d-96fc-a5f891331f7f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046735d0-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="123" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-92.154562716893992" q1="-2.5673526451535702" p2="93.609820606518738" q2="7.3388894454456581">
+    <iidm:line id="_046735d0-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="123" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-92.488424762870707" q1="-2.4717924733726528" p2="93.954205064726253" q2="7.2970586128091428">
         <iidm:alias>_04570934-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b3894-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10828,7 +10828,7 @@
             <iidm:temporaryLimit name="_32655e4f-e7da-46b0-a908-b601224ddb73" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046d294b-c766-11e1-8775-005056c00008" name="21-22" r="3.641616" x="16.901281399999998" g1="0" b1="7.0592299999999998e-05" g2="0" b2="7.0592299999999998e-05" node1="22" voltageLevelId1="_0460f448-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04773b6a-c766-11e1-8775-005056c00008" p1="-39.39056574410003" q1="-3.4451526394896592" p2="39.742066390710924" q2="2.7713951100007073">
+    <iidm:line id="_046d294b-c766-11e1-8775-005056c00008" name="21-22" r="3.641616" x="16.901281399999998" g1="0" b1="7.0592299999999998e-05" g2="0" b2="7.0592299999999998e-05" node1="22" voltageLevelId1="_0460f448-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04773b6a-c766-11e1-8775-005056c00008" p1="-47.066557391464613" q1="-5.5856378913194558" p2="47.590052694637095" q2="5.7818621633359539">
         <iidm:alias>_044a37f0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_044be5a2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10836,7 +10836,7 @@
             <iidm:temporaryLimit name="_bafaeace-e459-4dc2-87a0-467a9ea25f8d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_6a131803-f462-47e2-bc21-bda919364fe9" name="reactor1" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="36" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="37" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="5.8286708792820718e-14" q1="-83.151439201261041" p2="-6.106226635438361e-14" q2="92.151084564051018">
+    <iidm:line id="_6a131803-f462-47e2-bc21-bda919364fe9" name="reactor1" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="36" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="37" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="-6.6613381477509392e-14" q1="-83.15138972892305" p2="6.6613381477509392e-14" q2="92.151029737223652">
         <iidm:alias>_04531196-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_ca0adad2-ffe3-4efa-b56b-7d333b8ae18f</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10844,7 +10844,7 @@
             <iidm:temporaryLimit name="_ae4eadea-f3fc-4ac6-8899-c1698ece7a89" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_9803b364-2a93-4f21-94b7-8bdbe27a16f2" name="reactor2" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="38" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="5.9466509529093603e-07" q1="27.482702004563027" p2="-5.9466509529093603e-07" q2="-26.596964400879997">
+    <iidm:line id="_9803b364-2a93-4f21-94b7-8bdbe27a16f2" name="reactor2" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="38" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="5.8586444723340847e-08" q1="27.474062167057063" p2="-5.8586445417230237e-08" q2="-26.588880885402212">
         <iidm:alias>_0461b792-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_afe0e60b-3870-44fb-ba93-a056228f9636</iidm:alias>
     </iidm:line>

--- a/tests/main_sa/reference/launch/two_windings_transformer_contingency/outputIIDM.xml
+++ b/tests/main_sa/reference/launch/two_windings_transformer_contingency/outputIIDM.xml
@@ -31,8 +31,8 @@
                     <iidm:alias>_bea273f1-1e21-476d-b0d0-92dd6cb9a2d4</iidm:alias>
                     <iidm:alias>_c94e6b68-da6c-43d1-94fd-09ad60c74134</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_047abdd7-c766-11e1-8775-005056c00008-BREAKER" name="BREAKER-Jay LD" kind="BREAKER" retained="true" open="false" node1="0" node2="8"/>
                 <iidm:internalConnection node1="7" node2="0"/>
-                <iidm:internalConnection node1="8" node2="0"/>
                 <iidm:internalConnection node1="9" node2="1"/>
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="4"/>
@@ -47,9 +47,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="124.37035187414391" angle="7.1970161692199088" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.48325980404657" angle="-3.8266682730721597" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047abdd7-c766-11e1-8775-005056c00008" name="Jay LD" loadType="UNDEFINED" p0="14" q0="8" node="8" p="13.983652210264269" q="7.9844367373246312">
+            <iidm:load id="_047abdd7-c766-11e1-8775-005056c00008" name="Jay LD" loadType="UNDEFINED" p0="14" q0="8" node="8" p="13.984295667834676" q="7.9850490863005792">
                 <iidm:alias>_04590500-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -139,12 +139,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="127.66707615231424" angle="10.716647455518549" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="127.86433335605749" angle="-0.50059358567611512" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045b00d5-c766-11e1-8775-005056c00008" name="Madison LD" loadType="UNDEFINED" p0="62" q0="13" node="14" p="61.98840845776283" q="12.995949444681015">
+            <iidm:load id="_045b00d5-c766-11e1-8775-005056c00008" name="Madison LD" loadType="UNDEFINED" p0="62" q0="13" node="14" p="61.989696831366146" q="12.996399629767536">
                 <iidm:alias>_045b27e3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_04689566-c766-11e1-8775-005056c00008" name="Madison NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="15" p="8.9983173567720236" q="0">
+            <iidm:load id="_04689566-c766-11e1-8775-005056c00008" name="Madison NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="15" p="8.9985043787467003" q="0">
                 <iidm:alias>_04765100-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -272,16 +272,16 @@
                 <iidm:internalConnection node1="61" node2="12"/>
                 <iidm:internalConnection node1="62" node2="15"/>
                 <iidm:internalConnection node1="63" node2="18"/>
-                <iidm:bus v="126.06000120259574" angle="-13.65434300548206" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63"/>
+                <iidm:bus v="126.06001244252671" angle="-24.70699889033693" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_046c3ee7-c766-11e1-8775-005056c00008" name="Torrey SM" energySource="THERMAL" minP="20" maxP="80" ratedS="100" voltageRegulatorOn="true" targetP="48" targetV="126.06" targetQ="0" node="21" p="-53.418517519266139" q="-3.9229970534607408">
+            <iidm:generator id="_046c3ee7-c766-11e1-8775-005056c00008" name="Torrey SM" energySource="THERMAL" minP="20" maxP="80" ratedS="100" voltageRegulatorOn="true" targetP="48" targetV="126.06" targetQ="0" node="21" p="-53.409182830909444" q="-3.9314732872978868">
                 <iidm:alias>_047147f3-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_b97aee41-3115-4cfd-9071-b52fb44d0b66"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_5005c073-28d1-4a7d-b257-649dec43ec73"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-30" maxQ="85"/>
             </iidm:generator>
-            <iidm:load id="_044afb44-c766-11e1-8775-005056c00008" name="Torrey LD" loadType="UNDEFINED" p0="113" q0="32" node="20" p="113.00000161700758" q="32.000000763189426">
+            <iidm:load id="_044afb44-c766-11e1-8775-005056c00008" name="Torrey LD" loadType="UNDEFINED" p0="113" q0="32" node="20" p="113.00001673019455" q="32.000007896257408">
                 <iidm:alias>_04522737-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -332,9 +332,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="123.78725154553915" angle="9.0711189046055551" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="123.77655555204505" angle="-2.0410248305755805" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04481515-c766-11e1-8775-005056c00008" name="Darrah LD" loadType="UNDEFINED" p0="68" q0="36" node="8" p="67.988746869718923" q="35.990071315129448">
+            <iidm:load id="_04481515-c766-11e1-8775-005056c00008" name="Darrah LD" loadType="UNDEFINED" p0="68" q0="36" node="8" p="67.988664125093052" q="35.989998313250091">
                 <iidm:alias>_044e7db8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -385,9 +385,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.45262123360428" angle="24.128942250938685" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.44675973834845" angle="13.039147369422389" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044c0cb3-c766-11e1-8775-005056c00008" name="Smythe LD" loadType="UNDEFINED" p0="5" q0="3" node="8" p="4.9997755335867922" q="2.9997755369458199">
+            <iidm:load id="_044c0cb3-c766-11e1-8775-005056c00008" name="Smythe LD" loadType="UNDEFINED" p0="5" q0="3" node="8" p="4.9997741470143824" q="2.9997741504150373">
                 <iidm:alias>_045163e8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -514,9 +514,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="125.91721798897723" angle="-13.772911415978022" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="125.9172173971082" angle="-24.825666847395127" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0450a093-c766-11e1-8775-005056c00008" name="Sunnysde LD" loadType="UNDEFINED" p0="84" q0="18" node="20" p="84.002297313879978" q="18.000820476722495">
+            <iidm:load id="_0450a093-c766-11e1-8775-005056c00008" name="Sunnysde LD" loadType="UNDEFINED" p0="84" q0="18" node="20" p="84.002313691354274" q="18.000826325927481">
                 <iidm:alias>_045f4695-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -568,12 +568,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="126.71119963774122" angle="8.6852796548051394" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="126.71328762284989" angle="-2.4439692489251952" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044b2251-c766-11e1-8775-005056c00008" name="Bellefnt LD" loadType="UNDEFINED" p0="68" q0="27" node="8" p="67.995240316138464" q="26.99685028270008">
+            <iidm:load id="_044b2251-c766-11e1-8775-005056c00008" name="Bellefnt LD" loadType="UNDEFINED" p0="68" q0="27" node="8" p="67.995197498380961" q="26.996821948747574">
                 <iidm:alias>_04622cc1-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0449e9d5-c766-11e1-8775-005056c00008" name="Bellefnt SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.40300000000001" targetDeadband="1" node="9" q="-11.062396670294865">
+            <iidm:shunt id="_0449e9d5-c766-11e1-8775-005056c00008" name="Bellefnt SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.40300000000001" targetDeadband="1" node="9" q="-11.062761252271653">
                 <iidm:alias>_047bcf48-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_6cc38790-c6a6-4309-99f4-a3258e24e785"/>
                 <iidm:shuntLinearModel bPerSection="0.00013779999999999999" gPerSection="0" maximumSectionCount="10"/>
@@ -665,12 +665,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="126.06648280484995" angle="9.785308986131211" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="126.06645253830463" angle="-1.3111478605806548" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04682035-c766-11e1-8775-005056c00008" name="Fieldale LD" loadType="UNDEFINED" p0="39" q0="30" node="14" p="39.000081176555135" q="30.000104072578786">
+            <iidm:load id="_04682035-c766-11e1-8775-005056c00008" name="Fieldale LD" loadType="UNDEFINED" p0="39" q0="30" node="14" p="39.000076219271698" q="30.000097717078656">
                 <iidm:alias>_0478c20a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_045c6067-c766-11e1-8775-005056c00008" name="Fieldale SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.066" targetDeadband="1" node="15" q="-5.4671087818542228">
+            <iidm:shunt id="_045c6067-c766-11e1-8775-005056c00008" name="Fieldale SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.066" targetDeadband="1" node="15" q="-5.467106156723859">
                 <iidm:alias>_0451b209-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_2d222dd9-7306-4afd-baa5-fd303b0eeb40"/>
                 <iidm:shuntLinearModel bPerSection="6.8800000000000005e-05" gPerSection="0" maximumSectionCount="10"/>
@@ -780,7 +780,7 @@
                 <iidm:internalConnection node1="51" node2="9"/>
                 <iidm:internalConnection node1="52" node2="12"/>
                 <iidm:internalConnection node1="53" node2="15"/>
-                <iidm:bus v="132.56916594326279" angle="-7.1218554240123666" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,16,17,19,20,21,22,23,24,25,26,27,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,49,50,51,52"/>
+                <iidm:bus v="132.5699012803266" angle="-18.172825222938449" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,16,17,19,20,21,22,23,24,25,26,27,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="_047f0391-c766-11e1-8775-005056c00008" name="Muskngum SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="392" targetV="138.59999099999999" targetQ="0" node="18" p="-0" q="-0">
                 <iidm:alias>_047eb572-c766-11e1-8775-005056c00008</iidm:alias>
@@ -789,7 +789,7 @@
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
-            <iidm:load id="_047e1936-c766-11e1-8775-005056c00008" name="Muskngum LD" loadType="UNDEFINED" p0="39" q0="18" node="17" p="38.403093557382896" q="17.543187722179557">
+            <iidm:load id="_047e1936-c766-11e1-8775-005056c00008" name="Muskngum LD" loadType="UNDEFINED" p0="39" q0="18" node="17" p="38.403186786728874" q="17.543258703494246">
                 <iidm:alias>_046e88d5-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -876,9 +876,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="221.10000082334219" angle="11.866586562695959" nodes="0,1,2,3,4,5,6,7,8,9,10,13,14,15,16,17,18,19,20,21,23,24,25,26,27,28,29,30,31,32,33,34,35,36,39,40,41"/>
+                <iidm:bus v="221.10000309119167" angle="0.80384327486175977" nodes="0,1,2,3,4,5,6,7,8,9,10,13,14,15,16,17,18,19,20,21,23,24,25,26,27,28,29,30,31,32,33,34,35,36,39,40,41"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0458ddf1-c766-11e1-8775-005056c00008" name="Muskngum SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="391" targetV="221.09999999999999" targetQ="0" node="14" p="-435.13834062568878" q="-79.844806555891253">
+            <iidm:generator id="_0458ddf1-c766-11e1-8775-005056c00008" name="Muskngum SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="391" targetV="221.09999999999999" targetQ="0" node="14" p="-435.06230181011654" q="-79.707550514220387">
                 <iidm:alias>_04522732-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_5036c3a5-56f9-489c-9ecb-8c15aa7c70c5"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_12b01822-ca11-4cf8-a6b4-2f8ff805ca20"/>
@@ -961,9 +961,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="123.70164219032583" angle="5.2980164909615155" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="123.75783259313147" angle="-5.6016664474026747" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0453d4e2-c766-11e1-8775-005056c00008" name="Adams LD" loadType="UNDEFINED" p0="18" q0="3" node="8" p="17.975016463746567" q="2.9930633401013544">
+            <iidm:load id="_0453d4e2-c766-11e1-8775-005056c00008" name="Adams LD" loadType="UNDEFINED" p0="18" q0="3" node="8" p="17.975874260726819" q="2.9933014002945679">
                 <iidm:alias>_0448ff77-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1053,16 +1053,16 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="133.32000257192038" angle="15.515003878127123" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="133.31999174580997" angle="4.418954114307005" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_046bf0c4-c766-11e1-8775-005056c00008" name="Claytor SM" energySource="THERMAL" minP="0" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="40" targetV="133.31999200000001" targetQ="0" node="15" p="-44.515431266055124" q="-82.956201228497605">
+            <iidm:generator id="_046bf0c4-c766-11e1-8775-005056c00008" name="Claytor SM" energySource="THERMAL" minP="0" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="40" targetV="133.31999200000001" targetQ="0" node="15" p="-44.507652359091203" q="-82.960195594877732">
                 <iidm:alias>_0460a627-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e56da2eb-bb6a-4133-953c-40073c5bc5f4"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_d41be6b4-155e-4c8f-b46b-16b50c49f0f4"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-60" maxQ="170"/>
             </iidm:generator>
-            <iidm:load id="_048433b6-c766-11e1-8775-005056c00008" name="Claytor LD" loadType="UNDEFINED" p0="23" q0="16" node="14" p="23.000002735758194" q="16.000003171893685">
+            <iidm:load id="_048433b6-c766-11e1-8775-005056c00008" name="Claytor LD" loadType="UNDEFINED" p0="23" q0="16" node="14" p="22.999999934221748" q="15.999999923735361">
                 <iidm:alias>_0480ff6b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1133,12 +1133,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="129.79608660786502" angle="-10.817458680187736" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="129.78802919987498" angle="-21.850643311408753" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0449e9d7-c766-11e1-8775-005056c00008" name="N.Newark LD" loadType="UNDEFINED" p0="53" q0="22" node="11" p="53.004090815717106" q="22.002830196894955">
+            <iidm:load id="_0449e9d7-c766-11e1-8775-005056c00008" name="N.Newark LD" loadType="UNDEFINED" p0="53" q0="22" node="11" p="53.003623057364294" q="22.002506574787802">
                 <iidm:alias>_04531191-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_04684741-c766-11e1-8775-005056c00008" name="N.Newark SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.32300000000001" targetDeadband="1" node="12" q="-9.6701918326632121">
+            <iidm:shunt id="_04684741-c766-11e1-8775-005056c00008" name="N.Newark SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.32300000000001" targetDeadband="1" node="12" q="-9.6689912685392834">
                 <iidm:alias>_04607f19-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_eae61817-d3cb-488f-a1f3-13bc8e31431b"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -1191,9 +1191,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.94542261195474" angle="11.306672731208931" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="131.03258825349653" angle="0.055949834871722864" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0448d86a-c766-11e1-8775-005056c00008" name="Hillsbro NegG LD" loadType="UNDEFINED" p0="12" q0="0" node="8" p="11.999440246165499" q="0">
+            <iidm:load id="_0448d86a-c766-11e1-8775-005056c00008" name="Hillsbro NegG LD" loadType="UNDEFINED" p0="12" q0="0" node="8" p="11.999504457053636" q="0">
                 <iidm:alias>_044ef2e8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1244,9 +1244,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="124.41061501890037" angle="-8.9351318564842224" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.35891691814349" angle="-19.909348545579729" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047dcb12-c766-11e1-8775-005056c00008" name="S.Kenton LD" loadType="UNDEFINED" p0="18" q0="7" node="8" p="17.942765986940557" q="6.9629432121039381">
+            <iidm:load id="_047dcb12-c766-11e1-8775-005056c00008" name="S.Kenton LD" loadType="UNDEFINED" p0="18" q0="7" node="8" p="17.94250598425225" q="6.9627750500704275">
                 <iidm:alias>_0451b205-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1281,6 +1281,9 @@
                     <iidm:alias>_8ef85f09-3622-4a12-87bf-fefcecc01e4a</iidm:alias>
                     <iidm:alias>_a0244ab3-80e5-4c20-b201-a142d50e6ec1</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_dffdb415-95a8-496a-ad1a-93cdeb444fae-1" name="DISCONNECTOR723-1" kind="DISCONNECTOR" retained="false" open="false" node1="24" node2="25"/>
+                <iidm:switch id="_aa063f2e-1205-4d1a-a549-3ccc5b31e65d-1" name="BREAKER362-1" kind="BREAKER" retained="false" open="false" node1="23" node2="24"/>
+                <iidm:switch id="_28b3e895-483c-478d-a5a3-7b9d7c9e11f3-1" name="DISCONNECTOR724-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="23"/>
                 <iidm:internalConnection node1="7" node2="0"/>
                 <iidm:internalConnection node1="8" node2="0"/>
                 <iidm:internalConnection node1="9" node2="1"/>
@@ -1297,9 +1300,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="125.17887424468378" angle="22.586976442200399" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.14915184932849" angle="11.593556142101184" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044afb49-c766-11e1-8775-005056c00008" name="Hazard LD" loadType="UNDEFINED" p0="21" q0="10" node="8" p="20.996153482696332" q="9.9969473948836676">
+            <iidm:load id="_044afb49-c766-11e1-8775-005056c00008" name="Hazard LD" loadType="UNDEFINED" p0="21" q0="10" node="8" p="20.995767545363545" q="9.9966411346935846">
                 <iidm:alias>_045e5c31-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1320,6 +1323,9 @@
                     <iidm:alias>_2a61ce12-8d9c-4aae-8bc7-c8f820ecae6c</iidm:alias>
                     <iidm:alias>_a3d5e8cc-be34-4d4a-a586-ce582737826b</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_83a05cd7-017e-4e7a-bc5e-a01ee9681f9f-1" name="DISCONNECTOR725-1" kind="DISCONNECTOR" retained="false" open="false" node1="14" node2="15"/>
+                <iidm:switch id="_cf4393c0-21c2-4e35-b330-c1acda2647ba-1" name="BREAKER363-1" kind="BREAKER" retained="false" open="true" node1="13" node2="14"/>
+                <iidm:switch id="_b9ab29b9-3d90-4536-8d1a-7757d8c22ae4-1" name="DISCONNECTOR726-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="13"/>
                 <iidm:internalConnection node1="4" node2="0"/>
                 <iidm:internalConnection node1="5" node2="0"/>
                 <iidm:internalConnection node1="6" node2="1"/>
@@ -1329,14 +1335,14 @@
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="3"/>
-                <iidm:bus v="31.294718561170946" angle="22.586976442200399" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="31.037287962332115" angle="11.593556142101187" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13"/>
             </iidm:nodeBreakerTopology>
             <iidm:staticVarCompensator id="_047fc6e6-c766-11e1-8775-005056c00008" name="Pinevlle SVC" bMin="-10" bMax="10" voltageSetpoint="33.494999999999997" regulationMode="VOLTAGE" node="5" p="0" q="0">
                 <iidm:alias>_046ab846-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_98f667da-02d1-4a31-b826-44314a1fbbfe"/>
             </iidm:staticVarCompensator>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045e3525-c766-11e1-8775-005056c00008" name="86-87" r="0.30796918750000002" x="2.2585859312499998" g="0" b="-0.0040863184000000004" ratedU1="132" ratedU2="33" node1="22" voltageLevelId1="_0484f70a-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_04555b88-c766-11e1-8775-005056c00008" p1="5.2041704279304213e-16" q1="4.0019743765724485" p2="1.4930824737330232e-14" q2="-9.0715837519287951e-14">
+        <iidm:twoWindingsTransformer id="_045e3525-c766-11e1-8775-005056c00008" name="86-87" r="0.30796918750000002" x="2.2585859312499998" g="0" b="-0.0040863184000000004" ratedU1="132" ratedU2="33" node1="22" voltageLevelId1="_0484f70a-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_04555b88-c766-11e1-8775-005056c00008" p1="-1.222980050563649e-14" q1="3.9364046341527459" p2="2.0197944053636483e-14" q2="-9.8452924345250633e-14">
             <iidm:alias>_0452755a-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04682034-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_048c7110-c766-11e1-8775-005056c00008</iidm:alias>
@@ -1412,6 +1418,82 @@
                 <iidm:temporaryLimit name="_257d56c1-d70a-4a96-b85c-d928ade03ad4" acceptableDuration="60" value="12246"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
+        <iidm:twoWindingsTransformer id="_045e3525-c766-11e1-8775-005056c00008-1" name="86-87-open-ended" r="0.30796918750000002" x="2.2585859312499998" g="0" b="-0.0040863184000000004" ratedU1="132" ratedU2="33" node1="25" voltageLevelId1="_0484f70a-c766-11e1-8775-005056c00008" node2="15" voltageLevelId2="_04555b88-c766-11e1-8775-005056c00008" p1="-8.6736173798840355e-17" q1="3.9364046341526926" p2="0" q2="0">
+            <iidm:alias>_0452755a-c766-11e1-8775-005056c00008-1</iidm:alias>
+            <iidm:alias>_04682034-c766-11e1-8775-005056c00008-1</iidm:alias>
+            <iidm:alias>_048c7110-c766-11e1-8775-005056c00008-1</iidm:alias>
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="31" loadTapChangingCapabilities="false">
+                <iidm:step r="-78.460970487743992" x="-78.460970487743992" g="364.27347129590328" b="364.27347129590328" rho="0.4641016"/>
+                <iidm:step r="-76.770985444658564" x="-76.770985444658564" g="330.49609255595948" b="330.49609255595948" rho="0.48196488000000004"/>
+                <iidm:step r="-75.017181047101431" x="-75.017181047101431" g="300.27508580410921" b="300.27508580410921" rho="0.49982816000000002"/>
+                <iidm:step r="-73.199557295072623" x="-73.199557295072623" g="273.1281647135425" b="273.1281647135425" rho="0.51769144000000011"/>
+                <iidm:step r="-71.318114188572153" x="-71.318114188572153" g="248.65210975826625" b="248.65210975826625" rho="0.53555472000000004"/>
+                <iidm:step r="-69.372851727600008" x="-69.372851727600008" g="226.50770848984379" b="226.50770848984379" rho="0.55341799999999997"/>
+                <iidm:step r="-67.363769912156158" x="-67.363769912156158" g="206.40793906293555" b="206.40793906293555" rho="0.57128128"/>
+                <iidm:step r="-65.290868742240633" x="-65.290868742240633" g="188.10862264852744" b="188.10862264852744" rho="0.58914456000000004"/>
+                <iidm:step r="-63.154148217853432" x="-63.154148217853432" g="171.40097232995538" b="171.40097232995538" rho="0.60700784000000008"/>
+                <iidm:step r="-60.953608338994556" x="-60.953608338994556" g="156.10561116167679" b="156.10561116167679" rho="0.62487112"/>
+                <iidm:step r="-58.689249105663997" x="-58.689249105663997" g="142.06773741726079" b="142.06773741726079" rho="0.64273440000000004"/>
+                <iidm:step r="-56.361070517861769" x="-56.361070517861769" g="129.15319231405709" b="129.15319231405709" rho="0.66059767999999996"/>
+                <iidm:step r="-53.969072575587838" x="-53.969072575587838" g="117.24524269951107" b="117.24524269951107" rho="0.67846096"/>
+                <iidm:step r="-51.51325527884223" x="-51.51325527884223" g="106.24193390397649" b="106.24193390397649" rho="0.69632424000000004"/>
+                <iidm:step r="-48.993618627624947" x="-48.993618627624947" g="96.053900138385018" b="96.053900138385018" rho="0.71418752000000008"/>
+                <iidm:step r="-46.410162621936003" x="-46.410162621936003" g="86.602544237115268" b="86.602544237115268" rho="0.7320508"/>
+                <iidm:step r="-43.762887261775354" x="-43.762887261775354" g="77.81851722275475" b="77.81851722275475" rho="0.74991407999999993"/>
+                <iidm:step r="-41.051792547143037" x="-41.051792547143037" g="69.640442552852292" b="69.640442552852292" rho="0.76777735999999996"/>
+                <iidm:step r="-38.276878478039045" x="-38.276878478039045" g="62.013841060226049" b="62.013841060226049" rho="0.78564064"/>
+                <iidm:step r="-35.438145054463355" x="-35.438145054463355" g="54.890221299184191" b="54.890221299184191" rho="0.80350392000000004"/>
+                <iidm:step r="-32.53559227641599" x="-32.53559227641599" g="48.2263068397802" b="48.2263068397802" rho="0.82136720000000008"/>
+                <iidm:step r="-29.569220143896956" x="-29.569220143896956" g="41.983377444222199" b="41.983377444222199" rho="0.83923048"/>
+                <iidm:step r="-26.53902865690624" x="-26.53902865690624" g="36.126705339843348" b="36.126705339843348" rho="0.85709376000000004"/>
+                <iidm:step r="-23.445017815443848" x="-23.445017815443848" g="30.625071218648301" b="30.625071218648301" rho="0.87495704000000007"/>
+                <iidm:step r="-20.287187619509762" x="-20.287187619509762" g="25.450347332714429" b="25.450347332714429" rho="0.89282032000000011"/>
+                <iidm:step r="-17.06553806910399" x="-17.06553806910399" g="20.577137262099331" b="20.577137262099331" rho="0.91068360000000004"/>
+                <iidm:step r="-13.780069164226571" x="-13.780069164226571" g="15.982463718828566" b="15.982463718828566" rho="0.92854687999999996"/>
+                <iidm:step r="-10.430780904877434" x="-10.430780904877434" g="11.645497203453271" b="11.645497203453271" rho="0.94641016"/>
+                <iidm:step r="-7.0176732910566368" x="-7.0176732910566368" g="7.5473195169912355" b="7.5473195169912355" rho="0.96427344000000004"/>
+                <iidm:step r="-3.5407463227641656" x="-3.5407463227641656" g="3.6707171036300279" b="3.6707171036300279" rho="0.98213671999999985"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1"/>
+                <iidm:step r="3.6045656772358381" x="3.6045656772358381" g="-3.4791571719583358" b="-3.4791571719583358" rho="1.01786328"/>
+                <iidm:step r="7.272950708943382" x="7.272950708943382" g="-6.7798551833225922" b="-6.7798551833225922" rho="1.0357265600000001"/>
+                <iidm:step r="11.005155095122543" x="11.005155095122543" g="-9.9140937064517427" b="-9.9140937064517427" rho="1.0535898399999999"/>
+                <iidm:step r="14.801178835773431" x="14.801178835773431" g="-12.892880531259154" b="-12.892880531259154" rho="1.0714531199999999"/>
+                <iidm:step r="18.661021930895984" x="18.661021930895984" g="-15.726328348801433" b="-15.726328348801433" rho="1.0893164"/>
+                <iidm:step r="22.584684380490238" x="22.584684380490238" g="-18.423740693731116" b="-18.423740693731116" rho="1.10717968"/>
+                <iidm:step r="26.572166184556178" x="26.572166184556178" g="-20.993688411566747" b="-20.993688411566747" rho="1.12504296"/>
+                <iidm:step r="30.623467343093779" x="30.623467343093779" g="-23.444077826121855" b="-23.444077826121855" rho="1.1429062400000001"/>
+                <iidm:step r="34.738587856103067" x="34.738587856103067" g="-25.782211620922489" b="-25.782211620922489" rho="1.1607695200000001"/>
+                <iidm:step r="38.917527723583987" x="38.917527723583987" g="-28.014843311220961" b="-28.014843311220961" rho="1.1786327999999999"/>
+                <iidm:step r="43.16028694553664" x="43.16028694553664" g="-30.148226066322692" b="-30.148226066322692" rho="1.19649608"/>
+                <iidm:step r="47.466865521960955" x="47.466865521960955" g="-32.188156542116317" b="-32.188156542116317" rho="1.21435936"/>
+                <iidm:step r="51.837263452856973" x="51.837263452856973" g="-34.140014298236885" b="-34.140014298236885" rho="1.23222264"/>
+                <iidm:step r="56.271480738224653" x="56.271480738224653" g="-36.0087973009527" b="-36.0087973009527" rho="1.2500859200000001"/>
+                <iidm:step r="60.769517378063973" x="60.769517378063973" g="-37.799153949786998" b="-37.799153949786998" rho="1.2679491999999999"/>
+                <iidm:step r="65.331373372375026" x="65.331373372375026" g="-39.515412011505823" b="-39.515412011505823" rho="1.2858124799999999"/>
+                <iidm:step r="69.957048721157761" x="69.957048721157761" g="-41.161604798123854" b="-41.161604798123854" rho="1.30367576"/>
+                <iidm:step r="74.646543424412172" x="74.646543424412172" g="-42.741494884907091" b="-42.741494884907091" rho="1.32153904"/>
+                <iidm:step r="79.399857482138245" x="79.399857482138245" g="-44.258595629064871" b="-44.258595629064871" rho="1.33940232"/>
+                <iidm:step r="84.216990894335964" x="84.216990894335964" g="-45.716190719151165" b="-45.716190719151165" rho="1.3572655999999998"/>
+                <iidm:step r="89.097943661005473" x="89.097943661005473" g="-47.11735195848069" b="-47.11735195848069" rho="1.3751288800000001"/>
+                <iidm:step r="94.04271578214653" x="94.04271578214653" g="-48.464955462553469" b="-48.464955462553469" rho="1.3929921599999999"/>
+                <iidm:step r="99.051307257759348" x="99.051307257759348" g="-49.761696430103783" b="-49.761696430103783" rho="1.41085544"/>
+                <iidm:step r="104.12371808784383" x="104.12371808784383" g="-51.010102629540867" b="-51.010102629540867" rho="1.42871872"/>
+                <iidm:step r="109.25994827240002" x="109.25994827240002" g="-52.212546726893493" b="-52.212546726893493" rho="1.446582"/>
+                <iidm:step r="114.45999781142788" x="114.45999781142788" g="-53.371257567609966" b="-53.371257567609966" rho="1.4644452800000001"/>
+                <iidm:step r="119.72386670492732" x="119.72386670492732" g="-54.488330512455207" b="-54.488330512455207" rho="1.4823085599999999"/>
+                <iidm:step r="125.05155495289854" x="125.05155495289854" g="-55.565736917068101" b="-55.565736917068101" rho="1.5001718399999999"/>
+                <iidm:step r="130.44306255534144" x="130.44306255534144" g="-56.605332835313817" b="-56.605332835313817" rho="1.51803512"/>
+                <iidm:step r="135.89838951225599" x="135.89838951225599" g="-57.608867018227542" b="-57.608867018227542" rho="1.5358984"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="2186">
+                <iidm:temporaryLimit name="_580d3b53-5508-4d8d-97cc-4ea463e0cdb9-1" acceptableDuration="900" value="2514"/>
+                <iidm:temporaryLimit name="_a867e68a-58d1-49cb-955f-bb8e59cf2a11-1" acceptableDuration="60" value="3061"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="8747">
+                <iidm:temporaryLimit name="_1a7f23f9-e2c0-46a6-a93c-687f2209e33d-1" acceptableDuration="900" value="10059"/>
+                <iidm:temporaryLimit name="_257d56c1-d70a-4a96-b85c-d928ade03ad4-1" acceptableDuration="60" value="12246"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
     </iidm:substation>
     <iidm:substation id="_045beb3a-c766-11e1-8775-005056c00008" name="Minas Tirith" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
         <iidm:voltageLevel id="_048a9c58-c766-11e1-8775-005056c00008" name="MNT132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -1460,12 +1542,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="132.68202309089585" angle="12.032041341035967" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="132.80038185790283" angle="0.167472477510415" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0447ee05-c766-11e1-8775-005056c00008" name="NwCarlsl NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="8" p="8.9982295290910326" q="0">
+            <iidm:load id="_0447ee05-c766-11e1-8775-005056c00008" name="NwCarlsl NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="8" p="8.998230057227353" q="0">
                 <iidm:alias>_04731cb7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_047a48a8-c766-11e1-8775-005056c00008" name="NwCarlsl LD" loadType="UNDEFINED" p0="30" q0="12" node="9" p="29.994098430303438" q="11.996065878197008">
+            <iidm:load id="_047a48a8-c766-11e1-8775-005056c00008" name="NwCarlsl LD" loadType="UNDEFINED" p0="30" q0="12" node="9" p="29.994100190757838" q="11.996067051679374">
                 <iidm:alias>_044c0cb9-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1516,9 +1598,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.62263554582941" angle="10.796698631752895" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.62259958072879" angle="-0.29950445888789279" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044ecbd1-c766-11e1-8775-005056c00008" name="Blaine LD" loadType="UNDEFINED" p0="2" q0="1" node="8" p="2.0000054399220604" q="1.0000045332724936">
+            <iidm:load id="_044ecbd1-c766-11e1-8775-005056c00008" name="Blaine LD" loadType="UNDEFINED" p0="2" q0="1" node="8" p="2.0000051906150946" q="1.0000043255163209">
                 <iidm:alias>_04700f74-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1569,9 +1651,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="133.17128823049927" angle="16.701043820042884" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="133.14647839040609" angle="5.6063412641236221" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046b7b95-c766-11e1-8775-005056c00008" name="Sundial LD" loadType="UNDEFINED" p0="15" q0="9" node="8" p="14.999231894400813" q="8.9992319075116924">
+            <iidm:load id="_046b7b95-c766-11e1-8775-005056c00008" name="Sundial LD" loadType="UNDEFINED" p0="15" q0="9" node="8" p="14.999221836013971" q="8.999221849470473">
                 <iidm:alias>_046efe07-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1622,9 +1704,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.67758250105504" angle="7.2034678961472274" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.72585204540067" angle="-4.4925924230183591" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045645e2-c766-11e1-8775-005056c00008" name="Riversde LD" loadType="UNDEFINED" p0="51" q0="27" node="8" p="50.995813815159416" q="26.996306408556485">
+            <iidm:load id="_045645e2-c766-11e1-8775-005056c00008" name="Riversde LD" loadType="UNDEFINED" p0="51" q0="27" node="8" p="50.995832865057046" q="26.996323216371966">
                 <iidm:alias>_0476ed4b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1675,9 +1757,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.58980137233854" angle="10.099467932026306" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.74097658022657" angle="-1.0657795936006074" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04887973-c766-11e1-8775-005056c00008" name="Randolph LD" loadType="UNDEFINED" p0="10" q0="5" node="8" p="9.9915311380151675" q="4.992944607467475">
+            <iidm:load id="_04887973-c766-11e1-8775-005056c00008" name="Randolph LD" loadType="UNDEFINED" p0="10" q0="5" node="8" p="9.9919171904686479" q="4.9932661403260648">
                 <iidm:alias>_0462f018-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1728,9 +1810,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.59134014892588" angle="-13.45428534109648" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.59112686131422" angle="-24.505883699395383" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0477627b-c766-11e1-8775-005056c00008" name="WNwPhil2 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="12.003843106073257" q="3.001601465133982">
+            <iidm:load id="_0477627b-c766-11e1-8775-005056c00008" name="WNwPhil2 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="12.003845027418855" q="3.0016022658656065">
                 <iidm:alias>_045841b6-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1800,9 +1882,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="126.73133112372277" angle="11.520344984532482" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="126.73129400480583" angle="0.42437000201551728" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0476781a-c766-11e1-8775-005056c00008" name="Cloverdl LD" loadType="UNDEFINED" p0="43" q0="16" node="11" p="43.000123216041672" q="16.000076413122081">
+            <iidm:load id="_0476781a-c766-11e1-8775-005056c00008" name="Cloverdl LD" loadType="UNDEFINED" p0="43" q0="16" node="11" p="43.00011794876081" q="16.000073146585208">
                 <iidm:alias>_0481749a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1872,9 +1954,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="128.11733842028886" angle="12.890091238954925" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="128.11731270461763" angle="1.7940997767522397" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046b0665-c766-11e1-8775-005056c00008" name="Hancock LD" loadType="UNDEFINED" p0="38" q0="25" node="11" p="38.000063161363137" q="25.000069255919005">
+            <iidm:load id="_046b0665-c766-11e1-8775-005056c00008" name="Hancock LD" loadType="UNDEFINED" p0="38" q0="25" node="11" p="38.000058528191531" q="25.000064175681551">
                 <iidm:alias>_0464c4d5-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1926,12 +2008,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="128.4567344881039" angle="-11.018784415770007" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="128.43578174197594" angle="-22.036921697393108" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044bbe92-c766-11e1-8775-005056c00008" name="WMVernon LD" loadType="UNDEFINED" p0="16" q0="8" node="8" p="15.987337615332756" q="7.9894507966329904">
+            <iidm:load id="_044bbe92-c766-11e1-8775-005056c00008" name="WMVernon LD" loadType="UNDEFINED" p0="16" q0="8" node="8" p="15.987098471016287" q="7.9892516158532754">
                 <iidm:alias>_04500452-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_047825c8-c766-11e1-8775-005056c00008" name="WMVernon SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.21199999999999" targetDeadband="1" node="9" q="-9.4716501326893088">
+            <iidm:shunt id="_047825c8-c766-11e1-8775-005056c00008" name="WMVernon SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.21199999999999" targetDeadband="1" node="9" q="-9.4685605181800057">
                 <iidm:alias>_047084aa-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_2a6c1dcd-201b-4911-83b2-c16acc50a0f4"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -1965,9 +2047,9 @@
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="3"/>
-                <iidm:bus v="231.000007234854" angle="34.769695358700183" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="230.99998709839247" angle="22.594896485028062" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_045868c0-c766-11e1-8775-005056c00008" name="Breed SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="450" targetV="230.99998500000001" targetQ="0" node="5" p="-500.79860174312012" q="21.700639857733464">
+            <iidm:generator id="_045868c0-c766-11e1-8775-005056c00008" name="Breed SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="450" targetV="230.99998500000001" targetQ="0" node="5" p="-500.71108903977597" q="25.329368098705384">
                 <iidm:alias>_045b7606-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_f26d4eb3-ebdb-4025-8080-f856ce656b42"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_7566f2a7-61eb-42fe-a59a-8276257fdbc6"/>
@@ -2041,9 +2123,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="127.63209124193857" angle="-12.703766665820421" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="127.63175607653288" angle="-23.75451262387643" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044d1e22-c766-11e1-8775-005056c00008" name="Newcmrst LD" loadType="UNDEFINED" p0="17" q0="8" node="11" p="17.008033107944762" q="8.0063014691675285">
+            <iidm:load id="_044d1e22-c766-11e1-8775-005056c00008" name="Newcmrst LD" loadType="UNDEFINED" p0="17" q0="8" node="11" p="17.008034771186292" q="8.0063027740816466">
                 <iidm:alias>_048a754b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2113,9 +2195,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="138.60000025034464" angle="24.404477420780729" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="138.59999126595162" angle="12.674341246515048" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_045ab2b0-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="220" targetV="138.59999099999999" targetQ="0" node="11" p="-244.83487196330316" q="-49.243805503244531">
+            <iidm:generator id="_045ab2b0-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="220" targetV="138.59999099999999" targetQ="0" node="11" p="-244.79208797500164" q="-46.490940038447853">
                 <iidm:alias>_046ba2a5-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_56975783-9739-40fc-8ec1-e1de8cb06c9a"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b8449cd9-5a17-497e-bf04-70f728b0f9f2"/>
@@ -2168,9 +2250,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="223.30001598573475" angle="26.802970633363689" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="223.30000061339243" angle="14.813266445223617" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0483224a-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="314" targetV="223.30000000000001" targetQ="0" node="8" p="-349.44613543853268" q="-24.897888382031603">
+            <iidm:generator id="_0483224a-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="314" targetV="223.30000000000001" targetQ="0" node="8" p="-349.38507101886597" q="-20.430195231445214">
                 <iidm:alias>_045cd594-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_05df66ba-3f64-40cb-8b18-c66d26c4e2c1"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_c1d29442-5f57-41d1-bb60-4b74b4994c20"/>
@@ -2178,7 +2260,7 @@
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045b7604-c766-11e1-8775-005056c00008" name="26-25" r="0" x="6.6559680000000006" g="0" b="0" ratedU1="220" ratedU2="132" node1="22" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="121.62134383882646" q1="22.727994698807453" p2="-121.62134383882628" q2="-17.496798627508763">
+        <iidm:twoWindingsTransformer id="_045b7604-c766-11e1-8775-005056c00008" name="26-25" r="0" x="6.6559680000000006" g="0" b="0" ratedU1="220" ratedU2="132" node1="22" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="108.46579759140289" q1="22.206795261006018" p2="-108.46579759140286" q2="-18.017969327234717">
             <iidm:alias>_0447c6f3-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0463b364-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04803c1c-c766-11e1-8775-005056c00008</iidm:alias>
@@ -2321,9 +2403,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="136.62000155867469" angle="15.129339622399776" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="136.62000045884824" angle="4.0357077026804467" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_048aea70-c766-11e1-8775-005056c00008" name="Sporn SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="513.43743900000004" targetV="136.62" targetQ="-62.132553100000003" node="20" p="-571.39722563059672" q="45.083842808211131">
+            <iidm:generator id="_048aea70-c766-11e1-8775-005056c00008" name="Sporn SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="513.43743900000004" targetV="136.62" targetQ="-62.132553100000003" node="20" p="-571.29737607885238" q="45.352907869740775">
                 <iidm:alias>_04555b84-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_27799004-aa1e-4889-ba95-ee6fdae64895"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_827a9c80-183d-4e33-9e73-ef0aab3dfb13"/>
@@ -2413,9 +2495,9 @@
                 <iidm:internalConnection node1="39" node2="9"/>
                 <iidm:internalConnection node1="40" node2="12"/>
                 <iidm:internalConnection node1="41" node2="3"/>
-                <iidm:bus v="219.70212476268267" angle="12.66499680321291" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41"/>
+                <iidm:bus v="219.70202021075147" angle="1.5886334962463864" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41"/>
             </iidm:nodeBreakerTopology>
-            <iidm:danglingLine id="_0482fb33-c766-11e1-8775-005056c00008" name="68-116" p0="184" q0="0" r="0.16456000000000001" x="1.9601999999999999" g="0" b="0.00033884300000000002" ucteXnodeCode="XWE_BR21" node="41" p="184.1155775913397" q="-14.97892701074759">
+            <iidm:danglingLine id="_0482fb33-c766-11e1-8775-005056c00008" name="68-116" p0="184" q0="0" r="0.16456000000000001" x="1.9601999999999999" g="0" b="0.00033884300000000002" ucteXnodeCode="XWE_BR21" node="41" p="184.11557656119996" q="-14.978910582376237">
                 <iidm:alias>_0459c855-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_04684742-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_5631ccc0-d9d2-11e2-bb49-005056c00008</iidm:alias>
@@ -2428,7 +2510,7 @@
                 </iidm:currentLimits>
             </iidm:danglingLine>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_044f6815-c766-11e1-8775-005056c00008" name="68-69" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-128.4645132317176" q1="98.227262929198673" p2="128.4645132317176" q2="-89.745186988798324">
+        <iidm:twoWindingsTransformer id="_044f6815-c766-11e1-8775-005056c00008" name="68-69" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-127.56479982674892" q1="98.187190132971608" p2="127.56479982674892" q2="-89.782371954783855">
             <iidm:alias>_047e8e67-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04840ca7-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0487dd39-c766-11e1-8775-005056c00008</iidm:alias>
@@ -2535,9 +2617,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="130.37112202860658" angle="-1.4035118942034379" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="130.37168017441425" angle="-12.460693158607418" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04547126-c766-11e1-8775-005056c00008" name="Natrium LD" loadType="UNDEFINED" p0="77" q0="14" node="14" p="76.724242534289147" q="13.916536924957962">
+            <iidm:load id="_04547126-c766-11e1-8775-005056c00008" name="Natrium LD" loadType="UNDEFINED" p0="77" q0="14" node="14" p="76.724374402591209" q="13.916576789610163">
                 <iidm:alias>_047b3307-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2588,9 +2670,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="122.65860929960111" angle="-6.0748509072210437" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="122.59379735500546" angle="-17.01776370365419" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045d4ac9-c766-11e1-8775-005056c00008" name="Sterling LD" loadType="UNDEFINED" p0="31" q0="17" node="8" p="30.871924335977457" q="16.883102879381632">
+            <iidm:load id="_045d4ac9-c766-11e1-8775-005056c00008" name="Sterling LD" loadType="UNDEFINED" p0="31" q0="17" node="8" p="30.872020321120168" q="16.883190366030291">
                 <iidm:alias>_0477b094-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2698,9 +2780,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="130.27460563660509" angle="19.31115142191096" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="130.25207596933342" angle="8.2178055239348371" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0466246a-c766-11e1-8775-005056c00008" name="Switchbk LD" loadType="UNDEFINED" p0="30" q0="16" node="17" p="29.997695599185619" q="15.997951696168041">
+            <iidm:load id="_0466246a-c766-11e1-8775-005056c00008" name="Switchbk LD" loadType="UNDEFINED" p0="30" q0="16" node="17" p="29.997674938930619" q="15.997933332441598">
                 <iidm:alias>_04882b59-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2751,9 +2833,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="135.0845213644499" angle="16.544057764983506" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="135.08454021039154" angle="5.4491508528432799" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046adf5a-c766-11e1-8775-005056c00008" name="Bradley LD" loadType="UNDEFINED" p0="34" q0="8" node="8" p="33.999750936688152" q="7.9999023283514941">
+            <iidm:load id="_046adf5a-c766-11e1-8775-005056c00008" name="Bradley LD" loadType="UNDEFINED" p0="34" q0="8" node="8" p="33.999748646193254" q="7.999901430122609">
                 <iidm:alias>_04555b85-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2788,6 +2870,9 @@
                     <iidm:alias>_7f359893-b7c5-41b0-ada8-8df06cf7a8e6</iidm:alias>
                     <iidm:alias>_a4edf081-2fb2-4da4-94db-98a2a596247f</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_312f25f3-55bc-4417-848c-236d31d823f4-1" name="DISCONNECTOR524-1" kind="DISCONNECTOR" retained="false" open="false" node1="24" node2="25"/>
+                <iidm:switch id="_686e884a-a0b1-454e-b7d1-33c7ad46f89f-1" name="BREAKER262-1" kind="BREAKER" retained="false" open="false" node1="23" node2="24"/>
+                <iidm:switch id="_346a5319-3ec2-40a2-aefd-38dfacbbe97c-1" name="DISCONNECTOR523-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="23"/>
                 <iidm:internalConnection node1="7" node2="0"/>
                 <iidm:internalConnection node1="8" node2="0"/>
                 <iidm:internalConnection node1="9" node2="1"/>
@@ -2804,9 +2889,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.85957600261715" angle="8.8724085655572793" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.13646138922969" angle="-2.2425173024529372" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047a48a2-c766-11e1-8775-005056c00008" name="Mullin LD" loadType="UNDEFINED" p0="17" q0="7" node="8" p="16.9980387994997" q="6.9986541298460034">
+            <iidm:load id="_047a48a2-c766-11e1-8775-005056c00008" name="Mullin LD" loadType="UNDEFINED" p0="17" q0="7" node="8" p="16.998297297905545" q="6.9988315179678295">
                 <iidm:alias>_0474553a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2972,16 +3057,16 @@
                 <iidm:internalConnection node1="81" node2="18"/>
                 <iidm:internalConnection node1="82" node2="21"/>
                 <iidm:internalConnection node1="83" node2="24"/>
-                <iidm:bus v="134.24399818908353" angle="19.045467601358471" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
+                <iidm:bus v="134.24398763945686" angle="7.9497695195018823" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_044cd00a-c766-11e1-8775-005056c00008" name="Glen Lyn SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="252" targetV="134.243988" targetQ="0" node="27" p="-280.44721697614722" q="-84.023112602708153">
+            <iidm:generator id="_044cd00a-c766-11e1-8775-005056c00008" name="Glen Lyn SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="252" targetV="134.243988" targetQ="0" node="27" p="-280.39820986227454" q="-84.376237740269161">
                 <iidm:alias>_045e5c30-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e54b499b-436c-4b89-9803-b1d75e2fa364"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_32c8ab65-80f7-4c17-b3f5-ff075cce0ba5"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
-            <iidm:load id="_04566cf5-c766-11e1-8775-005056c00008" name="Glen Lyn LD" loadType="UNDEFINED" p0="37" q0="18" node="26" p="37.000004212435542" q="18.000003415488408">
+            <iidm:load id="_04566cf5-c766-11e1-8775-005056c00008" name="Glen Lyn LD" loadType="UNDEFINED" p0="37" q0="18" node="26" p="36.999999850941961" q="17.999999879142131">
                 <iidm:alias>_04577e64-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3032,9 +3117,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.53196497575829" angle="9.6608420015839496" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.60485794438259" angle="-2.0782634948845842" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044ea4c0-c766-11e1-8775-005056c00008" name="Kankakee LD" loadType="UNDEFINED" p0="52" q0="22" node="8" p="51.994281916770625" q="21.995968166027289">
+            <iidm:load id="_044ea4c0-c766-11e1-8775-005056c00008" name="Kankakee LD" loadType="UNDEFINED" p0="52" q0="22" node="8" p="51.994313555878769" q="21.995990474023834">
                 <iidm:alias>_047e6758-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3143,12 +3228,12 @@
                 <iidm:internalConnection node1="51" node2="9"/>
                 <iidm:internalConnection node1="52" node2="12"/>
                 <iidm:internalConnection node1="53" node2="15"/>
-                <iidm:bus v="127.42318466797482" angle="11.789111397407908" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
+                <iidm:bus v="127.42316086257819" angle="0.6930766043176434" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0484cffb-c766-11e1-8775-005056c00008" name="Roanoke LD" loadType="UNDEFINED" p0="31" q0="26" node="17" p="31.000044688027501" q="26.000062467165229">
+            <iidm:load id="_0484cffb-c766-11e1-8775-005056c00008" name="Roanoke LD" loadType="UNDEFINED" p0="31" q0="26" node="17" p="31.000040898724428" q="26.000057170285096">
                 <iidm:alias>_0454983a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0489d903-c766-11e1-8775-005056c00008" name="Roanoke SC" sectionCount="5" voltageRegulatorOn="true" targetV="127.423" targetDeadband="1" node="18" q="-18.639694853586281">
+            <iidm:shunt id="_0489d903-c766-11e1-8775-005056c00008" name="Roanoke SC" sectionCount="5" voltageRegulatorOn="true" targetV="127.423" targetDeadband="1" node="18" q="-18.639687888993635">
                 <iidm:alias>_0476c638-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_5be38d1a-9d01-42d8-b8bb-e9a26cfbcf1a"/>
                 <iidm:shuntLinearModel bPerSection="0.0002296" gPerSection="0" maximumSectionCount="10"/>
@@ -3240,12 +3325,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="119.9005210146925" angle="-15.170365309360859" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="119.86039460798955" angle="-26.179665483718768" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047a219a-c766-11e1-8775-005056c00008" name="Howard LD" loadType="UNDEFINED" p0="37" q0="23" node="14" p="36.899978308859176" q="22.896467328741146">
+            <iidm:load id="_047a219a-c766-11e1-8775-005056c00008" name="Howard LD" loadType="UNDEFINED" p0="37" q0="23" node="14" p="36.899165261932133" q="22.895626507755683">
                 <iidm:alias>_04882b51-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_04488a49-c766-11e1-8775-005056c00008" name="Howard NegG LD" loadType="UNDEFINED" p0="59" q0="0" node="15" p="58.840505951964637" q="0">
+            <iidm:load id="_04488a49-c766-11e1-8775-005056c00008" name="Howard NegG LD" loadType="UNDEFINED" p0="59" q0="0" node="15" p="58.839209471729617" q="0">
                 <iidm:alias>_046d9e74-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3295,7 +3380,7 @@
                 <iidm:internalConnection node1="19" node2="6"/>
                 <iidm:internalConnection node1="20" node2="3"/>
                 <iidm:internalConnection node1="21" node2="6"/>
-                <iidm:bus v="218.7677120688476" angle="14.321486018520506" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
+                <iidm:bus v="218.76746528321149" angle="3.2382709112320107" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_046efe09-c766-11e1-8775-005056c00008" name="CRI132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -3458,20 +3543,20 @@
                 <iidm:internalConnection node1="81" node2="18"/>
                 <iidm:internalConnection node1="82" node2="21"/>
                 <iidm:internalConnection node1="83" node2="24"/>
-                <iidm:bus v="137.28000472094791" angle="16.994848816161053" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
+                <iidm:bus v="137.2799991885239" angle="5.9004078155343063" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_045868c1-c766-11e1-8775-005056c00008" name="CabinCrk SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="477" targetV="137.28" targetQ="0" node="27" p="-530.84651784770722" q="-137.16832587656239">
+            <iidm:generator id="_045868c1-c766-11e1-8775-005056c00008" name="CabinCrk SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="477" targetV="137.28" targetQ="0" node="27" p="-530.75375438216247" q="-138.02554971538055">
                 <iidm:alias>_0487dd36-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_a6ec9760-88da-48df-a23f-7877e7c85ccd"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_e6131af8-c298-413b-84e3-4e21c3b6b06f"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-225" maxQ="640"/>
             </iidm:generator>
-            <iidm:load id="_04747c44-c766-11e1-8775-005056c00008" name="CabinCrk LD" loadType="UNDEFINED" p0="130" q0="26" node="26" p="130.00000670589199" q="26.000002235297359">
+            <iidm:load id="_04747c44-c766-11e1-8775-005056c00008" name="CabinCrk LD" loadType="UNDEFINED" p0="130" q0="26" node="26" p="129.99999884733509" q="25.999999615778364">
                 <iidm:alias>_046a9138-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_0488c79b-c766-11e1-8775-005056c00008" name="81-80" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="21" voltageLevelId1="_048a272b-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-139.43064574471501" q1="70.882251984593495" p2="139.43064574471504" q2="-62.879255914336817">
+        <iidm:twoWindingsTransformer id="_0488c79b-c766-11e1-8775-005056c00008" name="81-80" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="21" voltageLevelId1="_048a272b-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-138.84541341097011" q1="70.851582718005218" p2="138.84541341097011" q2="-62.903263759186167">
             <iidm:alias>_044974a0-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_045a3d83-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_046adf57-c766-11e1-8775-005056c00008</iidm:alias>
@@ -3551,12 +3636,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="134.76803659890342" angle="-8.7102230105163994" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="134.76811477791219" angle="-19.757922518315009" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04524e4a-c766-11e1-8775-005056c00008" name="Zanesvll LD" loadType="UNDEFINED" p0="20" q0="11" node="8" p="20.001160515366827" q="11.001063826328839">
+            <iidm:load id="_04524e4a-c766-11e1-8775-005056c00008" name="Zanesvll LD" loadType="UNDEFINED" p0="20" q0="11" node="8" p="20.00116142009723" q="11.001064655697137">
                 <iidm:alias>_045c1240-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_048b5fa9-c766-11e1-8775-005056c00008" name="Zanesvll SC" sectionCount="5" voltageRegulatorOn="true" targetV="134.72300000000001" targetDeadband="1" node="9" q="-15.63784679599082">
+            <iidm:shunt id="_048b5fa9-c766-11e1-8775-005056c00008" name="Zanesvll SC" sectionCount="5" voltageRegulatorOn="true" targetV="134.72300000000001" targetDeadband="1" node="9" q="-15.63786493904235">
                 <iidm:alias>_04736ad5-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_99c6c4ad-5247-4058-96d4-ee8495103e85"/>
                 <iidm:shuntLinearModel bPerSection="0.00017220000000000001" gPerSection="0" maximumSectionCount="10"/>
@@ -3609,9 +3694,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.7541165071425" angle="22.092723640777027" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.73850925544514" angle="11.001864316233688" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044ca8f2-c766-11e1-8775-005056c00008" name="Tazewell LD" loadType="UNDEFINED" p0="12" q0="7" node="8" p="11.999058472167029" q="6.9990846496584433">
+            <iidm:load id="_044ca8f2-c766-11e1-8775-005056c00008" name="Tazewell LD" loadType="UNDEFINED" p0="12" q0="7" node="8" p="11.999052133966391" q="6.9990784878423469">
                 <iidm:alias>_04542305-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3662,9 +3747,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="118.45724501177813" angle="-10.68346944408583" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="118.39308191748393" angle="-21.650461280007004" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04778989-c766-11e1-8775-005056c00008" name="NwLibrty LD" loadType="UNDEFINED" p0="27" q0="11" node="8" p="26.864442960013218" q="10.908109223549983">
+            <iidm:load id="_04778989-c766-11e1-8775-005056c00008" name="NwLibrty LD" loadType="UNDEFINED" p0="27" q0="11" node="8" p="26.864112936179787" q="10.907885884885975">
                 <iidm:alias>_0483e592-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3697,12 +3782,12 @@
                 <iidm:internalConnection node1="11" node2="2"/>
                 <iidm:internalConnection node1="12" node2="3"/>
                 <iidm:internalConnection node1="13" node2="3"/>
-                <iidm:bus v="122.60586560127909" angle="7.1381700584173551" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13"/>
+                <iidm:bus v="122.60583496746212" angle="-3.9582876259526643" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0463da70-c766-11e1-8775-005056c00008" name="Danville LD" loadType="UNDEFINED" p0="25" q0="13" node="5" p="25.00005489784937" q="13.000047578170951">
+            <iidm:load id="_0463da70-c766-11e1-8775-005056c00008" name="Danville LD" loadType="UNDEFINED" p0="25" q0="13" node="5" p="25.000051715877834" q="13.000044820458362">
                 <iidm:alias>_0488eeab-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_0448b150-c766-11e1-8775-005056c00008" name="Danville NegG LD" loadType="UNDEFINED" p0="43" q0="0" node="6" p="43.000094424300919" q="0">
+            <iidm:load id="_0448b150-c766-11e1-8775-005056c00008" name="Danville NegG LD" loadType="UNDEFINED" p0="43" q0="0" node="6" p="43.000088951309877" q="0">
                 <iidm:alias>_0457cc88-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3753,9 +3838,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.57367574280403" angle="27.90430351977993" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.43674176629327" angle="16.830781453966509" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045cae82-c766-11e1-8775-005056c00008" name="Fremont LD" loadType="UNDEFINED" p0="48" q0="10" node="8" p="47.996186813730738" q="9.9986760120508897">
+            <iidm:load id="_045cae82-c766-11e1-8775-005056c00008" name="Fremont LD" loadType="UNDEFINED" p0="48" q0="10" node="8" p="47.996053687494502" q="9.9986297901541619">
                 <iidm:alias>_045f4693-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3901,9 +3986,9 @@
                 <iidm:internalConnection node1="70" node2="15"/>
                 <iidm:internalConnection node1="71" node2="18"/>
                 <iidm:internalConnection node1="72" node2="21"/>
-                <iidm:bus v="132.31525433006061" angle="14.452195708209251" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
+                <iidm:bus v="132.29629508379423" angle="3.3539832901620259" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0448d863-c766-11e1-8775-005056c00008" name="Turner LD" loadType="UNDEFINED" p0="61" q0="28" node="23" p="60.993118272991367" q="27.994735488795286">
+            <iidm:load id="_0448d863-c766-11e1-8775-005056c00008" name="Turner LD" loadType="UNDEFINED" p0="61" q0="28" node="23" p="60.993073366861061" q="27.994701136970939">
                 <iidm:alias>_046e3ab3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3938,6 +4023,9 @@
                     <iidm:alias>_0b877750-4384-4ec3-bb38-08ee5ccf16d3</iidm:alias>
                     <iidm:alias>_1ed822d3-f3ab-4432-80f0-4c55ae3b4b78</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_3be2355e-0065-43df-a264-57a295042faa-1" name="DISCONNECTOR526-1" kind="DISCONNECTOR" retained="false" open="false" node1="24" node2="25"/>
+                <iidm:switch id="_2463ff2c-7690-4dd6-bf44-039f9f475bb1-1" name="BREAKER263-1" kind="BREAKER" retained="false" open="true" node1="23" node2="24"/>
+                <iidm:switch id="_ddcf7aac-e7c3-45e9-bd81-6146e951addd-1" name="DISCONNECTOR525-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="23"/>
                 <iidm:internalConnection node1="7" node2="0"/>
                 <iidm:internalConnection node1="8" node2="0"/>
                 <iidm:internalConnection node1="9" node2="1"/>
@@ -3954,9 +4042,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.13076249151426" angle="7.7480330554235159" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.1996291743335" angle="-3.2258516423850105" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047d7cf6-c766-11e1-8775-005056c00008" name="Grant LD" loadType="UNDEFINED" p0="24" q0="4" node="8" p="23.999336306827775" q="3.9998156424849149">
+            <iidm:load id="_047d7cf6-c766-11e1-8775-005056c00008" name="Grant LD" loadType="UNDEFINED" p0="24" q0="4" node="8" p="23.999429200335697" q="3.99984144579469">
                 <iidm:alias>_0481e9c0-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4026,9 +4114,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="220.86243116223568" angle="18.081059685644053" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="221.31873588477711" angle="5.9347947728399388" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04867dab-c766-11e1-8775-005056c00008" name="Olive NegG LD" loadType="UNDEFINED" p0="28" q0="0" node="11" p="27.990377664669836" q="0">
+            <iidm:load id="_04867dab-c766-11e1-8775-005056c00008" name="Olive NegG LD" loadType="UNDEFINED" p0="28" q0="0" node="11" p="27.990324331452033" q="0">
                 <iidm:alias>_048433b8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4134,15 +4222,15 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="133.13450213262186" angle="12.526452228015586" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="133.26063165573146" angle="0.6388409157654642" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:shunt id="_0447c6f6-c766-11e1-8775-005056c00008" name="Olive SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.67599999999999" targetDeadband="1" node="17" q="-40.696130831000112">
+            <iidm:shunt id="_0447c6f6-c766-11e1-8775-005056c00008" name="Olive SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.67599999999999" targetDeadband="1" node="17" q="-40.773277099557291">
                 <iidm:alias>_045e8340-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_c701959a-91c1-4a35-9a37-71fb790426ca"/>
                 <iidm:shuntLinearModel bPerSection="0.00045919999999999999" gPerSection="0" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_04575750-c766-11e1-8775-005056c00008" name="8-5" r="0" x="4.6522079999999999" g="0" b="0" ratedU1="220" ratedU2="132" node1="32" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="372.66499023518736" q1="58.593030096447364" p2="-372.66499023518747" q2="-22.014356768265529">
+        <iidm:twoWindingsTransformer id="_04575750-c766-11e1-8775-005056c00008" name="8-5" r="0" x="4.6522079999999999" g="0" b="0" ratedU1="220" ratedU2="132" node1="32" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="356.43382773491851" q1="61.482573628663239" p2="-356.43382773491857" q2="-27.994969796175301">
             <iidm:alias>_045eaa55-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_046b2d74-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04745533-c766-11e1-8775-005056c00008</iidm:alias>
@@ -4213,9 +4301,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.76971835066837" angle="21.037955988338197" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.76626061996888" angle="9.9452530846304175" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047b0bf0-c766-11e1-8775-005056c00008" name="Wythe LD" loadType="UNDEFINED" p0="22" q0="15" node="8" p="21.999354187965171" q="14.999266129868726">
+            <iidm:load id="_047b0bf0-c766-11e1-8775-005056c00008" name="Wythe LD" loadType="UNDEFINED" p0="22" q0="15" node="8" p="21.999349565590304" q="14.999260877273182">
                 <iidm:alias>_0479d376-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4266,9 +4354,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="122.72552175045873" angle="-6.0971744359057727" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="122.66103651213339" angle="-17.040716163880333" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0458ddf5-c766-11e1-8775-005056c00008" name="WestLima LD" loadType="UNDEFINED" p0="33" q0="9" node="8" p="32.863582484146583" q="8.9380775217113708">
+            <iidm:load id="_0458ddf5-c766-11e1-8775-005056c00008" name="WestLima LD" loadType="UNDEFINED" p0="33" q0="9" node="8" p="32.863688191557962" q="8.9381254380764918">
                 <iidm:alias>_04492686-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4376,9 +4464,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="128.42041277233224" angle="23.913594248209421" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="128.08527246055888" angle="12.849132824484593" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044b2257-c766-11e1-8775-005056c00008" name="BeaverCk LD" loadType="UNDEFINED" p0="24" q0="15" node="17" p="23.996845840012895" q="14.996714560616303">
+            <iidm:load id="_044b2257-c766-11e1-8775-005056c00008" name="BeaverCk LD" loadType="UNDEFINED" p0="24" q0="15" node="17" p="23.996688911692232" q="14.996551108294479">
                 <iidm:alias>_045868c4-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4437,6 +4525,9 @@
                     <iidm:alias>_2b636cdd-aa2f-4a65-92fc-12b4fc392e5f</iidm:alias>
                     <iidm:alias>_c96e50b9-ea15-4421-b6c8-bd9c9158a69a</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_e5318967-afcc-4fcc-b0de-d5f2522a95a6-1" name="DISCONNECTOR699-1" kind="DISCONNECTOR" retained="false" open="false" node1="43" node2="44"/>
+                <iidm:switch id="_e9f91b69-a29b-44ea-aa0f-cff86ee80320-1" name="BREAKER350-1" kind="BREAKER" retained="true" open="true" node1="42" node2="43"/>
+                <iidm:switch id="_ad86e83d-6334-4dd8-b642-b4c16d65329a-1" name="DISCONNECTOR700-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="42"/>
                 <iidm:internalConnection node1="13" node2="0"/>
                 <iidm:internalConnection node1="14" node2="1"/>
                 <iidm:internalConnection node1="15" node2="2"/>
@@ -4466,7 +4557,7 @@
                 <iidm:internalConnection node1="39" node2="9"/>
                 <iidm:internalConnection node1="40" node2="12"/>
                 <iidm:internalConnection node1="41" node2="3"/>
-                <iidm:bus v="214.31166386139626" angle="15.604834129491568" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41"/>
+                <iidm:bus v="215.31109296634125" angle="2.986409285627329" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_047bcf46-c766-11e1-8775-005056c00008" name="STN132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -4546,6 +4637,9 @@
                     <iidm:alias>_4aab41d6-d1b6-4dbe-a6aa-cb7ccd941912</iidm:alias>
                     <iidm:alias>_e9315b98-af75-40bb-bf8e-05bd03d43db5</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_b8b0b9a9-af8b-41d2-a4f8-940637e63f70-1" name="DISCONNECTOR701-1" kind="DISCONNECTOR" retained="false" open="false" node1="64" node2="65"/>
+                <iidm:switch id="_0b78ffaa-9859-4658-af17-c8d355633556-1" name="BREAKER351-1" kind="BREAKER" retained="true" open="false" node1="63" node2="64"/>
+                <iidm:switch id="_9dfeeaef-5c49-4c2c-97b1-03876970bee4-1" name="DISCONNECTOR702-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="63"/>
                 <iidm:internalConnection node1="19" node2="0"/>
                 <iidm:internalConnection node1="20" node2="0"/>
                 <iidm:internalConnection node1="21" node2="1"/>
@@ -4590,9 +4684,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="129.12901656160082" angle="8.8354046153261621" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="129.08411827208491" angle="-1.6320875819380412" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045dbff4-c766-11e1-8775-005056c00008" name="Sorenson LD" loadType="UNDEFINED" p0="11" q0="3" node="20" p="10.990253921245827" q="2.9955712726792987">
+            <iidm:load id="_045dbff4-c766-11e1-8775-005056c00008" name="Sorenson LD" loadType="UNDEFINED" p0="11" q0="3" node="20" p="10.990958104294164" q="2.9958911736233382">
                 <iidm:alias>_044d4536-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4613,6 +4707,9 @@
                     <iidm:alias>_340082f1-db9c-446d-97df-80e45aa0058b</iidm:alias>
                     <iidm:alias>_90c04b95-703a-4bae-82b8-7edf3075aa24</iidm:alias>
                 </iidm:switch>
+                <iidm:switch id="_4d08a684-cdcb-484a-a767-03b10f4ada7f-1" name="DISCONNECTOR735-1" kind="DISCONNECTOR" retained="false" open="false" node1="14" node2="15"/>
+                <iidm:switch id="_f468d841-1bf6-470e-85d4-55d34fab8bff-1" name="BREAKER368-1" kind="BREAKER" retained="true" open="false" node1="13" node2="14"/>
+                <iidm:switch id="_f193bd8f-badf-4600-82ac-f212d1f33534-1" name="DISCONNECTOR736-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="13"/>
                 <iidm:internalConnection node1="4" node2="0"/>
                 <iidm:internalConnection node1="5" node2="1"/>
                 <iidm:internalConnection node1="6" node2="2"/>
@@ -4622,13 +4719,13 @@
                 <iidm:internalConnection node1="10" node2="3"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="0"/>
-                <iidm:bus v="383.82866053871112" angle="15.38148374617313" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="388.54262051813311" angle="0" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15"/>
             </iidm:nodeBreakerTopology>
             <iidm:lccConverterStation id="_7393a68e-c4e6-48dd-9347-543858363fdb" name="Conv1" lossFactor="0" powerFactor="0.80000000000000004" node="12" p="10" q="6">
                 <iidm:alias>_739658a7-e08b-4395-8d79-93e87b7855e3</iidm:alias>
             </iidm:lccConverterStation>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_047120e9-c766-11e1-8775-005056c00008" name="30-17" r="0" x="6.7605125399999997" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_047b8123-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="301.57034031466912" q1="113.24993236019461" p2="-301.57034031466907" q2="-74.147778512429127">
+        <iidm:twoWindingsTransformer id="_047120e9-c766-11e1-8775-005056c00008" name="30-17" r="0" x="6.7605125399999997" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_047b8123-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="206.89368056064538" q1="117.52956945089504" p2="-206.89368056064546" q2="-96.392597222479822">
             <iidm:alias>_044f6811-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0463b36a-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_047d2ed8-c766-11e1-8775-005056c00008</iidm:alias>
@@ -4647,7 +4744,7 @@
                 <iidm:temporaryLimit name="_f62f2fc6-4b6c-4571-a8c5-40d6a89ac703" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_b08e9e50-4e0c-4ac0-9f21-4a27429caeb2" name="PowTrans1" r="0.4840000000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_3bbfa58a-a1ad-4b23-a526-3d76b096c1f4" node2="41" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="-10.000000835628944" q1="-6.0000009919193982" p2="10.001441153635408" q2="6.0540129171581931">
+        <iidm:twoWindingsTransformer id="_b08e9e50-4e0c-4ac0-9f21-4a27429caeb2" name="PowTrans1" r="0.4840000000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_3bbfa58a-a1ad-4b23-a526-3d76b096c1f4" node2="41" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="-133.21197865572285" q1="20.063385198267365" p2="133.3995406882666" q2="-13.029808977875067">
             <iidm:alias>_046ba2aa-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_a5bf9702-545a-437d-9663-773550202828</iidm:alias>
             <iidm:alias>_ee9505e1-96d7-49b3-9d1a-924397ffb27e</iidm:alias>
@@ -4667,6 +4764,32 @@
                 <iidm:temporaryLimit name="_611bb05e-9b9a-469c-b1d1-80a944c3ce2f" acceptableDuration="60" value="1400"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
+        <iidm:threeWindingsTransformer id="_86d83c7d-7826-4c16-b161-4ce17174e77f-1" name="T422" r1="-1.5199999809265099" x1="23.199999999999999" g1="0" b1="0" ratedU1="400" r2="2.0000000630528461" x2="19.999999999999996" g2="0" b2="0" ratedU2="220" r3="1.2000000564689806" x3="12" g3="0" b3="0" ratedU3="132" ratedU0="400" node1="15" voltageLevelId1="_3bbfa58a-a1ad-4b23-a526-3d76b096c1f4" node2="44" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" node3="65" voltageLevelId3="_047bcf46-c766-11e1-8775-005056c00008" p1="123.21197869770795" q1="-26.063385173077254" p2="0" q2="0" p3="-123.24559803853879" q3="29.761513537486888">
+            <iidm:alias>_1b2d419c-ac88-4dae-8dfe-2eb92d18c40a-1</iidm:alias>
+            <iidm:alias>_206474da-93c8-46b1-863f-9a308bfc2117-1</iidm:alias>
+            <iidm:alias>_9ac069ea-557b-4b8c-b12e-f9f2aecc3bf5-1</iidm:alias>
+            <iidm:alias>_ae46e10e-1fbe-4139-b493-ed8e2844ee8d-1</iidm:alias>
+            <iidm:ratioTapChanger1 lowTapPosition="1" tapPosition="11" targetDeadband="0" loadTapChangingCapabilities="true" regulating="false" targetV="220">
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.95238095238095233"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.96385542168674687"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.97560975609756106"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="0.98765432098765438"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0126582278481011"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0256410256410258"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0389610389610389"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0526315789473684"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0666666666666667"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.0810810810810809"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.095890410958904"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.1111111111111112"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.1267605633802817"/>
+                <iidm:step r="0" x="0" g="0" b="0" rho="1.1428571428571428"/>
+            </iidm:ratioTapChanger1>
+            <iidm:currentLimits1 permanentLimit="500">
+                <iidm:temporaryLimit name="_3fd18f6e-749a-4fa7-af1b-b0c2d3952638-1" acceptableDuration="1800" value="533"/>
+            </iidm:currentLimits1>
+        </iidm:threeWindingsTransformer>
     </iidm:substation>
     <iidm:substation id="_04642898-c766-11e1-8775-005056c00008" name="Rómenna" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
         <iidm:voltageLevel id="_0457f394-c766-11e1-8775-005056c00008" name="RÓM132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -4905,16 +5028,16 @@
                 <iidm:internalConnection node1="121" node2="30"/>
                 <iidm:internalConnection node1="122" node2="33"/>
                 <iidm:internalConnection node1="123" node2="36"/>
-                <iidm:bus v="135.30000323283468" angle="-8.107797661870638" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123"/>
+                <iidm:bus v="135.30001820760256" angle="-19.15629660153645" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04859346-c766-11e1-8775-005056c00008" name="Philo SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="204" targetV="135.30000000000001" targetQ="0" node="39" p="-227.02869945688113" q="-293.20634612246039">
+            <iidm:generator id="_04859346-c766-11e1-8775-005056c00008" name="Philo SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="204" targetV="135.30000000000001" targetQ="0" node="39" p="-226.98902703136511" q="-293.20260564145281">
                 <iidm:alias>_048719e2-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e3753d6d-b894-4cce-b6fa-307c50dc107f"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_dff93c01-9c84-4c1f-8529-66c054ed9e37"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
-            <iidm:load id="_045163e2-c766-11e1-8775-005056c00008" name="Philo LD" loadType="UNDEFINED" p0="87" q0="30" node="38" p="87.000003118144321" q="30.000001792036983">
+            <iidm:load id="_045163e2-c766-11e1-8775-005056c00008" name="Philo LD" loadType="UNDEFINED" p0="87" q0="30" node="38" p="87.000017561657174" q="30.000010092907097">
                 <iidm:alias>_04513cd3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4965,9 +5088,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.75885974472048" angle="21.882020951696546" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.47270932697478" angle="10.806665650088508" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04524e46-c766-11e1-8775-005056c00008" name="BetsyLne LD" loadType="UNDEFINED" p0="11" q0="7" node="8" p="10.99817701495745" q="6.9980666378260805">
+            <iidm:load id="_04524e46-c766-11e1-8775-005056c00008" name="BetsyLne LD" loadType="UNDEFINED" p0="11" q0="7" node="8" p="10.998110317764979" q="6.9979959063382928">
                 <iidm:alias>_04549830-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5020,15 +5143,15 @@
                 <iidm:internalConnection node1="22" node2="6"/>
                 <iidm:internalConnection node1="23" node2="3"/>
                 <iidm:internalConnection node1="24" node2="6"/>
-                <iidm:bus v="124.75972777839377" angle="8.8136108553857575" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24"/>
+                <iidm:bus v="124.75969685632202" angle="-2.2823949736739979" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04566cf3-c766-11e1-8775-005056c00008" name="Reusens NegG LD" loadType="UNDEFINED" p0="22" q0="0" node="8" p="22.000047303389493" q="0">
+            <iidm:load id="_04566cf3-c766-11e1-8775-005056c00008" name="Reusens NegG LD" loadType="UNDEFINED" p0="22" q0="0" node="8" p="22.000044607481001" q="0">
                 <iidm:alias>_0483be81-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_0482fb36-c766-11e1-8775-005056c00008" name="Reusens LD" loadType="UNDEFINED" p0="28" q0="12" node="9" p="28.000060204313904" q="12.000043003112181">
+            <iidm:load id="_0482fb36-c766-11e1-8775-005056c00008" name="Reusens LD" loadType="UNDEFINED" p0="28" q0="12" node="9" p="28.000056773157638" q="12.000040552282861">
                 <iidm:alias>_0486cbc1-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_04558293-c766-11e1-8775-005056c00008" name="Reusens SC" sectionCount="5" voltageRegulatorOn="true" targetV="124.76300000000001" targetDeadband="1" node="10" q="-5.3543564483165875">
+            <iidm:shunt id="_04558293-c766-11e1-8775-005056c00008" name="Reusens SC" sectionCount="5" voltageRegulatorOn="true" targetV="124.76300000000001" targetDeadband="1" node="10" q="-5.3543537941303923">
                 <iidm:alias>_04893ccc-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_99303cd3-6b53-4ee2-a5ce-fe8d5feeb304"/>
                 <iidm:shuntLinearModel bPerSection="6.8800000000000005e-05" gPerSection="0" maximumSectionCount="10"/>
@@ -5101,12 +5224,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="126.42025767199593" angle="26.191693904744191" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="126.41844289238698" angle="15.106117960988271" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045c8777-c766-11e1-8775-005056c00008" name="Holston NegG LD" loadType="UNDEFINED" p0="85" q0="0" node="11" p="84.998594985689408" q="0">
+            <iidm:load id="_045c8777-c766-11e1-8775-005056c00008" name="Holston NegG LD" loadType="UNDEFINED" p0="85" q0="0" node="11" p="84.998577608305993" q="0">
                 <iidm:alias>_0487dd31-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_0451d918-c766-11e1-8775-005056c00008" name="Holston LD" loadType="UNDEFINED" p0="78" q0="42" node="12" p="77.998710692750279" q="41.998842935766589">
+            <iidm:load id="_0451d918-c766-11e1-8775-005056c00008" name="Holston LD" loadType="UNDEFINED" p0="78" q0="42" node="12" p="77.998694746445494" q="41.99882862513892">
                 <iidm:alias>_0485ba54-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5214,9 +5337,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="127.70983142119752" angle="9.8252141380370119" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="127.70757000231272" angle="-1.2960325989505235" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04742e27-c766-11e1-8775-005056c00008" name="SthPoint LD" loadType="UNDEFINED" p0="47" q0="11" node="17" p="46.99682959394093" q="10.998763344592687">
+            <iidm:load id="_04742e27-c766-11e1-8775-005056c00008" name="SthPoint LD" loadType="UNDEFINED" p0="47" q0="11" node="17" p="46.996794677658073" q="10.998749725381906">
                 <iidm:alias>_047b3303-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5268,12 +5391,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="132.89563595387736" angle="14.551313193712208" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="132.88290593165331" angle="3.4543244170072871" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04716f06-c766-11e1-8775-005056c00008" name="CapitlHl LD" loadType="UNDEFINED" p0="39" q0="32" node="8" p="38.996786572302767" q="31.995605689656053">
+            <iidm:load id="_04716f06-c766-11e1-8775-005056c00008" name="CapitlHl LD" loadType="UNDEFINED" p0="39" q0="32" node="8" p="38.996764953705963" q="31.99557612739244">
                 <iidm:alias>_04700f70-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0466c0a0-c766-11e1-8775-005056c00008" name="CapitlHl SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.00200000000001" targetDeadband="1" node="9" q="-20.275115063812152">
+            <iidm:shunt id="_0466c0a0-c766-11e1-8775-005056c00008" name="CapitlHl SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.00200000000001" targetDeadband="1" node="9" q="-20.271230958789037">
                 <iidm:alias>_045e8346-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_99931a87-ee15-4fd0-b251-9556df7fe598"/>
                 <iidm:shuntLinearModel bPerSection="0.0002296" gPerSection="0" maximumSectionCount="10"/>
@@ -5326,9 +5449,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="132.03047061589567" angle="14.180859617625641" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="132.01361746908611" angle="3.08294532763923" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046efe03-c766-11e1-8775-005056c00008" name="Chemical LD" loadType="UNDEFINED" p0="71" q0="26" node="8" p="70.993319856495376" q="25.995923044977381">
+            <iidm:load id="_046efe03-c766-11e1-8775-005056c00008" name="Chemical LD" loadType="UNDEFINED" p0="71" q0="26" node="8" p="70.993270930023812" q="25.995893185630525">
                 <iidm:alias>_045d71d5-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5379,9 +5502,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.50126167533929" angle="9.1125256164485222" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.54555470633125" angle="-2.5694466569127705" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046a4319-c766-11e1-8775-005056c00008" name="JacksnRd LD" loadType="UNDEFINED" p0="19" q0="2" node="8" p="18.998707162221525" q="1.999773191499135">
+            <iidm:load id="_046a4319-c766-11e1-8775-005056c00008" name="JacksnRd LD" loadType="UNDEFINED" p0="19" q0="2" node="8" p="18.998714177134897" q="1.9997744221300153">
                 <iidm:alias>_046c8d06-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5527,9 +5650,9 @@
                 <iidm:internalConnection node1="70" node2="15"/>
                 <iidm:internalConnection node1="71" node2="18"/>
                 <iidm:internalConnection node1="72" node2="21"/>
-                <iidm:bus v="130.59378206492406" angle="25.831051162823442" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
+                <iidm:bus v="130.58701795374819" angle="14.7427614920263" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0458ddf4-c766-11e1-8775-005056c00008" name="Saltvlle LD" loadType="UNDEFINED" p0="65" q0="10" node="23" p="64.996899651283428" q="9.9992050514299553">
+            <iidm:load id="_0458ddf4-c766-11e1-8775-005056c00008" name="Saltvlle LD" loadType="UNDEFINED" p0="65" q0="10" node="23" p="64.996879753417403" q="9.999199949575786">
                 <iidm:alias>_045645e4-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5599,9 +5722,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="131.59371472328721" angle="13.967144763937226" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="131.73083283653233" angle="2.6270064015457701" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0476ed42-c766-11e1-8775-005056c00008" name="Trenton NegG LD" loadType="UNDEFINED" p0="13" q0="0" node="11" p="12.998849395565024" q="0">
+            <iidm:load id="_0476ed42-c766-11e1-8775-005056c00008" name="Trenton NegG LD" loadType="UNDEFINED" p0="13" q0="0" node="11" p="12.999013734347336" q="0">
                 <iidm:alias>_0471e432-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5671,9 +5794,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="128.32003428800519" angle="8.1380618104311715" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="128.37999940279769" angle="-3.5876239903840332" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044a5f08-c766-11e1-8775-005056c00008" name="HickryCk LD" loadType="UNDEFINED" p0="39" q0="10" node="11" p="38.996084214111235" q="9.9983266432338542">
+            <iidm:load id="_044a5f08-c766-11e1-8775-005056c00008" name="HickryCk LD" loadType="UNDEFINED" p0="39" q0="10" node="11" p="38.996096492686455" q="9.9983318901375355">
                 <iidm:alias>_047d7cf3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5802,9 +5925,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="124.16231089812547" angle="-5.1942700672529858" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="124.09996573962967" angle="-16.139801534094023" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:shunt id="_0450eeb7-c766-11e1-8775-005056c00008" name="EastLima SC" sectionCount="5" voltageRegulatorOn="true" targetV="131.565" targetDeadband="1" node="20" q="-22.122361007252568">
+            <iidm:shunt id="_0450eeb7-c766-11e1-8775-005056c00008" name="EastLima SC" sectionCount="5" voltageRegulatorOn="true" targetV="131.565" targetDeadband="1" node="20" q="-22.100150147588366">
                 <iidm:alias>_044aad27-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_6c36f421-303e-4932-93a9-5b0ff86cb7d4"/>
                 <iidm:shuntLinearModel bPerSection="0.00028699999999999998" gPerSection="0" maximumSectionCount="10"/>
@@ -5892,16 +6015,16 @@
                 <iidm:internalConnection node1="41" node2="7"/>
                 <iidm:internalConnection node1="42" node2="12"/>
                 <iidm:internalConnection node1="43" node2="11"/>
-                <iidm:bus v="217.93639012460466" angle="6.441036227242499" nodes="0,1,2,3,8,9,10,13,17,18,21,22,23,24,25,26,31,32,33,34,35,39,40"/>
-                <iidm:bus v="237.93768374163594" angle="-9.6766365116644835" nodes="11,15,37,43"/>
-                <iidm:bus v="226.19467152731224" angle="6.4410362175679623" nodes="12,16,38,42"/>
-                <iidm:bus v="214.70024945370827" angle="-9.6766365116644852" nodes="4,5,6,7,14,19,20,27,28,29,30,36,41"/>
+                <iidm:bus v="217.93733161191744" angle="-4.6195230043942663" nodes="0,1,2,3,8,9,10,13,17,18,21,22,23,24,25,26,31,32,33,34,35,39,40"/>
+                <iidm:bus v="237.93770146710358" angle="-20.73252047765277" nodes="11,15,37,43"/>
+                <iidm:bus v="226.19468032310337" angle="-4.6195228223546909" nodes="12,16,38,42"/>
+                <iidm:bus v="214.70026544807399" angle="-20.732520477652766" nodes="4,5,6,7,14,19,20,27,28,29,30,36,41"/>
             </iidm:nodeBreakerTopology>
-            <iidm:vscConverterStation id="_b46bfb8e-7af6-459e-acf3-53a42c943a7c" name="VSC2" voltageRegulatorOn="true" lossFactor="0.32362458" voltageSetpoint="218.47" reactivePowerSetpoint="0" node="42" p="-0" q="-31.132987613927028">
+            <iidm:vscConverterStation id="_b46bfb8e-7af6-459e-acf3-53a42c943a7c" name="VSC2" voltageRegulatorOn="true" lossFactor="0.32362458" voltageSetpoint="218.47" reactivePowerSetpoint="0" node="42" p="-0" q="-31.129470221384064">
                 <iidm:alias>_a168e701-bd48-4f66-8f0b-0f69b2545530</iidm:alias>
                 <iidm:minMaxReactiveLimits minQ="-1.7976931348623157e+308" maxQ="1.7976931348623157e+308"/>
             </iidm:vscConverterStation>
-            <iidm:vscConverterStation id="_b48ce7cf-abf5-413f-bc51-9e1d3103c9bd" name="VSC1" voltageRegulatorOn="true" lossFactor="0.32467531999999999" voltageSetpoint="213.53999999999999" reactivePowerSetpoint="0" node="43" p="-0" q="-92.151020935009015">
+            <iidm:vscConverterStation id="_b48ce7cf-abf5-413f-bc51-9e1d3103c9bd" name="VSC1" voltageRegulatorOn="true" lossFactor="0.32467531999999999" voltageSetpoint="213.53999999999999" reactivePowerSetpoint="0" node="43" p="-0" q="-92.15102093510383">
                 <iidm:alias>_071bb138-ff00-4874-8acc-a884aa5cf4a9</iidm:alias>
                 <iidm:minMaxReactiveLimits minQ="-1.7976931348623157e+308" maxQ="1.7976931348623157e+308"/>
             </iidm:vscConverterStation>
@@ -5969,7 +6092,7 @@
                 <iidm:internalConnection node1="29" node2="6"/>
                 <iidm:internalConnection node1="30" node2="9"/>
                 <iidm:internalConnection node1="31" node2="3"/>
-                <iidm:bus v="199.57114479399291" angle="-0.26700532823737527" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
+                <iidm:bus v="199.52922063221496" angle="-11.241603765984161" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_0448d867-c766-11e1-8775-005056c00008" name="EDO132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -6055,9 +6178,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="131.34000006270804" angle="1.6461406988061664" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="131.34000846335468" angle="-9.4125042020503589" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0472a789-c766-11e1-8775-005056c00008" name="W.Kammer SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="160" targetV="131.34" targetQ="0" node="14" p="-178.0617250642205" q="52.206454779684442">
+            <iidm:generator id="_0472a789-c766-11e1-8775-005056c00008" name="W.Kammer SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="160" targetV="131.34" targetQ="0" node="14" p="-178.03060943636481" q="52.232649941857289">
                 <iidm:alias>_04697fc0-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_17852426-f663-4add-9a2b-0a635d51f101"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b512ea0a-96d0-4a48-9de1-a5cf499bf0dd"/>
@@ -6206,16 +6329,16 @@
                 <iidm:internalConnection node1="71" node2="15"/>
                 <iidm:internalConnection node1="72" node2="18"/>
                 <iidm:internalConnection node1="73" node2="21"/>
-                <iidm:bus v="130.02000040526372" angle="-9.6766365116644852" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
+                <iidm:bus v="130.02001009126752" angle="-20.732520477652763" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04839777-c766-11e1-8775-005056c00008" name="Tidd SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="155" targetV="130.02000000000001" targetQ="0" node="24" p="-172.4972961559636" q="-103.14272997232268">
+            <iidm:generator id="_04839777-c766-11e1-8775-005056c00008" name="Tidd SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="155" targetV="130.02000000000001" targetQ="0" node="24" p="-172.46715289147838" q="-103.13601678471309">
                 <iidm:alias>_045fe2d8-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_d2a96d8d-65be-4fd6-a012-ceeeabd2bee6"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_29df1e0b-36ca-4536-97b4-6f98b84d49d8"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-90" maxQ="255"/>
             </iidm:generator>
-            <iidm:load id="_04798556-c766-11e1-8775-005056c00008" name="Tidd LD" loadType="UNDEFINED" p0="277" q0="113" node="23" p="277.00000129508595" q="113.00000088053375">
+            <iidm:load id="_04798556-c766-11e1-8775-005056c00008" name="Tidd LD" loadType="UNDEFINED" p0="277" q0="113" node="23" p="277.00003224828288" q="113.00002192572865">
                 <iidm:alias>_04502b62-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6245,13 +6368,13 @@
                 <iidm:internalConnection node1="10" node2="3"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="0"/>
-                <iidm:bus v="356.93944418288623" angle="0" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="356.86387671982772" angle="-10.974485792260985" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
             </iidm:nodeBreakerTopology>
             <iidm:lccConverterStation id="_9793118d-5ba1-4a9c-b2e0-db1d15be5913" name="Conv2" lossFactor="0" powerFactor="-0.75741000000000003" node="12" p="-10" q="8.6206896551724146">
                 <iidm:alias>_453bdc57-5855-4eb5-8712-d6a0255e0da8</iidm:alias>
             </iidm:lccConverterStation>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045c1248-c766-11e1-8775-005056c00008" name="38-37" r="0" x="6.5340005399999992" g="0" b="0" ratedU1="220" ratedU2="132" node1="30" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="209.02384822769591" q1="85.526417559998094" p2="-209.02384822769591" q2="-65.206430874013563">
+        <iidm:twoWindingsTransformer id="_045c1248-c766-11e1-8775-005056c00008" name="38-37" r="0" x="6.5340005399999992" g="0" b="0" ratedU1="220" ratedU2="132" node1="30" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="207.64581866943769" q1="86.092802411527387" p2="-207.64581866943757" q2="-65.954378136284717">
             <iidm:alias>_0453d4e8-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0477d7aa-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_047df228-c766-11e1-8775-005056c00008</iidm:alias>
@@ -6275,7 +6398,7 @@
                 <iidm:temporaryLimit name="_c97df399-5a91-4c8b-b72c-496cade334b5" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_0485ba57-c766-11e1-8775-005056c00008" name="64-61" r="0" x="4.669632" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="312.1106547795157" q1="53.241296039725071" p2="-312.11065477951576" q2="-26.678883262124504">
+        <iidm:twoWindingsTransformer id="_0485ba57-c766-11e1-8775-005056c00008" name="64-61" r="0" x="4.669632" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="311.98770523243775" q1="53.247166014140767" p2="-311.98770523243775" q2="-26.70514860525719">
             <iidm:alias>_04549831-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0472ce92-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0489d905-c766-11e1-8775-005056c00008</iidm:alias>
@@ -6301,7 +6424,7 @@
                 <iidm:temporaryLimit name="_f6b1a81c-eda7-4a08-b290-bd29a5ed9fa4" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_044cd007-c766-11e1-8775-005056c00008" name="63-59" r="0" x="6.7256646120000001" g="0" b="0" ratedU1="220" ratedU2="132" node1="41" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="73" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="6.3837823915946501e-14" q1="83.151382304703375" p2="-5.5511151231257827e-14" q2="-80.568830735712893">
+        <iidm:twoWindingsTransformer id="_044cd007-c766-11e1-8775-005056c00008" name="63-59" r="0" x="6.7256646120000001" g="0" b="0" ratedU1="220" ratedU2="132" node1="41" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="73" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-3.8857805861880479e-14" q1="83.15139469363821" p2="0" q2="-80.568842739866994">
             <iidm:alias>_044e7db4-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_046eafe5-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0488797a-c766-11e1-8775-005056c00008</iidm:alias>
@@ -6347,7 +6470,7 @@
                 <iidm:temporaryLimit name="_f2daef4d-6f1a-44d1-9c9b-228acff12575" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_ffd940c8-03c8-4dcf-ad46-62018a0d813d" name="PowTrans2" r="0.3932500000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_04f97116-552a-4a34-afd9-4862f62ac7aa" node2="31" voltageLevelId2="_04742e21-c766-11e1-8775-005056c00008" p1="9.9999994373381202" q1="-8.6206891701190962" p2="-9.9982649689039604" q2="8.7007415593886108">
+        <iidm:twoWindingsTransformer id="_ffd940c8-03c8-4dcf-ad46-62018a0d813d" name="PowTrans2" r="0.3932500000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_04f97116-552a-4a34-afd9-4862f62ac7aa" node2="31" voltageLevelId2="_04742e21-c766-11e1-8775-005056c00008" p1="9.9999990591568828" q1="-8.6206913655158832" p2="-9.9982638557813175" q2="8.700777675166302">
             <iidm:alias>_04479fea-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_c089eb25-9f67-4d82-88a8-635dd4808bae</iidm:alias>
             <iidm:alias>_ea8cd467-31f0-40dc-95d7-4064463724c4</iidm:alias>
@@ -6414,9 +6537,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="124.87256553624871" angle="-14.589634563870609" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.87238968684815" angle="-25.641622501323312" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0481c2b3-c766-11e1-8775-005056c00008" name="Wooster LD" loadType="UNDEFINED" p0="23" q0="11" node="8" p="23.005942898888211" q="11.004737501305945">
+            <iidm:load id="_0481c2b3-c766-11e1-8775-005056c00008" name="Wooster LD" loadType="UNDEFINED" p0="23" q0="11" node="8" p="23.005945328018324" q="11.004739437902668">
                 <iidm:alias>_04614268-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6486,9 +6609,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="125.57932996411655" angle="-13.953022650682705" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="125.57932981634742" angle="-25.005940984292277" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044974a8-c766-11e1-8775-005056c00008" name="Wagenhls LD" loadType="UNDEFINED" p0="63" q0="22" node="11" p="63.001876111807377" q="22.00109192776382">
+            <iidm:load id="_044974a8-c766-11e1-8775-005056c00008" name="Wagenhls LD" loadType="UNDEFINED" p0="63" q0="22" node="11" p="63.001888681759624" q="22.001099243754783">
                 <iidm:alias>_048481d4-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6539,9 +6662,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.14864046299043" angle="7.1443513678700672" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.20709700428903" angle="-4.3103525311584532" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047fedf2-c766-11e1-8775-005056c00008" name="Concord LD" loadType="UNDEFINED" p0="34" q0="16" node="8" p="33.984704866035578" q="15.988005615443655">
+            <iidm:load id="_047fedf2-c766-11e1-8775-005056c00008" name="Concord LD" loadType="UNDEFINED" p0="34" q0="16" node="8" p="33.98528249348233" q="15.988458523265017">
                 <iidm:alias>_046d9e75-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6649,9 +6772,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="127.37309917464034" angle="9.8393902488110534" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="127.5034645012685" angle="-1.2676436486397531" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045f94ba-c766-11e1-8775-005056c00008" name="Delaware LD" loadType="UNDEFINED" p0="59" q0="23" node="17" p="58.985987408124707" q="22.990896494415345">
+            <iidm:load id="_045f94ba-c766-11e1-8775-005056c00008" name="Delaware LD" loadType="UNDEFINED" p0="59" q0="23" node="17" p="58.987343696441272" q="22.991777565911249">
                 <iidm:alias>_0463654a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6759,9 +6882,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="124.87126077818476" angle="4.8117030920616859" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="124.82342276083514" angle="-5.9352908751533562" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04697fc9-c766-11e1-8775-005056c00008" name="FtWayne LD" loadType="UNDEFINED" p0="90" q0="30" node="17" p="89.871658803260232" q="29.928733232415883">
+            <iidm:load id="_04697fc9-c766-11e1-8775-005056c00008" name="FtWayne LD" loadType="UNDEFINED" p0="90" q0="30" node="17" p="89.875652186837911" q="29.930949702056974">
                 <iidm:alias>_044d1e25-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6812,9 +6935,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.11422749868572" angle="-12.605538029577076" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.11403853368364" angle="-23.656888219205243" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0474f170-c766-11e1-8775-005056c00008" name="WNwPhil1 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="12.003520108904715" q="3.0014668554552388">
+            <iidm:load id="_0474f170-c766-11e1-8775-005056c00008" name="WNwPhil1 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="12.003522472913051" q="3.0014678406513964">
                 <iidm:alias>_0466c0a7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6885,12 +7008,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="129.5733709741632" angle="16.616229377170086" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="129.46901918297314" angle="5.5216386338159671" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044a5f05-c766-11e1-8775-005056c00008" name="Logan LD" loadType="UNDEFINED" p0="54" q0="27" node="11" p="53.991948440746981" q="26.993290700770018">
+            <iidm:load id="_044a5f05-c766-11e1-8775-005056c00008" name="Logan LD" loadType="UNDEFINED" p0="54" q0="27" node="11" p="53.991810369422296" q="26.993175652868267">
                 <iidm:alias>_04767811-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0475dbd6-c766-11e1-8775-005056c00008" name="Logan SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.41900000000001" targetDeadband="1" node="12" q="-19.274068718518116">
+            <iidm:shunt id="_0475dbd6-c766-11e1-8775-005056c00008" name="Logan SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.41900000000001" targetDeadband="1" node="12" q="-19.243036513574829">
                 <iidm:alias>_04577e67-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_a7768441-642e-48a2-b4a8-0ae06bebf676"/>
                 <iidm:shuntLinearModel bPerSection="0.0002296" gPerSection="0" maximumSectionCount="10"/>
@@ -6964,19 +7087,19 @@
                 <iidm:internalConnection node1="32" node2="3"/>
                 <iidm:internalConnection node1="33" node2="6"/>
                 <iidm:internalConnection node1="34" node2="9"/>
-                <iidm:bus v="132.66000248877606" angle="-8.6396951874977272" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34"/>
+                <iidm:bus v="132.66001614027965" angle="-19.684376867774816" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04633e31-c766-11e1-8775-005056c00008" name="W.Lancst SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="19" targetV="132.66" targetQ="0" node="13" p="-21.144829851376183" q="-2.1265528017631983">
+            <iidm:generator id="_04633e31-c766-11e1-8775-005056c00008" name="W.Lancst SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="19" targetV="132.66" targetQ="0" node="13" p="-21.141134870568319" q="-2.1302247622747101">
                 <iidm:alias>_047bcf42-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_83fae784-1da1-4055-8108-ba978276d1b6"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_5f711f63-f631-45d3-b26c-33821ab2ee56"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-15" maxQ="45"/>
             </iidm:generator>
-            <iidm:load id="_048a9c51-c766-11e1-8775-005056c00008" name="W.Lancst LD" loadType="UNDEFINED" p0="28" q0="10" node="11" p="28.000000787943595" q="10.000000469014045">
+            <iidm:load id="_048a9c51-c766-11e1-8775-005056c00008" name="W.Lancst LD" loadType="UNDEFINED" p0="28" q0="10" node="11" p="28.000005109993726" q="10.000003041663115">
                 <iidm:alias>_044e7db6-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_045b00d9-c766-11e1-8775-005056c00008" name="W.Lancst SC" sectionCount="5" voltageRegulatorOn="true" targetV="132.66" targetDeadband="1" node="12" q="-10.101640173424869">
+            <iidm:shunt id="_045b00d9-c766-11e1-8775-005056c00008" name="W.Lancst SC" sectionCount="5" voltageRegulatorOn="true" targetV="132.66" targetDeadband="1" node="12" q="-10.101642252462737">
                 <iidm:alias>_04758db6-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_be267a3c-f7a7-4bdf-bb17-71b773247fbf"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -7086,9 +7209,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="129.85999159496544" angle="10.152094547842738" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="129.87573425460963" angle="-1.0029899246031757" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045dbff2-c766-11e1-8775-005056c00008" name="Portsmth LD" loadType="UNDEFINED" p0="66" q0="20" node="17" p="65.994841959716496" q="19.997394997014275">
+            <iidm:load id="_045dbff2-c766-11e1-8775-005056c00008" name="Portsmth LD" loadType="UNDEFINED" p0="66" q0="20" node="17" p="65.994864266697746" q="19.997406262580704">
                 <iidm:alias>_0454bf45-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7159,16 +7282,16 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="127.64400510735321" angle="7.8176066973608132" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="127.64400000336879" angle="-3.104843232873983" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04856c34-c766-11e1-8775-005056c00008" name="DeerCrk SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="7" targetV="127.64400000000001" targetQ="0" node="12" p="-7.7902004715596469" q="-41.181900510619428">
+            <iidm:generator id="_04856c34-c766-11e1-8775-005056c00008" name="DeerCrk SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="7" targetV="127.64400000000001" targetQ="0" node="12" p="-7.7888391628409606" q="-38.864639847912052">
                 <iidm:alias>_0477d7a5-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e5a479a8-ab8d-4a54-bb52-376874ae2784"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b55d80d5-720f-46f9-897f-ff8c5eaf8b44"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-15" maxQ="45"/>
             </iidm:generator>
-            <iidm:load id="_04791028-c766-11e1-8775-005056c00008" name="DeerCrk LD" loadType="UNDEFINED" p0="43" q0="27" node="11" p="43.000002580805088" q="27.000002700842586">
+            <iidm:load id="_04791028-c766-11e1-8775-005056c00008" name="DeerCrk LD" loadType="UNDEFINED" p0="43" q0="27" node="11" p="43.00000000170229" q="27.000000001781466">
                 <iidm:alias>_04486337-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7219,9 +7342,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.79854588038422" angle="9.6614033568390507" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.96388536135385" angle="-1.4982185985424981" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0462c904-c766-11e1-8775-005056c00008" name="Medford LD" loadType="UNDEFINED" p0="22" q0="7" node="8" p="21.995251805113927" q="6.9974821990173357">
+            <iidm:load id="_0462c904-c766-11e1-8775-005056c00008" name="Medford LD" loadType="UNDEFINED" p0="22" q0="7" node="8" p="21.995744008041232" q="6.9977431801102483">
                 <iidm:alias>_0489b1f7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7310,9 +7433,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="131.97962378142802" angle="15.497443608438266" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="132.11995347950835" angle="4.1103396988161229" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046205b5-c766-11e1-8775-005056c00008" name="CollCrnr LD" loadType="UNDEFINED" p0="7" q0="3" node="14" p="6.9985409316308669" q="2.998957880720341">
+            <iidm:load id="_046205b5-c766-11e1-8775-005056c00008" name="CollCrnr LD" loadType="UNDEFINED" p0="7" q0="3" node="14" p="6.9986593450383845" q="2.9990424504489805">
                 <iidm:alias>_04486334-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7363,9 +7486,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.90337829457653" angle="17.864283592438422" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.86918352920284" angle="6.7701802339158865" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0483be82-c766-11e1-8775-005056c00008" name="Caldwell LD" loadType="UNDEFINED" p0="42" q0="31" node="8" p="41.996067513512401" q="30.995162568399593">
+            <iidm:load id="_0483be82-c766-11e1-8775-005056c00008" name="Caldwell LD" loadType="UNDEFINED" p0="42" q0="31" node="8" p="41.996025150635091" q="30.995110458606725">
                 <iidm:alias>_045841b9-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7416,9 +7539,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.33223209983456" angle="10.423927905571967" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.3321957285022" angle="-0.67234460268930596" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045f94b4-c766-11e1-8775-005056c00008" name="Franklin LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="8.0000220771731403" q="3.000013798245905">
+            <iidm:load id="_045f94b4-c766-11e1-8775-005056c00008" name="Franklin LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="8.0000210738806175" q="3.0000131711869509">
                 <iidm:alias>_047da403-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7469,9 +7592,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="124.55521996400577" angle="5.6324354532112073" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.49607643907467" angle="-4.9666184725530043" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045f6da2-c766-11e1-8775-005056c00008" name="McKinley LD" loadType="UNDEFINED" p0="60" q0="34" node="8" p="59.921070624188189" q="33.925488281756444">
+            <iidm:load id="_045f6da2-c766-11e1-8775-005056c00008" name="McKinley LD" loadType="UNDEFINED" p0="60" q0="34" node="8" p="59.924291022018295" q="33.928527155087075">
                 <iidm:alias>_0465d641-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7618,19 +7741,19 @@
                 <iidm:internalConnection node1="71" node2="18"/>
                 <iidm:internalConnection node1="72" node2="21"/>
                 <iidm:internalConnection node1="73" node2="12"/>
-                <iidm:bus v="130.68001415686479" angle="8.5831843624357127" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
+                <iidm:bus v="130.68000800576738" angle="-3.0047643227381839" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_044ca8f0-c766-11e1-8775-005056c00008" name="TwinBrch SM" energySource="THERMAL" minP="50" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="85" targetV="130.68000799999999" targetQ="0" node="24" p="-94.59529144036712" q="-94.617060046285403">
+            <iidm:generator id="_044ca8f0-c766-11e1-8775-005056c00008" name="TwinBrch SM" energySource="THERMAL" minP="50" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="85" targetV="130.68000799999999" targetQ="0" node="24" p="-94.578761263068799" q="-90.688454303839009">
                 <iidm:alias>_04633e38-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_0f6ab5a4-6b72-42f4-92bc-1993e1ae58a3"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_668eb671-5c36-4351-a95d-53ca850581db"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-60" maxQ="170"/>
             </iidm:generator>
-            <iidm:load id="_048740f1-c766-11e1-8775-005056c00008" name="TwinBrch LD" loadType="UNDEFINED" p0="47" q0="10" node="23" p="47.000003321540753" q="10.00000117785136">
+            <iidm:load id="_048740f1-c766-11e1-8775-005056c00008" name="TwinBrch LD" loadType="UNDEFINED" p0="47" q0="10" node="23" p="47.000000003111417" q="10.00000000110334">
                 <iidm:alias>_044ecbda-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:danglingLine id="_045338a1-c766-11e1-8775-005056c00008" name="12-117" p0="20" q0="8" r="5.7324960000000003" x="24.393599999999999" g="0" b="0.00020546369999999999" ucteXnodeCode="XMO_TE32" node="73" p="20.161795490662143" q="5.1797260747545604">
+            <iidm:danglingLine id="_045338a1-c766-11e1-8775-005056c00008" name="12-117" p0="20" q0="8" r="5.7324960000000003" x="24.393599999999999" g="0" b="0.00020546369999999999" ucteXnodeCode="XMO_TE32" node="73" p="20.161793617717009" q="5.1797255243578011">
                 <iidm:alias>_044afb42-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_0457f391-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_5631f3d0-d9d2-11e2-bb49-005056c00008</iidm:alias>
@@ -7728,9 +7851,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="123.66490669859316" angle="4.0268660184400922" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="123.6229037482864" angle="-6.7041506958574901" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0479fa87-c766-11e1-8775-005056c00008" name="Lincoln LD" loadType="UNDEFINED" p0="45" q0="25" node="14" p="44.926609189137281" q="24.932082494658637">
+            <iidm:load id="_0479fa87-c766-11e1-8775-005056c00008" name="Lincoln LD" loadType="UNDEFINED" p0="45" q0="25" node="14" p="44.928603561639527" q="24.933927154813716">
                 <iidm:alias>_047fc6e2-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7781,9 +7904,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="134.64432537749127" angle="17.083523005847866" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="134.64433878243577" angle="5.9881867772409558" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044c81e4-c766-11e1-8775-005056c00008" name="Hinton NegG LD" loadType="UNDEFINED" p0="42" q0="0" node="8" p="41.999736665838398" q="0">
+            <iidm:load id="_044c81e4-c766-11e1-8775-005056c00008" name="Hinton NegG LD" loadType="UNDEFINED" p0="42" q0="0" node="8" p="41.999732927173504" q="0">
                 <iidm:alias>_04494d96-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7834,9 +7957,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.17117681557284" angle="7.8747200177024457" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.14998126636513" angle="-3.3617247709556612" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_048bfbe0-c766-11e1-8775-005056c00008" name="N. E. LD" loadType="UNDEFINED" p0="25" q0="10" node="8" p="24.992909229381528" q="9.9952732665264659">
+            <iidm:load id="_048bfbe0-c766-11e1-8775-005056c00008" name="N. E. LD" loadType="UNDEFINED" p0="25" q0="10" node="8" p="24.993433801819798" q="9.9956229178017928">
                 <iidm:alias>_0480b140-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7887,9 +8010,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.3057706321041" angle="-13.646086543419701" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.30541045397385" angle="-24.697165509138511" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04854525-c766-11e1-8775-005056c00008" name="SCoshoct LD" loadType="UNDEFINED" p0="18" q0="5" node="8" p="18.0090636868579" q="5.0041968555911396">
+            <iidm:load id="_04854525-c766-11e1-8775-005056c00008" name="SCoshoct LD" loadType="UNDEFINED" p0="18" q0="5" node="8" p="18.009064835261356" q="5.0041973874378805">
                 <iidm:alias>_04747c42-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7940,9 +8063,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="125.01544672479919" angle="9.0103955526259156" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="125.0092469836552" angle="-2.1066823988371319" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044aad24-c766-11e1-8775-005056c00008" name="WHuntngd LD" loadType="UNDEFINED" p0="33" q0="15" node="8" p="32.996404879817547" q="14.997276523010274">
+            <iidm:load id="_044aad24-c766-11e1-8775-005056c00008" name="WHuntngd LD" loadType="UNDEFINED" p0="33" q0="15" node="8" p="32.996370699557325" q="14.99725063076337">
                 <iidm:alias>_04784cd2-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7974,9 +8097,9 @@
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="3"/>
-                <iidm:bus v="129.36001123743659" angle="11.352015100368169" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="129.36000000287436" angle="0.25520749453178487" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0452ea80-c766-11e1-8775-005056c00008" name="DanRiver SM" energySource="THERMAL" minP="20" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="36" targetV="129.36000000000001" targetQ="0" node="5" p="-40.063888139449602" q="-20.215465369491341">
+            <iidm:generator id="_0452ea80-c766-11e1-8775-005056c00008" name="DanRiver SM" energySource="THERMAL" minP="20" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="36" targetV="129.36000000000001" targetQ="0" node="5" p="-40.056887123182079" q="-20.21749105932858">
                 <iidm:alias>_046a4316-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_fec62959-21c5-4921-90b2-7c85e9f3bfab"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_9db08c95-4586-4a2b-87e3-5a17c944b43a"/>
@@ -8049,9 +8172,9 @@
                 <iidm:internalConnection node1="29" node2="3"/>
                 <iidm:internalConnection node1="30" node2="9"/>
                 <iidm:internalConnection node1="31" node2="6"/>
-                <iidm:bus v="130.12336944092135" angle="10.222435073117943" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
+                <iidm:bus v="130.15148427943535" angle="-0.94839226333189808" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
             </iidm:nodeBreakerTopology>
-            <iidm:danglingLine id="_044ef2e7-c766-11e1-8775-005056c00008" name="71-73" p0="6" q0="0" r="1.508918" x="7.9104960000000002" g="0" b="6.76079e-05" ucteXnodeCode="XMO_TE31" node="31" p="6.0032119066265022" q="-1.1279061264070291">
+            <iidm:danglingLine id="_044ef2e7-c766-11e1-8775-005056c00008" name="71-73" p0="6" q0="0" r="1.508918" x="7.9104960000000002" g="0" b="6.76079e-05" ucteXnodeCode="XMO_TE31" node="31" p="6.0032102382277435" q="-1.1284081855259698">
                 <iidm:alias>_04670ec2-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_046b2d7a-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_26a070b9-db0c-47cd-9991-0a461576aec2</iidm:alias>
@@ -8111,9 +8234,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.63516043107913" angle="-5.3370173834848309" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.63617161874024" angle="-16.390838385319466" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0453add4-c766-11e1-8775-005056c00008" name="Summerfl LD" loadType="UNDEFINED" p0="28" q0="7" node="8" p="27.705140533738358" q="6.8775736558864198">
+            <iidm:load id="_0453add4-c766-11e1-8775-005056c00008" name="Summerfl LD" loadType="UNDEFINED" p0="28" q0="7" node="8" p="27.705231040754835" q="6.8776111019667043">
                 <iidm:alias>_04851e16-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8240,9 +8363,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="132.66001450947144" angle="32.525972606182634" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="132.66000096169822" angle="21.441331816266803" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0489b1fa-c766-11e1-8775-005056c00008" name="ClinchRv SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="607" targetV="132.66" targetQ="0" node="20" p="-675.5216694623864" q="-46.364463026704897">
+            <iidm:generator id="_0489b1fa-c766-11e1-8775-005056c00008" name="ClinchRv SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="607" targetV="132.66" targetQ="0" node="20" p="-675.40362454920898" q="-49.413973624352117">
                 <iidm:alias>_04840caa-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_2621b09a-22e3-4630-b3bd-32c102e36741"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b0d662e5-64c9-4d59-b8e0-9b1ed175769b"/>
@@ -8297,9 +8420,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.46292454845164" angle="7.6575985025836895" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.48000644793004" angle="-3.9708253403350908" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0485e168-c766-11e1-8775-005056c00008" name="Pokagon LD" loadType="UNDEFINED" p0="20" q0="9" node="8" p="19.999390859352769" q="8.9995431491527462">
+            <iidm:load id="_0485e168-c766-11e1-8775-005056c00008" name="Pokagon LD" loadType="UNDEFINED" p0="20" q0="9" node="8" p="19.999392279954574" q="8.9995442145824889">
                 <iidm:alias>_0462c902-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8350,9 +8473,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.93858879017085" angle="7.1557497832966268" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.94673444962231" angle="-4.2157348609157728" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04812679-c766-11e1-8775-005056c00008" name="GoshenJt LD" loadType="UNDEFINED" p0="14" q0="1" node="8" p="13.994662594509045" q="0.99936467533583917">
+            <iidm:load id="_04812679-c766-11e1-8775-005056c00008" name="GoshenJt LD" loadType="UNDEFINED" p0="14" q0="1" node="8" p="13.994873720343978" q="0.99938980310164249">
                 <iidm:alias>_045b9d17-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8403,9 +8526,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="116.83365400339511" angle="-14.44042955973004" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="116.77723021005028" angle="-25.428417687130469" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0489b1f2-c766-11e1-8775-005056c00008" name="S.Tiffin LD" loadType="UNDEFINED" p0="37" q0="10" node="8" p="36.836270366237692" q="9.9263567536949591">
+            <iidm:load id="_0489b1f2-c766-11e1-8775-005056c00008" name="S.Tiffin LD" loadType="UNDEFINED" p0="37" q0="10" node="8" p="36.835493210933691" q="9.9260077196915812">
                 <iidm:alias>_046476b8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8456,9 +8579,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="122.77605667720314" angle="-0.77280938760760898" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="122.70030525600259" angle="-11.613118285616354" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045cfca7-c766-11e1-8775-005056c00008" name="Haviland LD" loadType="UNDEFINED" p0="23" q0="9" node="8" p="22.93197644781597" q="8.9556805635636003">
+            <iidm:load id="_045cfca7-c766-11e1-8775-005056c00008" name="Haviland LD" loadType="UNDEFINED" p0="23" q0="9" node="8" p="22.932437683252356" q="8.9559807779051965">
                 <iidm:alias>_0482ad17-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8528,9 +8651,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="130.73826842345372" angle="-0.14038016943672929" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="130.73845241750817" angle="-11.198574304054789" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04555b82-c766-11e1-8775-005056c00008" name="SWKammer LD" loadType="UNDEFINED" p0="78" q0="3" node="11" p="77.939149977280508" q="2.9961003719400456">
+            <iidm:load id="_04555b82-c766-11e1-8775-005056c00008" name="SWKammer LD" loadType="UNDEFINED" p0="78" q0="3" node="11" p="77.93919082062753" q="2.9961029887419266">
                 <iidm:alias>_0474ca6b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8638,9 +8761,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="130.37416015207421" angle="17.105955472189219" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="130.32616175041952" angle="6.0112570308071316" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04817492-c766-11e1-8775-005056c00008" name="Baileysv LD" loadType="UNDEFINED" p0="38" q0="15" node="17" p="37.99615684021115" q="14.997471690640088">
+            <iidm:load id="_04817492-c766-11e1-8775-005056c00008" name="Baileysv LD" loadType="UNDEFINED" p0="38" q0="15" node="17" p="37.996109189161608" q="14.997440343392224">
                 <iidm:alias>_0474f17b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8691,9 +8814,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.03859482751119" angle="25.715186402396959" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.03479723317722" angle="14.628498136832143" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0461b790-c766-11e1-8775-005056c00008" name="HolstonT NegG LD" loadType="UNDEFINED" p0="10" q0="0" node="8" p="9.9997048393448971" q="0">
+            <iidm:load id="_0461b790-c766-11e1-8775-005056c00008" name="HolstonT NegG LD" loadType="UNDEFINED" p0="10" q0="0" node="8" p="9.999702357879265" q="0">
                 <iidm:alias>_0464ebe7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8744,9 +8867,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.83444442885281" angle="9.6458197136610551" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.99474466553403" angle="-1.5060392431041076" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044c81e5-c766-11e1-8775-005056c00008" name="WMedford LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="7.9982465636990909" q="2.9989041823799978">
+            <iidm:load id="_044c81e5-c766-11e1-8775-005056c00008" name="WMedford LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="7.9984265057542396" q="2.999016630573959">
                 <iidm:alias>_04570939-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8836,12 +8959,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="123.50759920420464" angle="-5.5566824890682156" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="123.4428538588667" angle="-16.49739903026186" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04854520-c766-11e1-8775-005056c00008" name="Rockhill LD" loadType="UNDEFINED" p0="59" q0="26" node="14" p="58.759928453047486" q="25.823915527525791">
+            <iidm:load id="_04854520-c766-11e1-8775-005056c00008" name="Rockhill LD" loadType="UNDEFINED" p0="59" q0="26" node="14" p="58.760103657914883" q="25.824043859886299">
                 <iidm:alias>_0461b799-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0460cd38-c766-11e1-8775-005056c00008" name="Rockhill SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.81399999999999" targetDeadband="1" node="15" q="-12.249064030132722">
+            <iidm:shunt id="_0460cd38-c766-11e1-8775-005056c00008" name="Rockhill SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.81399999999999" targetDeadband="1" node="15" q="-12.236224949563683">
                 <iidm:alias>_048b86b4-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_069d84c6-bd26-4c26-ac6c-e801a0202a00"/>
                 <iidm:shuntLinearModel bPerSection="0.0001606" gPerSection="0" maximumSectionCount="10"/>
@@ -8914,12 +9037,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="128.65879506361532" angle="18.386038415984224" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="128.48230064230256" angle="7.2955479299722059" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047a48a5-c766-11e1-8775-005056c00008" name="Sprigg LD" loadType="UNDEFINED" p0="20" q0="10" node="11" p="19.996333263470486" q="9.9969445729647202">
+            <iidm:load id="_047a48a5-c766-11e1-8775-005056c00008" name="Sprigg LD" loadType="UNDEFINED" p0="20" q0="10" node="11" p="19.996253663016908" q="9.9968782474492706">
                 <iidm:alias>_0472ce97-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_04553478-c766-11e1-8775-005056c00008" name="Sprigg SC" sectionCount="5" voltageRegulatorOn="true" targetV="129.935" targetDeadband="1" node="12" q="-9.5014711041050646">
+            <iidm:shunt id="_04553478-c766-11e1-8775-005056c00008" name="Sprigg SC" sectionCount="5" voltageRegulatorOn="true" targetV="129.935" targetDeadband="1" node="12" q="-9.4754207059666022">
                 <iidm:alias>_045bc428-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_f4cdc674-4a66-4ab8-8d4f-552cb066e259"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -9011,12 +9134,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="117.15407949666221" angle="-12.951408438276964" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="117.09312320916347" angle="-23.930318646407766" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04819ba4-c766-11e1-8775-005056c00008" name="West End NegG LD" loadType="UNDEFINED" p0="46" q0="0" node="14" p="45.77523993646102" q="0">
+            <iidm:load id="_04819ba4-c766-11e1-8775-005056c00008" name="West End NegG LD" loadType="UNDEFINED" p0="46" q0="0" node="14" p="45.77440716981129" q="0">
                 <iidm:alias>_04627ae0-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_04555b89-c766-11e1-8775-005056c00008" name="West End LD" loadType="UNDEFINED" p0="20" q0="23" node="15" p="19.902278233243923" q="22.813005167803226">
+            <iidm:load id="_04555b89-c766-11e1-8775-005056c00008" name="West End LD" loadType="UNDEFINED" p0="20" q0="23" node="15" p="19.901916160787518" q="22.812313462174316">
                 <iidm:alias>_04592c18-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9067,9 +9190,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.93601825054117" angle="8.8555987961851841" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.91558225693217" angle="-1.6934834511080468" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046d0232-c766-11e1-8775-005056c00008" name="Deer Crk NegG LD" loadType="UNDEFINED" p0="6" q0="0" node="8" p="5.9951660015619757" q="0">
+            <iidm:load id="_046d0232-c766-11e1-8775-005056c00008" name="Deer Crk NegG LD" loadType="UNDEFINED" p0="6" q0="0" node="8" p="5.9955263858868468" q="0">
                 <iidm:alias>_0480150a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9139,9 +9262,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="133.21367465456282" angle="-5.9558646327919194" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="133.21877904627192" angle="-17.008904889007784" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046c3ee3-c766-11e1-8775-005056c00008" name="Crooksvl LD" loadType="UNDEFINED" p0="34" q0="0" node="11" p="33.931521045362381" q="0">
+            <iidm:load id="_046c3ee3-c766-11e1-8775-005056c00008" name="Crooksvl LD" loadType="UNDEFINED" p0="34" q0="0" node="11" p="33.931723062221693" q="0">
                 <iidm:alias>_047e4047-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9192,9 +9315,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="132.14491387693874" angle="-10.120734852743883" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="132.14473511077941" angle="-21.17022240485473" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046dc585-c766-11e1-8775-005056c00008" name="WCambrdg LD" loadType="UNDEFINED" p0="17" q0="4" node="8" p="17.004463046938493" q="4.0017503676437522">
+            <iidm:load id="_046dc585-c766-11e1-8775-005056c00008" name="WCambrdg LD" loadType="UNDEFINED" p0="17" q0="4" node="8" p="17.004465802917522" q="4.0017514486090535">
                 <iidm:alias>_045dbff8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9283,9 +9406,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="130.19960967233988" angle="9.1480245761303678" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="130.2572254909702" angle="-2.5112020364449554" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_048b5fa5-c766-11e1-8775-005056c00008" name="SouthBnd LD" loadType="UNDEFINED" p0="70" q0="23" node="14" p="69.990665478711875" q="22.994888465563911">
+            <iidm:load id="_048b5fa5-c766-11e1-8775-005056c00008" name="SouthBnd LD" loadType="UNDEFINED" p0="70" q0="23" node="14" p="69.990892408180443" q="22.995012725549703">
                 <iidm:alias>_04522734-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9335,11 +9458,11 @@
                 <iidm:internalConnection node1="19" node2="6"/>
                 <iidm:internalConnection node1="20" node2="3"/>
                 <iidm:internalConnection node1="21" node2="6"/>
-                <iidm:bus v="227.66623191518252" angle="26.298503113573368" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
+                <iidm:bus v="227.91085101945509" angle="14.129378454919463" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:line id="_044cd006-c766-11e1-8775-005056c00008" name="31-32" r="5.1923519999999996" x="17.16264" g1="0" b1="7.20271e-05" g2="0" b2="7.20271e-05" node1="31" voltageLevelId1="_04636548-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="-29.896368150859047" q1="10.475782229244713" p2="30.224455441395421" q2="-11.733430523113091">
+    <iidm:line id="_044cd006-c766-11e1-8775-005056c00008" name="31-32" r="5.1923519999999996" x="17.16264" g1="0" b1="7.20271e-05" g2="0" b2="7.20271e-05" node1="31" voltageLevelId1="_04636548-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="-27.427564392533643" q1="8.6570121383937639" p2="27.698100643878814" q2="-10.107281015850505">
         <iidm:alias>_04682030-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0471bd25-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9347,7 +9470,7 @@
             <iidm:temporaryLimit name="_de6da3cb-8cb5-4900-9c33-8ad45632b535" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045a3d89-c766-11e1-8775-005056c00008" name="2-12" r="3.2582879999999999" x="10.7331839" g1="0" b1="4.5110200000000001e-05" g2="0" b2="4.5110200000000001e-05" node1="21" voltageLevelId1="_045d4ac5-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-30.452980859959165" q1="-17.831521057207016" p2="30.693729075433456" q2="17.109773971351729">
+    <iidm:line id="_045a3d89-c766-11e1-8775-005056c00008" name="2-12" r="3.2582879999999999" x="10.7331839" g1="0" b1="4.5110200000000001e-05" g2="0" b2="4.5110200000000001e-05" node1="21" voltageLevelId1="_045d4ac5-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-31.406771758293122" q1="-17.322885704830725" p2="31.655720794046289" q2="16.627955166071263">
         <iidm:alias>_046adf51-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046fe868-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9355,7 +9478,7 @@
             <iidm:temporaryLimit name="_6bd63dd1-1344-4183-b7bd-af326919f4eb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04513cd7-c766-11e1-8775-005056c00008" name="32-114" r="2.3522400000000001" x="10.6634884" g1="0" b1="4.6717149999999997e-05" g2="0" b2="4.6717149999999997e-05" node1="49" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04791027-c766-11e1-8775-005056c00008" p1="6.2361200691632002" q1="4.3092130098126225" p2="-6.2267590192883944" q2="-5.7762486019057411">
+    <iidm:line id="_04513cd7-c766-11e1-8775-005056c00008" name="32-114" r="2.3522400000000001" x="10.6634884" g1="0" b1="4.6717149999999997e-05" g2="0" b2="4.6717149999999997e-05" node1="49" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04791027-c766-11e1-8775-005056c00008" p1="7.307171726989953" q1="3.7245504999842063" p2="-7.2965368375754718" q2="-5.1892644949307352">
         <iidm:alias>_046d0237-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0470d2c7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9363,7 +9486,7 @@
             <iidm:temporaryLimit name="_5f05650a-c63d-46e5-a426-2db4f036929f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045d71d4-c766-11e1-8775-005056c00008" name="24-72" r="8.5029120000000002" x="34.151040000000002" g1="0" b1="0.00014003675" g2="0" b2="0.00014003675" node1="30" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="22.766828594682924" q1="-5.0515660147417982" p2="-22.508932541242238" q2="1.2612061709338511">
+    <iidm:line id="_045d71d4-c766-11e1-8775-005056c00008" name="24-72" r="8.5029120000000002" x="34.151040000000002" g1="0" b1="0.00014003675" g2="0" b2="0.00014003675" node1="30" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="22.100107754142631" q1="-4.7304066122572639" p2="-21.858193459723186" q2="0.86760368368209906">
         <iidm:alias>_04667281-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d0234-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9371,7 +9494,7 @@
             <iidm:temporaryLimit name="_d2074163-ab09-4251-a1d7-6983091dc4f1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045f94b8-c766-11e1-8775-005056c00008" name="17-18" r="2.1431520000000002" x="8.7991200000000003" g1="0" b1="3.7247499999999999e-05" g2="0" b2="3.7247499999999999e-05" node1="57" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04689563-c766-11e1-8775-005056c00008" p1="112.49932072487636" q1="41.954946341656054" p2="-110.63964061493041" q2="-35.518608263529416">
+    <iidm:line id="_045f94b8-c766-11e1-8775-005056c00008" name="17-18" r="2.1431520000000002" x="8.7991200000000003" g1="0" b1="3.7247499999999999e-05" g2="0" b2="3.7247499999999999e-05" node1="57" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04689563-c766-11e1-8775-005056c00008" p1="116.46955374961195" q1="41.410785795044838" p2="-114.49758313416747" q2="-34.512437123062497">
         <iidm:alias>_045e0e17-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0485ba59-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9379,7 +9502,7 @@
             <iidm:temporaryLimit name="_2b6693c7-4e29-4c2c-91d0-3485bbe8fe87" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048963d8-c766-11e1-8775-005056c00008" name="17-113" r="1.590811" x="5.244624" g1="0" b1="2.2038549999999999e-05" g2="0" b2="2.2038549999999999e-05" node1="58" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="0.2953399712871046" q1="4.2949895096069728" p2="-0.29325767969397515" q2="-5.0219818231353557">
+    <iidm:line id="_048963d8-c766-11e1-8775-005056c00008" name="17-113" r="1.590811" x="5.244624" g1="0" b1="2.2038549999999999e-05" g2="0" b2="2.2038549999999999e-05" node1="58" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="4.2662649774503105" q1="2.4886654359452192" p2="-4.2637486292081554" q2="-3.2138551098055261">
         <iidm:alias>_045841b5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046958b4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9387,7 +9510,7 @@
             <iidm:temporaryLimit name="_786432da-fa4d-4751-a275-87d0e20529f1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0458ddf0-c766-11e1-8775-005056c00008" name="49-50" r="4.6522079999999999" x="13.102848099999999" g1="0" b1="5.3776400000000002e-05" g2="0" b2="5.3776400000000002e-05" node1="112" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044d1e26-c766-11e1-8775-005056c00008" p1="53.101541560113162" q1="13.583165143506177" p2="-52.331008832717629" q2="-13.336469698762432">
+    <iidm:line id="_0458ddf0-c766-11e1-8775-005056c00008" name="49-50" r="4.6522079999999999" x="13.102848099999999" g1="0" b1="5.3776400000000002e-05" g2="0" b2="5.3776400000000002e-05" node1="112" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044d1e26-c766-11e1-8775-005056c00008" p1="53.123276697843139" q1="13.578278124074448" p2="-52.352193569816393" q2="-13.330030164468088">
         <iidm:alias>_0464ebe8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f9fd8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9395,7 +9518,7 @@
             <iidm:temporaryLimit name="_1f0844a5-ea5c-42b2-abcb-6fac2c426092" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04535fb7-c766-11e1-8775-005056c00008" name="1-3" r="2.2476959999999999" x="7.3877759999999997" g1="0" b1="3.1049149999999997e-05" g2="0" b2="3.1049149999999997e-05" node1="21" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_047eb579-c766-11e1-8775-005056c00008" p1="-40.609399611669041" q1="-16.013305882689465" p2="40.874105211119662" q2="15.873837492363277">
+    <iidm:line id="_04535fb7-c766-11e1-8775-005056c00008" name="1-3" r="2.2476959999999999" x="7.3877759999999997" g1="0" b1="3.1049149999999997e-05" g2="0" b2="3.1049149999999997e-05" node1="21" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_047eb579-c766-11e1-8775-005056c00008" p1="-39.659098324360599" q1="-16.532190922193799" p2="39.915215686982656" q2="16.363636804719391">
         <iidm:alias>_044ef2e9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047c4474-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9403,7 +9526,7 @@
             <iidm:temporaryLimit name="_4ea43e34-67a3-42b8-9601-2189db7790d4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0478e912-c766-11e1-8775-005056c00008" name="92-102" r="2.1431520000000002" x="9.7400160000000007" g1="0" b1="4.2011000000000001e-05" g2="0" b2="4.2011000000000001e-05" node1="66" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="50.113679865537406" q1="-9.0788482029681088" p2="-49.789304294852279" q2="9.1216179342641954">
+    <iidm:line id="_0478e912-c766-11e1-8775-005056c00008" name="92-102" r="2.1431520000000002" x="9.7400160000000007" g1="0" b1="4.2011000000000001e-05" g2="0" b2="4.2011000000000001e-05" node1="66" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="50.150402134988738" q1="-9.0977631509228711" p2="-49.825490270746336" q2="9.143108648579517">
         <iidm:alias>_045a1673-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0468bc79-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9411,7 +9534,7 @@
             <iidm:temporaryLimit name="_23cc194e-9273-46e9-a793-84a9c2911737" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04547127-c766-11e1-8775-005056c00008" name="93-94" r="3.8855520000000001" x="12.7543688" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="21" voltageLevelId1="_04789af0-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="57.813042725051758" q1="-22.252390866635807" p2="-56.936515240394748" q2="23.309610570041666">
+    <iidm:line id="_04547127-c766-11e1-8775-005056c00008" name="93-94" r="3.8855520000000001" x="12.7543688" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="21" voltageLevelId1="_04789af0-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="57.86879999106911" q1="-22.195772862993252" p2="-56.991127744705828" q2="23.257284266634667">
         <iidm:alias>_04500450-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047b0bfb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9419,7 +9542,7 @@
             <iidm:temporaryLimit name="_1a9fe09e-3f63-4904-8e36-aa38c5e16c59" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04791021-c766-11e1-8775-005056c00008" name="46-48" r="10.4718237" x="32.931359999999998" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044778d3-c766-11e1-8775-005056c00008" p1="-1.8453512328440946" q1="-10.288405973619618" p2="1.8845582787450688" q2="5.5680279782563362">
+    <iidm:line id="_04791021-c766-11e1-8775-005056c00008" name="46-48" r="10.4718237" x="32.931359999999998" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044778d3-c766-11e1-8775-005056c00008" p1="-1.8194467457104797" q1="-10.296868679831766" p2="1.8586769424357688" q2="5.5765601435283543">
         <iidm:alias>_0459ef69-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04640186-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9427,7 +9550,7 @@
             <iidm:temporaryLimit name="_467ba04d-dbad-4fe1-81c8-3bc87b41fcd1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046958b6-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="113" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-14.178667589970367" q1="24.714565251346844" p2="14.329081468612939" q2="-26.500110138298389">
+    <iidm:line id="_046958b6-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="113" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-14.133561851238785" q1="24.698816894484015" p2="14.283616554732342" q2="-26.486209733441253">
         <iidm:alias>_04776270-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a96c8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9435,7 +9558,7 @@
             <iidm:temporaryLimit name="_d0737ab4-5a3a-46c8-8aeb-789313f0f332" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046f4c26-c766-11e1-8775-005056c00008" name="75-118" r="2.5264799999999998" x="8.3809430000000003" g1="0" b1="3.4377849999999998e-05" g2="0" b2="3.4377849999999998e-05" node1="48" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="36.232959550226582" q1="29.766682264931809" p2="-35.887120769615201" q2="-29.717434252691572">
+    <iidm:line id="_046f4c26-c766-11e1-8775-005056c00008" name="75-118" r="2.5264799999999998" x="8.3809430000000003" g1="0" b1="3.4377849999999998e-05" g2="0" b2="3.4377849999999998e-05" node1="48" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="36.120086169218354" q1="29.858034078456093" p2="-35.774640802096364" q2="-29.810017968017206">
         <iidm:alias>_04619088-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04814d8a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9443,7 +9566,7 @@
             <iidm:temporaryLimit name="_173dc7ff-ae18-4410-b2e1-a4c2abac8ff6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c3954-c766-11e1-8775-005056c00008" name="94-96" r="4.6870560000000001" x="15.1414566" g1="0" b1="6.60009e-05" g2="0" b2="6.60009e-05" node1="49" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="39.380431813003739" q1="-13.336233531011807" p2="-38.910924139469692" q2="12.610992666641712">
+    <iidm:line id="_045c3954-c766-11e1-8775-005056c00008" name="94-96" r="4.6870560000000001" x="15.1414566" g1="0" b1="6.60009e-05" g2="0" b2="6.60009e-05" node1="49" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="39.445347010898963" q1="-13.136132454290946" p2="-38.975600256559076" q2="12.412877216401398">
         <iidm:alias>_046ba2a0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0472ce94-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9451,7 +9574,7 @@
             <iidm:temporaryLimit name="_efde58bf-c92e-496d-b558-d0095a271083" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04518af7-c766-11e1-8775-005056c00008" name="62-67" r="4.4953919999999998" x="20.38608" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="39" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="54.710388605934646" q1="-13.296893880758335" p2="-53.881985201650927" q2="14.023512580697773">
+    <iidm:line id="_04518af7-c766-11e1-8775-005056c00008" name="62-67" r="4.4953919999999998" x="20.38608" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="39" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="54.663118974533695" q1="-13.292723751810945" p2="-53.836116134879596" q2="14.012954605632952">
         <iidm:alias>_04544a10-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04814d86-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9459,7 +9582,7 @@
             <iidm:temporaryLimit name="_8a81d4ae-2bc8-4038-8650-27a6150946b1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0452c375-c766-11e1-8775-005056c00008" name="47-49" r="3.3279839999999998" x="10.890000000000001" g1="0" b1="4.6028449999999998e-05" g2="0" b2="4.6028449999999998e-05" node1="30" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="114" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="50.032171802328499" q1="-40.460784245787025" p2="-49.267990215718321" q2="41.301961960619892">
+    <iidm:line id="_0452c375-c766-11e1-8775-005056c00008" name="47-49" r="3.3279839999999998" x="10.890000000000001" g1="0" b1="4.6028449999999998e-05" g2="0" b2="4.6028449999999998e-05" node1="30" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="114" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="49.930222882866673" q1="-40.373285665719145" p2="-49.169311331504481" q2="41.203700219347454">
         <iidm:alias>_0465fd54-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0471e431-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9467,7 +9590,7 @@
             <iidm:temporaryLimit name="_8d6a074c-900d-4a37-830c-5da4c1de1ab5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046c17d9-c766-11e1-8775-005056c00008" name="100-106" r="10.54152" x="39.900959999999998" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="76" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="59.344671949718041" q1="10.063325577808072" p2="-57.181627400246683" q2="-7.9396999374637458">
+    <iidm:line id="_046c17d9-c766-11e1-8775-005056c00008" name="100-106" r="10.54152" x="39.900959999999998" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="76" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="59.346650035310745" q1="10.063159391997308" p2="-57.183470399687543" q2="-7.9390202560106236">
         <iidm:alias>_045d98e5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0480d851-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9475,7 +9598,7 @@
             <iidm:temporaryLimit name="_3154dc30-b0e5-4570-8e52-9333bae20ef2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046b2d77-c766-11e1-8775-005056c00008" name="77-78" r="0.655142" x="2.1605759999999998" g1="0" b1="3.6271800000000001e-05" g2="0" b2="3.6271800000000001e-05" node1="66" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044fb634-c766-11e1-8775-005056c00008" p1="39.935094791532038" q1="4.7866646567620066" p2="-39.874315329676847" q2="-5.8535355306729171">
+    <iidm:line id="_046b2d77-c766-11e1-8775-005056c00008" name="77-78" r="0.655142" x="2.1605759999999998" g1="0" b1="3.6271800000000001e-05" g2="0" b2="3.6271800000000001e-05" node1="66" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044fb634-c766-11e1-8775-005056c00008" p1="39.850508458105125" q1="4.6808121370727127" p2="-39.79000680991993" q2="-5.748255827346088">
         <iidm:alias>_046ed6fb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04893cc3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9483,7 +9606,7 @@
             <iidm:temporaryLimit name="_cce754c5-b9d5-4105-a431-32da96e4a6cf" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c8776-c766-11e1-8775-005056c00008" name="6-7" r="0.79976199999999997" x="3.6241919999999999" g1="0" b1="1.5782850000000001e-05" g2="0" b2="1.5782850000000001e-05" node1="21" voltageLevelId1="_044f6818-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047eb571-c766-11e1-8775-005056c00008" p1="43.169608813794206" q1="-8.4742259794642205" p2="-43.078973740527402" q2="8.3472381533135884">
+    <iidm:line id="_045c8776-c766-11e1-8775-005056c00008" name="6-7" r="0.79976199999999997" x="3.6241919999999999" g1="0" b1="1.5782850000000001e-05" g2="0" b2="1.5782850000000001e-05" node1="21" voltageLevelId1="_044f6818-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047eb571-c766-11e1-8775-005056c00008" p1="38.943120089396729" q1="-6.5529422378694564" p2="-38.870163226535162" q2="6.3453611257565541">
         <iidm:alias>_046efe08-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04720b4a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9491,7 +9614,7 @@
             <iidm:temporaryLimit name="_361a9cc3-fb33-4037-9b9a-c20adb90b66b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047ba839-c766-11e1-8775-005056c00008" name="77-80" r="5.1226560000000001" x="18.295200000000001" g1="0" b1="6.5426999999999995e-05" g2="0" b2="6.5426999999999995e-05" node1="67" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="76" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-49.91246387909095" q1="-22.098742448677317" p2="50.769870083088584" q2="22.782431473457155">
+    <iidm:line id="_047ba839-c766-11e1-8775-005056c00008" name="77-80" r="5.1226560000000001" x="18.295200000000001" g1="0" b1="6.5426999999999995e-05" g2="0" b2="6.5426999999999995e-05" node1="67" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="76" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-50.000676354831" q1="-22.202867038582102" p2="50.862192274937698" q2="22.901561956774728">
         <iidm:alias>_047c6b85-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0480b148-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9499,7 +9622,7 @@
             <iidm:temporaryLimit name="_da00c66f-a882-4938-923b-f2455f7f9a81" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04592c16-c766-11e1-8775-005056c00008" name="78-79" r="0.95135000000000003" x="4.2514560000000001" g1="0" b1="1.8595050000000001e-05" g2="0" b2="1.8595050000000001e-05" node1="22" voltageLevelId1="_044fb634-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04481510-c766-11e1-8775-005056c00008" p1="-31.119005523029148" q1="-20.142387578636161" p2="31.193290258364087" q2="19.821794553126573">
+    <iidm:line id="_04592c16-c766-11e1-8775-005056c00008" name="78-79" r="0.95135000000000003" x="4.2514560000000001" g1="0" b1="1.8595050000000001e-05" g2="0" b2="1.8595050000000001e-05" node1="22" voltageLevelId1="_044fb634-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04481510-c766-11e1-8775-005056c00008" p1="-31.203264048471386" q1="-20.247637218293534" p2="31.278082920805129" q2="19.929576841001502">
         <iidm:alias>_0453add6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045b7605-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9507,7 +9630,7 @@
             <iidm:temporaryLimit name="_ba4abe9d-8490-4c19-b19b-c9d2c3597fc9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047b3301-c766-11e1-8775-005056c00008" name="103-104" r="8.1195839999999997" x="27.599615100000001" g1="0" b1="0.00011679295" g2="0" b2="0.00011679295" node1="40" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="33.065391412606985" q1="13.977355371861513" p2="-32.448217928200371" q2="-15.872444905788063">
+    <iidm:line id="_047b3301-c766-11e1-8775-005056c00008" name="103-104" r="8.1195839999999997" x="27.599615100000001" g1="0" b1="0.00011679295" g2="0" b2="0.00011679295" node1="40" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="33.064816156155615" q1="13.977565805133732" p2="-32.447656868242149" q2="-15.87270248822866">
         <iidm:alias>_0459a142-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045d98e6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9515,7 +9638,7 @@
             <iidm:temporaryLimit name="_2320da74-eda7-4f7f-ade9-1ed0e994f3af" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045e5c32-c766-11e1-8775-005056c00008" name="95-96" r="2.9795039999999999" x="9.5309279999999994" g1="0" b1="4.2298000000000001e-05" g2="0" b2="4.2298000000000001e-05" node1="21" voltageLevelId1="_044f4108-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="15.638337015411979" q1="-25.329107155706492" p2="-15.485738369494936" q2="24.395460412939517">
+    <iidm:line id="_045e5c32-c766-11e1-8775-005056c00008" name="95-96" r="2.9795039999999999" x="9.5309279999999994" g1="0" b1="4.2298000000000001e-05" g2="0" b2="4.2298000000000001e-05" node1="21" voltageLevelId1="_044f4108-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="15.69624015113572" q1="-25.154773183646444" p2="-15.544766754622977" q2="24.218429076696356">
         <iidm:alias>_04597a34-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04801509-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9523,7 +9646,7 @@
             <iidm:temporaryLimit name="_3bc03415-e95f-47a7-8e92-01089d304a9c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045ed169-c766-11e1-8775-005056c00008" name="77-80" r="2.9620799999999998" x="8.4506409999999992" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="68" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="77" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-108.5280698641462" q1="-39.949524056940625" p2="110.75977641553078" q2="41.392590419523643">
+    <iidm:line id="_045ed169-c766-11e1-8775-005056c00008" name="77-80" r="2.9620799999999998" x="8.4506409999999992" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="68" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="77" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-108.72904272233606" q1="-40.158008545141541" p2="110.97144628095246" q2="41.632272556516412">
         <iidm:alias>_0464289a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04828605-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9531,7 +9654,7 @@
             <iidm:temporaryLimit name="_f93b6d4c-39fa-4f6f-a42d-c63a4cf21a67" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047f78c2-c766-11e1-8775-005056c00008" name="5-11" r="3.5370720000000002" x="11.8831682" g1="0" b1="4.987375e-05" g2="0" b2="4.987375e-05" node1="48" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="88.650029990079517" q1="8.1454926906371767" p2="-87.065491351388175" q2="-4.5515259869396294">
+    <iidm:line id="_047f78c2-c766-11e1-8775-005056c00008" name="5-11" r="3.5370720000000002" x="11.8831682" g1="0" b1="4.987375e-05" g2="0" b2="4.987375e-05" node1="48" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="83.548709978224238" q1="10.133707031078137" p2="-82.134188827439488" q2="-7.1133562940434825">
         <iidm:alias>_045bc426-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0476c633-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9539,7 +9662,7 @@
             <iidm:temporaryLimit name="_3bc4ab96-7a0d-4e18-b9f5-d89f63a82f0a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04845ac7-c766-11e1-8775-005056c00008" name="71-72" r="7.7711040000000002" x="31.363201100000001" g1="0" b1="0.00012752525" g2="0" b2="0.00012752525" node1="29" voltageLevelId1="_04664b78-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="-10.459046876841082" q1="-2.8811100045282192" p2="10.50949210131011" q2="-1.2612062455314796">
+    <iidm:line id="_04845ac7-c766-11e1-8775-005056c00008" name="71-72" r="7.7711040000000002" x="31.363201100000001" g1="0" b1="0.00012752525" g2="0" b2="0.00012752525" node1="29" voltageLevelId1="_04664b78-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="-9.8139071965196134" q1="-3.30141467908342" p2="9.8586890074734725" q2="-0.86760367501451241">
         <iidm:alias>_04642891-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046b0661-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9547,7 +9670,7 @@
             <iidm:temporaryLimit name="_bcb69c6e-125e-449c-acb3-a4deb151668d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047343c2-c766-11e1-8775-005056c00008" name="66-67" r="3.9029759999999998" x="17.685359999999999" g1="0" b1="7.6962800000000001e-05" g2="0" b2="7.6962800000000001e-05" node1="50" voltageLevelId1="_047147f4-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="-25.932380525348592" q1="19.342782325739343" p2="26.176844028397333" q2="-20.901058390035214">
+    <iidm:line id="_047343c2-c766-11e1-8775-005056c00008" name="66-67" r="3.9029759999999998" x="17.685359999999999" g1="0" b1="7.6962800000000001e-05" g2="0" b2="7.6962800000000001e-05" node1="50" voltageLevelId1="_047147f4-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="-25.887058251929236" q1="19.329267549249398" p2="26.130873426446392" q2="-20.890516690514566">
         <iidm:alias>_0465af34-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04860874-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9555,7 +9678,7 @@
             <iidm:temporaryLimit name="_b4b8a31d-dc3c-4b51-88ad-a22e070eb96c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04569409-c766-11e1-8775-005056c00008" name="34-43" r="7.1961120000000003" x="29.289743399999999" g1="0" b1="0.0001212695" g2="0" b2="0.0001212695" node1="40" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_045e8349-c766-11e1-8775-005056c00008" p1="28.484743827892796" q1="-11.744252187965031" p2="-28.055792504583788" q2="9.7633076945366888">
+    <iidm:line id="_04569409-c766-11e1-8775-005056c00008" name="34-43" r="7.1961120000000003" x="29.289743399999999" g1="0" b1="0.0001212695" g2="0" b2="0.0001212695" node1="40" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_045e8349-c766-11e1-8775-005056c00008" p1="28.737571128807577" q1="-11.840129817200646" p2="-28.300418975174775" q2="9.8960630910023877">
         <iidm:alias>_04500454-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04505274-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9563,7 +9686,7 @@
             <iidm:temporaryLimit name="_5585c67a-0839-48e6-8847-4393e1e9b9c7" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04817498-c766-11e1-8775-005056c00008" name="52-53" r="7.0567200000000003" x="28.488240000000001" g1="0" b1="0.00011644859999999999" g2="0" b2="0.00011644859999999999" node1="21" voltageLevelId1="_04806326-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04876804-c766-11e1-8775-005056c00008" p1="10.090344095242303" q1="2.0721791453092728" p2="-10.038475642147512" q2="-5.5363073686322686">
+    <iidm:line id="_04817498-c766-11e1-8775-005056c00008" name="52-53" r="7.0567200000000003" x="28.488240000000001" g1="0" b1="0.00011644859999999999" g2="0" b2="0.00011644859999999999" node1="21" voltageLevelId1="_04806326-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04876804-c766-11e1-8775-005056c00008" p1="10.098420505441114" q1="2.0694981865959394" p2="-10.046488985908015" q2="-5.5333560991617388">
         <iidm:alias>_045115c7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0472a784-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9571,7 +9694,7 @@
             <iidm:temporaryLimit name="_e7c9dfab-fb45-4470-964f-4ba9e391f60b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044b7078-c766-11e1-8775-005056c00008" name="105-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="49" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="23" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="26.900987996351112" q1="1.3257423925258769" p2="-26.482332591924173" q2="-4.1875830266545417">
+    <iidm:line id="_044b7078-c766-11e1-8775-005056c00008" name="105-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="49" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="23" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="26.900748894730864" q1="1.3258255386089488" p2="-26.482100320321024" q2="-4.1876878888682496">
         <iidm:alias>_0452c378-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0481c2b7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9579,7 +9702,7 @@
             <iidm:temporaryLimit name="_fff133bf-25fd-46b2-b144-a227c31ee882" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048ac367-c766-11e1-8775-005056c00008" name="100-101" r="4.8264480000000001" x="21.9890881" g1="0" b1="9.4123049999999997e-05" g2="0" b2="9.4123049999999997e-05" node1="77" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046ed6f7-c766-11e1-8775-005056c00008" p1="-21.939031918935246" q1="24.812491740879924" p2="22.256136067099327" q2="-26.673584762699022">
+    <iidm:line id="_048ac367-c766-11e1-8775-005056c00008" name="100-101" r="4.8264480000000001" x="21.9890881" g1="0" b1="9.4123049999999997e-05" g2="0" b2="9.4123049999999997e-05" node1="77" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046ed6f7-c766-11e1-8775-005056c00008" p1="-21.973412707838161" q1="24.842521108359897" p2="22.291347864652099" q2="-26.699742706704942">
         <iidm:alias>_044afb45-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b5fa2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9587,7 +9710,7 @@
             <iidm:temporaryLimit name="_217e3c95-24b5-438f-a721-d2257e1a43b4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0481c2b1-c766-11e1-8775-005056c00008" name="56-57" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="57" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="-22.459702212554316" q1="-9.3631519855602114" p2="22.675575706888047" q2="7.7302609024767435">
+    <iidm:line id="_0481c2b1-c766-11e1-8775-005056c00008" name="56-57" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="57" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="-22.479951399184429" q1="-9.3540738577546723" p2="22.696111394213453" q2="7.7219930269480663">
         <iidm:alias>_045e0e12-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0487dd35-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9595,7 +9718,7 @@
             <iidm:temporaryLimit name="_f5547027-3d48-4a53-937b-bd5ba63ef70d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047a6fb7-c766-11e1-8775-005056c00008" name="47-69" r="14.705855400000001" x="48.403869999999998" g1="0" b1="0.00020351240000000001" g2="0" b2="0.00020351240000000001" node1="31" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="57" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-119.44160198800651" q1="48.476324315821209" p2="133.51231154365914" q2="-9.5730885565258212">
+    <iidm:line id="_047a6fb7-c766-11e1-8775-005056c00008" name="47-69" r="14.705855400000001" x="48.403869999999998" g1="0" b1="0.00020351240000000001" g2="0" b2="0.00020351240000000001" node1="31" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="57" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-119.24132114958894" q1="48.334109364634664" p2="133.2591052565275" q2="-9.6053528000274326">
         <iidm:alias>_04758db9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0485ba56-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9603,7 +9726,7 @@
             <iidm:temporaryLimit name="_e9fec217-cf6f-4d39-9495-26ed10c05100" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0453fbf0-c766-11e1-8775-005056c00008" name="110-111" r="3.8332799999999998" x="13.1551189" g1="0" b1="5.7392100000000002e-05" g2="0" b2="5.7392100000000002e-05" node1="40" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_046a1c00-c766-11e1-8775-005056c00008" p1="-39.593491198113661" q1="-20.473646393086014" p2="40.063896518953939" q2="20.215472910366046">
+    <iidm:line id="_0453fbf0-c766-11e1-8775-005056c00008" name="110-111" r="3.8332799999999998" x="13.1551189" g1="0" b1="5.7392100000000002e-05" g2="0" b2="5.7392100000000002e-05" node1="40" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_046a1c00-c766-11e1-8775-005056c00008" p1="-39.586591148456904" q1="-20.476038993624872" p2="40.056887501102977" q2="20.217492156692586">
         <iidm:alias>_0447c6f5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04812675-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9611,7 +9734,7 @@
             <iidm:temporaryLimit name="_ea48fee0-31b6-4990-a332-25d08b7d731f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04778984-c766-11e1-8775-005056c00008" name="41-42" r="7.14384" x="23.522401800000001" g1="0" b1="9.8714400000000005e-05" g2="0" b2="9.8714400000000005e-05" node1="21" voltageLevelId1="_048c4a08-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="2.7239409259375282" q1="-17.359257546888966" p2="-2.5858813896680752" q2="15.047250626017087">
+    <iidm:line id="_04778984-c766-11e1-8775-005056c00008" name="41-42" r="7.14384" x="23.522401800000001" g1="0" b1="9.8714400000000005e-05" g2="0" b2="9.8714400000000005e-05" node1="21" voltageLevelId1="_048c4a08-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="2.9012249315247325" q1="-17.482528793864425" p2="-2.7604115867885461" q2="15.181840173240172">
         <iidm:alias>_044d1e2a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046512f1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9619,7 +9742,7 @@
             <iidm:temporaryLimit name="_063af52c-fe10-4c1e-85d4-dd80dcc1d2f9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04653a08-c766-11e1-8775-005056c00008" name="80-99" r="7.9104960000000002" x="35.893439999999998" g1="0" b1="0.00015668044999999999" g2="0" b2="0.00015668044999999999" node1="78" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04644fa4-c766-11e1-8775-005056c00008" p1="1.3587836662422044" q1="6.8289509771697201" p2="-1.3178462982504109" q2="-12.436442963022079">
+    <iidm:line id="_04653a08-c766-11e1-8775-005056c00008" name="80-99" r="7.9104960000000002" x="35.893439999999998" g1="0" b1="0.00015668044999999999" g2="0" b2="0.00015668044999999999" node1="78" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04644fa4-c766-11e1-8775-005056c00008" p1="1.3664391986215416" q1="6.8271788000147744" p2="-1.3255076233696694" q2="-12.434697397695858">
         <iidm:alias>_04773b69-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0477b092-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9627,7 +9750,7 @@
             <iidm:temporaryLimit name="_c05229ce-6abb-4209-ad4f-0dcd4a070f28" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04581aa5-c766-11e1-8775-005056c00008" name="54-59" r="8.7642720000000001" x="39.953229999999998" g1="0" b1="0.0001716024" g2="0" b2="0.0001716024" node1="58" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-29.559172914083838" q1="-7.7490896401511566" p2="30.054970903002378" q2="4.3813301131047133">
+    <iidm:line id="_04581aa5-c766-11e1-8775-005056c00008" name="54-59" r="8.7642720000000001" x="39.953229999999998" g1="0" b1="0.0001716024" g2="0" b2="0.0001716024" node1="58" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-29.537513116621305" q1="-7.7554402049390152" p2="30.032640258656052" q2="4.384621604653602">
         <iidm:alias>_0457cc82-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045cae81-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9635,7 +9758,7 @@
             <iidm:temporaryLimit name="_ac528cbe-6fc1-41dd-ba9d-d8b7a4c77576" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04690a93-c766-11e1-8775-005056c00008" name="92-94" r="8.3809430000000003" x="27.529920000000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="67" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="65.754721788418323" q1="-16.493806734241794" p2="-63.526584223439407" q2="19.84858998304906">
+    <iidm:line id="_04690a93-c766-11e1-8775-005056c00008" name="92-94" r="8.3809430000000003" x="27.529920000000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="67" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="65.812154807189799" q1="-16.431085182136052" p2="-63.58096226418224" q2="19.79679316196582">
         <iidm:alias>_044c33c1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0483706b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9643,7 +9766,7 @@
             <iidm:temporaryLimit name="_6ac84228-6b04-4b10-b560-29655c8e93b4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046009e3-c766-11e1-8775-005056c00008" name="37-39" r="5.5931040000000003" x="18.469439999999999" g1="0" b1="7.7479350000000006e-05" g2="0" b2="7.7479350000000006e-05" node1="57" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046bf0c7-c766-11e1-8775-005056c00008" p1="81.428954143604571" q1="16.150990532499918" p2="-78.914156933879553" q2="-10.12831852113627">
+    <iidm:line id="_046009e3-c766-11e1-8775-005056c00008" name="37-39" r="5.5931040000000003" x="18.469439999999999" g1="0" b1="7.7479350000000006e-05" g2="0" b2="7.7479350000000006e-05" node1="57" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046bf0c7-c766-11e1-8775-005056c00008" p1="81.632726545407749" q1="16.108185659853415" p2="-79.103888421173139" q2="-10.036771332664751">
         <iidm:alias>_044c33c9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04789afa-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9651,7 +9774,7 @@
             <iidm:temporaryLimit name="_2ccdc288-c132-40d1-a928-3887bec4ff67" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0458b6e8-c766-11e1-8775-005056c00008" name="46-47" r="6.6211200000000003" x="22.12848" g1="0" b1="9.0679499999999998e-05" g2="0" b2="9.0679499999999998e-05" node1="33" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_0457f396-c766-11e1-8775-005056c00008" p1="-34.992972769088674" q1="6.4312174702918101" p2="35.477909140529654" q2="-8.0155360428742224">
+    <iidm:line id="_0458b6e8-c766-11e1-8775-005056c00008" name="46-47" r="6.6211200000000003" x="22.12848" g1="0" b1="9.0679499999999998e-05" g2="0" b2="9.0679499999999998e-05" node1="33" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_0457f396-c766-11e1-8775-005056c00008" p1="-34.897340109387763" q1="6.3666699783521619" p2="35.379373450113548" q2="-7.9608144355175909">
         <iidm:alias>_04507980-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0464c4da-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9659,7 +9782,7 @@
             <iidm:temporaryLimit name="_06ca3245-2668-448f-a5c6-961924217a5c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044f8f22-c766-11e1-8775-005056c00008" name="82-83" r="1.9514879999999999" x="6.3858959999999998" g1="0" b1="0.0001089302" g2="0" b2="0.0001089302" node1="31" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728074-c766-11e1-8775-005056c00008" p1="-68.203794662007482" q1="38.816335095794194" p2="68.936511305787704" q2="-40.050638923067957">
+    <iidm:line id="_044f8f22-c766-11e1-8775-005056c00008" name="82-83" r="1.9514879999999999" x="6.3858959999999998" g1="0" b1="0.0001089302" g2="0" b2="0.0001089302" node1="31" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728074-c766-11e1-8775-005056c00008" p1="-67.808274020319331" q1="40.149155162216914" p2="68.548701102018171" q2="-41.350339722681881">
         <iidm:alias>_047a48a6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b3891-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9667,7 +9790,7 @@
             <iidm:temporaryLimit name="_dfbd2f07-76ab-41e3-910f-dc706979ea4b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045cfca6-c766-11e1-8775-005056c00008" name="108-109" r="1.82952" x="5.0181120000000004" g1="0" b1="2.1809000000000001e-05" g2="0" b2="2.1809000000000001e-05" node1="21" voltageLevelId1="_046c65f4-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b7b99-c766-11e1-8775-005056c00008" p1="20.686198386105893" q1="-0.49626036417949815" p2="-20.637367158438767" q2="-0.067540610799372153">
+    <iidm:line id="_045cfca6-c766-11e1-8775-005056c00008" name="108-109" r="1.82952" x="5.0181120000000004" g1="0" b1="2.1809000000000001e-05" g2="0" b2="2.1809000000000001e-05" node1="21" voltageLevelId1="_046c65f4-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b7b99-c766-11e1-8775-005056c00008" p1="20.68960758956165" q1="-0.49746984396431393" p2="-20.640760197662846" q2="-0.066286395780751267">
         <iidm:alias>_04481514-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04716f00-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9675,7 +9798,7 @@
             <iidm:temporaryLimit name="_11451cec-81c7-4f83-a7db-df7dcaffa94e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04784cd5-c766-11e1-8775-005056c00008" name="70-74" r="6.9870239999999999" x="23.051952400000001" g1="0" b1="9.6648299999999994e-05" g2="0" b2="9.6648299999999994e-05" node1="48" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047dcb11-c766-11e1-8775-005056c00008" p1="21.723694010004802" q1="9.7579168573131643" p2="-21.474435933131421" q2="-12.11715044937843">
+    <iidm:line id="_04784cd5-c766-11e1-8775-005056c00008" name="70-74" r="6.9870239999999999" x="23.051952400000001" g1="0" b1="9.6648299999999994e-05" g2="0" b2="9.6648299999999994e-05" node1="48" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047dcb11-c766-11e1-8775-005056c00008" p1="21.450960719479273" q1="9.9111327480014904" p2="-21.205181663017115" q2="-12.282290834222072">
         <iidm:alias>_045e5c33-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046ab84b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9683,7 +9806,7 @@
             <iidm:temporaryLimit name="_37a5cc00-bd7f-4ec7-a77c-e140e23450d2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04747c40-c766-11e1-8775-005056c00008" name="77-82" r="5.1923519999999996" x="14.8626719" g1="0" b1="0.0002345615" g2="0" b2="0.0002345615" node1="69" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_046512f8-c766-11e1-8775-005056c00008" p1="-30.963746203651553" q1="31.943154834538788" p2="31.633526779611422" q2="-38.070622559477265">
+    <iidm:line id="_04747c40-c766-11e1-8775-005056c00008" name="77-82" r="5.1923519999999996" x="14.8626719" g1="0" b1="0.0002345615" g2="0" b2="0.0002345615" node1="69" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_046512f8-c766-11e1-8775-005056c00008" p1="-30.755614305096522" q1="32.630194691143934" p2="31.436585770408271" q2="-38.718112119932655">
         <iidm:alias>_0451b202-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0452ea84-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9691,7 +9814,7 @@
             <iidm:temporaryLimit name="_e9798d58-b518-4fab-984c-c72076dfc2ae" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045e3524-c766-11e1-8775-005056c00008" name="23-24" r="2.3522400000000001" x="8.5726080000000007" g1="0" b1="0.00014290635" g2="0" b2="0.00014290635" node1="39" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_048c22fa-c766-11e1-8775-005056c00008" p1="52.016386136280076" q1="-10.098184918625138" p2="-51.643184845810183" q2="6.4943689311401904">
+    <iidm:line id="_045e3524-c766-11e1-8775-005056c00008" name="23-24" r="2.3522400000000001" x="8.5726080000000007" g1="0" b1="0.00014290635" g2="0" b2="0.00014290635" node1="39" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_048c22fa-c766-11e1-8775-005056c00008" p1="50.578714033654478" q1="-9.6954232791760706" p2="-50.226995571125798" q2="6.002858207085068">
         <iidm:alias>_046cb413-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f9fd3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9699,7 +9822,7 @@
             <iidm:temporaryLimit name="_e8ec73b8-1ecf-4d18-9ef9-80eabf3a4969" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0474f177-c766-11e1-8775-005056c00008" name="15-17" r="2.2999679999999998" x="7.6142880000000002" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="48" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-154.05355491923461" q1="-20.059021615394389" p2="157.60231225511419" q2="27.696389008560594">
+    <iidm:line id="_0474f177-c766-11e1-8775-005056c00008" name="15-17" r="2.2999679999999998" x="7.6142880000000002" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="48" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-163.18840795947679" q1="-16.574024058520028" p2="167.15087244142279" q2="25.584011852823867">
         <iidm:alias>_044c5ad2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046931a7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9707,7 +9830,7 @@
             <iidm:temporaryLimit name="_2ceac3d1-f73d-43db-8d37-9e329f1787bb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0483be84-c766-11e1-8775-005056c00008" name="8-30" r="2.0860400000000001" x="24.393599999999999" g1="0" b1="0.00053099175999999997" g2="0" b2="0.00053099175999999997" node1="30" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="38" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="88.415192103855532" q1="27.660478523760005" p2="-87.958207926854456" q2="-72.606698191512777">
+    <iidm:line id="_0483be84-c766-11e1-8775-005056c00008" name="8-30" r="2.0860400000000001" x="24.393599999999999" g1="0" b1="0.00053099175999999997" g2="0" b2="0.00053099175999999997" node1="30" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="38" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="104.59713815126412" q1="22.138383080796277" p2="-104.03247642934875" q2="-66.16058379164285">
         <iidm:alias>_0454e651-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04801506-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9715,7 +9838,7 @@
             <iidm:temporaryLimit name="_ca795ad3-97e5-4416-aaba-53cce27f6434" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0488eea6-c766-11e1-8775-005056c00008" name="49-69" r="17.16264" x="56.453762099999999" g1="0" b1="0.00023760329999999999" g2="0" b2="0.00023760329999999999" node1="115" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-111.74282104298649" q1="53.019262314694217" p2="126.53494726100516" q2="-13.147385644198762">
+    <iidm:line id="_0488eea6-c766-11e1-8775-005056c00008" name="49-69" r="17.16264" x="56.453762099999999" g1="0" b1="0.00023760329999999999" g2="0" b2="0.00023760329999999999" node1="115" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-111.55412890963599" q1="52.860270425910727" p2="126.28967023134396" q2="-13.17452162231991">
         <iidm:alias>_04492681-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046735d6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9723,7 +9846,7 @@
             <iidm:temporaryLimit name="_c42dc3ef-3a2e-4070-8efb-78e5c0cd5554" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047566a0-c766-11e1-8775-005056c00008" name="13-15" r="12.9634562" x="42.584255200000001" g1="0" b1="0.00017986685000000001" g2="0" b2="0.00017986685000000001" node1="21" voltageLevelId1="_04851e1b-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="15.868598851248558" q1="-0.62978915725885665" p2="-15.66251973519965" q2="-4.4057527945130452">
+    <iidm:line id="_047566a0-c766-11e1-8775-005056c00008" name="13-15" r="12.9634562" x="42.584255200000001" g1="0" b1="0.00017986685000000001" g2="0" b2="0.00017986685000000001" node1="21" voltageLevelId1="_04851e1b-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="11.702195173363354" q1="0.79751010219062302" p2="-11.581473431813519" q2="-6.113972335632992">
         <iidm:alias>_04662461-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04865694-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9731,7 +9854,7 @@
             <iidm:temporaryLimit name="_ad988fd9-9270-4230-95a2-1858f32259df" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0476c63a-c766-11e1-8775-005056c00008" name="69-70" r="5.2271999999999998" x="22.12848" g1="0" b1="0.00035009184999999998" g2="0" b2="0.00035009184999999998" node1="59" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="75.897689189281508" q1="20.296069461550253" p2="-74.082849984904442" q2="-25.051538253838544">
+    <iidm:line id="_0476c63a-c766-11e1-8775-005056c00008" name="69-70" r="5.2271999999999998" x="22.12848" g1="0" b1="0.00035009184999999998" g2="0" b2="0.00035009184999999998" node1="59" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="76.712263500802919" q1="20.08189026275895" p2="-74.865816082564535" q2="-24.704982345956022">
         <iidm:alias>_047e193a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b1184-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9739,7 +9862,7 @@
             <iidm:temporaryLimit name="_519e3ecb-3561-4d11-ac6b-172a0b4b09b2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04520028-c766-11e1-8775-005056c00008" name="19-20" r="4.3908480000000001" x="20.38608" g1="0" b1="8.5514249999999999e-05" g2="0" b2="8.5514249999999999e-05" node1="39" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b2d70-c766-11e1-8775-005056c00008" p1="-15.916500248777835" q1="2.0822231799779476" p2="15.992535988189507" q2="-4.3455175986001953">
+    <iidm:line id="_04520028-c766-11e1-8775-005056c00008" name="19-20" r="4.3908480000000001" x="20.38608" g1="0" b1="8.5514249999999999e-05" g2="0" b2="8.5514249999999999e-05" node1="39" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b2d70-c766-11e1-8775-005056c00008" p1="-13.939440473696191" q1="1.0161685353914252" p2="13.996817563072323" q2="-3.3663932423000538">
         <iidm:alias>_0472f5a9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04745537-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9747,7 +9870,7 @@
             <iidm:temporaryLimit name="_b88528bf-cb1c-4c00-ad79-d5937197d40c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04862f83-c766-11e1-8775-005056c00008" name="94-95" r="2.2999679999999998" x="7.5620159999999998" g1="0" b1="3.1852600000000001e-05" g2="0" b2="3.1852600000000001e-05" node1="51" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f4108-c766-11e1-8775-005056c00008" p1="58.09784523913212" q1="6.1199371255340056" p2="-57.634405698581389" q2="-5.6660550071660847">
+    <iidm:line id="_04862f83-c766-11e1-8775-005056c00008" name="94-95" r="2.2999679999999998" x="7.5620159999999998" g1="0" b1="3.1852600000000001e-05" g2="0" b2="3.1852600000000001e-05" node1="51" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f4108-c766-11e1-8775-005056c00008" p1="58.157127453085344" q1="6.299364831066165" p2="-57.69226522806926" q2="-5.8403373733976149">
         <iidm:alias>_044ca8f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04837060-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9755,7 +9878,7 @@
             <iidm:temporaryLimit name="_b70e76a1-6e79-4fb6-b487-dffa9bfeab7b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047b0bf6-c766-11e1-8775-005056c00008" name="12-16" r="3.6938879999999998" x="14.5316162" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="68" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046f7338-c766-11e1-8775-005056c00008" p1="16.752225890513778" q1="8.3504162984235624" p2="-16.672413759853693" q2="-10.109775799172855">
+    <iidm:line id="_047b0bf6-c766-11e1-8775-005056c00008" name="12-16" r="3.6938879999999998" x="14.5316162" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="68" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046f7338-c766-11e1-8775-005056c00008" p1="10.087245251039571" q1="10.168922910883312" p2="-10.038017014062653" q2="-12.048261965023851">
         <iidm:alias>_0450798a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045c8772-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9763,7 +9886,7 @@
             <iidm:temporaryLimit name="_af73f526-c58b-40e7-8e1c-14f05a39f6a2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04524e47-c766-11e1-8775-005056c00008" name="100-103" r="2.7878400000000001" x="9.1476000000000006" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="78" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0475b4c0-c766-11e1-8775-005056c00008" p1="115.05821638211826" q1="-20.564244234607003" p2="-112.96132296458372" q2="21.938912695776981">
+    <iidm:line id="_04524e47-c766-11e1-8775-005056c00008" name="100-103" r="2.7878400000000001" x="9.1476000000000006" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="78" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0475b4c0-c766-11e1-8775-005056c00008" p1="115.06937330070895" q1="-20.566902056278337" p2="-112.97206773591996" q2="21.942923755290799">
         <iidm:alias>_04684744-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048aea71-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9771,7 +9894,7 @@
             <iidm:temporaryLimit name="_1631e50b-21a3-470b-803b-f9665b6fcd60" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04682038-c766-11e1-8775-005056c00008" name="27-32" r="3.9900959999999999" x="13.1551189" g1="0" b1="5.5268600000000001e-05" g2="0" b2="5.5268600000000001e-05" node1="40" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="18.163832962017455" q1="-3.4122523965771081" p2="-18.081520660851687" q2="1.8861423570615388">
+    <iidm:line id="_04682038-c766-11e1-8775-005056c00008" name="27-32" r="3.9900959999999999" x="13.1551189" g1="0" b1="5.5268600000000001e-05" g2="0" b2="5.5268600000000001e-05" node1="40" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="16.198078716297029" q1="-2.1980548357383678" p2="-16.133635648292742" q2="0.60840870386445656">
         <iidm:alias>_0455347a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479ac63-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9779,7 +9902,7 @@
             <iidm:temporaryLimit name="_52eb4b09-42bb-4106-ac26-fe1059639d3a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0482fb31-c766-11e1-8775-005056c00008" name="59-61" r="5.7150720000000002" x="26.1360016" g1="0" b1="0.0001113407" g2="0" b2="0.0001113407" node1="68" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-121.14519197293652" q1="30.758517047173463" p2="126.46688231467257" q2="-10.224402756253065">
+    <iidm:line id="_0482fb31-c766-11e1-8775-005056c00008" name="59-61" r="5.7150720000000002" x="26.1360016" g1="0" b1="0.0001113407" g2="0" b2="0.0001113407" node1="68" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-121.11703379495984" q1="30.746186313849083" p2="126.4361450975761" q2="-10.223866936002421">
         <iidm:alias>_044a10e9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0473b8f5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9787,7 +9910,7 @@
             <iidm:temporaryLimit name="_b5a7dea0-bfce-4548-a04d-7bb7b6d9f80a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047d55e3-c766-11e1-8775-005056c00008" name="100-104" r="7.8582239999999999" x="35.544960000000003" g1="0" b1="0.00015524565000000001" g2="0" b2="0.00015524565000000001" node1="79" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="54.929980050547911" q1="10.98679640320003" p2="-53.531434990696248" q2="-10.006745388908746">
+    <iidm:line id="_047d55e3-c766-11e1-8775-005056c00008" name="100-104" r="7.8582239999999999" x="35.544960000000003" g1="0" b1="0.00015524565000000001" g2="0" b2="0.00015524565000000001" node1="79" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="54.932382296111328" q1="10.986586107100546" p2="-53.533724469465163" q2="-10.006023554166235">
         <iidm:alias>_04636547-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048aea76-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9795,7 +9918,7 @@
             <iidm:temporaryLimit name="_17a10cd0-b653-4dcf-bdc3-4d5005ea9591" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04653a02-c766-11e1-8775-005056c00008" name="75-77" r="10.4718237" x="34.830577900000002" g1="0" b1="0.00014284895" g2="0" b2="0.00014284895" node1="49" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-40.11178188090723" q1="-5.5753724521163335" p2="41.151586010345738" q2="4.2031481380990403">
+    <iidm:line id="_04653a02-c766-11e1-8775-005056c00008" name="75-77" r="10.4718237" x="34.830577900000002" g1="0" b1="0.00014284895" g2="0" b2="0.00014284895" node1="49" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-40.263020332609457" q1="-5.4527822209404473" p2="41.310165307217446" q2="4.1057736239133922">
         <iidm:alias>_04642894-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04720b47-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9803,7 +9926,7 @@
             <iidm:temporaryLimit name="_6f81df11-7e71-4b6e-a6ee-a8c5f72f4ba5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04483c2a-c766-11e1-8775-005056c00008" name="23-32" r="5.5234079999999999" x="20.089872400000001" g1="0" b1="0.00033660465000000001" g2="0" b2="0.00033660465000000001" node1="40" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="85.478231728393993" q1="4.974982119468538" p2="-83.124098877981012" q2="-7.7367046955072727">
+    <iidm:line id="_04483c2a-c766-11e1-8775-005056c00008" name="23-32" r="5.5234079999999999" x="20.089872400000001" g1="0" b1="0.00033660465000000001" g2="0" b2="0.00033660465000000001" node1="40" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="81.771685908756581" q1="5.6936493329135534" p2="-79.613525032494053" q2="-9.191825180612998">
         <iidm:alias>_044b978a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0461dea6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9811,7 +9934,7 @@
             <iidm:temporaryLimit name="_a8f6a7d2-e58d-4671-a776-97be7291355e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048719e5-c766-11e1-8775-005056c00008" name="96-97" r="3.0143520000000001" x="15.42024" g1="0" b1="6.8870549999999994e-05" g2="0" b2="6.8870549999999994e-05" node1="50" voltageLevelId1="_045a1672-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="3.2165911210373843" q1="-25.420283619540189" p2="-3.1104711551685966" q2="23.571138770737988">
+    <iidm:line id="_048719e5-c766-11e1-8775-005056c00008" name="96-97" r="3.0143520000000001" x="15.42024" g1="0" b1="6.8870549999999994e-05" g2="0" b2="6.8870549999999994e-05" node1="50" voltageLevelId1="_045a1672-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="3.1771561894483602" q1="-25.59900264816169" p2="-3.0694513621915624" q2="23.75928216661876">
         <iidm:alias>_0451b207-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04828601-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9819,7 +9942,7 @@
             <iidm:temporaryLimit name="_ea6d39aa-df95-4d3e-b7b6-a800e552e72a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048481d0-c766-11e1-8775-005056c00008" name="25-27" r="5.5408330000000001" x="28.401121100000001" g1="0" b1="0.000506198385" g2="0" b2="0.000506198385" node1="30" voltageLevelId1="_04728079-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0476c639-c766-11e1-8775-005056c00008" p1="155.37509279281204" q1="31.011476271246956" p2="-147.93322731863472" q2="-10.840589277384339">
+    <iidm:line id="_048481d0-c766-11e1-8775-005056c00008" name="25-27" r="5.5408330000000001" x="28.401121100000001" g1="0" b1="0.000506198385" g2="0" b2="0.000506198385" node1="30" voltageLevelId1="_04728079-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0476c639-c766-11e1-8775-005056c00008" p1="149.94111766190696" q1="29.838798879697713" p2="-143.00494922240804" q2="-12.28552025882686">
         <iidm:alias>_046d2947-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04725960-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9827,7 +9950,7 @@
             <iidm:temporaryLimit name="_d9d53af2-5ffa-4f2a-a4e6-ed22371332d6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04885268-c766-11e1-8775-005056c00008" name="110-112" r="4.3037280000000004" x="11.1513615" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="41" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="13" voltageLevelId2="_04784cd1-c766-11e1-8775-005056c00008" p1="69.354537048383975" q1="11.007355988893968" p2="-68.000152232529402" q2="-13.000047416605511">
+    <iidm:line id="_04885268-c766-11e1-8775-005056c00008" name="110-112" r="4.3037280000000004" x="11.1513615" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="41" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="13" voltageLevelId2="_04784cd1-c766-11e1-8775-005056c00008" p1="69.354525679598353" q1="11.007356704845941" p2="-68.00014064525611" q2="-13.000044872267685">
         <iidm:alias>_04611b55-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0481c2ba-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9835,7 +9958,7 @@
             <iidm:temporaryLimit name="_d50299b9-a055-408a-aa1e-2e93a715120f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0484a8e4-c766-11e1-8775-005056c00008" name="89-92" r="1.7249760000000001" x="8.7991200000000003" g1="0" b1="0.00015725434999999999" g2="0" b2="0.00015725434999999999" node1="57" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="68" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="229.45995888780439" q1="-3.1731922035816984" p2="-224.29914548531781" q2="24.049153190800244">
+    <iidm:line id="_0484a8e4-c766-11e1-8775-005056c00008" name="89-92" r="1.7249760000000001" x="8.7991200000000003" g1="0" b1="0.00015725434999999999" g2="0" b2="0.00015725434999999999" node1="57" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="68" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="229.59024762375986" q1="-3.0830369926358236" p2="-224.42357721292495" q2="23.989153018185881">
         <iidm:alias>_04481517-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04808a3c-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9843,7 +9966,7 @@
             <iidm:temporaryLimit name="_eee9ca2b-764f-4ab8-a745-405338044743" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04689568-c766-11e1-8775-005056c00008" name="49-54" r="15.1414566" x="50.703842199999997" g1="0" b1="0.00020948120000000001" g2="0" b2="0.00020948120000000001" node1="116" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="37.04285444302463" q1="11.334585500333919" p2="-35.717563575579753" q2="-14.06028850321418">
+    <iidm:line id="_04689568-c766-11e1-8775-005056c00008" name="49-54" r="15.1414566" x="50.703842199999997" g1="0" b1="0.00020948120000000001" g2="0" b2="0.00020948120000000001" node1="116" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="37.065813171098242" q1="11.330101370941406" p2="-35.739227776941462" q2="-14.051470864929843">
         <iidm:alias>_046030f0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04605808-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9851,7 +9974,7 @@
             <iidm:temporaryLimit name="_690202a4-aad2-4ad3-8842-961b39e37709" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046c8d04-c766-11e1-8775-005056c00008" name="40-41" r="2.5264799999999998" x="8.4854880000000001" g1="0" b1="3.5066600000000001e-05" g2="0" b2="3.5066600000000001e-05" node1="40" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048c4a08-c766-11e1-8775-005056c00008" p1="39.861461297701275" q1="-7.3810786446662373" p2="-39.560210299593138" q2="7.4329119558664729">
+    <iidm:line id="_046c8d04-c766-11e1-8775-005056c00008" name="40-41" r="2.5264799999999998" x="8.4854880000000001" g1="0" b1="3.5066600000000001e-05" g2="0" b2="3.5066600000000001e-05" node1="40" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048c4a08-c766-11e1-8775-005056c00008" p1="40.041223391413482" q1="-7.4928388660198424" p2="-39.736724129896444" q2="7.5565447925732911">
         <iidm:alias>_045cae80-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a2194-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9859,7 +9982,7 @@
             <iidm:temporaryLimit name="_34f2ef7c-32da-4444-b989-d02f5f931c50" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046735d5-c766-11e1-8775-005056c00008" name="39-40" r="3.206016" x="10.54152" g1="0" b1="4.4536249999999999e-05" g2="0" b2="4.4536249999999999e-05" node1="22" voltageLevelId1="_046bf0c7-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="52.04971567575145" q1="-0.77978442715842111" p2="-51.430726583164798" q2="1.5788460006396956">
+    <iidm:line id="_046735d5-c766-11e1-8775-005056c00008" name="39-40" r="3.206016" x="10.54152" g1="0" b1="4.4536249999999999e-05" g2="0" b2="4.4536249999999999e-05" node1="22" voltageLevelId1="_046bf0c7-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="52.239770233430185" q1="-0.87109832172643509" p2="-51.615568103987862" q2="1.6886133326352359">
         <iidm:alias>_045115c1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048badc2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9867,7 +9990,7 @@
             <iidm:temporaryLimit name="_38d58455-5205-46bb-8e44-c66873f62938" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0470d2c4-c766-11e1-8775-005056c00008" name="89-92" r="6.8476319999999999" x="27.5473423" g1="0" b1="0.00011880164999999999" g2="0" b2="0.00011880164999999999" node1="58" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="72.385774600780934" q1="-5.8453151697210162" p2="-70.341526377441042" q2="9.9522394770430687">
+    <iidm:line id="_0470d2c4-c766-11e1-8775-005056c00008" name="89-92" r="6.8476319999999999" x="27.5473423" g1="0" b1="0.00011880164999999999" g2="0" b2="0.00011880164999999999" node1="58" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="72.428304190503951" q1="-5.8189310900964077" p2="-70.381735949373066" q2="9.935398906860696">
         <iidm:alias>_04690a97-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04690a98-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9875,7 +9998,7 @@
             <iidm:temporaryLimit name="_0cce41c7-b99f-4fec-93d2-73ea24433fa1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0479ac60-c766-11e1-8775-005056c00008" name="33-37" r="7.2309599999999996" x="24.742080000000001" g1="0" b1="0.00010502754999999999" g2="0" b2="0.00010502754999999999" node1="21" voltageLevelId1="_0456bb11-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="42.402256075969596" q1="-19.020696902007156" p2="-41.393920509745975" q2="19.268590187591268">
+    <iidm:line id="_0479ac60-c766-11e1-8775-005056c00008" name="33-37" r="7.2309599999999996" x="24.742080000000001" g1="0" b1="0.00010502754999999999" g2="0" b2="0.00010502754999999999" node1="21" voltageLevelId1="_0456bb11-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="43.397844201822359" q1="-19.285832250111394" p2="-42.342727953815675" q2="19.697372992381162">
         <iidm:alias>_04716f08-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0483be89-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9883,7 +10006,7 @@
             <iidm:temporaryLimit name="_343677c6-7477-4bf6-a12c-2c7e4a684d6f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048c4a00-c766-11e1-8775-005056c00008" name="105-108" r="4.5476640000000002" x="12.249072099999999" g1="0" b1="5.2915499999999998e-05" g2="0" b2="5.2915499999999998e-05" node1="50" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_046c65f4-c766-11e1-8775-005056c00008" p1="22.832216254611566" q1="-0.81055463145515982" p2="-22.686203912630912" q2="-0.50374413926995643">
+    <iidm:line id="_048c4a00-c766-11e1-8775-005056c00008" name="105-108" r="4.5476640000000002" x="12.249072099999999" g1="0" b1="5.2915499999999998e-05" g2="0" b2="5.2915499999999998e-05" node1="50" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_046c65f4-c766-11e1-8775-005056c00008" p1="22.835669314347548" q1="-0.81164445071165847" p2="-22.689612779279724" q2="-0.50253448354729502">
         <iidm:alias>_046adf53-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04795e46-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9891,7 +10014,7 @@
             <iidm:temporaryLimit name="_74cf84b9-e14f-4f81-9e8b-3a791cd474a0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04631724-c766-11e1-8775-005056c00008" name="34-37" r="0.44605400000000001" x="1.637856" g1="0" b1="2.8236900000000001e-05" g2="0" b2="2.8236900000000001e-05" node1="41" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-67.602835509537442" q1="-31.203021990268613" p2="67.764163287835274" q2="30.929360755872509">
+    <iidm:line id="_04631724-c766-11e1-8775-005056c00008" name="34-37" r="0.44605400000000001" x="1.637856" g1="0" b1="2.8236900000000001e-05" g2="0" b2="2.8236900000000001e-05" node1="41" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-66.855143092174984" q1="-31.566345600517359" p2="67.014356548422498" q2="31.285809358989823">
         <iidm:alias>_04592c19-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04719611-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9899,7 +10022,7 @@
             <iidm:temporaryLimit name="_8e90bf2e-3be4-41be-a84e-c1d4e709f8a1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04814d85-c766-11e1-8775-005056c00008" name="61-62" r="1.435738" x="6.5514239999999999" g1="0" b1="2.812215e-05" g2="0" b2="2.812215e-05" node1="40" voltageLevelId1="_0448d867-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="137.51184089260954" q1="-7.4956669687136515" p2="-135.93390746200876" q2="13.732849371895991">
+    <iidm:line id="_04814d85-c766-11e1-8775-005056c00008" name="61-62" r="1.435738" x="6.5514239999999999" g1="0" b1="2.812215e-05" g2="0" b2="2.812215e-05" node1="40" voltageLevelId1="_0448d867-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="137.44575765509316" q1="-7.4957398625926679" p2="-135.86933664205023" q2="13.726016790117987">
         <iidm:alias>_045a3d85-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047abdd8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9907,7 +10030,7 @@
             <iidm:temporaryLimit name="_39a23399-348e-44d9-8032-8fc62e6c7d63" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046a4318-c766-11e1-8775-005056c00008" name="101-102" r="4.2863040000000003" x="19.5148811" g1="0" b1="8.4366399999999999e-05" g2="0" b2="8.4366399999999999e-05" node1="22" voltageLevelId1="_046ed6f7-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="-44.255491207600848" q1="11.674319048344174" p2="44.789528531912289" q2="-12.121393396810088">
+    <iidm:line id="_046a4318-c766-11e1-8775-005056c00008" name="101-102" r="4.2863040000000003" x="19.5148811" g1="0" b1="8.4366399999999999e-05" g2="0" b2="8.4366399999999999e-05" node1="22" voltageLevelId1="_046ed6f7-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="-44.290697426782877" q1="11.700481794082286" p2="44.825716120321012" q2="-12.142882807292802">
         <iidm:alias>_04878f1b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04885261-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9915,7 +10038,7 @@
             <iidm:temporaryLimit name="_0501dacc-29fc-44a2-8cad-31a20b011d25" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c81e3-c766-11e1-8775-005056c00008" name="26-30" r="3.8671600000000002" x="41.624000000000002" g1="0" b1="0.00093801650000000002" g2="0" b2="0.00093801650000000002" node1="21" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="227.82481664819207" q1="2.1699308633618686" p2="-223.61357354145005" q2="-46.697247085840523">
+    <iidm:line id="_044c81e3-c766-11e1-8775-005056c00008" name="26-30" r="3.8671600000000002" x="41.624000000000002" g1="0" b1="0.00093801650000000002" g2="0" b2="0.00093801650000000002" node1="21" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="240.91927024197562" q1="-1.7765934972628794" p2="-236.2607448195634" q2="-38.339176681377097">
         <iidm:alias>_0463654b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04747c4a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9923,7 +10046,7 @@
             <iidm:temporaryLimit name="_c95a66fd-913c-48c7-b8ef-cf3007c60af6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048915b9-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="41" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="117" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-40.247270017102764" q1="-25.259281092636442" p2="42.059500943380876" q2="25.380485482179395">
+    <iidm:line id="_048915b9-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="41" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="117" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-40.070433242926597" q1="-25.395466330080886" p2="41.876795373724448" q2="25.492531803141087">
         <iidm:alias>_044bbe98-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0456e224-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9931,7 +10054,7 @@
             <iidm:temporaryLimit name="_6cd83bc2-204f-44d5-afd4-fbfef8d2146f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c5ad6-c766-11e1-8775-005056c00008" name="105-106" r="2.4393600000000002" x="9.5309279999999994" g1="0" b1="4.1150150000000001e-05" g2="0" b2="4.1150150000000001e-05" node1="51" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="9.6855124717279395" q1="6.1212706911330672" p2="-9.6644934231685511" q2="-7.3681931645091012">
+    <iidm:line id="_044c5ad6-c766-11e1-8775-005056c00008" name="105-106" r="2.4393600000000002" x="9.5309279999999994" g1="0" b1="4.1150150000000001e-05" g2="0" b2="4.1150150000000001e-05" node1="51" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="9.6838893015745278" q1="6.1218543389610272" p2="-9.6628737783985112" q2="-7.3687899497157261">
         <iidm:alias>_04505270-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04531190-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9939,7 +10062,7 @@
             <iidm:temporaryLimit name="_487e1317-48f9-4747-b931-f3f79e95f55a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048badc5-c766-11e1-8775-005056c00008" name="60-61" r="0.45999400000000001" x="2.3522400000000001" g1="0" b1="4.1781450000000003e-05" g2="0" b2="4.1781450000000003e-05" node1="30" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-224.82800398118337" q1="13.356141698509546" p2="226.19367200155924" q2="-7.8075055253415915">
+    <iidm:line id="_048badc5-c766-11e1-8775-005056c00008" name="60-61" r="0.45999400000000001" x="2.3522400000000001" g1="0" b1="4.1781450000000003e-05" g2="0" b2="4.1781450000000003e-05" node1="30" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-224.77154444558155" q1="13.353026182685667" p2="226.13652312604233" q2="-7.8079171424215499">
         <iidm:alias>_04793734-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048a4e31-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9947,7 +10070,7 @@
             <iidm:temporaryLimit name="_3c55a929-a755-409b-af5f-bae188892af1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044cd003-c766-11e1-8775-005056c00008" name="23-25" r="2.7181440000000001" x="13.9391994" g1="0" b1="0.00024793390000000002" g2="0" b2="0.00024793390000000002" node1="41" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="-204.54472522633549" q1="-11.290556196408996" p2="211.08113875176215" q2="35.729157135550565">
+    <iidm:line id="_044cd003-c766-11e1-8775-005056c00008" name="23-25" r="2.7181440000000001" x="13.9391994" g1="0" b1="0.00024793390000000002" g2="0" b2="0.00024793390000000002" node1="41" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="-197.2475996429076" q1="-12.636839745218028" p2="203.31676620727026" q2="34.670114461381218">
         <iidm:alias>_045ed161-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0473b8f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9955,7 +10078,7 @@
             <iidm:temporaryLimit name="_9658628a-596f-41a9-96a7-c5a8aaf5400c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0457a574-c766-11e1-8775-005056c00008" name="19-34" r="13.102848099999999" x="43.037277199999998" g1="0" b1="0.00018135905000000001" g2="0" b2="0.00018135905000000001" node1="40" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0483be8b-c766-11e1-8775-005056c00008" p1="55.578199461032298" q1="-14.28958244207349" p2="-52.818013015838247" q2="17.815620104827197">
+    <iidm:line id="_0457a574-c766-11e1-8775-005056c00008" name="19-34" r="13.102848099999999" x="43.037277199999998" g1="0" b1="0.00018135905000000001" g2="0" b2="0.00018135905000000001" node1="40" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0483be8b-c766-11e1-8775-005056c00008" p1="56.780052576031217" q1="-14.374311508957049" p2="-53.900495889396971" q2="18.297213064198097">
         <iidm:alias>_04502b61-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04686e5b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9963,7 +10086,7 @@
             <iidm:temporaryLimit name="_b69ab61b-751d-487a-a538-2d47eea7572e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04595326-c766-11e1-8775-005056c00008" name="59-60" r="5.5234079999999999" x="25.264800000000001" g1="0" b1="0.00010789715" g2="0" b2="0.00010789715" node1="69" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_045cfca4-c766-11e1-8775-005056c00008" p1="-105.21351195776114" q1="26.779096117804741" p2="109.09766542534042" q2="-12.6807179706902">
+    <iidm:line id="_04595326-c766-11e1-8775-005056c00008" name="59-60" r="5.5234079999999999" x="25.264800000000001" g1="0" b1="0.00010789715" g2="0" b2="0.00010789715" node1="69" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_045cfca4-c766-11e1-8775-005056c00008" p1="-105.18925865470479" q1="26.768416222661617" p2="109.07154468703079" q2="-12.678585434531314">
         <iidm:alias>_04611b57-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0463b366-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9971,7 +10094,7 @@
             <iidm:temporaryLimit name="_a38d4859-b54a-482f-a2ad-0b4ce4c4da2a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045a8ba1-c766-11e1-8775-005056c00008" name="15-19" r="2.0908799999999998" x="6.865056" g1="0" b1="2.8983e-05" g2="0" b2="2.8983e-05" node1="50" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="34.370289982596113" q1="11.23385205219205" p2="-34.193573079124903" q2="-11.548795879761592">
+    <iidm:line id="_045a8ba1-c766-11e1-8775-005056c00008" name="15-19" r="2.0908799999999998" x="6.865056" g1="0" b1="2.8983e-05" g2="0" b2="2.8983e-05" node1="50" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="33.742049174414618" q1="11.302387862713628" p2="-33.570724642150218" q2="-11.634389402281586">
         <iidm:alias>_047629f1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0481e9c1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9979,7 +10102,7 @@
             <iidm:temporaryLimit name="_15d16bd2-d87c-4584-93d2-b294dc1be116" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04513cd6-c766-11e1-8775-005056c00008" name="90-91" r="4.4256960000000003" x="14.566463499999999" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="31" voltageLevelId1="_047d07c3-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044f8f29-c766-11e1-8775-005056c00008" p1="4.564526808344187" q1="-16.375170051184881" p2="-4.4931374321095214" q2="14.621943313508066">
+    <iidm:line id="_04513cd6-c766-11e1-8775-005056c00008" name="90-91" r="4.4256960000000003" x="14.566463499999999" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="31" voltageLevelId1="_047d07c3-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044f8f29-c766-11e1-8775-005056c00008" p1="4.5887948509368153" q1="-16.364927314512176" p2="-4.5174289692295213" q2="14.611711144458269">
         <iidm:alias>_045f94b9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04627ae1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9987,7 +10110,7 @@
             <iidm:temporaryLimit name="_7d2a67fb-9d8c-4745-a67e-ce6ade5e520e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0487b623-c766-11e1-8775-005056c00008" name="22-23" r="5.9590079999999999" x="27.704158799999998" g1="0" b1="0.00011593205" g2="0" b2="0.00011593205" node1="21" voltageLevelId1="_04773b6a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_047f9fdb-c766-11e1-8775-005056c00008" p1="-58.73637398605149" q1="-11.177495623063418" p2="60.051566317410142" q2="13.414801041118176">
+    <iidm:line id="_0487b623-c766-11e1-8775-005056c00008" name="22-23" r="5.9590079999999999" x="27.704158799999998" g1="0" b1="0.00011593205" g2="0" b2="0.00011593205" node1="21" voltageLevelId1="_04773b6a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_047f9fdb-c766-11e1-8775-005056c00008" p1="-56.670401743198596" q1="-11.815725668012206" p2="57.898540358406827" q2="13.639571238758979">
         <iidm:alias>_045e0e18-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0477b095-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9995,7 +10118,7 @@
             <iidm:temporaryLimit name="_6477d99a-dd64-4083-8f56-1396610879f0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048b1189-c766-11e1-8775-005056c00008" name="83-85" r="7.4923200000000003" x="25.787520000000001" g1="0" b1="9.9862250000000004e-05" g2="0" b2="9.9862250000000004e-05" node1="32" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-55.795337437897906" q1="18.726439877270245" p2="57.392394344897333" q2="-16.529529711594883">
+    <iidm:line id="_048b1189-c766-11e1-8775-005056c00008" name="83-85" r="7.4923200000000003" x="25.787520000000001" g1="0" b1="9.9862250000000004e-05" g2="0" b2="9.9862250000000004e-05" node1="32" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-55.619379491988582" q1="19.484785773948111" p2="57.226132197119341" q2="-17.241387180961169">
         <iidm:alias>_0455d0b1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0462c906-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10003,7 +10126,7 @@
             <iidm:temporaryLimit name="_38cb3e5b-af1a-4684-aa2f-242826ed460c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045868c5-c766-11e1-8775-005056c00008" name="17-31" r="8.2589760000000005" x="27.233711199999998" g1="0" b1="0.00011449725" g2="0" b2="0.00011449725" node1="60" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="11.827186734034122" q1="1.6407818260530349" p2="-11.751659415975906" q2="-5.1663975048082902">
+    <iidm:line id="_045868c5-c766-11e1-8775-005056c00008" name="17-31" r="8.2589760000000005" x="27.233711199999998" g1="0" b1="0.00011449725" g2="0" b2="0.00011449725" node1="60" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="16.191437553495568" q1="0.20772984970887479" p2="-16.059276634725812" q2="-3.5452704744337113">
         <iidm:alias>_04544a16-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0467f924-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10011,7 +10134,7 @@
             <iidm:temporaryLimit name="_9066b19a-f404-42c3-88ce-51d375f6fdb5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0488c796-c766-11e1-8775-005056c00008" name="89-90" r="9.0256319999999999" x="32.75712" g1="0" b1="0.00015151515000000001" g2="0" b2="0.00015151515000000001" node1="59" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="59.772026331224112" q1="9.2598025612836725" p2="-57.866792449936575" q2="-7.4330481517777383">
+    <iidm:line id="_0488c796-c766-11e1-8775-005056c00008" name="89-90" r="9.0256319999999999" x="32.75712" g1="0" b1="0.00015151515000000001" g2="0" b2="0.00015151515000000001" node1="59" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="59.781078378729354" q1="9.2654778416329524" p2="-57.875219657105646" q2="-7.4363856050139248">
         <iidm:alias>_0459ef61-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04837069-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10019,7 +10142,7 @@
             <iidm:temporaryLimit name="_924b4a0b-bef5-432a-ad87-ab5c10d9c019" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0462c907-c766-11e1-8775-005056c00008" name="70-75" r="7.4574720000000001" x="24.56784" g1="0" b1="0.0001033058" g2="0" b2="0.0001033058" node1="50" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="6.6881692137058666" q1="7.6039643348293078" p2="-6.6297601474593391" q2="-10.838548476298286">
+    <iidm:line id="_0462c907-c766-11e1-8775-005056c00008" name="70-75" r="7.4574720000000001" x="24.56784" g1="0" b1="0.0001033058" g2="0" b2="0.0001033058" node1="50" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="6.3497050511710356" q1="7.8006803621598548" p2="-6.2916147830484093" q2="-11.036677490063598">
         <iidm:alias>_04649dc9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04784cdb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10027,7 +10150,7 @@
             <iidm:temporaryLimit name="_d432d118-553c-4f4c-a734-e98e0762ec40" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045fbbc3-c766-11e1-8775-005056c00008" name="50-57" r="8.2589760000000005" x="23.34816" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="22" voltageLevelId1="_044d1e26-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="35.32654573686662" q1="9.3347190673090221" p2="-34.679095806782733" q2="-10.73172795250192">
+    <iidm:line id="_045fbbc3-c766-11e1-8775-005056c00008" name="50-57" r="8.2589760000000005" x="23.34816" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="22" voltageLevelId1="_044d1e26-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="35.347726970189051" q1="9.3282783766056152" p2="-34.699634312590184" q2="-10.723461154385417">
         <iidm:alias>_04500455-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0468e383-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10035,7 +10158,7 @@
             <iidm:temporaryLimit name="_2f32bda4-7275-4485-9901-12f8cff9e4a1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044b9789-c766-11e1-8775-005056c00008" name="5-6" r="2.0734560000000002" x="9.4089600000000004" g1="0" b1="4.0920549999999999e-05" g2="0" b2="4.0920549999999999e-05" node1="49" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f6818-c766-11e1-8775-005056c00008" p1="96.285966777003935" q1="17.19097400112128" p2="-95.163891800559881" q2="-13.521742220231998">
+    <iidm:line id="_044b9789-c766-11e1-8775-005056c00008" name="5-6" r="2.0734560000000002" x="9.4089600000000004" g1="0" b1="4.0920549999999999e-05" g2="0" b2="4.0920549999999999e-05" node1="49" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f6818-c766-11e1-8775-005056c00008" p1="91.969082850746702" q1="18.699790831811111" p2="-90.937433627682893" q2="-15.443048269024779">
         <iidm:alias>_044a5f01-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0455d0b2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10043,7 +10166,7 @@
             <iidm:temporaryLimit name="_b3b0e81b-a434-4e9c-ad94-1161ff47b077" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04720b41-c766-11e1-8775-005056c00008" name="55-59" r="8.2572340000000004" x="37.600994100000001" g1="0" b1="0.00016201790000000001" g2="0" b2="0.00016201790000000001" node1="30" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-33.744321460687587" q1="-8.7666988293384662" p2="34.360734853009177" q2="6.2796679514057292">
+    <iidm:line id="_04720b41-c766-11e1-8775-005056c00008" name="55-59" r="8.2572340000000004" x="37.600994100000001" g1="0" b1="0.00016201790000000001" g2="0" b2="0.00016201790000000001" node1="30" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-33.723299040296546" q1="-8.7730235371749323" p2="34.339010959477598" q2="6.2827979565852452">
         <iidm:alias>_04656113-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04675ce4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10051,7 +10174,7 @@
             <iidm:temporaryLimit name="_6db0d250-4a2e-4169-abf0-f842aeca485d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048963d9-c766-11e1-8775-005056c00008" name="1-2" r="5.2794720000000002" x="17.4065762" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="22" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_045d4ac5-c766-11e1-8775-005056c00008" p1="-10.38641525054704" q1="-10.983000295720535" p2="10.453589542014917" q2="8.8319780513859936">
+    <iidm:line id="_048963d9-c766-11e1-8775-005056c00008" name="1-2" r="5.2794720000000002" x="17.4065762" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="22" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_045d4ac5-c766-11e1-8775-005056c00008" p1="-11.336734527546957" q1="-10.464132314562884" p2="11.407379479116026" q2="8.3233414880169061">
         <iidm:alias>_044b9786-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04845acb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10059,7 +10182,7 @@
             <iidm:temporaryLimit name="_9f39cb45-314c-445e-b177-909854a9ce45" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0484f709-c766-11e1-8775-005056c00008" name="11-12" r="1.0367280000000001" x="3.4151039999999999" g1="0" b1="1.4405399999999999e-05" g2="0" b2="1.4405399999999999e-05" node1="40" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="39.946812868080457" q1="-30.444062544805018" p2="-39.793444842382989" q2="30.459070562837713">
+    <iidm:line id="_0484f709-c766-11e1-8775-005056c00008" name="11-12" r="1.0367280000000001" x="3.4151039999999999" g1="0" b1="1.4405399999999999e-05" g2="0" b2="1.4405399999999999e-05" node1="40" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="34.882229539732009" q1="-26.774295248032992" p2="-34.764875211360703" q2="26.670453759645152">
         <iidm:alias>_0456e227-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04880440-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10067,7 +10190,7 @@
             <iidm:temporaryLimit name="_70fad3e1-4529-4a7f-9e6c-8ab249d65460" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044bbe91-c766-11e1-8775-005056c00008" name="8-9" r="1.18096" x="14.762" g1="0" b1="0.001200413215" g2="0" b2="0.001200413215" node1="31" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_045c8779-c766-11e1-8775-005056c00008" p1="-489.07056087260639" q1="-86.253509635457007" p2="494.87987917796073" q2="38.093862028447781">
+    <iidm:line id="_044bbe91-c766-11e1-8775-005056c00008" name="8-9" r="1.18096" x="14.762" g1="0" b1="0.001200413215" g2="0" b2="0.001200413215" node1="31" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_045c8779-c766-11e1-8775-005056c00008" p1="-489.02129020972166" q1="-83.620956844332241" p2="494.80187638840835" q2="34.726173574754817">
         <iidm:alias>_04745535-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048a7548-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="2000">
@@ -10075,7 +10198,7 @@
             <iidm:temporaryLimit name="_205e5d8a-f05a-479d-adaa-3514f48f6857" acceptableDuration="60" value="2400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04566cf8-c766-11e1-8775-005056c00008" name="64-65" r="1.30196" x="14.6168" g1="0" b1="0.000392562" g2="0" b2="0.000392562" node1="35" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-312.11065491824502" q1="-23.244962080737221" p2="314.7815058011995" q2="15.394272678547521">
+    <iidm:line id="_04566cf8-c766-11e1-8775-005056c00008" name="64-65" r="1.30196" x="14.6168" g1="0" b1="0.000392562" g2="0" b2="0.000392562" node1="35" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-311.98770262204431" q1="-23.2540902757247" p2="314.65642928175879" q2="15.379391227534271">
         <iidm:alias>_044a10e2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04793738-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10083,7 +10206,7 @@
             <iidm:temporaryLimit name="_8cee2b62-2953-439b-ba4b-4a48d55116c0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046783f3-c766-11e1-8775-005056c00008" name="54-56" r="0.47915999999999997" x="1.6639919999999999" g1="0" b1="2.1005500000000001e-05" g2="0" b2="2.1005500000000001e-05" node1="60" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="21.110664200079178" q1="4.4245476999643865" p2="-21.096543638195822" q2="-5.0423571075652402">
+    <iidm:line id="_046783f3-c766-11e1-8775-005056c00008" name="54-56" r="0.47915999999999997" x="1.6639919999999999" g1="0" b1="2.1005500000000001e-05" g2="0" b2="2.1005500000000001e-05" node1="60" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="21.126217913418163" q1="4.4210004490062556" p2="-21.112078563045017" q2="-5.0387446656986041">
         <iidm:alias>_0460f444-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d2949-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10091,7 +10214,7 @@
             <iidm:temporaryLimit name="_640627c7-0672-413e-8dc8-c9965709a5cb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04670ec6-c766-11e1-8775-005056c00008" name="84-85" r="5.2620480000000001" x="11.1687832" g1="0" b1="3.541095e-05" g2="0" b2="3.541095e-05" node1="21" voltageLevelId1="_047b0bf4-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-45.17809076628879" q1="14.063055156320045" p2="45.905200888171485" q2="-13.681731464189435">
+    <iidm:line id="_04670ec6-c766-11e1-8775-005056c00008" name="84-85" r="5.2620480000000001" x="11.1687832" g1="0" b1="3.541095e-05" g2="0" b2="3.541095e-05" node1="21" voltageLevelId1="_047b0bf4-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-44.974792385558196" q1="14.551353018422065" p2="45.703917574364411" q2="-14.160121972094444">
         <iidm:alias>_0453fbf5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046512f7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10099,7 +10222,7 @@
             <iidm:temporaryLimit name="_8b888209-5038-4b98-80fc-062b5ea55747" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0460cd36-c766-11e1-8775-005056c00008" name="34-36" r="1.51763" x="4.669632" g1="0" b1="1.6299349999999998e-05" g2="0" b2="1.6299349999999998e-05" node1="43" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="33.176181497603324" q1="11.556806831194107" p2="-33.052811422377772" q2="-11.671064767553071">
+    <iidm:line id="_0460cd36-c766-11e1-8775-005056c00008" name="34-36" r="1.51763" x="4.669632" g1="0" b1="1.6299349999999998e-05" g2="0" b2="1.6299349999999998e-05" node1="43" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="33.257956768295699" q1="11.521465861842026" p2="-33.133999773563175" q2="-11.633398200177243">
         <iidm:alias>_046a6a26-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0487b620-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10107,7 +10230,7 @@
             <iidm:temporaryLimit name="_c0a08025-3a61-4d24-9944-f3ef0b079f64" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04549836-c766-11e1-8775-005056c00008" name="24-70" r="0.38507000000000002" x="71.699759999999998" g1="0" b1="0.00029264234999999998" g2="0" b2="0.00029264234999999998" node1="32" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="15.877506574208095" q1="-1.442803064845724" p2="-15.871608640307407" q2="-7.4616744647788638">
+    <iidm:line id="_04549836-c766-11e1-8775-005056c00008" name="24-70" r="0.38507000000000002" x="71.699759999999998" g1="0" b1="0.00029264234999999998" g2="0" b2="0.00029264234999999998" node1="32" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="15.127874086268553" q1="-1.2724515928955338" p2="-15.122474356088791" q2="-7.7365540195459905">
         <iidm:alias>_04549834-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04854522-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10115,7 +10238,7 @@
             <iidm:temporaryLimit name="_32793450-bbfd-4dcd-a911-89e199600780" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0452273a-c766-11e1-8775-005056c00008" name="85-86" r="6.0983999999999998" x="21.431519999999999" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="50" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0484f70a-c766-11e1-8775-005056c00008" p1="21.231065628920039" q1="12.277237330832788" p2="-20.996154209522754" q2="-13.998921858754358">
+    <iidm:line id="_0452273a-c766-11e1-8775-005056c00008" name="85-86" r="6.0983999999999998" x="21.431519999999999" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="50" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0484f70a-c766-11e1-8775-005056c00008" p1="21.279856386964298" q1="16.34773200055044" p2="-20.995767538505859" q2="-17.869450454514283">
         <iidm:alias>_044afb43-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479fa85-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10123,7 +10246,7 @@
             <iidm:temporaryLimit name="_2ec4bef5-7abb-4f52-bb62-49ee474d672b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0450eeb5-c766-11e1-8775-005056c00008" name="16-17" r="7.9104960000000002" x="31.380622899999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="22" voltageLevelId1="_046f7338-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-8.3204957081605411" q1="0.11450211411364285" p2="8.3559268231651718" q2="-4.4349001682289391">
+    <iidm:line id="_0450eeb5-c766-11e1-8775-005056c00008" name="16-17" r="7.9104960000000002" x="31.380622899999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="22" voltageLevelId1="_046f7338-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-14.955416770238571" q1="2.0526390400589074" p2="15.070191819684045" q2="-6.0560003901879131">
         <iidm:alias>_044ef2ea-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04837066-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10131,7 +10254,7 @@
             <iidm:temporaryLimit name="_9280074c-8555-49ff-9e62-8ed8f7d95060" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048a4e33-c766-11e1-8775-005056c00008" name="62-66" r="8.3983679999999996" x="37.984317799999999" g1="0" b1="0.00016586315" g2="0" b2="0.00016586315" node1="41" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="42.110299020090061" q1="-17.409695447887664" p2="-41.128897251874733" q2="16.114309959921027">
+    <iidm:line id="_048a4e33-c766-11e1-8775-005056c00008" name="62-66" r="8.3983679999999996" x="37.984317799999999" g1="0" b1="0.00016586315" g2="0" b2="0.00016586315" node1="41" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="42.062762628468967" q1="-17.404739774529553" p2="-41.083418150123265" q2="16.099993055839047">
         <iidm:alias>_046e13a9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a96c7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10139,7 +10262,7 @@
             <iidm:temporaryLimit name="_ace48562-0a49-4b76-ae82-c896a00b04f9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0478e913-c766-11e1-8775-005056c00008" name="76-77" r="7.736256" x="25.787520000000001" g1="0" b1="0.00010560145" g2="0" b2="0.00010560145" node1="21" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-65.142518516639797" q1="-20.213074072491104" p2="67.459524694676148" q2="24.4694679605592">
+    <iidm:line id="_0478e913-c766-11e1-8775-005056c00008" name="76-77" r="7.736256" x="25.787520000000001" g1="0" b1="0.00010560145" g2="0" b2="0.00010560145" node1="21" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-65.255289208849916" q1="-20.121908270497691" p2="67.578418656000622" q2="24.399522467115283">
         <iidm:alias>_044b9785-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04725965-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10147,7 +10270,7 @@
             <iidm:temporaryLimit name="_3f744dba-88dc-4d89-90d4-a6f196054b28" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048badc1-c766-11e1-8775-005056c00008" name="60-62" r="2.1431520000000002" x="9.7748640000000009" g1="0" b1="4.2125800000000002e-05" g2="0" b2="4.2125800000000002e-05" node1="32" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="37.79118849983292" q1="-3.6715218729899912" p2="-37.611023847048969" q2="3.0572168280894618">
+    <iidm:line id="_048badc1-c766-11e1-8775-005056c00008" name="60-62" r="2.1431520000000002" x="9.7748640000000009" g1="0" b1="4.2125800000000002e-05" g2="0" b2="4.2125800000000002e-05" node1="32" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="37.760805819362467" q1="-3.6705366420794125" p2="-37.580930222517814" q2="3.0549050627376984">
         <iidm:alias>_045b7600-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04720b44-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10155,7 +10278,7 @@
             <iidm:temporaryLimit name="_43f91aaf-c5f4-4995-85a2-37afac616331" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0472a780-c766-11e1-8775-005056c00008" name="27-28" r="3.3332109999999999" x="14.89752" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="42" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04819ba0-c766-11e1-8775-005056c00008" p1="34.913582897663183" q1="-1.3387656701908917" p2="-34.664277163910633" q2="0.44523365139111926">
+    <iidm:line id="_0472a780-c766-11e1-8775-005056c00008" name="27-28" r="3.3332109999999999" x="14.89752" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="42" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04819ba0-c766-11e1-8775-005056c00008" p1="33.027213685118184" q1="-1.6514502944433889" p2="-32.804744478383967" q2="0.63049109786775226">
         <iidm:alias>_04531198-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0475188b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10163,7 +10286,7 @@
             <iidm:temporaryLimit name="_2c20e8bd-84e6-4a1e-b88e-071f631327cb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c81e1-c766-11e1-8775-005056c00008" name="45-46" r="6.9695999999999998" x="23.626943600000001" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="31" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="34" voltageLevelId2="_048a7544-c766-11e1-8775-005056c00008" p1="-29.603276478489676" q1="-8.0792352485630463" p2="29.98316373067351" q2="6.0853801373277623">
+    <iidm:line id="_044c81e1-c766-11e1-8775-005056c00008" name="45-46" r="6.9695999999999998" x="23.626943600000001" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="31" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="34" voltageLevelId2="_048a7544-c766-11e1-8775-005056c00008" p1="-29.480551069219739" q1="-8.1641722417772389" p2="29.857944458356179" q2="6.1620618561265106">
         <iidm:alias>_04561ed6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045c877a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10171,7 +10294,7 @@
             <iidm:temporaryLimit name="_6ad31f7e-233f-4801-898f-9ffc883ec724" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c1249-c766-11e1-8775-005056c00008" name="18-19" r="1.949746" x="8.5900320000000008" g1="0" b1="3.2770900000000002e-05" g2="0" b2="3.2770900000000002e-05" node1="22" voltageLevelId1="_04689563-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="50.718573772105621" q1="1.5931149209460456" p2="-50.39473173764928" q2="-1.1759315909378061">
+    <iidm:line id="_045c1249-c766-11e1-8775-005056c00008" name="18-19" r="1.949746" x="8.5900320000000008" g1="0" b1="3.2770900000000002e-05" g2="0" b2="3.2770900000000002e-05" node1="22" voltageLevelId1="_04689563-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="54.573292208538724" q1="0.58391090507150867" p2="-54.19849114236677" q2="0.058606666352357256">
         <iidm:alias>_046b066b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047ae4e0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10179,7 +10302,7 @@
             <iidm:temporaryLimit name="_a025c9d8-58f9-4320-a1fe-73ecc68d4147" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044a5f09-c766-11e1-8775-005056c00008" name="9-10" r="1.2487200000000001" x="15.584800700000001" g1="0" b1="0.0012706611300000001" g2="0" b2="0.0012706611300000001" node1="21" voltageLevelId1="_045c8779-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_044f4102-c766-11e1-8775-005056c00008" p1="-494.87987917796045" q1="-38.093862028447447" p2="500.79866331179426" q2="-21.700588243611652">
+    <iidm:line id="_044a5f09-c766-11e1-8775-005056c00008" name="9-10" r="1.2487200000000001" x="15.584800700000001" g1="0" b1="0.0012706611300000001" g2="0" b2="0.0012706611300000001" node1="21" voltageLevelId1="_045c8779-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_044f4102-c766-11e1-8775-005056c00008" p1="-494.80187638840823" q1="-34.726173574754625" p2="500.71108720509096" q2="-25.32935192445731">
         <iidm:alias>_04614262-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04834957-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="2000">
@@ -10187,7 +10310,7 @@
             <iidm:temporaryLimit name="_b7fac0a3-c5af-48b9-af49-261fd8d46e00" acceptableDuration="60" value="2400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0480b14b-c766-11e1-8775-005056c00008" name="85-88" r="3.4847999999999999" x="17.772480000000002" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="51" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0470f9d2-c766-11e1-8775-005056c00008" p1="-63.892099533595825" q1="5.1585818614742092" p2="64.763519878408303" q2="-3.3502409892639475">
+    <iidm:line id="_0480b14b-c766-11e1-8775-005056c00008" name="85-88" r="3.4847999999999999" x="17.772480000000002" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="51" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0470f9d2-c766-11e1-8775-005056c00008" p1="-63.789617102411178" q1="3.7200091225633947" p2="64.659298368860732" q2="-1.9109199448660352">
         <iidm:alias>_047602e2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04765105-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10195,7 +10318,7 @@
             <iidm:temporaryLimit name="_51646744-d343-42b5-8ba7-fcedc7cc3a98" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04486330-c766-11e1-8775-005056c00008" name="69-77" r="5.3840159999999999" x="17.598240000000001" g1="0" b1="0.00029786500000000002" g2="0" b2="0.00029786500000000002" node1="60" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="20.469762705768474" q1="21.66848956498454" p2="-20.135044606600704" q2="-31.348904605801142">
+    <iidm:line id="_04486330-c766-11e1-8775-005056c00008" name="69-77" r="5.3840159999999999" x="17.598240000000001" g1="0" b1="0.00029786500000000002" g2="0" b2="0.00029786500000000002" node1="60" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="20.584689897898372" q1="21.781469180224121" p2="-20.246832400194254" q2="-31.450128327340714">
         <iidm:alias>_046205b9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479d379-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10203,7 +10326,7 @@
             <iidm:temporaryLimit name="_76311a15-b79a-4439-a7ce-47afa8fa6fe2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04553477-c766-11e1-8775-005056c00008" name="11-13" r="3.8768400000000001" x="12.7369442" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="41" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04851e1b-c766-11e1-8775-005056c00008" p1="50.499632685937456" q1="15.698756264685217" p2="-49.853303651501534" q2="-15.358217465468776">
+    <iidm:line id="_04553477-c766-11e1-8775-005056c00008" name="11-13" r="3.8768400000000001" x="12.7369442" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="41" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04851e1b-c766-11e1-8775-005056c00008" p1="46.248251261489138" q1="16.843816035649041" p2="-45.68747761377179" q2="-16.7859686266208">
         <iidm:alias>_0479fa89-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0485452a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10211,7 +10334,7 @@
             <iidm:temporaryLimit name="_efbf8de7-4b84-4834-bb7c-6250b6072211" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04488a45-c766-11e1-8775-005056c00008" name="103-105" r="9.3218399999999999" x="28.314" g1="0" b1="0.0001170799" g2="0" b2="0.0001170799" node1="42" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="43.80043126766671" q1="12.532611462319959" p2="-42.682267389713019" q2="-13.118311035828608">
+    <iidm:line id="_04488a45-c766-11e1-8775-005056c00008" name="103-105" r="9.3218399999999999" x="28.314" g1="0" b1="0.0001170799" g2="0" b2="0.0001170799" node1="42" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="43.800295055953029" q1="12.532704977959785" p2="-42.682135826091979" q2="-13.118417621244419">
         <iidm:alias>_044f8f24-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04611b58-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10219,7 +10342,7 @@
             <iidm:temporaryLimit name="_22b6919a-a7a0-49fc-9e90-329069c55055" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046009e6-c766-11e1-8775-005056c00008" name="45-49" r="11.918016400000001" x="32.408639999999998" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="32" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="118" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-29.509697992217411" q1="-12.731771398743946" p2="30.20500577739066" q2="10.143646377990681">
+    <iidm:line id="_046009e6-c766-11e1-8775-005056c00008" name="45-49" r="11.918016400000001" x="32.408639999999998" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="32" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="118" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-29.393120447447046" q1="-12.812199582013209" p2="30.084869540526029" q2="10.214663388655294">
         <iidm:alias>_044ca8f9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047dcb1b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10227,7 +10350,7 @@
             <iidm:temporaryLimit name="_8b91f4fd-4038-45b7-870c-fbc08592b95a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046a6a27-c766-11e1-8775-005056c00008" name="88-89" r="2.4219360000000001" x="12.4058876" g1="0" b1="5.549815e-05" g2="0" b2="5.549815e-05" node1="22" voltageLevelId1="_0470f9d2-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-112.75970903638904" q1="-6.6484352947612404" p2="114.59858236663125" q2="14.159228499500387">
+    <iidm:line id="_046a6a27-c766-11e1-8775-005056c00008" name="88-89" r="2.4219360000000001" x="12.4058876" g1="0" b1="5.549815e-05" g2="0" b2="5.549815e-05" node1="22" voltageLevelId1="_0470f9d2-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-112.65535214318288" q1="-8.0877099552726506" p2="114.49740009188389" q2="15.616733084959739">
         <iidm:alias>_045ef879-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04649dc1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10235,7 +10358,7 @@
             <iidm:temporaryLimit name="_970bc323-73bf-440d-a3c5-00aebc3a1992" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048a7540-c766-11e1-8775-005056c00008" name="80-98" r="4.1469120000000004" x="18.817920000000001" g1="0" b1="8.20707e-05" g2="0" b2="8.20707e-05" node1="79" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04773b62-c766-11e1-8775-005056c00008" p1="10.766752735128771" q1="12.127573323208132" p2="-10.70009945201204" q2="-14.86941303024458">
+    <iidm:line id="_048a7540-c766-11e1-8775-005056c00008" name="80-98" r="4.1469120000000004" x="18.817920000000001" g1="0" b1="8.20707e-05" g2="0" b2="8.20707e-05" node1="79" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04773b62-c766-11e1-8775-005056c00008" p1="10.774371338482505" q1="12.125779127001994" p2="-10.707692735103191" q2="-14.867504228574239">
         <iidm:alias>_045338a2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04887972-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10243,7 +10366,7 @@
             <iidm:temporaryLimit name="_cb084dc7-1b26-415f-9495-4695df661912" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04640183-c766-11e1-8775-005056c00008" name="91-92" r="6.7430880000000002" x="22.163329999999998" g1="0" b1="9.3778700000000004e-05" g2="0" b2="9.3778700000000004e-05" node1="22" voltageLevelId1="_044f8f29-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="-5.5065679117003041" q1="-14.621943423179939" p2="5.5894597295164372" q2="11.757626190992474">
+    <iidm:line id="_04640183-c766-11e1-8775-005056c00008" name="91-92" r="6.7430880000000002" x="22.163329999999998" g1="0" b1="9.3778700000000004e-05" g2="0" b2="9.3778700000000004e-05" node1="22" voltageLevelId1="_044f8f29-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="-5.4822734105405075" q1="-14.611711163852531" p2="5.5649512098555345" q2="11.746947361949845">
         <iidm:alias>_04492680-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_044c5ad5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10251,7 +10374,7 @@
             <iidm:temporaryLimit name="_3a165a76-f6ba-461b-84d6-159a5e0b5077" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0474a358-c766-11e1-8775-005056c00008" name="7-12" r="1.501949" x="5.9241599999999996" g1="0" b1="2.5080350000000001e-05" g2="0" b2="2.5080350000000001e-05" node1="22" voltageLevelId1="_047eb571-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="24.080266121227751" q1="-10.34701143172855" p2="-24.020449204418728" q2="9.7275114947998489">
+    <iidm:line id="_0474a358-c766-11e1-8775-005056c00008" name="7-12" r="1.501949" x="5.9241599999999996" g1="0" b1="2.5080350000000001e-05" g2="0" b2="2.5080350000000001e-05" node1="22" voltageLevelId1="_047eb571-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="19.871449049617517" q1="-8.3451355544945685" p2="-19.831123203760715" q2="7.6484667410532765">
         <iidm:alias>_046ab848-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0477feb7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10259,7 +10382,7 @@
             <iidm:temporaryLimit name="_b19bc945-cc51-4d77-8eaa-3f6afe2d9316" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04765108-c766-11e1-8775-005056c00008" name="99-100" r="3.13632" x="14.165711399999999" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_04644fa4-c766-11e1-8775-005056c00008" node2="80" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-40.681891676237818" q1="12.436442762371753" p2="41.000018971223639" q2="-13.240305205394762">
+    <iidm:line id="_04765108-c766-11e1-8775-005056c00008" name="99-100" r="3.13632" x="14.165711399999999" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_04644fa4-c766-11e1-8775-005056c00008" node2="80" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-40.674225193907795" q1="12.434697380751638" p2="40.992236335906242" q2="-13.239084496261388">
         <iidm:alias>_0471e436-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047e4040-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10267,7 +10390,7 @@
             <iidm:temporaryLimit name="_a9e283ed-fcad-4f4c-ab57-8531875bb098" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047b8128-c766-11e1-8775-005056c00008" name="114-115" r="0.400752" x="1.8120959999999999" g1="0" b1="7.9201000000000006e-06" g2="0" b2="7.9201000000000006e-06" node1="22" voltageLevelId1="_04791027-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="-1.7714876623119844" q1="2.7773443278208569" p2="1.771776033008635" q2="-3.0307891996927654">
+    <iidm:line id="_047b8128-c766-11e1-8775-005056c00008" name="114-115" r="0.400752" x="1.8120959999999999" g1="0" b1="7.9201000000000006e-06" g2="0" b2="7.9201000000000006e-06" node1="22" voltageLevelId1="_04791027-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="-0.70188966548651055" q1="2.1902478629681412" p2="0.70203542026281285" q2="-2.4449921700397659">
         <iidm:alias>_046c17d3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d0233-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10275,7 +10398,7 @@
             <iidm:temporaryLimit name="_c59e4022-b1c0-4811-a32e-f54656bff32d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046931a5-c766-11e1-8775-005056c00008" name="83-84" r="10.890000000000001" x="22.999680000000001" g1="0" b1="7.4035799999999993e-05" g2="0" b2="7.4035799999999993e-05" node1="33" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b0bf4-c766-11e1-8775-005056c00008" p1="-33.137507595251336" q1="20.828725474762379" p2="34.179913424972078" q2="-21.061121774630891">
+    <iidm:line id="_046931a5-c766-11e1-8775-005056c00008" name="83-84" r="10.890000000000001" x="22.999680000000001" g1="0" b1="7.4035799999999993e-05" g2="0" b2="7.4035799999999993e-05" node1="33" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b0bf4-c766-11e1-8775-005056c00008" p1="-32.92557524324414" q1="21.344096391286289" p2="33.976682078287631" q2="-21.549348952941944">
         <iidm:alias>_0465d645-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479102b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10283,7 +10406,7 @@
             <iidm:temporaryLimit name="_1268eb09-e233-44ce-b8af-22dc30eb16ad" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047ae4ea-c766-11e1-8775-005056c00008" name="14-15" r="10.367279999999999" x="33.976799999999997" g1="0" b1="0.0001440542" g2="0" b2="0.0001440542" node1="21" voltageLevelId1="_047b8129-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="22.149862401735621" q1="6.6781498795615581" p2="-21.792584685422629" q2="-10.148376700436588">
+    <iidm:line id="_047ae4ea-c766-11e1-8775-005056c00008" name="14-15" r="10.367279999999999" x="33.976799999999997" g1="0" b1="0.0001440542" g2="0" b2="0.0001440542" node1="21" voltageLevelId1="_047b8129-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="17.432103903412845" q1="8.1476229358541286" p2="-17.173328172914442" q2="-11.939253284980927">
         <iidm:alias>_0449e9d9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046ed6fa-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10291,7 +10414,7 @@
             <iidm:temporaryLimit name="_9c0c454b-ecc3-40f6-b505-f32fec412522" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046e3ab2-c766-11e1-8775-005056c00008" name="80-96" r="6.2029439999999996" x="31.711680000000001" g1="0" b1="0.0001417585" g2="0" b2="0.0001417585" node1="80" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="4.5782641309045591" q1="26.329412346108061" p2="-4.2945383209630119" q2="-29.959985283040069">
+    <iidm:line id="_046e3ab2-c766-11e1-8775-005056c00008" name="80-96" r="6.2029439999999996" x="31.711680000000001" g1="0" b1="0.0001417585" g2="0" b2="0.0001417585" node1="80" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="4.6202340258369272" q1="26.528957897347887" p2="-4.3325585241206399" q2="-30.137564522198058">
         <iidm:alias>_045338a4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04865695-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10299,7 +10422,7 @@
             <iidm:temporaryLimit name="_1432f4d6-9299-4b0d-bd7f-16e059f9de66" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04893cc4-c766-11e1-8775-005056c00008" name="56-59" r="13.9914722" x="41.643360000000001" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="59" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-28.676645791647086" q1="-4.205112982345721" p2="29.40508715927211" q2="1.3343044967932323">
+    <iidm:line id="_04893cc4-c766-11e1-8775-005056c00008" name="56-59" r="13.9914722" x="41.643360000000001" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="59" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-28.657879551967458" q1="-4.2129818974587412" p2="29.385396031262921" q2="1.339420266504783">
         <iidm:alias>_046b5484-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04798557-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10307,7 +10430,7 @@
             <iidm:temporaryLimit name="_193f6952-4267-4cc8-a541-726c095028ba" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c1243-c766-11e1-8775-005056c00008" name="92-100" r="11.290752400000001" x="51.400799999999997" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="71" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="37.001479931184249" q1="-17.322729859404813" p2="-35.945877847253236" q2="17.377419175961673">
+    <iidm:line id="_045c1243-c766-11e1-8775-005056c00008" name="92-100" r="11.290752400000001" x="51.400799999999997" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="71" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="37.038831385845974" q1="-17.34228337487826" p2="-35.980895162945778" q2="17.407838455652438">
         <iidm:alias>_045e8348-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045ed164-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10315,7 +10438,7 @@
             <iidm:temporaryLimit name="_579249ce-1c81-4d29-8d3f-5fc627a18f99" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0474a356-c766-11e1-8775-005056c00008" name="43-44" r="10.593792000000001" x="42.7584953" g1="0" b1="0.00017412765" g2="0" b2="0.00017412765" node1="22" voltageLevelId1="_045e8349-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04544a15-c766-11e1-8775-005056c00008" p1="10.113026691144658" q1="-16.726248678591084" p2="-9.9082792628557161" q2="11.984195590779974">
+    <iidm:line id="_0474a356-c766-11e1-8775-005056c00008" name="43-44" r="10.593792000000001" x="42.7584953" g1="0" b1="0.00017412765" g2="0" b2="0.00017412765" node1="22" voltageLevelId1="_045e8349-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04544a15-c766-11e1-8775-005056c00008" p1="10.357910048154023" q1="-16.858831348599949" p2="-10.146954269977432" q2="12.145013004737729">
         <iidm:alias>_04642899-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047b0bf2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10323,7 +10446,7 @@
             <iidm:temporaryLimit name="_3d2cb4b5-ee82-4866-9855-4a5f4803cd3b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04627ae6-c766-11e1-8775-005056c00008" name="109-110" r="4.8438720000000002" x="13.2770882" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="22" voltageLevelId1="_046b7b99-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="12.637344737738223" q1="-2.9324731080320858" p2="-12.587651457216783" q2="1.2223154622527044">
+    <iidm:line id="_04627ae6-c766-11e1-8775-005056c00008" name="109-110" r="4.8438720000000002" x="13.2770882" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="22" voltageLevelId1="_046b7b99-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="12.640739127298836" q1="-2.9337267824819735" p2="-12.591018247701932" q2="1.2236457610105251">
         <iidm:alias>_0466e7b5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a6fbb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10331,7 +10454,7 @@
             <iidm:temporaryLimit name="_6fc48d8d-05f8-4104-a6a2-3686d430a091" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0478c207-c766-11e1-8775-005056c00008" name="68-81" r="0.84699999999999998" x="9.7767990000000005" g1="0" b1="0.00083471078000000004" g2="0" b2="0.00083471078000000004" node1="38" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_048a272b-c766-11e1-8775-005056c00008" p1="-139.06965165602742" q1="-5.190203125969453" p2="139.43064574471512" q2="-70.882251984593964">
+    <iidm:line id="_0478c207-c766-11e1-8775-005056c00008" name="68-81" r="0.84699999999999998" x="9.7767990000000005" g1="0" b1="0.00083471078000000004" g2="0" b2="0.00083471078000000004" node1="38" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_048a272b-c766-11e1-8775-005056c00008" p1="-138.48733415926341" q1="-5.2543894590074256" p2="138.84541341097005" q2="-70.851582718005204">
         <iidm:alias>_044a37f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045b4ef6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10339,7 +10462,7 @@
             <iidm:temporaryLimit name="_191836a1-39cd-402b-8dcf-4f3867c45bd0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0467d215-c766-11e1-8775-005056c00008" name="85-89" r="4.1643359999999996" x="30.143518400000001" g1="0" b1="0.00013487144999999999" g2="0" b2="0.00013487144999999999" node1="52" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-84.63340803510799" q1="-2.2212724329158995" p2="86.442086217629921" q2="10.715544690140222">
+    <iidm:line id="_0467d215-c766-11e1-8775-005056c00008" name="85-89" r="4.1643359999999996" x="30.143518400000001" g1="0" b1="0.00013487144999999999" g2="0" b2="0.00013487144999999999" node1="52" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-84.416977959734169" q1="-3.6627831399208608" p2="86.226380120087939" q2="12.173890668170634">
         <iidm:alias>_047629f9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0478e915-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10347,7 +10470,7 @@
             <iidm:temporaryLimit name="_66cbdeeb-a4e4-4bfc-aec1-9fb7a2d2b6bc" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044a37f2-c766-11e1-8775-005056c00008" name="89-90" r="4.1469120000000004" x="17.371727" g1="0" b1="0.00030417815" g2="0" b2="0.00030417815" node1="62" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="112.86338349869709" q1="21.248482927875866" p2="-109.69504888904866" q2="-18.190624146558164">
+    <iidm:line id="_044a37f2-c766-11e1-8775-005056c00008" name="89-90" r="4.1469120000000004" x="17.371727" g1="0" b1="0.00030417815" g2="0" b2="0.00030417815" node1="62" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="112.88022176850825" q1="21.259868129784675" p2="-109.71084807211975" q2="-18.197515871325272">
         <iidm:alias>_045386c2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048719e9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10355,7 +10478,7 @@
             <iidm:temporaryLimit name="_8489e809-6588-4ed2-a9a4-43c44a0d47da" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04658820-c766-11e1-8775-005056c00008" name="98-100" r="6.9173280000000004" x="31.188960999999999" g1="0" b1="0.0001365932" g2="0" b2="0.0001365932" node1="22" voltageLevelId1="_04773b62-c766-11e1-8775-005056c00008" node2="82" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-23.299652316169766" q1="6.8695107682335221" p2="23.53866841572847" q2="-10.745967965953355">
+    <iidm:line id="_04658820-c766-11e1-8775-005056c00008" name="98-100" r="6.9173280000000004" x="31.188960999999999" g1="0" b1="0.0001365932" g2="0" b2="0.0001365932" node1="22" voltageLevelId1="_04773b62-c766-11e1-8775-005056c00008" node2="82" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-23.29205580131919" q1="6.8676027678073517" p2="23.530924129423028" q2="-10.744726548449881">
         <iidm:alias>_046f4c22-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046fe865-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10363,7 +10486,7 @@
             <iidm:temporaryLimit name="_620beaaf-63c8-4020-bea5-c3609c0eaadf" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c5ada-c766-11e1-8775-005056c00008" name="28-29" r="4.1294880000000003" x="16.430831900000001" g1="0" b1="6.8296599999999999e-05" g2="0" b2="6.8296599999999999e-05" node1="22" voltageLevelId1="_04819ba0-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04588fd5-c766-11e1-8775-005056c00008" p1="17.666238061552889" q1="-7.4438878095565544" p2="-17.575825978441774" q2="5.6006820759650289">
+    <iidm:line id="_044c5ada-c766-11e1-8775-005056c00008" name="28-29" r="4.1294880000000003" x="16.430831900000001" g1="0" b1="6.8296599999999999e-05" g2="0" b2="6.8296599999999999e-05" node1="22" voltageLevelId1="_04819ba0-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04588fd5-c766-11e1-8775-005056c00008" p1="15.806135142130701" q1="-5.4202337723231269" p2="-15.737547996427798" q2="3.484189374868349">
         <iidm:alias>_0461697a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04697fc1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10371,7 +10494,13 @@
             <iidm:temporaryLimit name="_6748d0d0-aec8-4b7b-a9ab-be6aecda7c5d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0468e382-c766-11e1-8775-005056c00008" name="3-5" r="4.1991839999999998" x="18.817920000000001" g1="0" b1="8.1496799999999995e-05" g2="0" b2="8.1496799999999995e-05" node1="31" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-72.583585156990324" q1="-15.313494773986882" p2="73.97691325720362" q2="18.771011746887332">
+    <iidm:line id="_044c5ada-c766-11e1-8775-005056c00008-1" name="28-29-open-ended" r="4.1294880000000003" x="16.430831900000001" g1="0" b1="6.8296599999999999e-05" g2="0" b2="6.8296599999999999e-05" node1="25" voltageLevelId1="_04819ba0-c766-11e1-8775-005056c00008" node2="25" voltageLevelId2="_04588fd5-c766-11e1-8775-005056c00008" p1="0.00031203968590705735" q1="-2.2090888440051479" p2="0" q2="0">
+        <iidm:currentLimits1 permanentLimit="1000">
+            <iidm:temporaryLimit name="_accb8136-1faf-4399-9787-3cd567284fd2-1" acceptableDuration="900" value="1150"/>
+            <iidm:temporaryLimit name="_6748d0d0-aec8-4b7b-a9ab-be6aecda7c5d-1" acceptableDuration="60" value="1400"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+    <iidm:line id="_0468e382-c766-11e1-8775-005056c00008" name="3-5" r="4.1991839999999998" x="18.817920000000001" g1="0" b1="8.1496799999999995e-05" g2="0" b2="8.1496799999999995e-05" node1="31" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-70.37610824213975" q1="-16.463284457358178" p2="71.696243609770235" q2="19.588808002634401">
         <iidm:alias>_046b0668-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04742e24-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10379,7 +10508,7 @@
             <iidm:temporaryLimit name="_828ca44c-560b-4f94-b825-21e237285fae" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0447c6f1-c766-11e1-8775-005056c00008" name="82-96" r="2.8226879999999999" x="9.2347199999999994" g1="0" b1="0.00015610649999999999" g2="0" b2="0.00015610649999999999" node1="33" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="-17.421681680420757" q1="-8.4649346493740367" p2="17.478451921532205" q2="3.3763440733584305">
+    <iidm:line id="_0447c6f1-c766-11e1-8775-005056c00008" name="82-96" r="2.8226879999999999" x="9.2347199999999994" g1="0" b1="0.00015610649999999999" g2="0" b2="0.00015610649999999999" node1="33" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="-17.620122035157557" q1="-9.1811821837796828" p2="17.679660247438317" q2="4.1078205062685127">
         <iidm:alias>_0478e91a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0480d856-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10387,7 +10516,7 @@
             <iidm:temporaryLimit name="_233b7735-85f4-4a6f-9d87-15129fe42ef5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0483e594-c766-11e1-8775-005056c00008" name="38-65" r="4.3608399999999996" x="47.7224" g1="0" b1="0.0010805785" g2="0" b2="0.0010805785" node1="29" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-199.02558325879193" q1="-94.227159119386329" p2="203.64951401300416" q2="48.966384148396529">
+    <iidm:line id="_0483e594-c766-11e1-8775-005056c00008" name="38-65" r="4.3608399999999996" x="47.7224" g1="0" b1="0.0010805785" g2="0" b2="0.0010805785" node1="29" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-197.64755481365663" q1="-94.793580086693837" p2="202.22014562373283" q2="48.98905086471089">
         <iidm:alias>_04638c56-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d5054-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10395,7 +10524,7 @@
             <iidm:temporaryLimit name="_990ce3c5-c90c-41b9-abee-fb803d9df3a5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04784cd4-c766-11e1-8775-005056c00008" name="106-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_04479fe8-c766-11e1-8775-005056c00008" node2="24" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="23.84599582854079" q1="-0.69218290092551216" p2="-23.517776953885281" q2="-2.4581033141941746">
+    <iidm:line id="_04784cd4-c766-11e1-8775-005056c00008" name="106-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_04479fe8-c766-11e1-8775-005056c00008" node2="24" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="23.846226264510424" q1="-0.69226298186935376" p2="-23.518001017265018" q2="-2.4579989104246183">
         <iidm:alias>_04483c21-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f0395-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10403,7 +10532,7 @@
             <iidm:temporaryLimit name="_1372c3b0-62d7-47d7-a8c0-ed8e10bc1f1a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046f9a43-c766-11e1-8775-005056c00008" name="27-115" r="2.8575360000000001" x="12.9111843" g1="0" b1="5.6588600000000002e-05" g2="0" b2="5.6588600000000002e-05" node1="43" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="23.869084187087257" q1="2.5956569723138774" p2="-23.767028194152605" q2="-3.9666932725825692">
+    <iidm:line id="_046f9a43-c766-11e1-8775-005056c00008" name="27-115" r="2.8575360000000001" x="12.9111843" g1="0" b1="5.6588600000000002e-05" g2="0" b2="5.6588600000000002e-05" node1="43" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="22.791455628132379" q1="3.1386257314793569" p2="-22.697779421090413" q2="-4.5527510145551515">
         <iidm:alias>_046d0238-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048c22f4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10411,7 +10540,7 @@
             <iidm:temporaryLimit name="_64cfd0fb-1d8e-45d2-a52f-469238dfc0c6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04529c61-c766-11e1-8775-005056c00008" name="12-14" r="3.7461600000000002" x="12.3187675" g1="0" b1="5.2112050000000002e-05" g2="0" b2="5.2112050000000002e-05" node1="71" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b8129-c766-11e1-8775-005056c00008" p1="36.449356837131589" q1="6.9236121970936901" p2="-36.144525231458132" q2="-7.6775149899409918">
+    <iidm:line id="_04529c61-c766-11e1-8775-005056c00008" name="12-14" r="3.7461600000000002" x="12.3187675" g1="0" b1="5.2112050000000002e-05" g2="0" b2="5.2112050000000002e-05" node1="71" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b8129-c766-11e1-8775-005056c00008" p1="31.664946886170377" q1="8.1731323471423387" p2="-31.426977609743133" q2="-9.1470127338252585">
         <iidm:alias>_045fbbc1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047bf65b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10419,7 +10548,7 @@
             <iidm:temporaryLimit name="_efe2501d-bcee-42ff-a037-3d8a280487b0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0463da77-c766-11e1-8775-005056c00008" name="76-118" r="2.8575360000000001" x="9.4786560000000009" g1="0" b1="3.8911849999999999e-05" g2="0" b2="3.8911849999999999e-05" node1="22" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="-2.8462289048500038" q1="-15.776997381840655" p2="2.8907155862725098" q2="14.720157713838541">
+    <iidm:line id="_0463da77-c766-11e1-8775-005056c00008" name="76-118" r="2.8575360000000001" x="9.4786560000000009" g1="0" b1="3.8911849999999999e-05" g2="0" b2="3.8911849999999999e-05" node1="22" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="-2.7333751400596955" q1="-15.868089671070376" p2="2.778270045340244" q2="14.812767464559723">
         <iidm:alias>_046931a0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04806320-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10427,7 +10556,7 @@
             <iidm:temporaryLimit name="_2ae204bf-78cc-49cb-b886-a933b33057e4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046931a3-c766-11e1-8775-005056c00008" name="74-75" r="2.1431520000000002" x="7.0741440000000004" g1="0" b1="2.9671699999999999e-05" g2="0" b2="2.9671699999999999e-05" node1="23" voltageLevelId1="_047dcb11-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="-46.520805029155724" q1="-3.8173031329301685" p2="46.811174864098241" q2="3.815419389840677">
+    <iidm:line id="_046931a3-c766-11e1-8775-005056c00008" name="74-75" r="2.1431520000000002" x="7.0741440000000004" g1="0" b1="2.9671699999999999e-05" g2="0" b2="2.9671699999999999e-05" node1="23" voltageLevelId1="_047dcb11-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="-46.790015905619889" q1="-3.651769682330773" p2="47.083585178531528" q2="3.6604481235746049">
         <iidm:alias>_044f4103-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04638c58-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10435,7 +10564,7 @@
             <iidm:temporaryLimit name="_e822432e-79af-4bba-8f40-5250468f81a0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045ed162-c766-11e1-8775-005056c00008" name="3-12" r="8.4332159999999998" x="27.878398900000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="32" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-7.2866051505771896" q1="-10.558669512442869" p2="7.352032890018978" q2="6.8669658336146995">
+    <iidm:line id="_045ed162-c766-11e1-8775-005056c00008" name="3-12" r="8.4332159999999998" x="27.878398900000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="32" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-8.5352039310893986" q1="-9.8986842598083893" p2="8.6050514165127012" q2="6.2197981166591854">
         <iidm:alias>_047a48a1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047b5a14-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10443,7 +10572,7 @@
             <iidm:temporaryLimit name="_c437e52c-43d7-4ae9-87ad-dc19396dc6ff" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04499bb6-c766-11e1-8775-005056c00008" name="49-51" r="8.468064" x="23.8708782" g1="0" b1="9.81405e-05" g2="0" b2="9.81405e-05" node1="119" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04542300-c766-11e1-8775-005056c00008" p1="65.914648137563262" q1="20.60838798181706" p2="-63.672642443213668" q2="-17.683604073772567">
+    <iidm:line id="_04499bb6-c766-11e1-8775-005056c00008" name="49-51" r="8.468064" x="23.8708782" g1="0" b1="9.81405e-05" g2="0" b2="9.81405e-05" node1="119" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04542300-c766-11e1-8775-005056c00008" p1="65.940978668846057" q1="20.603304399384463" p2="-63.697472819996406" q2="-17.674283662283987">
         <iidm:alias>_0487dd38-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b1180-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10451,7 +10580,7 @@
             <iidm:temporaryLimit name="_90dcdbe1-437b-443f-b0b5-c2353f7c6954" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04839779-c766-11e1-8775-005056c00008" name="40-42" r="9.6703209999999995" x="31.885919999999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="42" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="12.909253059332679" q1="-15.511013701885481" p2="-12.660065189938843" q2="12.574864700713626">
+    <iidm:line id="_04839779-c766-11e1-8775-005056c00008" name="40-42" r="9.6703209999999995" x="31.885919999999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="42" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="13.092198564095996" q1="-15.627011184307044" p2="-12.837111791194712" q2="12.713508558106202">
         <iidm:alias>_044974a9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04616975-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10459,7 +10588,7 @@
             <iidm:temporaryLimit name="_9b8510fa-bd0e-4e63-8f4c-0e5443a3eb63" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0484a8e1-c766-11e1-8775-005056c00008" name="32-113" r="10.71576" x="35.370719999999999" g1="0" b1="0.00014864555000000001" g2="0" b2="0.00014864555000000001" node1="52" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="5.7590558468724398" q1="-9.7161173925226407" p2="-5.7019084095323889" q2="5.0219814374359526">
+    <iidm:line id="_0484a8e1-c766-11e1-8775-005056c00008" name="32-113" r="10.71576" x="35.370719999999999" g1="0" b1="0.00014864555000000001" g2="0" b2="0.00014864555000000001" node1="52" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="1.754544632767759" q1="-8.0256305727052855" p2="-1.7317777314070673" q2="3.2138551224979541">
         <iidm:alias>_04723258-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0482860a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10467,7 +10596,7 @@
             <iidm:temporaryLimit name="_336bfd86-a922-4154-9e06-cd87382cdc5f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04898ae4-c766-11e1-8775-005056c00008" name="51-58" r="4.4431200000000004" x="12.5278568" g1="0" b1="5.1308550000000002e-05" g2="0" b2="5.1308550000000002e-05" node1="31" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="18.380952312709148" q1="3.358885878232245" p2="-18.284001200931556" q2="-4.7435738609015559">
+    <iidm:line id="_04898ae4-c766-11e1-8775-005056c00008" name="51-58" r="4.4431200000000004" x="12.5278568" g1="0" b1="5.1308550000000002e-05" g2="0" b2="5.1308550000000002e-05" node1="31" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="18.397608501850058" q1="3.3519644708886869" p2="-18.300505629341782" q2="-4.736217387352899">
         <iidm:alias>_044778d4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04789af1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10475,7 +10604,7 @@
             <iidm:temporaryLimit name="_2be10dec-f0ac-470d-83f7-a2a4e70f3491" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046efe04-c766-11e1-8775-005056c00008" name="29-31" r="1.8817919999999999" x="5.7673439999999996" g1="0" b1="2.3817700000000001e-05" g2="0" b2="2.3817700000000001e-05" node1="22" voltageLevelId1="_04588fd5-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="-6.4235108153266243" q1="-9.6004977081232123" p2="6.4382030514726072" q2="8.8725179307685433">
+    <iidm:line id="_046efe04-c766-11e1-8775-005056c00008" name="29-31" r="1.8817919999999999" x="5.7673439999999996" g1="0" b1="2.3817700000000001e-05" g2="0" b2="2.3817700000000001e-05" node1="22" voltageLevelId1="_04588fd5-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="-8.2618812040260377" q1="-7.4840308195305498" p2="8.2756808118405321" q2="6.7528981682700344">
         <iidm:alias>_04492688-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047cb9a5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10483,7 +10612,7 @@
             <iidm:temporaryLimit name="_f0e21213-6535-44a7-89b6-3063f8738d6b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044a10e4-c766-11e1-8775-005056c00008" name="65-68" r="0.66791999999999996" x="7.7439999999999998" g1="0" b1="0.00065909092999999995" g2="0" b2="0.00065909092999999995" node1="41" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0449e9d2-c766-11e1-8775-005056c00008" p1="-83.292705138558489" q1="15.484161638417465" p2="83.418587296406443" q2="-78.058132792478816">
+    <iidm:line id="_044a10e4-c766-11e1-8775-005056c00008" name="65-68" r="0.66791999999999996" x="7.7439999999999998" g1="0" b1="0.00065909092999999995" g2="0" b2="0.00065909092999999995" node1="41" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0449e9d2-c766-11e1-8775-005056c00008" p1="-81.814199394332292" q1="15.339089107822467" p2="81.936557424812477" q2="-77.953890091589656">
         <iidm:alias>_0461dea7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047629f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10491,7 +10620,7 @@
             <iidm:temporaryLimit name="_ab31cd46-6d0c-4d9c-95f1-396a45a237e1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046b7b92-c766-11e1-8775-005056c00008" name="49-54" r="12.719519999999999" x="50.355361899999998" g1="0" b1="0.00021177684999999999" g2="0" b2="0.00021177684999999999" node1="120" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="37.045961131084375" q1="13.178401110394415" p2="-35.890271159642133" q2="-15.845313584866705">
+    <iidm:line id="_046b7b92-c766-11e1-8775-005056c00008" name="49-54" r="12.719519999999999" x="50.355361899999998" g1="0" b1="0.00021177684999999999" g2="0" b2="0.00021177684999999999" node1="120" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="37.069526742803944" q1="13.174836893202329" p2="-35.912707908577339" q2="-15.837281766281903">
         <iidm:alias>_0462f017-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047120e1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10499,7 +10628,7 @@
             <iidm:temporaryLimit name="_1bf78539-b6fa-4d8b-ba8e-9b5970019be6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04607f15-c766-11e1-8775-005056c00008" name="70-71" r="1.536797" x="6.1855200000000004" g1="0" b1="2.5195149999999999e-05" g2="0" b2="2.5195149999999999e-05" node1="52" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04664b78-c766-11e1-8775-005056c00008" p1="-4.4522472044346015" q1="-4.8460635287824783" p2="4.4558349702144691" q2="4.0090161309357404">
+    <iidm:line id="_04607f15-c766-11e1-8775-005056c00008" name="70-71" r="1.536797" x="6.1855200000000004" g1="0" b1="2.5195149999999999e-05" g2="0" b2="2.5195149999999999e-05" node1="52" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04664b78-c766-11e1-8775-005056c00008" p1="-3.8072396695453792" q1="-5.2676828139474319" p2="3.8106969582918557" q2="4.4298228646092044">
         <iidm:alias>_04486336-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f51b4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10507,7 +10636,7 @@
             <iidm:temporaryLimit name="_08ff3ae4-d1dd-49f7-9eda-32ffc8eb0010" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c5ad7-c766-11e1-8775-005056c00008" name="55-56" r="0.85029100000000002" x="2.631024" g1="0" b1="1.0732300000000001e-05" g2="0" b2="1.0732300000000001e-05" node1="31" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="-21.816614746915629" q1="-9.2163558398256704" p2="21.846690831114906" q2="8.9700067986643699">
+    <iidm:line id="_044c5ad7-c766-11e1-8775-005056c00008" name="55-56" r="0.85029100000000002" x="2.631024" g1="0" b1="1.0732300000000001e-05" g2="0" b2="1.0732300000000001e-05" node1="31" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="-21.832064366400566" q1="-9.2112878953439186" p2="21.862171867467374" q2="8.9650360682331431">
         <iidm:alias>_04558294-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045868c2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10515,7 +10644,7 @@
             <iidm:temporaryLimit name="_94316214-afd8-4c0d-bca4-916acb92af85" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048a2725-c766-11e1-8775-005056c00008" name="35-37" r="1.9166399999999999" x="8.6597279999999994" g1="0" b1="3.7821399999999997e-05" g2="0" b2="3.7821399999999997e-05" node1="21" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-30.683486778225465" q1="-13.922203247482907" p2="30.825981396704709" q2="13.413305523696057">
+    <iidm:line id="_048a2725-c766-11e1-8775-005056c00008" name="35-37" r="1.9166399999999999" x="8.6597279999999994" g1="0" b1="3.7821399999999997e-05" g2="0" b2="3.7821399999999997e-05" node1="21" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-30.602533469339022" q1="-13.960321425599858" p2="30.744677843561082" q2="13.451025111027112">
         <iidm:alias>_0471bd29-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04808a30-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10523,7 +10652,7 @@
             <iidm:temporaryLimit name="_4ea6b532-d914-4b0c-97ee-9f02a14a40b3" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04614263-c766-11e1-8775-005056c00008" name="4-5" r="0.30666199999999999" x="1.3904350000000001" g1="0" b1="6.0261499999999999e-06" g2="0" b2="6.0261499999999999e-06" node1="22" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-113.52215297791719" q1="-17.773396724975388" p2="113.75208021090097" q2="18.603009160619326">
+    <iidm:line id="_04614263-c766-11e1-8775-005056c00008" name="4-5" r="0.30666199999999999" x="1.3904350000000001" g1="0" b1="6.0261499999999999e-06" g2="0" b2="6.0261499999999999e-06" node1="22" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-109.00657139191763" q1="-19.592473064864567" p2="109.21979129617738" q2="20.345941030206312">
         <iidm:alias>_04529c66-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04753f92-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10531,7 +10660,7 @@
             <iidm:temporaryLimit name="_2a95fb2b-6661-46e7-a9f6-fe63c1b7433c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0451b208-c766-11e1-8775-005056c00008" name="20-21" r="3.1885919999999999" x="14.7929754" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_046b2d70-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0460f448-c766-11e1-8775-005056c00008" p1="-33.967552092620224" q1="1.3524526320258123" p2="34.209078576636955" q2="-2.1391654670918796">
+    <iidm:line id="_0451b208-c766-11e1-8775-005056c00008" name="20-21" r="3.1885919999999999" x="14.7929754" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_046b2d70-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0460f448-c766-11e1-8775-005056c00008" p1="-31.972691673301252" q1="0.37309220086051176" p2="32.185875522107402" q2="-1.2938997280062619">
         <iidm:alias>_046c65f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048c22f6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10539,7 +10668,7 @@
             <iidm:temporaryLimit name="_4b67f5f5-f0e1-4bfb-9d57-4d3474720a45" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047d55e4-c766-11e1-8775-005056c00008" name="104-105" r="1.731946" x="6.5862720000000001" g1="0" b1="2.8294300000000001e-05" g2="0" b2="2.8294300000000001e-05" node1="32" voltageLevelId1="_0483977a-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="47.97958812400568" q1="0.87912182483138313" p2="-47.73649539146578" q2="-0.87851416448932329">
+    <iidm:line id="_047d55e4-c766-11e1-8775-005056c00008" name="104-105" r="1.731946" x="6.5862720000000001" g1="0" b1="2.8294300000000001e-05" g2="0" b2="2.8294300000000001e-05" node1="32" voltageLevelId1="_0483977a-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="47.981322833327553" q1="0.87866181911546581" p2="-47.738212568995955" q2="-0.87798713050328236">
         <iidm:alias>_0451d910-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046c65f2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10547,7 +10676,7 @@
             <iidm:temporaryLimit name="_1ca40dc7-6736-4fa8-b4cb-ca696949e421" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046dc589-c766-11e1-8775-005056c00008" name="44-45" r="3.9029759999999998" x="15.699023199999999" g1="0" b1="6.4279149999999996e-05" g2="0" b2="6.4279149999999996e-05" node1="23" voltageLevelId1="_04544a15-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_045d23b4-c766-11e1-8775-005056c00008" p1="-6.0790588460774133" q1="-10.50199542182658" p2="6.1088834398672658" q2="8.4783683494803359">
+    <iidm:line id="_046dc589-c766-11e1-8775-005056c00008" name="44-45" r="3.9029759999999998" x="15.699023199999999" g1="0" b1="6.4279149999999996e-05" g2="0" b2="6.4279149999999996e-05" node1="23" voltageLevelId1="_04544a15-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_045d23b4-c766-11e1-8775-005056c00008" p1="-5.8401461192004973" q1="-10.665701768676378" p2="5.8700459852280469" q2="8.6428578993097513">
         <iidm:alias>_04518afa-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04667287-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10555,7 +10684,7 @@
             <iidm:temporaryLimit name="_ba738481-ddba-4ebe-a218-8aad0b537f5b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04642896-c766-11e1-8775-005056c00008" name="4-11" r="3.641616" x="11.9877129" g1="0" b1="5.0160700000000002e-05" g2="0" b2="5.0160700000000002e-05" node1="23" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="74.529824222764177" q1="5.7773303846956852" p2="-73.371621061646948" q2="-3.6980565612839049">
+    <iidm:line id="_04642896-c766-11e1-8775-005056c00008" name="4-11" r="3.641616" x="11.9877129" g1="0" b1="5.0160700000000002e-05" g2="0" b2="5.0160700000000002e-05" node1="23" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="70.014241171347408" q1="7.5964059503550523" p2="-68.987184358799297" q2="-5.9511772602699669">
         <iidm:alias>_0455f7c5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04803c17-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10563,7 +10692,7 @@
             <iidm:temporaryLimit name="_b1d87c24-e527-4174-aa04-cd0b9de271ea" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047d07c0-c766-11e1-8775-005056c00008" name="92-93" r="4.4953919999999998" x="14.775551800000001" g1="0" b1="6.2557400000000005e-05" g2="0" b2="6.2557400000000005e-05" node1="72" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04789af0-c766-11e1-8775-005056c00008" p1="71.184427827867665" q1="-12.862839455738456" p2="-69.812101661486579" q2="15.253306322987276">
+    <iidm:line id="_047d07c0-c766-11e1-8775-005056c00008" name="92-93" r="4.4953919999999998" x="14.775551800000001" g1="0" b1="6.2557400000000005e-05" g2="0" b2="6.2557400000000005e-05" node1="72" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04789af0-c766-11e1-8775-005056c00008" p1="71.242093797426804" q1="-12.79956765485708" p2="-69.867852117275248" q2="15.196694347050673">
         <iidm:alias>_044a5f07-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047602e5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10571,7 +10700,7 @@
             <iidm:temporaryLimit name="_4e1daf8e-7708-4b96-8d3f-67f58f2505f9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044f4109-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="43" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="121" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-40.247270017102764" q1="-25.259281092636442" p2="42.059500943380876" q2="25.380485482179395">
+    <iidm:line id="_044f4109-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="43" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="121" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-40.070433242926597" q1="-25.395466330080886" p2="41.876795373724448" q2="25.492531803141087">
         <iidm:alias>_046958b0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04758db0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10579,7 +10708,7 @@
             <iidm:temporaryLimit name="_c58940cb-bd36-4dfc-9615-11716dd652a7" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046e61c8-c766-11e1-8775-005056c00008" name="69-75" r="7.0567200000000003" x="21.257280000000002" g1="0" b1="0.00035583104999999999" g2="0" b2="0.00035583104999999999" node1="61" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="86.51799920749437" q1="25.417280917964192" p2="-83.299422442942713" q2="-28.166944120705235">
+    <iidm:line id="_046e61c8-c766-11e1-8775-005056c00008" name="69-75" r="7.0567200000000003" x="21.257280000000002" g1="0" b1="0.00035583104999999999" g2="0" b2="0.00035583104999999999" node1="61" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="86.88686326664515" q1="25.345958491266927" p2="-83.645830923850212" q2="-28.027772092928831">
         <iidm:alias>_046d294a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048ac362-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10587,7 +10716,7 @@
             <iidm:temporaryLimit name="_3c9a454c-10ee-4c72-a059-77f723f5b7c7" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0463da71-c766-11e1-8775-005056c00008" name="79-80" r="2.7181440000000001" x="12.2664957" g1="0" b1="5.3661600000000001e-05" g2="0" b2="5.3661600000000001e-05" node1="23" voltageLevelId1="_04481510-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-70.190077337454625" q1="-31.542284918093234" p2="71.092368583220434" q2="33.655136559979063">
+    <iidm:line id="_0463da71-c766-11e1-8775-005056c00008" name="79-80" r="2.7181440000000001" x="12.2664957" g1="0" b1="5.3661600000000001e-05" g2="0" b2="5.3661600000000001e-05" node1="23" voltageLevelId1="_04481510-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-70.274847893465534" q1="-31.65392199911739" p2="71.180200112769455" q2="33.780768903221215">
         <iidm:alias>_0464ebe9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04662468-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10595,7 +10724,7 @@
             <iidm:temporaryLimit name="_270a7d04-9ff9-4178-8b72-b610735a72ac" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044fdd41-c766-11e1-8775-005056c00008" name="51-52" r="3.5370720000000002" x="10.2453117" g1="0" b1="4.0059699999999999e-05" g2="0" b2="4.0059699999999999e-05" node1="32" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04806326-c766-11e1-8775-005056c00008" p1="28.28365728790817" q1="6.3184162782840305" p2="-28.099407647753228" q2="-7.076376530414195">
+    <iidm:line id="_044fdd41-c766-11e1-8775-005056c00008" name="51-52" r="3.5370720000000002" x="10.2453117" g1="0" b1="4.0059699999999999e-05" g2="0" b2="4.0059699999999999e-05" node1="32" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04806326-c766-11e1-8775-005056c00008" p1="28.291829466317026" q1="6.316015826218857" p2="-28.107485743913653" q2="-7.0736964920933039">
         <iidm:alias>_045115c2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0464ebe5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10603,7 +10732,7 @@
             <iidm:temporaryLimit name="_9d1eb182-ceb5-426e-9440-5f4d426a31cb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c3958-c766-11e1-8775-005056c00008" name="53-54" r="4.5825120000000004" x="21.257280000000002" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="22" voltageLevelId1="_04876804-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="-12.967467115866571" q1="-5.4684304194286089" p2="13.02177966355055" q2="2.9196037119830391">
+    <iidm:line id="_045c3958-c766-11e1-8775-005056c00008" name="53-54" r="4.5825120000000004" x="21.257280000000002" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="22" voltageLevelId1="_04876804-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="-12.959456890823867" q1="-5.4713835055075943" p2="13.013715654116661" q2="2.9223109586407281">
         <iidm:alias>_044f6817-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0455f7c6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10611,7 +10740,7 @@
             <iidm:temporaryLimit name="_735ac8df-6a6a-43f0-86f2-49d3280c9a3b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044ef2e1-c766-11e1-8775-005056c00008" name="54-55" r="2.9446560000000002" x="12.3187675" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="63" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04767817-c766-11e1-8775-005056c00008" p1="7.4530774721144573" q1="2.2335345620808349" p2="-7.4409401275424862" q2="-4.0180372621214877">
+    <iidm:line id="_044ef2e1-c766-11e1-8775-005056c00008" name="54-55" r="2.9446560000000002" x="12.3187675" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="63" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04767817-c766-11e1-8775-005056c00008" p1="7.4586795848614438" q1="2.2323429500655587" p2="-7.4465281555268614" q2="-4.0167868895760064">
         <iidm:alias>_04640181-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047dcb17-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10619,7 +10748,7 @@
             <iidm:temporaryLimit name="_52aadf8d-53f2-4827-8c70-421bdf1ba822" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0456e226-c766-11e1-8775-005056c00008" name="80-97" r="3.1885919999999999" x="16.2740154" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="82" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="12.090066647356053" q1="30.931529330985203" p2="-11.888761053922925" q2="-32.570370582546524">
+    <iidm:line id="_0456e226-c766-11e1-8775-005056c00008" name="80-97" r="3.1885919999999999" x="16.2740154" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="82" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="12.133455318152302" q1="31.132287953299421" p2="-11.929770437333891" q2="-32.758504035188061">
         <iidm:alias>_04479fe9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047df222-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10627,7 +10756,7 @@
             <iidm:temporaryLimit name="_fece5807-6af8-4161-8de8-8f8473d92f11" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0487b624-c766-11e1-8775-005056c00008" name="103-110" r="6.8058139999999998" x="31.5897121" g1="0" b1="0.00013228879999999999" g2="0" b2="0.00013228879999999999" node1="43" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="57.61093734440702" q1="18.507336416627709" p2="-56.1734773737697" q2="-16.289019316589439">
+    <iidm:line id="_0487b624-c766-11e1-8775-005056c00008" name="103-110" r="6.8058139999999998" x="31.5897121" g1="0" b1="0.00013228879999999999" g2="0" b2="0.00013228879999999999" node1="43" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="57.614609369772538" q1="18.507001795053078" p2="-56.176992506087529" q2="-16.287955072402507">
         <iidm:alias>_046a9139-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b3895-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10635,7 +10764,7 @@
             <iidm:temporaryLimit name="_3eacc034-737e-41de-a7b6-b610d3bd0921" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045338a8-c766-11e1-8775-005056c00008" name="56-58" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="61" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="-6.2624099080507198" q1="-3.9059121377255193" p2="6.2801581153294901" q2="1.7419721834542941">
+    <iidm:line id="_045338a8-c766-11e1-8775-005056c00008" name="56-58" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="61" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="-6.2788501720712917" q1="-3.8983769170420164" p2="6.2966601855398903" q2="1.7346147895910273">
         <iidm:alias>_0451d915-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04817494-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10643,7 +10772,7 @@
             <iidm:temporaryLimit name="_0d0c3ec5-798a-48a4-9bc8-d19c57128a13" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04854529-c766-11e1-8775-005056c00008" name="15-33" r="6.6211200000000003" x="21.675455100000001" g1="0" b1="9.1655200000000003e-05" g2="0" b2="9.1655200000000003e-05" node1="52" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456bb11-c766-11e1-8775-005056c00008" p1="67.266714366571762" q1="-6.5494423379498903" p2="-65.334230024252292" q2="10.065014612382859">
+    <iidm:line id="_04854529-c766-11e1-8775-005056c00008" name="15-33" r="6.6211200000000003" x="21.675455100000001" g1="0" b1="9.1655200000000003e-05" g2="0" b2="9.1655200000000003e-05" node1="52" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456bb11-c766-11e1-8775-005056c00008" p1="68.325508689399257" q1="-6.6060859812735213" p2="-66.330282309011665" q2="10.32985502385158">
         <iidm:alias>_0448d862-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047d2ed5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10651,7 +10780,7 @@
             <iidm:temporaryLimit name="_5b0395f4-534d-4975-a1af-e0b6ef439193" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04649dc2-c766-11e1-8775-005056c00008" name="35-36" r="0.39029799999999998" x="1.7772479999999999" g1="0" b1="7.6905500000000004e-06" g2="0" b2="7.6905500000000004e-06" node1="22" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="-2.1800923673825321" q1="4.9841283655901014" p2="2.1808895295730077" q2="-5.2120354246894838">
+    <iidm:line id="_04649dc2-c766-11e1-8775-005056c00008" name="35-36" r="0.39029799999999998" x="1.7772479999999999" g1="0" b1="7.6905500000000004e-06" g2="0" b2="7.6905500000000004e-06" node1="22" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="-2.261156372923451" q1="5.0222089702719463" p2="2.2619737939151165" q2="-5.2497798422721083">
         <iidm:alias>_044c0cb5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0456e225-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10659,7 +10788,7 @@
             <iidm:temporaryLimit name="_74c4b341-7b99-4a81-b88a-2ed3b0c4b1de" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0470d2c9-c766-11e1-8775-005056c00008" name="37-40" r="10.3324327" x="29.272320000000001" g1="0" b1="0.0001205234" g2="0" b2="0.0001205234" node1="61" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="70.398669909297851" q1="7.5665448816068901" p2="-67.017503461087074" q2="-1.4997397485337767">
+    <iidm:line id="_0470d2c9-c766-11e1-8775-005056c00008" name="37-40" r="10.3324327" x="29.272320000000001" g1="0" b1="0.0001205234" g2="0" b2="0.0001205234" node1="61" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="70.596785685862272" q1="7.5121351616208916" p2="-67.194190062805248" q2="-1.3810336704750763">
         <iidm:alias>_045b9d10-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046a4317-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10667,7 +10796,7 @@
             <iidm:temporaryLimit name="_e98d56fe-a54b-45e4-acff-0ac310beb3dd" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044e56a2-c766-11e1-8775-005056c00008" name="48-49" r="3.1188959999999999" x="8.7991200000000003" g1="0" b1="3.6099649999999999e-05" g2="0" b2="3.6099649999999999e-05" node1="23" voltageLevelId1="_044778d3-c766-11e1-8775-005056c00008" node2="122" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-21.885718945838857" q1="-0.931244962030503" p2="21.967984415856705" q2="-0.15316591588388981">
+    <iidm:line id="_044e56a2-c766-11e1-8775-005056c00008" name="48-49" r="3.1188959999999999" x="8.7991200000000003" g1="0" b1="3.6099649999999999e-05" g2="0" b2="3.6099649999999999e-05" node1="23" voltageLevelId1="_044778d3-c766-11e1-8775-005056c00008" node2="122" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-21.85983949441599" q1="-0.9397592415150493" p2="21.941911278567943" q2="-0.14519897556711098">
         <iidm:alias>_0454bf49-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0460a623-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10675,7 +10804,7 @@
             <iidm:temporaryLimit name="_f2e58700-2366-46e0-8408-9472d85acd23" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047eb573-c766-11e1-8775-005056c00008" name="56-59" r="14.3748007" x="43.734237700000001" g1="0" b1="0.0001632805" g2="0" b2="0.0001632805" node1="62" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-27.353686942471562" q1="-4.4542931041912395" p2="28.035206812594282" q2="1.178639746087131">
+    <iidm:line id="_047eb573-c766-11e1-8775-005056c00008" name="56-59" r="14.3748007" x="43.734237700000001" g1="0" b1="0.0001632805" g2="0" b2="0.0001632805" node1="62" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-27.335729858334616" q1="-4.4616843417441903" p2="28.016384415472295" q2="1.1833979477787928">
         <iidm:alias>_0468bc78-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048915b0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10683,7 +10812,7 @@
             <iidm:temporaryLimit name="_89654167-95a6-4c76-aad7-63a881116e17" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046f9a4b-c766-11e1-8775-005056c00008" name="94-100" r="3.1014719999999998" x="10.105919999999999" g1="0" b1="0.00017332415000000001" g2="0" b2="0.00017332415000000001" node1="52" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-7.0128741930417045" q1="-51.939855664624957" p2="7.4606046937974568" q2="47.333634006853202">
+    <iidm:line id="_046f9a4b-c766-11e1-8775-005056c00008" name="94-100" r="3.1014719999999998" x="10.105919999999999" g1="0" b1="0.00017332415000000001" g2="0" b2="0.00017332415000000001" node1="52" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-7.0280593462383996" q1="-52.215243198414704" p2="7.4809494017181404" q2="47.626851403689855">
         <iidm:alias>_04812676-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048a2722-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10691,7 +10820,7 @@
             <iidm:temporaryLimit name="_216c0f3b-03e8-4b7d-96fc-a5f891331f7f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046735d0-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="123" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-14.178667589970367" q1="24.714565251346844" p2="14.329081468612939" q2="-26.500110138298389">
+    <iidm:line id="_046735d0-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="123" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-14.133561851238785" q1="24.698816894484015" p2="14.283616554732342" q2="-26.486209733441253">
         <iidm:alias>_04570934-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b3894-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10699,7 +10828,7 @@
             <iidm:temporaryLimit name="_32655e4f-e7da-46b0-a908-b601224ddb73" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046d294b-c766-11e1-8775-005056c00008" name="21-22" r="3.641616" x="16.901281399999998" g1="0" b1="7.0592299999999998e-05" g2="0" b2="7.0592299999999998e-05" node1="22" voltageLevelId1="_0460f448-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04773b6a-c766-11e1-8775-005056c00008" p1="-48.192730054784676" q1="-5.8452723305034375" p2="48.744843099547403" q2="6.1845504377618852">
+    <iidm:line id="_046d294b-c766-11e1-8775-005056c00008" name="21-22" r="3.641616" x="16.901281399999998" g1="0" b1="7.0592299999999998e-05" g2="0" b2="7.0592299999999998e-05" node1="22" voltageLevelId1="_0460f448-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04773b6a-c766-11e1-8775-005056c00008" p1="-46.170171184210588" q1="-6.6911491759188202" p2="46.678484569184839" q2="6.8224595814315707">
         <iidm:alias>_044a37f0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_044be5a2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10707,7 +10836,7 @@
             <iidm:temporaryLimit name="_bafaeace-e459-4dc2-87a0-467a9ea25f8d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_6a131803-f462-47e2-bc21-bda919364fe9" name="reactor1" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="36" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="37" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="-2.7755575615628914e-14" q1="-83.15138230470383" p2="3.0531133177191805e-14" q2="92.15102150946646">
+    <iidm:line id="_6a131803-f462-47e2-bc21-bda919364fe9" name="reactor1" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="36" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="37" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="7.7715611723760958e-14" q1="-83.151394693638238" p2="-7.7715611723760958e-14" q2="92.151035239279821">
         <iidm:alias>_04531196-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_ca0adad2-ffe3-4efa-b56b-7d333b8ae18f</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10715,7 +10844,7 @@
             <iidm:temporaryLimit name="_ae4eadea-f3fc-4ac6-8899-c1698ece7a89" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_9803b364-2a93-4f21-94b7-8bdbe27a16f2" name="reactor2" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="38" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="-1.3872940435311065e-07" q1="31.132987487759262" p2="1.3872940365922126e-07" q2="-29.996333958987492">
+    <iidm:line id="_9803b364-2a93-4f21-94b7-8bdbe27a16f2" name="reactor2" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="38" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="2.6103933042920247e-06" q1="31.129472534051374" p2="-2.6103933042920247e-06" q2="-29.993075738415975">
         <iidm:alias>_0461b792-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_afe0e60b-3870-44fb-ba93-a056228f9636</iidm:alias>
     </iidm:line>

--- a/tests/main_sa/reference/launch/two_windings_transformer_open_ended/outputIIDM.xml
+++ b/tests/main_sa/reference/launch/two_windings_transformer_open_ended/outputIIDM.xml
@@ -31,7 +31,7 @@
                     <iidm:alias>_bea273f1-1e21-476d-b0d0-92dd6cb9a2d4</iidm:alias>
                     <iidm:alias>_c94e6b68-da6c-43d1-94fd-09ad60c74134</iidm:alias>
                 </iidm:switch>
-                <iidm:switch id="_047abdd7-c766-11e1-8775-005056c00008-BREAKER" name="BREAKER-Jay LD" kind="BREAKER" retained="true" open="true" node1="0" node2="8"/>
+                <iidm:switch id="_047abdd7-c766-11e1-8775-005056c00008-BREAKER" name="BREAKER-Jay LD" kind="BREAKER" retained="true" open="false" node1="0" node2="8"/>
                 <iidm:internalConnection node1="7" node2="0"/>
                 <iidm:internalConnection node1="9" node2="1"/>
                 <iidm:internalConnection node1="10" node2="2"/>
@@ -47,9 +47,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.00460477378802" angle="-2.8865023170678468" nodes="0,1,2,3,4,5,6,7,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.79233166185206" angle="-3.8304666459037668" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047abdd7-c766-11e1-8775-005056c00008" name="Jay LD" loadType="UNDEFINED" p0="14" q0="8" node="8" p="0" q="0">
+            <iidm:load id="_047abdd7-c766-11e1-8775-005056c00008" name="Jay LD" loadType="UNDEFINED" p0="14" q0="8" node="8" p="13.998864784942427" q="7.9989188720250946">
                 <iidm:alias>_04590500-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -139,12 +139,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="128.00466666497914" angle="-0.58466591852371985" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="127.91097395769994" angle="-0.6072882464379814" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045b00d5-c766-11e1-8775-005056c00008" name="Madison LD" loadType="UNDEFINED" p0="62" q0="13" node="14" p="62.017064759771444" q="13.005964038427845">
+            <iidm:load id="_045b00d5-c766-11e1-8775-005056c00008" name="Madison LD" loadType="UNDEFINED" p0="62" q0="13" node="14" p="61.999319151283238" q="12.999762069867774">
                 <iidm:alias>_045b27e3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_04689566-c766-11e1-8775-005056c00008" name="Madison NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="15" p="9.0024771425474679" q="0">
+            <iidm:load id="_04689566-c766-11e1-8775-005056c00008" name="Madison NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="15" p="8.9999011671217595" q="0">
                 <iidm:alias>_04765100-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -272,16 +272,16 @@
                 <iidm:internalConnection node1="61" node2="12"/>
                 <iidm:internalConnection node1="62" node2="15"/>
                 <iidm:internalConnection node1="63" node2="18"/>
-                <iidm:bus v="126.06004191903422" angle="-19.453196159616766" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63"/>
+                <iidm:bus v="126.06000121955863" angle="-18.730304489335907" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_046c3ee7-c766-11e1-8775-005056c00008" name="Torrey SM" energySource="THERMAL" minP="20" maxP="80" ratedS="100" voltageRegulatorOn="true" targetP="48" targetV="126.06" targetQ="0" node="21" p="-52.972604726432827" q="-7.3968276989235786">
+            <iidm:generator id="_046c3ee7-c766-11e1-8775-005056c00008" name="Torrey SM" energySource="THERMAL" minP="20" maxP="80" ratedS="100" voltageRegulatorOn="true" targetP="48" targetV="126.06" targetQ="0" node="21" p="-53.142854873646037" q="-7.2793315792945412">
                 <iidm:alias>_047147f3-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_b97aee41-3115-4cfd-9071-b52fb44d0b66"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_5005c073-28d1-4a7d-b257-649dec43ec73"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-30" maxQ="85"/>
             </iidm:generator>
-            <iidm:load id="_044afb44-c766-11e1-8775-005056c00008" name="Torrey LD" loadType="UNDEFINED" p0="113" q0="32" node="20" p="113.0000563642463" q="32.000026602598552">
+            <iidm:load id="_044afb44-c766-11e1-8775-005056c00008" name="Torrey LD" loadType="UNDEFINED" p0="113" q0="32" node="20" p="113.00000163981588" q="32.000000773954397">
                 <iidm:alias>_04522737-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -332,9 +332,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="123.87514365157477" angle="-3.7246511201894776" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="123.83980886762907" angle="-3.0045258445796779" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04481515-c766-11e1-8775-005056c00008" name="Darrah LD" loadType="UNDEFINED" p0="68" q0="36" node="8" p="68.010591029794995" q="36.009345511445289">
+            <iidm:load id="_04481515-c766-11e1-8775-005056c00008" name="Darrah LD" loadType="UNDEFINED" p0="68" q0="36" node="8" p="68.002667970452734" q="36.002354122363293">
                 <iidm:alias>_044e7db8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -385,9 +385,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.46784025344323" angle="10.508519079584536" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.46504503238128" angle="11.411727190444301" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044c0cb3-c766-11e1-8775-005056c00008" name="Smythe LD" loadType="UNDEFINED" p0="5" q0="3" node="8" p="5.0001148338470278" q="3.0001148347261459">
+            <iidm:load id="_044c0cb3-c766-11e1-8775-005056c00008" name="Smythe LD" loadType="UNDEFINED" p0="5" q0="3" node="8" p="5.0000664684913003" q="3.0000664687858367">
                 <iidm:alias>_045163e8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -514,9 +514,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="125.90792597604587" angle="-19.625773035683189" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="125.9081847305053" angle="-18.90272620385403" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0450a093-c766-11e1-8775-005056c00008" name="Sunnysde LD" loadType="UNDEFINED" p0="84" q0="18" node="20" p="83.999963706621131" q="17.999987038080839">
+            <iidm:load id="_0450a093-c766-11e1-8775-005056c00008" name="Sunnysde LD" loadType="UNDEFINED" p0="84" q0="18" node="20" p="84.000001266134745" q="18.000000452190974">
                 <iidm:alias>_045f4695-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -568,12 +568,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="126.80626361901399" angle="-3.8161785274804121" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="126.74216471979248" angle="-3.1631707920346592" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044b2251-c766-11e1-8775-005056c00008" name="Bellefnt LD" loadType="UNDEFINED" p0="68" q0="27" node="8" p="68.015353144195984" q="27.010160933593554">
+            <iidm:load id="_044b2251-c766-11e1-8775-005056c00008" name="Bellefnt LD" loadType="UNDEFINED" p0="68" q0="27" node="8" p="68.001673495821592" q="27.001107469555091">
                 <iidm:alias>_04622cc1-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0449e9d5-c766-11e1-8775-005056c00008" name="Bellefnt SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.40300000000001" targetDeadband="1" node="9" q="-11.079001831687245">
+            <iidm:shunt id="_0449e9d5-c766-11e1-8775-005056c00008" name="Bellefnt SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.40300000000001" targetDeadband="1" node="9" q="-11.067804083004857">
                 <iidm:alias>_047bcf48-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_6cc38790-c6a6-4309-99f4-a3258e24e785"/>
                 <iidm:shuntLinearModel bPerSection="0.00013779999999999999" gPerSection="0" maximumSectionCount="10"/>
@@ -665,12 +665,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="126.06561768013582" angle="-3.8254249805384455" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="126.06591526247986" angle="-2.9252077103850023" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04682035-c766-11e1-8775-005056c00008" name="Fieldale LD" loadType="UNDEFINED" p0="39" q0="30" node="14" p="38.999989128154127" q="29.999986061737349">
+            <iidm:load id="_04682035-c766-11e1-8775-005056c00008" name="Fieldale LD" loadType="UNDEFINED" p0="39" q0="30" node="14" p="39.000006777904169" q="30.000008689621225">
                 <iidm:alias>_0478c20a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_045c6067-c766-11e1-8775-005056c00008" name="Fieldale SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.066" targetDeadband="1" node="15" q="-5.4670337466095154">
+            <iidm:shunt id="_045c6067-c766-11e1-8775-005056c00008" name="Fieldale SC" sectionCount="5" voltageRegulatorOn="true" targetV="126.066" targetDeadband="1" node="15" q="-5.467059556892564">
                 <iidm:alias>_0451b209-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_2d222dd9-7306-4afd-baa5-fd303b0eeb40"/>
                 <iidm:shuntLinearModel bPerSection="6.8800000000000005e-05" gPerSection="0" maximumSectionCount="10"/>
@@ -780,7 +780,7 @@
                 <iidm:internalConnection node1="51" node2="9"/>
                 <iidm:internalConnection node1="52" node2="12"/>
                 <iidm:internalConnection node1="53" node2="15"/>
-                <iidm:bus v="138.01517582243704" angle="-7.6471172903115052" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
+                <iidm:bus v="138.0148307307235" angle="-6.9376231889759223" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
             </iidm:nodeBreakerTopology>
             <iidm:generator id="_047f0391-c766-11e1-8775-005056c00008" name="Muskngum SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="392" targetV="138.59999099999999" targetQ="0" node="18" p="-0" q="-0">
                 <iidm:alias>_047eb572-c766-11e1-8775-005056c00008</iidm:alias>
@@ -789,7 +789,7 @@
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
-            <iidm:load id="_047e1936-c766-11e1-8775-005056c00008" name="Muskngum LD" loadType="UNDEFINED" p0="39" q0="18" node="17" p="38.999801030837027" q="17.999846947057993">
+            <iidm:load id="_047e1936-c766-11e1-8775-005056c00008" name="Muskngum LD" loadType="UNDEFINED" p0="39" q0="18" node="17" p="38.999750842662806" q="17.999808340917998">
                 <iidm:alias>_046e88d5-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -876,9 +876,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="221.10006999226573" angle="-2.4917620988581559" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="221.10000322399904" angle="-1.7779419791272169" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0458ddf1-c766-11e1-8775-005056c00008" name="Muskngum SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="391" targetV="221.09999999999999" targetQ="0" node="14" p="-431.50600933406747" q="-158.32202649372789">
+            <iidm:generator id="_0458ddf1-c766-11e1-8775-005056c00008" name="Muskngum SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="391" targetV="221.09999999999999" targetQ="0" node="14" p="-432.89283865824177" q="-159.61358655573309">
                 <iidm:alias>_04522732-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_5036c3a5-56f9-489c-9ecb-8c15aa7c70c5"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_12b01822-ca11-4cf8-a6b4-2f8ff805ca20"/>
@@ -886,7 +886,7 @@
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045cae83-c766-11e1-8775-005056c00008" name="65-66" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="42" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="272.93269781532786" q1="97.396749748301261" p2="-272.93269781532786" q2="-70.502461043569156">
+        <iidm:twoWindingsTransformer id="_045cae83-c766-11e1-8775-005056c00008" name="65-66" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="42" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="273.16033942658413" q1="97.423957285620972" p2="-273.16033942658407" q2="-70.48814307430618">
             <iidm:alias>_044b2254-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_044b4964-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_045645e1-c766-11e1-8775-005056c00008</iidm:alias>
@@ -961,9 +961,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="125.57774163466446" angle="-4.9293514568909407" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.12709614603396" angle="-5.5373617708380989" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0453d4e2-c766-11e1-8775-005056c00008" name="Adams LD" loadType="UNDEFINED" p0="18" q0="3" node="8" p="18.077647772669192" q="3.0215998251803287">
+            <iidm:load id="_0453d4e2-c766-11e1-8775-005056c00008" name="Adams LD" loadType="UNDEFINED" p0="18" q0="3" node="8" p="17.998296581494973" q="2.9995268431193098">
                 <iidm:alias>_0448ff77-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1053,16 +1053,16 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="133.32005735690669" angle="1.9236922683418012" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="133.32000036593834" angle="2.8164930594356239" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_046bf0c4-c766-11e1-8775-005056c00008" name="Claytor SM" energySource="THERMAL" minP="0" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="40" targetV="133.31999200000001" targetQ="0" node="15" p="-44.143837272027362" q="-83.146696831248192">
+            <iidm:generator id="_046bf0c4-c766-11e1-8775-005056c00008" name="Claytor SM" energySource="THERMAL" minP="0" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="40" targetV="133.31999200000001" targetQ="0" node="15" p="-44.285712394705037" q="-83.073908894208188">
                 <iidm:alias>_0460a627-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e56da2eb-bb6a-4133-953c-40073c5bc5f4"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_d41be6b4-155e-4c8f-b46b-16b50c49f0f4"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-60" maxQ="170"/>
             </iidm:generator>
-            <iidm:load id="_048433b6-c766-11e1-8775-005056c00008" name="Claytor LD" loadType="UNDEFINED" p0="23" q0="16" node="14" p="23.000016912793971" q="16.000019609041296">
+            <iidm:load id="_048433b6-c766-11e1-8775-005056c00008" name="Claytor LD" loadType="UNDEFINED" p0="23" q0="16" node="14" p="23.000002164903208" q="16.000002510032779">
                 <iidm:alias>_0480ff6b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1133,12 +1133,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="129.7592447702105" angle="-16.201640914301979" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="129.73419086464335" angle="-15.55209473781728" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0449e9d7-c766-11e1-8775-005056c00008" name="N.Newark LD" loadType="UNDEFINED" p0="53" q0="22" node="11" p="53.001942485322175" q="22.001343874187747">
+            <iidm:load id="_0449e9d7-c766-11e1-8775-005056c00008" name="N.Newark LD" loadType="UNDEFINED" p0="53" q0="22" node="11" p="52.997768135954146" q="21.998455964786771">
                 <iidm:alias>_04531191-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_04684741-c766-11e1-8775-005056c00008" name="N.Newark SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.32300000000001" targetDeadband="1" node="12" q="-9.6647029603145178">
+            <iidm:shunt id="_04684741-c766-11e1-8775-005056c00008" name="N.Newark SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.32300000000001" targetDeadband="1" node="12" q="-9.6609712003203292">
                 <iidm:alias>_04607f19-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_eae61817-d3cb-488f-a1f3-13bc8e31431b"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -1191,9 +1191,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="131.20488698654398" angle="-0.6741940524460146" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="131.04047289314462" angle="-0.36086555126679215" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0448d86a-c766-11e1-8775-005056c00008" name="Hillsbro NegG LD" loadType="UNDEFINED" p0="12" q0="0" node="8" p="12.005756503069735" q="0">
+            <iidm:load id="_0448d86a-c766-11e1-8775-005056c00008" name="Hillsbro NegG LD" loadType="UNDEFINED" p0="12" q0="0" node="8" p="12.000002421977239" q="0">
                 <iidm:alias>_044ef2e8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1244,9 +1244,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="125.33681302748006" angle="-17.611548320015409" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="125.27544385600287" angle="-17.129851788444196" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047dcb12-c766-11e1-8775-005056c00008" name="S.Kenton LD" loadType="UNDEFINED" p0="18" q0="7" node="8" p="18.000177541131524" q="7.000115073333955">
+            <iidm:load id="_047dcb12-c766-11e1-8775-005056c00008" name="S.Kenton LD" loadType="UNDEFINED" p0="18" q0="7" node="8" p="17.996546227477822" q="6.9977615869139402">
                 <iidm:alias>_0451b205-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1282,7 +1282,7 @@
                     <iidm:alias>_a0244ab3-80e5-4c20-b201-a142d50e6ec1</iidm:alias>
                 </iidm:switch>
                 <iidm:switch id="_dffdb415-95a8-496a-ad1a-93cdeb444fae-1" name="DISCONNECTOR723-1" kind="DISCONNECTOR" retained="false" open="false" node1="24" node2="25"/>
-                <iidm:switch id="_aa063f2e-1205-4d1a-a549-3ccc5b31e65d-1" name="BREAKER362-1" kind="BREAKER" retained="false" open="false" node1="23" node2="24"/>
+                <iidm:switch id="_aa063f2e-1205-4d1a-a549-3ccc5b31e65d-1" name="BREAKER362-1" kind="BREAKER" retained="false" open="true" node1="23" node2="24"/>
                 <iidm:switch id="_28b3e895-483c-478d-a5a3-7b9d7c9e11f3-1" name="DISCONNECTOR724-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="23"/>
                 <iidm:internalConnection node1="7" node2="0"/>
                 <iidm:internalConnection node1="8" node2="0"/>
@@ -1300,9 +1300,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="124.19456593530134" angle="9.1251049783605787" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25"/>
+                <iidm:bus v="125.18683721615834" angle="9.9110794998392073" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044afb49-c766-11e1-8775-005056c00008" name="Hazard LD" loadType="UNDEFINED" p0="21" q0="10" node="8" p="20.998987672139442" q="9.9991965781002534">
+            <iidm:load id="_044afb49-c766-11e1-8775-005056c00008" name="Hazard LD" loadType="UNDEFINED" p0="21" q0="10" node="8" p="21.062823863164652" q="10.049909913158581">
                 <iidm:alias>_045e5c31-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1335,14 +1335,14 @@
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="3"/>
-                <iidm:bus v="31.048641483825328" angle="9.1251049783605804" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13"/>
+                <iidm:bus v="31.296709304039588" angle="9.9110794998392038" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13"/>
             </iidm:nodeBreakerTopology>
             <iidm:staticVarCompensator id="_047fc6e6-c766-11e1-8775-005056c00008" name="Pinevlle SVC" bMin="-10" bMax="10" voltageSetpoint="33.494999999999997" regulationMode="VOLTAGE" node="5" p="0" q="0">
                 <iidm:alias>_046ab846-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_98f667da-02d1-4a31-b826-44314a1fbbfe"/>
             </iidm:staticVarCompensator>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045e3525-c766-11e1-8775-005056c00008" name="86-87" r="0.30796918750000002" x="2.2585859312499998" g="0" b="-0.0040863184000000004" ratedU1="132" ratedU2="33" node1="22" voltageLevelId1="_0484f70a-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_04555b88-c766-11e1-8775-005056c00008" p1="-2.0383000842727483e-14" q1="3.9392850552069043" p2="7.6617565888779289e-15" q2="-4.770010142681741e-14">
+        <iidm:twoWindingsTransformer id="_045e3525-c766-11e1-8775-005056c00008" name="86-87" r="0.30796918750000002" x="2.2585859312499998" g="0" b="-0.0040863184000000004" ratedU1="132" ratedU2="33" node1="22" voltageLevelId1="_0484f70a-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_04555b88-c766-11e1-8775-005056c00008" p1="-1.0408340855860843e-15" q1="4.0024835458964549" p2="-7.9287245355202419e-15" q2="4.5377732274571352e-14">
             <iidm:alias>_0452755a-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04682034-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_048c7110-c766-11e1-8775-005056c00008</iidm:alias>
@@ -1418,7 +1418,7 @@
                 <iidm:temporaryLimit name="_257d56c1-d70a-4a96-b85c-d928ade03ad4" acceptableDuration="60" value="12246"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_045e3525-c766-11e1-8775-005056c00008-1" name="86-87-open-ended" r="0.30796918750000002" x="2.2585859312499998" g="0" b="-0.0040863184000000004" ratedU1="132" ratedU2="33" node1="25" voltageLevelId1="_0484f70a-c766-11e1-8775-005056c00008" node2="15" voltageLevelId2="_04555b88-c766-11e1-8775-005056c00008" p1="0" q1="3.939285055206851" p2="0" q2="0">
+        <iidm:twoWindingsTransformer id="_045e3525-c766-11e1-8775-005056c00008-1" name="86-87-open-ended" r="0.30796918750000002" x="2.2585859312499998" g="0" b="-0.0040863184000000004" ratedU1="132" ratedU2="33" node1="25" voltageLevelId1="_0484f70a-c766-11e1-8775-005056c00008" node2="15" voltageLevelId2="_04555b88-c766-11e1-8775-005056c00008" p1="0" q1="0" p2="0" q2="0">
             <iidm:alias>_0452755a-c766-11e1-8775-005056c00008-1</iidm:alias>
             <iidm:alias>_04682034-c766-11e1-8775-005056c00008-1</iidm:alias>
             <iidm:alias>_048c7110-c766-11e1-8775-005056c00008-1</iidm:alias>
@@ -1542,12 +1542,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="132.89895200873292" angle="0.10841572358231059" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="132.85831791774302" angle="0.13779620130408241" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0447ee05-c766-11e1-8775-005056c00008" name="NwCarlsl NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="8" p="9.0009599009513295" q="0">
+            <iidm:load id="_0447ee05-c766-11e1-8775-005056c00008" name="NwCarlsl NegG LD" loadType="UNDEFINED" p0="9" q0="0" node="8" p="8.9998795892340944" q="0">
                 <iidm:alias>_04731cb7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_047a48a8-c766-11e1-8775-005056c00008" name="NwCarlsl LD" loadType="UNDEFINED" p0="30" q0="12" node="9" p="30.00319966983777" q="12.002133189060483">
+            <iidm:load id="_047a48a8-c766-11e1-8775-005056c00008" name="NwCarlsl LD" loadType="UNDEFINED" p0="30" q0="12" node="9" p="29.999598630780316" q="11.999732421713524">
                 <iidm:alias>_044c0cb9-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1598,9 +1598,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.62149483698715" angle="-2.8019211753095714" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.6218982782765" angle="-1.9063296035346673" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044ecbd1-c766-11e1-8775-005056c00008" name="Blaine LD" loadType="UNDEFINED" p0="2" q0="1" node="8" p="1.9999989627506074" q="0.99999913562565557">
+            <iidm:load id="_044ecbd1-c766-11e1-8775-005056c00008" name="Blaine LD" loadType="UNDEFINED" p0="2" q0="1" node="8" p="2.0000005298319703" q="1.000000441526681">
                 <iidm:alias>_04700f74-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1651,9 +1651,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="133.16949499792705" angle="3.2941239740545489" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="133.18439201423519" angle="4.1153951396722501" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046b7b95-c766-11e1-8775-005056c00008" name="Sundial LD" loadType="UNDEFINED" p0="15" q0="9" node="8" p="15.000311357708068" q="9.0003113598623656">
+            <iidm:load id="_046b7b95-c766-11e1-8775-005056c00008" name="Sundial LD" loadType="UNDEFINED" p0="15" q0="9" node="8" p="15.000955362563953" q="9.0009553828464206">
                 <iidm:alias>_046efe07-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1704,9 +1704,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.7639827190831" angle="-4.5216785942785247" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.74823488846002" angle="-4.5023307890859225" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045645e2-c766-11e1-8775-005056c00008" name="Riversde LD" loadType="UNDEFINED" p0="51" q0="27" node="8" p="51.002204568424567" q="27.001945235461694">
+            <iidm:load id="_045645e2-c766-11e1-8775-005056c00008" name="Riversde LD" loadType="UNDEFINED" p0="51" q0="27" node="8" p="50.999672618759419" q="26.999711134817588">
                 <iidm:alias>_0476ed4b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1757,9 +1757,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.54523580849983" angle="-0.57889245491198116" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.96652498943115" angle="-1.145790806955727" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04887973-c766-11e1-8775-005056c00008" name="Randolph LD" loadType="UNDEFINED" p0="10" q0="5" node="8" p="10.046189321006166" q="5.0385503330645145">
+            <iidm:load id="_04887973-c766-11e1-8775-005056c00008" name="Randolph LD" loadType="UNDEFINED" p0="10" q0="5" node="8" p="9.9994077211739363" q="4.9995064440559611">
                 <iidm:alias>_0462f018-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1810,9 +1810,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.48264994279926" angle="-18.818579210606423" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.48449020559927" angle="-18.102547118328733" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0477627b-c766-11e1-8775-005056c00008" name="WNwPhil2 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="11.999926804255503" q="2.9999695018351358">
+            <iidm:load id="_0477627b-c766-11e1-8775-005056c00008" name="WNwPhil2 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="11.999991186981418" q="2.9999963279098232">
                 <iidm:alias>_045841b6-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1882,9 +1882,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="126.73013547423734" angle="-2.0673831748110851" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="126.73055978198417" angle="-1.175950457768361" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0476781a-c766-11e1-8775-005056c00008" name="Cloverdl LD" loadType="UNDEFINED" p0="43" q0="16" node="11" p="42.999975806089793" q="15.999984996027495">
+            <iidm:load id="_0476781a-c766-11e1-8775-005056c00008" name="Cloverdl LD" loadType="UNDEFINED" p0="43" q0="16" node="11" p="43.000012727119234" q="16.000007892787902">
                 <iidm:alias>_0481749a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -1954,9 +1954,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="128.11668253625842" angle="-0.69842948401275695" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="128.11689994968324" angle="0.1933057605790946" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046b0665-c766-11e1-8775-005056c00008" name="Hancock LD" loadType="UNDEFINED" p0="38" q0="25" node="11" p="37.999999800166151" q="24.999999780883936">
+            <iidm:load id="_046b0665-c766-11e1-8775-005056c00008" name="Hancock LD" loadType="UNDEFINED" p0="38" q0="25" node="11" p="38.000007729849642" q="25.0000084757129">
                 <iidm:alias>_0464c4d5-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2008,12 +2008,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="128.68602305991223" angle="-17.260662291872272" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="128.64878505239693" angle="-16.655226876145015" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044bbe92-c766-11e1-8775-005056c00008" name="WMVernon LD" loadType="UNDEFINED" p0="16" q0="8" node="8" p="16.000545367076924" q="8.0004544777277182">
+            <iidm:load id="_044bbe92-c766-11e1-8775-005056c00008" name="WMVernon LD" loadType="UNDEFINED" p0="16" q0="8" node="8" p="15.998646445879523" q="7.9988720700406777">
                 <iidm:alias>_04500452-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_047825c8-c766-11e1-8775-005056c00008" name="WMVernon SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.21199999999999" targetDeadband="1" node="9" q="-9.5054931127803748">
+            <iidm:shunt id="_047825c8-c766-11e1-8775-005056c00008" name="WMVernon SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.21199999999999" targetDeadband="1" node="9" q="-9.4999926799927934">
                 <iidm:alias>_047084aa-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_2a6c1dcd-201b-4911-83b2-c16acc50a0f4"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -2047,9 +2047,9 @@
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="3"/>
-                <iidm:bus v="230.99998646418615" angle="22.331569732169982" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="230.99998501935983" angle="22.437295186222681" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_045868c0-c766-11e1-8775-005056c00008" name="Breed SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="450" targetV="230.99998500000001" targetQ="0" node="5" p="-496.61816931030779" q="28.502009987292219">
+            <iidm:generator id="_045868c0-c766-11e1-8775-005056c00008" name="Breed SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="450" targetV="230.99998500000001" targetQ="0" node="5" p="-498.21426444043169" q="27.223848401333754">
                 <iidm:alias>_045b7606-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_f26d4eb3-ebdb-4025-8080-f856ce656b42"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_7566f2a7-61eb-42fe-a59a-8276257fdbc6"/>
@@ -2123,9 +2123,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="127.47047443094633" angle="-17.707724300545351" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="127.47310413144653" angle="-16.996874839432198" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044d1e22-c766-11e1-8775-005056c00008" name="Newcmrst LD" loadType="UNDEFINED" p0="17" q0="8" node="11" p="16.999848854412246" q="7.9998814547923045">
+            <iidm:load id="_044d1e22-c766-11e1-8775-005056c00008" name="Newcmrst LD" loadType="UNDEFINED" p0="17" q0="8" node="11" p="16.999980754343948" q="7.9999849053734984">
                 <iidm:alias>_048a754b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2195,9 +2195,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="138.59999143103315" angle="12.475248772064775" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="138.59999102569691" angle="12.494781364153626" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_045ab2b0-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="220" targetV="138.59999099999999" targetQ="0" node="11" p="-242.79110499615052" q="-41.74084076940126">
+            <iidm:generator id="_045ab2b0-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="220" targetV="138.59999099999999" targetQ="0" node="11" p="-243.57141817087776" q="-45.750456867394973">
                 <iidm:alias>_046ba2a5-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_56975783-9739-40fc-8ec1-e1de8cb06c9a"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b8449cd9-5a17-497e-bf04-70f728b0f9f2"/>
@@ -2250,9 +2250,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="223.300000793457" angle="14.610780978989476" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="223.30000001773891" angle="14.64703442796541" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0483224a-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="314" targetV="223.30000000000001" targetQ="0" node="8" p="-346.52912258541477" q="-17.240885598751788">
+            <iidm:generator id="_0483224a-c766-11e1-8775-005056c00008" name="TannrsCk SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="314" targetV="223.30000000000001" targetQ="0" node="8" p="-347.64284229843457" q="-18.508361423725521">
                 <iidm:alias>_045cd594-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_05df66ba-3f64-40cb-8b18-c66d26c4e2c1"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_c1d29442-5f57-41d1-bb60-4b74b4994c20"/>
@@ -2260,7 +2260,7 @@
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045b7604-c766-11e1-8775-005056c00008" name="26-25" r="0" x="6.6559680000000006" g="0" b="0" ratedU1="220" ratedU2="132" node1="22" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="108.29381751186271" q1="22.200376049018583" p2="-108.29381751186271" q2="-18.024386383599126">
+        <iidm:twoWindingsTransformer id="_045b7604-c766-11e1-8775-005056c00008" name="26-25" r="0" x="6.6559680000000006" g="0" b="0" ratedU1="220" ratedU2="132" node1="22" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="109.14134182752564" q1="22.232101786264991" p2="-109.14134182752552" q2="-17.992657195725986">
             <iidm:alias>_0447c6f3-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0463b364-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04803c1c-c766-11e1-8775-005056c00008</iidm:alias>
@@ -2403,9 +2403,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="136.6200429399974" angle="2.7951505216534032" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="136.62000282883616" angle="3.5196617753165991" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_048aea70-c766-11e1-8775-005056c00008" name="Sporn SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="513.43743900000004" targetV="136.62" targetQ="-62.132553100000003" node="20" p="-566.62746891456186" q="51.627636282073432">
+            <iidm:generator id="_048aea70-c766-11e1-8775-005056c00008" name="Sporn SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="513.43743900000004" targetV="136.62" targetQ="-62.132553100000003" node="20" p="-568.44856890569793" q="50.892192555428785">
                 <iidm:alias>_04555b84-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_27799004-aa1e-4889-ba95-ee6fdae64895"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_827a9c80-183d-4e33-9e73-ef0aab3dfb13"/>
@@ -2495,9 +2495,9 @@
                 <iidm:internalConnection node1="39" node2="9"/>
                 <iidm:internalConnection node1="40" node2="12"/>
                 <iidm:internalConnection node1="41" node2="3"/>
-                <iidm:bus v="219.70986543410694" angle="-0.98397715551021436" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41"/>
+                <iidm:bus v="219.70741623707451" angle="-0.25279828986355996" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41"/>
             </iidm:nodeBreakerTopology>
-            <iidm:danglingLine id="_0482fb33-c766-11e1-8775-005056c00008" name="68-116" p0="184" q0="0" r="0.16456000000000001" x="1.9601999999999999" g="0" b="0.00033884300000000002" ucteXnodeCode="XWE_BR21" node="41" p="184.11568647210419" q="-14.980175199335873">
+            <iidm:danglingLine id="_0482fb33-c766-11e1-8775-005056c00008" name="68-116" p0="184" q0="0" r="0.16456000000000001" x="1.9601999999999999" g="0" b="0.00033884300000000002" ucteXnodeCode="XWE_BR21" node="41" p="184.11557585462012" q="-14.979781543377163">
                 <iidm:alias>_0459c855-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_04684742-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_5631ccc0-d9d2-11e2-bb49-005056c00008</iidm:alias>
@@ -2510,7 +2510,7 @@
                 </iidm:currentLimits>
             </iidm:danglingLine>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_044f6815-c766-11e1-8775-005056c00008" name="68-69" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-196.92824771186682" q1="102.0721144952773" p2="196.92824771186682" q2="-86.115841772640607">
+        <iidm:twoWindingsTransformer id="_044f6815-c766-11e1-8775-005056c00008" name="68-69" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-196.57905572632387" q1="102.01458403618122" p2="196.57905572632387" q2="-86.106328947594761">
             <iidm:alias>_047e8e67-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04840ca7-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0487dd39-c766-11e1-8775-005056c00008</iidm:alias>
@@ -2617,9 +2617,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="131.60566408168276" angle="-9.0003936578583517" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="131.60565218308778" angle="-8.2743192650069162" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04547126-c766-11e1-8775-005056c00008" name="Natrium LD" loadType="UNDEFINED" p0="77" q0="14" node="14" p="76.999937419677025" q="13.999981036270903">
+            <iidm:load id="_04547126-c766-11e1-8775-005056c00008" name="Natrium LD" loadType="UNDEFINED" p0="77" q0="14" node="14" p="76.999907309079859" q="13.999971911853654">
                 <iidm:alias>_047b3307-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2670,9 +2670,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="123.83408022094392" angle="-16.528989866483592" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="123.75549752925514" angle="-16.12970281357385" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045d4ac9-c766-11e1-8775-005056c00008" name="Sterling LD" loadType="UNDEFINED" p0="31" q0="17" node="8" p="31.000094218841845" q="17.000086114082478">
+            <iidm:load id="_045d4ac9-c766-11e1-8775-005056c00008" name="Sterling LD" loadType="UNDEFINED" p0="31" q0="17" node="8" p="30.992011993268147" q="16.99269976074013">
                 <iidm:alias>_0477b094-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2780,9 +2780,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="130.28629568274323" angle="5.7801498864101548" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="130.29481955750299" angle="6.6529020753068195" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0466246a-c766-11e1-8775-005056c00008" name="Switchbk LD" loadType="UNDEFINED" p0="30" q0="16" node="17" p="30.000975288885574" q="16.000866932848261">
+            <iidm:load id="_0466246a-c766-11e1-8775-005056c00008" name="Switchbk LD" loadType="UNDEFINED" p0="30" q0="16" node="17" p="30.001710954942535" q="16.001520877749893">
                 <iidm:alias>_04882b59-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2833,9 +2833,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="135.0884829880909" angle="3.0939646589830416" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="135.08678053889943" angle="3.9263258183540883" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046adf5a-c766-11e1-8775-005056c00008" name="Bradley LD" loadType="UNDEFINED" p0="34" q0="8" node="8" p="34.000181309510616" q="8.0000711018952533">
+            <iidm:load id="_046adf5a-c766-11e1-8775-005056c00008" name="Bradley LD" loadType="UNDEFINED" p0="34" q0="8" node="8" p="33.999996912996842" q="7.9999987894105615">
                 <iidm:alias>_04555b85-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -2889,9 +2889,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.22155443479527" angle="-2.2945094818701235" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25"/>
+                <iidm:bus v="127.16485472501964" angle="-2.3256440589433187" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047a48a2-c766-11e1-8775-005056c00008" name="Mullin LD" loadType="UNDEFINED" p0="17" q0="7" node="8" p="17.002887338519567" q="7.0019816190070179">
+            <iidm:load id="_047a48a2-c766-11e1-8775-005056c00008" name="Mullin LD" loadType="UNDEFINED" p0="17" q0="7" node="8" p="16.999915815646403" q="6.9999422265193676">
                 <iidm:alias>_0474553a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3057,16 +3057,16 @@
                 <iidm:internalConnection node1="81" node2="18"/>
                 <iidm:internalConnection node1="82" node2="21"/>
                 <iidm:internalConnection node1="83" node2="24"/>
-                <iidm:bus v="134.24405275832822" angle="5.4709418522786244" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
+                <iidm:bus v="134.24399645856175" angle="6.357333050446262" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_044cd00a-c766-11e1-8775-005056c00008" name="Glen Lyn SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="252" targetV="134.243988" targetQ="0" node="27" p="-278.10617481377233" q="-84.220548557188451">
+            <iidm:generator id="_044cd00a-c766-11e1-8775-005056c00008" name="Glen Lyn SM" energySource="THERMAL" minP="200" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="252" targetV="134.243988" targetQ="0" node="27" p="-278.99998808664179" q="-83.969717729039004">
                 <iidm:alias>_045e5c30-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e54b499b-436c-4b89-9803-b1d75e2fa364"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_32c8ab65-80f7-4c17-b3f5-ff075cce0ba5"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
-            <iidm:load id="_04566cf5-c766-11e1-8775-005056c00008" name="Glen Lyn LD" loadType="UNDEFINED" p0="37" q0="18" node="26" p="37.000026772801547" q="18.000021707682162">
+            <iidm:load id="_04566cf5-c766-11e1-8775-005056c00008" name="Glen Lyn LD" loadType="UNDEFINED" p0="37" q0="18" node="26" p="37.000003496992235" q="18.000002835399197">
                 <iidm:alias>_04577e64-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3117,9 +3117,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.65833703178512" angle="-2.1149669950380527" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.63638629856311" angle="-2.0930864271749687" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044ea4c0-c766-11e1-8775-005056c00008" name="Kankakee LD" loadType="UNDEFINED" p0="52" q0="22" node="8" p="52.003045166288416" q="22.002147274553622">
+            <iidm:load id="_044ea4c0-c766-11e1-8775-005056c00008" name="Kankakee LD" loadType="UNDEFINED" p0="52" q0="22" node="8" p="51.999602861318337" q="21.999719967027108">
                 <iidm:alias>_047e6758-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3228,12 +3228,12 @@
                 <iidm:internalConnection node1="51" node2="9"/>
                 <iidm:internalConnection node1="52" node2="12"/>
                 <iidm:internalConnection node1="53" node2="15"/>
-                <iidm:bus v="127.42262394859442" angle="-1.8014750209015951" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
+                <iidm:bus v="127.4228054378703" angle="-0.90895095604958576" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0484cffb-c766-11e1-8775-005056c00008" name="Roanoke LD" loadType="UNDEFINED" p0="31" q0="26" node="17" p="31.000001602332155" q="26.000002239819175">
+            <iidm:load id="_0484cffb-c766-11e1-8775-005056c00008" name="Roanoke LD" loadType="UNDEFINED" p0="31" q0="26" node="17" p="31.000004949121646" q="26.000006918127394">
                 <iidm:alias>_0454983a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0489d903-c766-11e1-8775-005056c00008" name="Roanoke SC" sectionCount="5" voltageRegulatorOn="true" targetV="127.423" targetDeadband="1" node="18" q="-18.639530807848754">
+            <iidm:shunt id="_0489d903-c766-11e1-8775-005056c00008" name="Roanoke SC" sectionCount="5" voltageRegulatorOn="true" targetV="127.423" targetDeadband="1" node="18" q="-18.639583904814632">
                 <iidm:alias>_0476c638-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_5be38d1a-9d01-42d8-b8bb-e9a26cfbcf1a"/>
                 <iidm:shuntLinearModel bPerSection="0.0002296" gPerSection="0" maximumSectionCount="10"/>
@@ -3325,12 +3325,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="120.61298212356724" angle="-22.004925084917712" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="120.56801607728063" angle="-21.440180473429059" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047a219a-c766-11e1-8775-005056c00008" name="Howard LD" loadType="UNDEFINED" p0="37" q0="23" node="14" p="36.997706614682699" q="22.997624019258563">
+            <iidm:load id="_047a219a-c766-11e1-8775-005056c00008" name="Howard LD" loadType="UNDEFINED" p0="37" q0="23" node="14" p="36.991854744926314" q="22.991561841479328">
                 <iidm:alias>_04882b51-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_04488a49-c766-11e1-8775-005056c00008" name="Howard NegG LD" loadType="UNDEFINED" p0="59" q0="0" node="15" p="58.996342980169715" q="0">
+            <iidm:load id="_04488a49-c766-11e1-8775-005056c00008" name="Howard NegG LD" loadType="UNDEFINED" p0="59" q0="0" node="15" p="58.987011620287902" q="0">
                 <iidm:alias>_046d9e74-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3380,7 +3380,7 @@
                 <iidm:internalConnection node1="19" node2="6"/>
                 <iidm:internalConnection node1="20" node2="3"/>
                 <iidm:internalConnection node1="21" node2="6"/>
-                <iidm:bus v="218.7745998265824" angle="0.7756748972747558" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
+                <iidm:bus v="218.77339906567269" angle="1.5331394197071051" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_046efe09-c766-11e1-8775-005056c00008" name="CRI132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -3543,20 +3543,20 @@
                 <iidm:internalConnection node1="81" node2="18"/>
                 <iidm:internalConnection node1="82" node2="21"/>
                 <iidm:internalConnection node1="83" node2="24"/>
-                <iidm:bus v="137.28005266633096" angle="3.618052304529392" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
+                <iidm:bus v="137.28000527474975" angle="4.4185864485061099" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_045868c1-c766-11e1-8775-005056c00008" name="CabinCrk SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="477" targetV="137.28" targetQ="0" node="27" p="-526.41525946892625" q="-139.97770042459163">
+            <iidm:generator id="_045868c1-c766-11e1-8775-005056c00008" name="CabinCrk SM" energySource="THERMAL" minP="300" maxP="600" ratedS="750" voltageRegulatorOn="true" targetP="477" targetV="137.28" targetQ="0" node="27" p="-528.10712030685761" q="-139.8692498646318">
                 <iidm:alias>_0487dd36-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_a6ec9760-88da-48df-a23f-7877e7c85ccd"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_e6131af8-c298-413b-84e3-4e21c3b6b06f"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-225" maxQ="640"/>
             </iidm:generator>
-            <iidm:load id="_04747c44-c766-11e1-8775-005056c00008" name="CabinCrk LD" loadType="UNDEFINED" p0="130" q0="26" node="26" p="130.0000748101364" q="26.000024936716908">
+            <iidm:load id="_04747c44-c766-11e1-8775-005056c00008" name="CabinCrk LD" loadType="UNDEFINED" p0="130" q0="26" node="26" p="130.00000749254235" q="26.000002497514163">
                 <iidm:alias>_046a9138-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_0488c79b-c766-11e1-8775-005056c00008" name="81-80" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="21" voltageLevelId1="_048a272b-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-148.24339345515386" q1="71.403997675019724" p2="148.24339345515386" q2="-62.547966940119274">
+        <iidm:twoWindingsTransformer id="_0488c79b-c766-11e1-8775-005056c00008" name="81-80" r="0" x="6.4468800000000002" g="0" b="0" ratedU1="220" ratedU2="132" node1="21" voltageLevelId1="_048a272b-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-150.48691439999743" q1="71.50013541433502" p2="150.48691439999743" q2="-62.420288289921842">
             <iidm:alias>_044974a0-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_045a3d83-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_046adf57-c766-11e1-8775-005056c00008</iidm:alias>
@@ -3636,12 +3636,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="134.74792733744391" angle="-12.980705710713785" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="134.74747344706046" angle="-12.287353791242518" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04524e4a-c766-11e1-8775-005056c00008" name="Zanesvll LD" loadType="UNDEFINED" p0="20" q0="11" node="8" p="20.000036695403281" q="11.000033637473578">
+            <iidm:load id="_04524e4a-c766-11e1-8775-005056c00008" name="Zanesvll LD" loadType="UNDEFINED" p0="20" q0="11" node="8" p="20.000003663829922" q="11.000003358510963">
                 <iidm:alias>_045c1240-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_048b5fa9-c766-11e1-8775-005056c00008" name="Zanesvll SC" sectionCount="5" voltageRegulatorOn="true" targetV="134.72300000000001" targetDeadband="1" node="9" q="-15.633180376615611">
+            <iidm:shunt id="_048b5fa9-c766-11e1-8775-005056c00008" name="Zanesvll SC" sectionCount="5" voltageRegulatorOn="true" targetV="134.72300000000001" targetDeadband="1" node="9" q="-15.633075057915352">
                 <iidm:alias>_04736ad5-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_99c6c4ad-5247-4058-96d4-ee8495103e85"/>
                 <iidm:shuntLinearModel bPerSection="0.00017220000000000001" gPerSection="0" maximumSectionCount="10"/>
@@ -3694,9 +3694,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.77395053237214" angle="8.5151765190353768" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.77530489644124" angle="9.4037972101758349" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044ca8f2-c766-11e1-8775-005056c00008" name="Tazewell LD" loadType="UNDEFINED" p0="12" q0="7" node="8" p="12.000424094833242" q="7.0004123192784249">
+            <iidm:load id="_044ca8f2-c766-11e1-8775-005056c00008" name="Tazewell LD" loadType="UNDEFINED" p0="12" q0="7" node="8" p="12.000457471926902" q="7.0004447700252213">
                 <iidm:alias>_04542305-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3747,9 +3747,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="119.8276787853918" angle="-20.084281808582503" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="119.77101114629752" angle="-19.631882920401832" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04778989-c766-11e1-8775-005056c00008" name="NwLibrty LD" loadType="UNDEFINED" p0="27" q0="11" node="8" p="26.997560218048118" q="10.998343407833731">
+            <iidm:load id="_04778989-c766-11e1-8775-005056c00008" name="NwLibrty LD" loadType="UNDEFINED" p0="27" q0="11" node="8" p="26.992160956541937" q="10.994677707862596">
                 <iidm:alias>_0483e592-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3782,12 +3782,12 @@
                 <iidm:internalConnection node1="11" node2="2"/>
                 <iidm:internalConnection node1="12" node2="3"/>
                 <iidm:internalConnection node1="13" node2="3"/>
-                <iidm:bus v="122.60498159135881" angle="-6.4725949582195685" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13"/>
+                <iidm:bus v="122.60528757819061" angle="-5.5723656543954485" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0463da70-c766-11e1-8775-005056c00008" name="Danville LD" loadType="UNDEFINED" p0="25" q0="13" node="5" p="24.999991589170907" q="12.999992710615608">
+            <iidm:load id="_0463da70-c766-11e1-8775-005056c00008" name="Danville LD" loadType="UNDEFINED" p0="25" q0="13" node="5" p="25.000004581097617" q="13.000003970284846">
                 <iidm:alias>_0488eeab-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_0448b150-c766-11e1-8775-005056c00008" name="Danville NegG LD" loadType="UNDEFINED" p0="43" q0="0" node="6" p="42.999985533373966" q="0">
+            <iidm:load id="_0448b150-c766-11e1-8775-005056c00008" name="Danville NegG LD" loadType="UNDEFINED" p0="43" q0="0" node="6" p="43.000007879487903" q="0">
                 <iidm:alias>_0457cc88-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3838,9 +3838,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.46624585322255" angle="14.282214510987078" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.58851847904157" angle="15.179246632109184" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045cae82-c766-11e1-8775-005056c00008" name="Fremont LD" loadType="UNDEFINED" p0="48" q0="10" node="8" p="48.00059278192753" q="10.000205827905464">
+            <iidm:load id="_045cae82-c766-11e1-8775-005056c00008" name="Fremont LD" loadType="UNDEFINED" p0="48" q0="10" node="8" p="48.018117809305444" q="10.006291697485613">
                 <iidm:alias>_045f4693-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -3986,9 +3986,9 @@
                 <iidm:internalConnection node1="70" node2="15"/>
                 <iidm:internalConnection node1="71" node2="18"/>
                 <iidm:internalConnection node1="72" node2="21"/>
-                <iidm:bus v="132.34939545548423" angle="1.3249585304774061" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
+                <iidm:bus v="132.35091541421852" angle="2.1053466058241246" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0448d863-c766-11e1-8775-005056c00008" name="Turner LD" loadType="UNDEFINED" p0="61" q0="28" node="23" p="61.002833584906092" q="28.002167803439242">
+            <iidm:load id="_0448d863-c766-11e1-8775-005056c00008" name="Turner LD" loadType="UNDEFINED" p0="61" q0="28" node="23" p="61.003019403367198" q="28.002309964185613">
                 <iidm:alias>_046e3ab3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4042,9 +4042,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.22099623193147" angle="-3.2435943229995261" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="127.20630095724488" angle="-3.283199804348135" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047d7cf6-c766-11e1-8775-005056c00008" name="Grant LD" loadType="UNDEFINED" p0="24" q0="4" node="8" p="24.001058991736908" q="4.0002941686979767">
+            <iidm:load id="_047d7cf6-c766-11e1-8775-005056c00008" name="Grant LD" loadType="UNDEFINED" p0="24" q0="4" node="8" p="23.999970350932053" q="3.9999917641511837">
                 <iidm:alias>_0481e9c0-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4114,9 +4114,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="221.60904710000011" angle="5.8276057247881123" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="221.49046309600951" angle="5.8722048558799385" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04867dab-c766-11e1-8775-005056c00008" name="Olive NegG LD" loadType="UNDEFINED" p0="28" q0="0" node="11" p="28.005275362278027" q="0">
+            <iidm:load id="_04867dab-c766-11e1-8775-005056c00008" name="Olive NegG LD" loadType="UNDEFINED" p0="28" q0="0" node="11" p="27.999419749392334" q="0">
                 <iidm:alias>_048433b8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4222,15 +4222,15 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="133.36335965585442" angle="0.57565070857297151" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="133.3209782695061" angle="0.60633886346592014" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:shunt id="_0447c6f6-c766-11e1-8775-005056c00008" name="Olive SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.67599999999999" targetDeadband="1" node="17" q="-40.83616396420782">
+            <iidm:shunt id="_0447c6f6-c766-11e1-8775-005056c00008" name="Olive SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.67599999999999" targetDeadband="1" node="17" q="-40.81021353451073">
                 <iidm:alias>_045e8340-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_c701959a-91c1-4a35-9a37-71fb790426ca"/>
                 <iidm:shuntLinearModel bPerSection="0.00045919999999999999" gPerSection="0" maximumSectionCount="10"/>
             </iidm:shunt>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_04575750-c766-11e1-8775-005056c00008" name="8-5" r="0" x="4.6522079999999999" g="0" b="0" ratedU1="220" ratedU2="132" node1="32" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="354.21742670053584" q1="63.453241140798475" p2="-354.21742670053578" q2="-30.392584336121782">
+        <iidm:twoWindingsTransformer id="_04575750-c766-11e1-8775-005056c00008" name="8-5" r="0" x="4.6522079999999999" g="0" b="0" ratedU1="220" ratedU2="132" node1="32" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="354.85016378031975" q1="62.634419497110642" p2="-354.85016378031975" q2="-29.45007415040611">
             <iidm:alias>_045eaa55-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_046b2d74-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_04745533-c766-11e1-8775-005056c00008</iidm:alias>
@@ -4301,9 +4301,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.78017694943702" angle="7.439662247888104" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.77780305990419" angle="8.3347993011745878" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047b0bf0-c766-11e1-8775-005056c00008" name="Wythe LD" loadType="UNDEFINED" p0="22" q0="15" node="8" p="22.000345627599248" q="15.000392760692296">
+            <iidm:load id="_047b0bf0-c766-11e1-8775-005056c00008" name="Wythe LD" loadType="UNDEFINED" p0="22" q0="15" node="8" p="22.00016488117252" q="15.000187365436846">
                 <iidm:alias>_0479d376-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4354,9 +4354,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="123.90262772712643" angle="-16.561424020848236" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="123.82441331597961" angle="-16.160622886993821" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0458ddf5-c766-11e1-8775-005056c00008" name="WestLima LD" loadType="UNDEFINED" p0="33" q0="9" node="8" p="33.000066925733286" q="9.0000304208084199">
+            <iidm:load id="_0458ddf5-c766-11e1-8775-005056c00008" name="WestLima LD" loadType="UNDEFINED" p0="33" q0="9" node="8" p="32.99150669561088" q="8.9961397383092745">
                 <iidm:alias>_04492686-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4464,9 +4464,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="128.13066784473045" angle="10.379863870456695" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="128.44055430820652" angle="11.241307158521794" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044b2257-c766-11e1-8775-005056c00008" name="BeaverCk LD" loadType="UNDEFINED" p0="24" q0="15" node="17" p="24.000224735269228" q="15.000234099969475">
+            <iidm:load id="_044b2257-c766-11e1-8775-005056c00008" name="BeaverCk LD" loadType="UNDEFINED" p0="24" q0="15" node="17" p="24.02253989112512" q="15.023486402701131">
                 <iidm:alias>_045868c4-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4557,7 +4557,7 @@
                 <iidm:internalConnection node1="39" node2="9"/>
                 <iidm:internalConnection node1="40" node2="12"/>
                 <iidm:internalConnection node1="41" node2="3"/>
-                <iidm:bus v="215.846798692297" angle="2.9343943009065652" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="215.62242695756407" angle="2.950668585376905" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_047bcf46-c766-11e1-8775-005056c00008" name="STN132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -4684,9 +4684,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="129.51005828811179" angle="-1.6000391124252757" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65"/>
+                <iidm:bus v="129.32224879318795" angle="-1.6103551033557229" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045dbff4-c766-11e1-8775-005056c00008" name="Sorenson LD" loadType="UNDEFINED" p0="11" q0="3" node="20" p="11.005645150132171" q="3.0025664162570909">
+            <iidm:load id="_045dbff4-c766-11e1-8775-005056c00008" name="Sorenson LD" loadType="UNDEFINED" p0="11" q0="3" node="20" p="10.999407235452148" q="2.9997305664089917">
                 <iidm:alias>_044d4536-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -4719,13 +4719,13 @@
                 <iidm:internalConnection node1="10" node2="3"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="0"/>
-                <iidm:bus v="389.72480943846506" angle="0" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15"/>
+                <iidm:bus v="389.21345633543154" angle="0" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15"/>
             </iidm:nodeBreakerTopology>
             <iidm:lccConverterStation id="_7393a68e-c4e6-48dd-9347-543858363fdb" name="Conv1" lossFactor="0" powerFactor="0.80000000000000004" node="12" p="10" q="6">
                 <iidm:alias>_739658a7-e08b-4395-8d79-93e87b7855e3</iidm:alias>
             </iidm:lccConverterStation>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_047120e9-c766-11e1-8775-005056c00008" name="30-17" r="0" x="6.7605125399999997" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_047b8123-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="204.3132188104068" q1="115.7286959721221" p2="-204.31321881040674" q2="-95.246729280507509">
+        <iidm:twoWindingsTransformer id="_047120e9-c766-11e1-8775-005056c00008" name="30-17" r="0" x="6.7605125399999997" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_047b8123-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="204.99746819626174" q1="116.63994136819682" p2="-204.99746819626168" q2="-95.932249339117831">
             <iidm:alias>_044f6811-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0463b36a-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_047d2ed8-c766-11e1-8775-005056c00008</iidm:alias>
@@ -4744,7 +4744,7 @@
                 <iidm:temporaryLimit name="_f62f2fc6-4b6c-4571-a8c5-40d6a89ac703" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_b08e9e50-4e0c-4ac0-9f21-4a27429caeb2" name="PowTrans1" r="0.4840000000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_3bbfa58a-a1ad-4b23-a526-3d76b096c1f4" node2="41" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="-131.57604436580453" q1="21.425420451515041" p2="131.75860090030025" q2="-14.579550407926668">
+        <iidm:twoWindingsTransformer id="_b08e9e50-4e0c-4ac0-9f21-4a27429caeb2" name="PowTrans1" r="0.4840000000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_3bbfa58a-a1ad-4b23-a526-3d76b096c1f4" node2="41" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="-132.01465223730182" q1="20.725860760344094" p2="132.19857583225132" q2="-13.828725949737652">
             <iidm:alias>_046ba2aa-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_a5bf9702-545a-437d-9663-773550202828</iidm:alias>
             <iidm:alias>_ee9505e1-96d7-49b3-9d1a-924397ffb27e</iidm:alias>
@@ -4764,7 +4764,7 @@
                 <iidm:temporaryLimit name="_611bb05e-9b9a-469c-b1d1-80a944c3ce2f" acceptableDuration="60" value="1400"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:threeWindingsTransformer id="_86d83c7d-7826-4c16-b161-4ce17174e77f-1" name="T422" r1="-1.5199999809265099" x1="23.199999999999999" g1="0" b1="0" ratedU1="400" r2="2.0000000630528461" x2="19.999999999999996" g2="0" b2="0" ratedU2="220" r3="1.2000000564689806" x3="12" g3="0" b3="0" ratedU3="132" ratedU0="400" node1="15" voltageLevelId1="_3bbfa58a-a1ad-4b23-a526-3d76b096c1f4" node2="44" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" node3="65" voltageLevelId3="_047bcf46-c766-11e1-8775-005056c00008" p1="121.57604446886674" q1="-27.425420389679061" p2="0" q2="0" p3="-121.60876994601699" q3="31.025223725996483">
+        <iidm:threeWindingsTransformer id="_86d83c7d-7826-4c16-b161-4ce17174e77f-1" name="T422" r1="-1.5199999809265099" x1="23.199999999999999" g1="0" b1="0" ratedU1="400" r2="2.0000000630528461" x2="19.999999999999996" g2="0" b2="0" ratedU2="220" r3="1.2000000564689806" x3="12" g3="0" b3="0" ratedU3="132" ratedU0="400" node1="15" voltageLevelId1="_3bbfa58a-a1ad-4b23-a526-3d76b096c1f4" node2="44" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" node3="65" voltageLevelId3="_047bcf46-c766-11e1-8775-005056c00008" p1="122.01465224074116" q1="-26.72586075827844" p2="0" q2="0" p3="-122.04760943233532" q3="30.351152689482632">
             <iidm:alias>_1b2d419c-ac88-4dae-8dfe-2eb92d18c40a-1</iidm:alias>
             <iidm:alias>_206474da-93c8-46b1-863f-9a308bfc2117-1</iidm:alias>
             <iidm:alias>_9ac069ea-557b-4b8c-b12e-f9f2aecc3bf5-1</iidm:alias>
@@ -5028,16 +5028,16 @@
                 <iidm:internalConnection node1="121" node2="30"/>
                 <iidm:internalConnection node1="122" node2="33"/>
                 <iidm:internalConnection node1="123" node2="36"/>
-                <iidm:bus v="135.3000418094442" angle="-12.167339923097924" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123"/>
+                <iidm:bus v="135.30000117697068" angle="-11.470303056861928" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04859346-c766-11e1-8775-005056c00008" name="Philo SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="204" targetV="135.30000000000001" targetQ="0" node="39" p="-225.13357008733954" q="-174.75074628083078">
+            <iidm:generator id="_04859346-c766-11e1-8775-005056c00008" name="Philo SM" energySource="THERMAL" minP="100" maxP="400" ratedS="500" voltageRegulatorOn="true" targetP="204" targetV="135.30000000000001" targetQ="0" node="39" p="-225.85713321299568" q="-175.17399002576184">
                 <iidm:alias>_048719e2-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e3753d6d-b894-4cce-b6fa-307c50dc107f"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_dff93c01-9c84-4c1f-8529-66c054ed9e37"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-150" maxQ="450"/>
             </iidm:generator>
-            <iidm:load id="_045163e2-c766-11e1-8775-005056c00008" name="Philo LD" loadType="UNDEFINED" p0="87" q0="30" node="38" p="87.000040326185399" q="30.000023175972203">
+            <iidm:load id="_045163e2-c766-11e1-8775-005056c00008" name="Philo LD" loadType="UNDEFINED" p0="87" q0="30" node="38" p="87.000001135215626" q="30.00000065242277">
                 <iidm:alias>_04513cd3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5088,9 +5088,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.53403308608084" angle="8.3828392799385494" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.79012301963684" angle="9.240994705990456" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04524e46-c766-11e1-8775-005056c00008" name="BetsyLne LD" loadType="UNDEFINED" p0="11" q0="7" node="8" p="11.000300666642723" q="7.0003188917689183">
+            <iidm:load id="_04524e46-c766-11e1-8775-005056c00008" name="BetsyLne LD" loadType="UNDEFINED" p0="11" q0="7" node="8" p="11.008815660665878" q="7.0093524406634478">
                 <iidm:alias>_04549830-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5143,15 +5143,15 @@
                 <iidm:internalConnection node1="22" node2="6"/>
                 <iidm:internalConnection node1="23" node2="3"/>
                 <iidm:internalConnection node1="24" node2="6"/>
-                <iidm:bus v="124.75883271835093" angle="-4.7755817334349624" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24"/>
+                <iidm:bus v="124.75914292459224" angle="-3.8835896992689278" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04566cf3-c766-11e1-8775-005056c00008" name="Reusens NegG LD" loadType="UNDEFINED" p0="22" q0="0" node="8" p="21.999991320443076" q="0">
+            <iidm:load id="_04566cf3-c766-11e1-8775-005056c00008" name="Reusens NegG LD" loadType="UNDEFINED" p0="22" q0="0" node="8" p="22.000003133348862" q="0">
                 <iidm:alias>_0483be81-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_0482fb36-c766-11e1-8775-005056c00008" name="Reusens LD" loadType="UNDEFINED" p0="28" q0="12" node="9" p="27.999988953291194" q="11.999992109494745">
+            <iidm:load id="_0482fb36-c766-11e1-8775-005056c00008" name="Reusens LD" loadType="UNDEFINED" p0="28" q0="12" node="9" p="28.000003987898552" q="12.000002848499101">
                 <iidm:alias>_0486cbc1-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_04558293-c766-11e1-8775-005056c00008" name="Reusens SC" sectionCount="5" voltageRegulatorOn="true" targetV="124.76300000000001" targetDeadband="1" node="10" q="-5.3542796213884438">
+            <iidm:shunt id="_04558293-c766-11e1-8775-005056c00008" name="Reusens SC" sectionCount="5" voltageRegulatorOn="true" targetV="124.76300000000001" targetDeadband="1" node="10" q="-5.3543062476879202">
                 <iidm:alias>_04893ccc-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_99303cd3-6b53-4ee2-a5ce-fe8d5feeb304"/>
                 <iidm:shuntLinearModel bPerSection="6.8800000000000005e-05" gPerSection="0" maximumSectionCount="10"/>
@@ -5224,12 +5224,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="126.42567550768095" angle="12.518433314444202" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="126.42450332222268" angle="13.44030551156577" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045c8777-c766-11e1-8775-005056c00008" name="Holston NegG LD" loadType="UNDEFINED" p0="85" q0="0" node="11" p="85.000688467057486" q="0">
+            <iidm:load id="_045c8777-c766-11e1-8775-005056c00008" name="Holston NegG LD" loadType="UNDEFINED" p0="85" q0="0" node="11" p="85.000311129809617" q="0">
                 <iidm:alias>_0487dd31-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_0451d918-c766-11e1-8775-005056c00008" name="Holston LD" loadType="UNDEFINED" p0="78" q0="42" node="12" p="78.000631769770408" q="42.000566974401629">
+            <iidm:load id="_0451d918-c766-11e1-8775-005056c00008" name="Holston LD" loadType="UNDEFINED" p0="78" q0="42" node="12" p="78.000285507354718" q="42.000256224861715">
                 <iidm:alias>_0485ba54-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5337,9 +5337,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="127.78850064428582" angle="-2.7354164054360042" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="127.73656965696397" angle="-2.0574485136101823" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04742e27-c766-11e1-8775-005056c00008" name="SthPoint LD" loadType="UNDEFINED" p0="47" q0="11" node="17" p="47.008823724393181" q="11.003442093696291">
+            <iidm:load id="_04742e27-c766-11e1-8775-005056c00008" name="SthPoint LD" loadType="UNDEFINED" p0="47" q0="11" node="17" p="47.001215899385343" q="11.000474291084238">
                 <iidm:alias>_047b3303-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5391,12 +5391,12 @@
                 <iidm:internalConnection node1="21" node2="6"/>
                 <iidm:internalConnection node1="22" node2="3"/>
                 <iidm:internalConnection node1="23" node2="6"/>
-                <iidm:bus v="132.92085244873445" angle="1.3358914770338133" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
+                <iidm:bus v="132.92165286690573" angle="2.1234166215373036" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04716f06-c766-11e1-8775-005056c00008" name="CapitlHl LD" loadType="UNDEFINED" p0="39" q0="32" node="8" p="39.001224733558274" q="32.0016748668424">
+            <iidm:load id="_04716f06-c766-11e1-8775-005056c00008" name="CapitlHl LD" loadType="UNDEFINED" p0="39" q0="32" node="8" p="39.001275761822519" q="32.001744650575461">
                 <iidm:alias>_04700f70-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0466c0a0-c766-11e1-8775-005056c00008" name="CapitlHl SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.00200000000001" targetDeadband="1" node="9" q="-20.282810062021579">
+            <iidm:shunt id="_0466c0a0-c766-11e1-8775-005056c00008" name="CapitlHl SC" sectionCount="5" voltageRegulatorOn="true" targetV="133.00200000000001" targetDeadband="1" node="9" q="-20.283054339398976">
                 <iidm:alias>_045e8346-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_99931a87-ee15-4fd0-b251-9556df7fe598"/>
                 <iidm:shuntLinearModel bPerSection="0.0002296" gPerSection="0" maximumSectionCount="10"/>
@@ -5449,9 +5449,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="132.05821466379913" angle="1.0236051971696025" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="132.05976818522186" angle="1.8064463176455847" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046efe03-c766-11e1-8775-005056c00008" name="Chemical LD" loadType="UNDEFINED" p0="71" q0="26" node="8" p="71.002896250730515" q="26.001767688800676">
+            <iidm:load id="_046efe03-c766-11e1-8775-005056c00008" name="Chemical LD" loadType="UNDEFINED" p0="71" q0="26" node="8" p="71.003129988435262" q="26.001910349651837">
                 <iidm:alias>_045d71d5-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5502,9 +5502,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="130.5786422673259" angle="-2.5965811357712076" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="130.56504429523073" angle="-2.5778155068346749" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046a4319-c766-11e1-8775-005056c00008" name="JacksnRd LD" loadType="UNDEFINED" p0="19" q0="2" node="8" p="19.000689813326908" q="2.0001210213464891">
+            <iidm:load id="_046a4319-c766-11e1-8775-005056c00008" name="JacksnRd LD" loadType="UNDEFINED" p0="19" q0="2" node="8" p="18.999909898405033" q="1.9999841927276243">
                 <iidm:alias>_046c8d06-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5650,9 +5650,9 @@
                 <iidm:internalConnection node1="70" node2="15"/>
                 <iidm:internalConnection node1="71" node2="18"/>
                 <iidm:internalConnection node1="72" node2="21"/>
-                <iidm:bus v="130.60925273521102" angle="12.199494421129051" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
+                <iidm:bus v="130.6070180574697" angle="13.106734916934622" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0458ddf4-c766-11e1-8775-005056c00008" name="Saltvlle LD" loadType="UNDEFINED" p0="65" q0="10" node="23" p="65.001531863694424" q="10.000392788648272">
+            <iidm:load id="_0458ddf4-c766-11e1-8775-005056c00008" name="Saltvlle LD" loadType="UNDEFINED" p0="65" q0="10" node="23" p="65.001018141616569" q="10.000261063316032">
                 <iidm:alias>_045645e4-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5722,9 +5722,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="132.00363202787977" angle="2.2797082359095242" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="131.74345360545991" angle="2.3618305821136425" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0476ed42-c766-11e1-8775-005056c00008" name="Trenton NegG LD" loadType="UNDEFINED" p0="13" q0="0" node="11" p="13.009564869561229" q="0">
+            <iidm:load id="_0476ed42-c766-11e1-8775-005056c00008" name="Trenton NegG LD" loadType="UNDEFINED" p0="13" q0="0" node="11" p="12.999820909435645" q="0">
                 <iidm:alias>_0471e432-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5794,9 +5794,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="128.42780206515133" angle="-3.6219953920205135" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="128.40806896080099" angle="-3.6008889246078155" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044a5f08-c766-11e1-8775-005056c00008" name="HickryCk LD" loadType="UNDEFINED" p0="39" q0="10" node="11" p="39.00208764791207" q="10.000892173146175">
+            <iidm:load id="_044a5f08-c766-11e1-8775-005056c00008" name="HickryCk LD" loadType="UNDEFINED" p0="39" q0="10" node="11" p="38.999710208497142" q="9.9998761577841488">
                 <iidm:alias>_047d7cf3-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -5925,9 +5925,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="125.34039727161067" angle="-15.722224390227712" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="125.26459936039454" angle="-15.313149088140372" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:shunt id="_0450eeb7-c766-11e1-8775-005056c00008" name="EastLima SC" sectionCount="5" voltageRegulatorOn="true" targetV="131.565" targetDeadband="1" node="20" q="-22.544158795074445">
+            <iidm:shunt id="_0450eeb7-c766-11e1-8775-005056c00008" name="EastLima SC" sectionCount="5" voltageRegulatorOn="true" targetV="131.565" targetDeadband="1" node="20" q="-22.516900488940426">
                 <iidm:alias>_044aad27-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_6c36f421-303e-4932-93a9-5b0ff86cb7d4"/>
                 <iidm:shuntLinearModel bPerSection="0.00028699999999999998" gPerSection="0" maximumSectionCount="10"/>
@@ -6015,16 +6015,16 @@
                 <iidm:internalConnection node1="41" node2="7"/>
                 <iidm:internalConnection node1="42" node2="12"/>
                 <iidm:internalConnection node1="43" node2="11"/>
-                <iidm:bus v="218.90473505433636" angle="-5.2015393175667182" nodes="0,1,2,3,8,9,10,13,17,18,21,22,23,24,25,26,31,32,33,34,35,39,40"/>
-                <iidm:bus v="237.9377651463725" angle="-16.961599306812289" nodes="11,15,37,43"/>
-                <iidm:bus v="226.19474576907345" angle="-5.2015392762801618" nodes="12,16,38,42"/>
-                <iidm:bus v="214.7003229083077" angle="-16.961599306812285" nodes="4,5,6,7,14,19,20,27,28,29,30,36,41"/>
+                <iidm:bus v="218.90708133779543" angle="-4.4792597192942445" nodes="0,1,2,3,8,9,10,13,17,18,21,22,23,24,25,26,31,32,33,34,35,39,40"/>
+                <iidm:bus v="237.93768554358277" angle="-16.223936248802776" nodes="11,15,37,43"/>
+                <iidm:bus v="226.19467504676766" angle="-4.4792597239560825" nodes="12,16,38,42"/>
+                <iidm:bus v="214.70025107967368" angle="-16.223936248802776" nodes="4,5,6,7,14,19,20,27,28,29,30,36,41"/>
             </iidm:nodeBreakerTopology>
-            <iidm:vscConverterStation id="_b46bfb8e-7af6-459e-acf3-53a42c943a7c" name="VSC2" voltageRegulatorOn="true" lossFactor="0.32362458" voltageSetpoint="218.47" reactivePowerSetpoint="0" node="42" p="-0" q="-27.482684079051793">
+            <iidm:vscConverterStation id="_b46bfb8e-7af6-459e-acf3-53a42c943a7c" name="VSC2" voltageRegulatorOn="true" lossFactor="0.32362458" voltageSetpoint="218.47" reactivePowerSetpoint="0" node="42" p="-0" q="-27.473580774448607">
                 <iidm:alias>_a168e701-bd48-4f66-8f0b-0f69b2545530</iidm:alias>
                 <iidm:minMaxReactiveLimits minQ="-1.7976931348623157e+308" maxQ="1.7976931348623157e+308"/>
             </iidm:vscConverterStation>
-            <iidm:vscConverterStation id="_b48ce7cf-abf5-413f-bc51-9e1d3103c9bd" name="VSC1" voltageRegulatorOn="true" lossFactor="0.32467531999999999" voltageSetpoint="213.53999999999999" reactivePowerSetpoint="0" node="43" p="-0" q="-92.151020935015353">
+            <iidm:vscConverterStation id="_b48ce7cf-abf5-413f-bc51-9e1d3103c9bd" name="VSC1" voltageRegulatorOn="true" lossFactor="0.32467531999999999" voltageSetpoint="213.53999999999999" reactivePowerSetpoint="0" node="43" p="-0" q="-92.151020935009015">
                 <iidm:alias>_071bb138-ff00-4874-8acc-a884aa5cf4a9</iidm:alias>
                 <iidm:minMaxReactiveLimits minQ="-1.7976931348623157e+308" maxQ="1.7976931348623157e+308"/>
             </iidm:vscConverterStation>
@@ -6092,7 +6092,7 @@
                 <iidm:internalConnection node1="29" node2="6"/>
                 <iidm:internalConnection node1="30" node2="9"/>
                 <iidm:internalConnection node1="31" node2="3"/>
-                <iidm:bus v="201.92328378368711" angle="-11.863111626447182" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
+                <iidm:bus v="201.76370175253996" angle="-11.369892120647219" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_0448d867-c766-11e1-8775-005056c00008" name="EDO132KV" nominalV="132" topologyKind="NODE_BREAKER">
@@ -6178,9 +6178,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="131.34004395247288" angle="-7.6143615097689539" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="131.34000164567686" angle="-6.8846560202558127" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0472a789-c766-11e1-8775-005056c00008" name="W.Kammer SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="160" targetV="131.34" targetQ="0" node="14" p="-176.57534908810945" q="93.992680593075789">
+            <iidm:generator id="_0472a789-c766-11e1-8775-005056c00008" name="W.Kammer SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="160" targetV="131.34" targetQ="0" node="14" p="-177.14284957882015" q="94.093666856325996">
                 <iidm:alias>_04697fc0-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_17852426-f663-4add-9a2b-0a635d51f101"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b512ea0a-96d0-4a48-9de1-a5cf499bf0dd"/>
@@ -6329,16 +6329,16 @@
                 <iidm:internalConnection node1="71" node2="15"/>
                 <iidm:internalConnection node1="72" node2="18"/>
                 <iidm:internalConnection node1="73" node2="21"/>
-                <iidm:bus v="130.02004488852387" angle="-16.961599306812285" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
+                <iidm:bus v="130.02000138992963" angle="-16.223936248802779" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04839777-c766-11e1-8775-005056c00008" name="Tidd SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="155" targetV="130.02000000000001" targetQ="0" node="24" p="-171.05736942910602" q="-95.019216188652223">
+            <iidm:generator id="_04839777-c766-11e1-8775-005056c00008" name="Tidd SM" energySource="THERMAL" minP="120" maxP="240" ratedS="300" voltageRegulatorOn="true" targetP="155" targetV="130.02000000000001" targetQ="0" node="24" p="-171.60713552948206" q="-94.865928269517227">
                 <iidm:alias>_045fe2d8-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_d2a96d8d-65be-4fd6-a012-ceeeabd2bee6"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_29df1e0b-36ca-4536-97b4-6f98b84d49d8"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-90" maxQ="255"/>
             </iidm:generator>
-            <iidm:load id="_04798556-c766-11e1-8775-005056c00008" name="Tidd LD" loadType="UNDEFINED" p0="277" q0="113" node="23" p="277.00014344857158" q="113.00009753123577">
+            <iidm:load id="_04798556-c766-11e1-8775-005056c00008" name="Tidd LD" loadType="UNDEFINED" p0="277" q0="113" node="23" p="277.00000444174555" q="113.00000301995938">
                 <iidm:alias>_04502b62-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6368,13 +6368,13 @@
                 <iidm:internalConnection node1="10" node2="3"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="0"/>
-                <iidm:bus v="361.17890731901053" angle="-11.602314054031041" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="360.89129146870317" angle="-11.108680351329639" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
             </iidm:nodeBreakerTopology>
             <iidm:lccConverterStation id="_9793118d-5ba1-4a9c-b2e0-db1d15be5913" name="Conv2" lossFactor="0" powerFactor="-0.75741000000000003" node="12" p="-10" q="8.6206896551724146">
                 <iidm:alias>_453bdc57-5855-4eb5-8712-d6a0255e0da8</iidm:alias>
             </iidm:lccConverterStation>
         </iidm:voltageLevel>
-        <iidm:twoWindingsTransformer id="_045c1248-c766-11e1-8775-005056c00008" name="38-37" r="0" x="6.5340005399999992" g="0" b="0" ratedU1="220" ratedU2="132" node1="30" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="167.29168599769037" q1="89.641408096700133" p2="-167.29168599769037" q2="-75.623087232900374">
+        <iidm:twoWindingsTransformer id="_045c1248-c766-11e1-8775-005056c00008" name="38-37" r="0" x="6.5340005399999992" g="0" b="0" ratedU1="220" ratedU2="132" node1="30" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="170.6952406373706" q1="89.287926935985297" p2="-170.69524063737072" q2="-74.823694455494945">
             <iidm:alias>_0453d4e8-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0477d7aa-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_047df228-c766-11e1-8775-005056c00008</iidm:alias>
@@ -6398,7 +6398,7 @@
                 <iidm:temporaryLimit name="_c97df399-5a91-4c8b-b72c-496cade334b5" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_0485ba57-c766-11e1-8775-005056c00008" name="64-61" r="0" x="4.669632" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="157.89158635775999" q1="60.519703259203169" p2="-157.89158635775996" q2="-53.010519444912063">
+        <iidm:twoWindingsTransformer id="_0485ba57-c766-11e1-8775-005056c00008" name="64-61" r="0" x="4.669632" g="0" b="0" ratedU1="220" ratedU2="132" node1="40" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="157.4075691819269" q1="60.541938456580191" p2="-157.40756918192696" q2="-53.072287647177731">
             <iidm:alias>_04549831-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0472ce92-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0489d905-c766-11e1-8775-005056c00008</iidm:alias>
@@ -6424,7 +6424,7 @@
                 <iidm:temporaryLimit name="_f6b1a81c-eda7-4a08-b290-bd29a5ed9fa4" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_044cd007-c766-11e1-8775-005056c00008" name="63-59" r="0" x="6.7256646120000001" g="0" b="0" ratedU1="220" ratedU2="132" node1="41" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="73" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-1.4155343563970746e-13" q1="83.151439201261084" p2="-4.4408920985006262e-14" q2="-80.568885865152623">
+        <iidm:twoWindingsTransformer id="_044cd007-c766-11e1-8775-005056c00008" name="63-59" r="0" x="6.7256646120000001" g="0" b="0" ratedU1="220" ratedU2="132" node1="41" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="73" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="1.609823385706477e-13" q1="83.151383564146087" p2="-5.5511151231257827e-14" q2="-80.568831956038707">
             <iidm:alias>_044e7db4-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_046eafe5-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_0488797a-c766-11e1-8775-005056c00008</iidm:alias>
@@ -6470,7 +6470,7 @@
                 <iidm:temporaryLimit name="_f2daef4d-6f1a-44d1-9c9b-228acff12575" acceptableDuration="60" value="3061"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
-        <iidm:twoWindingsTransformer id="_ffd940c8-03c8-4dcf-ad46-62018a0d813d" name="PowTrans2" r="0.3932500000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_04f97116-552a-4a34-afd9-4862f62ac7aa" node2="31" voltageLevelId2="_04742e21-c766-11e1-8775-005056c00008" p1="10.000003534423998" q1="-8.6206919901176509" p2="-9.99830954360508" q2="8.6988761817665274">
+        <iidm:twoWindingsTransformer id="_ffd940c8-03c8-4dcf-ad46-62018a0d813d" name="PowTrans2" r="0.3932500000000001" x="18.150000000000002" g="0" b="0" ratedU1="400" ratedU2="220" node1="11" voltageLevelId1="_04f97116-552a-4a34-afd9-4862f62ac7aa" node2="31" voltageLevelId2="_04742e21-c766-11e1-8775-005056c00008" p1="10.000000095838331" q1="-8.620689528103318" p2="-9.998303404940815" q2="8.6989983387621663">
             <iidm:alias>_04479fea-c766-11e1-8775-005056c00008</iidm:alias>
             <iidm:alias>_c089eb25-9f67-4d82-88a8-635dd4808bae</iidm:alias>
             <iidm:alias>_ea8cd467-31f0-40dc-95d7-4064463724c4</iidm:alias>
@@ -6537,9 +6537,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="124.78661210135063" angle="-20.110735263632094" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.78799442399739" angle="-19.39204374119144" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0481c2b3-c766-11e1-8775-005056c00008" name="Wooster LD" loadType="UNDEFINED" p0="23" q0="11" node="8" p="22.999891122723419" q="10.999913213901987">
+            <iidm:load id="_0481c2b3-c766-11e1-8775-005056c00008" name="Wooster LD" loadType="UNDEFINED" p0="23" q0="11" node="8" p="22.999983651981939" q="10.999986968974197">
                 <iidm:alias>_04614268-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6609,9 +6609,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="125.569240580746" angle="-19.879044716207179" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="125.5694928967292" angle="-19.155182395866685" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044974a8-c766-11e1-8775-005056c00008" name="Wagenhls LD" loadType="UNDEFINED" p0="63" q0="22" node="11" p="62.999973180441316" q="21.999984390735257">
+            <iidm:load id="_044974a8-c766-11e1-8775-005056c00008" name="Wagenhls LD" loadType="UNDEFINED" p0="63" q0="22" node="11" p="63.000000246703166" q="22.000000143583858">
                 <iidm:alias>_048481d4-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6662,9 +6662,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.41115729229784" angle="-4.2975169699729667" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.32901539598257" angle="-4.2870807262440396" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047fedf2-c766-11e1-8775-005056c00008" name="Concord LD" loadType="UNDEFINED" p0="34" q0="16" node="8" p="34.007579313294151" q="16.005945001157791">
+            <iidm:load id="_047fedf2-c766-11e1-8775-005056c00008" name="Concord LD" loadType="UNDEFINED" p0="34" q0="16" node="8" p="33.998935553168558" q="15.999165148452468">
                 <iidm:alias>_046d9e75-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6772,9 +6772,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="127.70028465049954" angle="-1.3339863888821777" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="127.56337508010239" angle="-1.3644291404730016" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045f94ba-c766-11e1-8775-005056c00008" name="Delaware LD" loadType="UNDEFINED" p0="59" q0="23" node="17" p="59.023657936663376" q="23.015373030201474">
+            <iidm:load id="_045f94ba-c766-11e1-8775-005056c00008" name="Delaware LD" loadType="UNDEFINED" p0="59" q0="23" node="17" p="58.999123508903764" q="22.999430531203792">
                 <iidm:alias>_0463654a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6882,9 +6882,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="125.47558498741709" angle="-5.7960315876172537" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="125.21052466746634" angle="-5.8127626589809065" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04697fc9-c766-11e1-8775-005056c00008" name="FtWayne LD" loadType="UNDEFINED" p0="90" q0="30" node="17" p="90.065886076477369" q="30.036612307141869">
+            <iidm:load id="_04697fc9-c766-11e1-8775-005056c00008" name="FtWayne LD" loadType="UNDEFINED" p0="90" q0="30" node="17" p="89.991555281753378" q="29.995308636599631">
                 <iidm:alias>_044d1e25-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -6935,9 +6935,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.01280773058832" angle="-17.866480547623347" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.01455172301726" angle="-17.152015579723695" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0474f170-c766-11e1-8775-005056c00008" name="WNwPhil1 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="11.999933747771195" q="2.9999723949554675">
+            <iidm:load id="_0474f170-c766-11e1-8775-005056c00008" name="WNwPhil1 LD" loadType="UNDEFINED" p0="12" q0="3" node="8" p="11.999993422029828" q="2.999997259179596">
                 <iidm:alias>_0466c0a7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7008,12 +7008,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="129.53159473851238" angle="3.2495317719974453" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="129.61040930934476" angle="4.0809379837803519" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044a5f05-c766-11e1-8775-005056c00008" name="Logan LD" loadType="UNDEFINED" p0="54" q0="27" node="11" p="54.002565378434596" q="27.002137849215718">
+            <iidm:load id="_044a5f05-c766-11e1-8775-005056c00008" name="Logan LD" loadType="UNDEFINED" p0="54" q0="27" node="11" p="54.015257070228039" q="27.012715422571127">
                 <iidm:alias>_04767811-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0475dbd6-c766-11e1-8775-005056c00008" name="Logan SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.41900000000001" targetDeadband="1" node="12" q="-19.261642272756532">
+            <iidm:shunt id="_0475dbd6-c766-11e1-8775-005056c00008" name="Logan SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.41900000000001" targetDeadband="1" node="12" q="-19.285089215133596">
                 <iidm:alias>_04577e67-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_a7768441-642e-48a2-b4a8-0ae06bebf676"/>
                 <iidm:shuntLinearModel bPerSection="0.0002296" gPerSection="0" maximumSectionCount="10"/>
@@ -7087,19 +7087,19 @@
                 <iidm:internalConnection node1="32" node2="3"/>
                 <iidm:internalConnection node1="33" node2="6"/>
                 <iidm:internalConnection node1="34" node2="9"/>
-                <iidm:bus v="132.66003880086433" angle="-13.706712494333804" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34"/>
+                <iidm:bus v="132.66000102221798" angle="-13.027277957832299" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04633e31-c766-11e1-8775-005056c00008" name="W.Lancst SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="19" targetV="132.66" targetQ="0" node="13" p="-20.968322704212994" q="1.6590815259004281">
+            <iidm:generator id="_04633e31-c766-11e1-8775-005056c00008" name="W.Lancst SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="19" targetV="132.66" targetQ="0" node="13" p="-21.035713387484893" q="1.4896321963537464">
                 <iidm:alias>_047bcf42-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_83fae784-1da1-4055-8108-ba978276d1b6"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_5f711f63-f631-45d3-b26c-33821ab2ee56"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-15" maxQ="45"/>
             </iidm:generator>
-            <iidm:load id="_048a9c51-c766-11e1-8775-005056c00008" name="W.Lancst LD" loadType="UNDEFINED" p0="28" q0="10" node="11" p="28.00001228430893" q="10.000007312089716">
+            <iidm:load id="_048a9c51-c766-11e1-8775-005056c00008" name="W.Lancst LD" loadType="UNDEFINED" p0="28" q0="10" node="11" p="28.000000323633024" q="10.000000192638701">
                 <iidm:alias>_044e7db6-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_045b00d9-c766-11e1-8775-005056c00008" name="W.Lancst SC" sectionCount="5" voltageRegulatorOn="true" targetV="132.66" targetDeadband="1" node="12" q="-10.101645703527282">
+            <iidm:shunt id="_045b00d9-c766-11e1-8775-005056c00008" name="W.Lancst SC" sectionCount="5" voltageRegulatorOn="true" targetV="132.66" targetDeadband="1" node="12" q="-10.10163995007734">
                 <iidm:alias>_04758db6-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_be267a3c-f7a7-4bdf-bb17-71b773247fbf"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -7209,9 +7209,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="130.00688298897975" angle="-2.1657711656431569" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="129.90483493064497" angle="-1.588664348700378" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045dbff2-c766-11e1-8775-005056c00008" name="Portsmth LD" loadType="UNDEFINED" p0="66" q0="20" node="17" p="66.021217822329774" q="20.010717220184677">
+            <iidm:load id="_045dbff2-c766-11e1-8775-005056c00008" name="Portsmth LD" loadType="UNDEFINED" p0="66" q0="20" node="17" p="66.001019422175901" q="20.000514862335596">
                 <iidm:alias>_0454bf45-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7282,16 +7282,16 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="127.64400014027794" angle="-3.1099511625260816" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="127.64400000371566" angle="-3.1528582530300131" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_04856c34-c766-11e1-8775-005056c00008" name="DeerCrk SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="7" targetV="127.64400000000001" targetQ="0" node="12" p="-7.7251715226047883" q="-34.922503849408848">
+            <iidm:generator id="_04856c34-c766-11e1-8775-005056c00008" name="DeerCrk SM" energySource="THERMAL" minP="0" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="7" targetV="127.64400000000001" targetQ="0" node="12" p="-7.7499996690733823" q="-37.154418961209181">
                 <iidm:alias>_0477d7a5-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_e5a479a8-ab8d-4a54-bb52-376874ae2784"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b55d80d5-720f-46f9-897f-ff8c5eaf8b44"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-15" maxQ="45"/>
             </iidm:generator>
-            <iidm:load id="_04791028-c766-11e1-8775-005056c00008" name="DeerCrk LD" loadType="UNDEFINED" p0="43" q0="27" node="11" p="43.000000070884063" q="27.000000074181003">
+            <iidm:load id="_04791028-c766-11e1-8775-005056c00008" name="DeerCrk LD" loadType="UNDEFINED" p0="43" q0="27" node="11" p="43.000000001877559" q="27.000000001964885">
                 <iidm:alias>_04486337-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7342,9 +7342,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.13369949908704" angle="-1.5720836991082232" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.01753549038627" angle="-1.5994998136604295" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0462c904-c766-11e1-8775-005056c00008" name="Medford LD" loadType="UNDEFINED" p0="22" q0="7" node="8" p="22.007550494992845" q="7.0040045084266538">
+            <iidm:load id="_0462c904-c766-11e1-8775-005056c00008" name="Medford LD" loadType="UNDEFINED" p0="22" q0="7" node="8" p="21.999705190581942" q="6.9998436623705782">
                 <iidm:alias>_0489b1f7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7433,9 +7433,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="132.53653541190019" angle="3.9463977935578356" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="132.17158112285591" angle="3.9198029018188825" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046205b5-c766-11e1-8775-005056c00008" name="CollCrnr LD" loadType="UNDEFINED" p0="7" q0="3" node="14" p="7.0072164769755769" q="3.005156397553189">
+            <iidm:load id="_046205b5-c766-11e1-8775-005056c00008" name="CollCrnr LD" loadType="UNDEFINED" p0="7" q0="3" node="14" p="6.999878802756589" q="2.9999134310400386">
                 <iidm:alias>_04486334-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7486,9 +7486,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.90976274684002" angle="4.3749151008138565" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.92690957527304" angle="5.2340383599265348" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0483be82-c766-11e1-8775-005056c00008" name="Caldwell LD" loadType="UNDEFINED" p0="42" q0="31" node="8" p="42.001575859288366" q="31.001938581306167">
+            <iidm:load id="_0483be82-c766-11e1-8775-005056c00008" name="Caldwell LD" loadType="UNDEFINED" p0="42" q0="31" node="8" p="42.003719794780196" q="31.004576073113597">
                 <iidm:alias>_045841b9-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7539,9 +7539,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.3310726837484" angle="-3.1780055230897664" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.33148328031292" angle="-2.2811486611271254" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045f94b4-c766-11e1-8775-005056c00008" name="Franklin LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="7.9999956446859688" q="2.9999972779292245">
+            <iidm:load id="_045f94b4-c766-11e1-8775-005056c00008" name="Franklin LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="8.0000020913903498" q="3.0000013071190823">
                 <iidm:alias>_047da403-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7592,9 +7592,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="125.17244773251397" angle="-4.8284337372772992" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="124.84563023827901" angle="-4.8779209174270886" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045f6da2-c766-11e1-8775-005056c00008" name="McKinley LD" loadType="UNDEFINED" p0="60" q0="34" node="8" p="60.055911262466353" q="34.052821481735783">
+            <iidm:load id="_045f6da2-c766-11e1-8775-005056c00008" name="McKinley LD" loadType="UNDEFINED" p0="60" q0="34" node="8" p="59.994655343653534" q="33.994952418887536">
                 <iidm:alias>_0465d641-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7741,19 +7741,19 @@
                 <iidm:internalConnection node1="71" node2="18"/>
                 <iidm:internalConnection node1="72" node2="21"/>
                 <iidm:internalConnection node1="73" node2="12"/>
-                <iidm:bus v="130.68000801247155" angle="-3.0160753681959518" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
+                <iidm:bus v="130.68000801065168" angle="-3.0024675249196071" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_044ca8f0-c766-11e1-8775-005056c00008" name="TwinBrch SM" energySource="THERMAL" minP="50" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="85" targetV="130.68000799999999" targetQ="0" node="24" p="-93.805654203058126" q="-84.26243040869366">
+            <iidm:generator id="_044ca8f0-c766-11e1-8775-005056c00008" name="TwinBrch SM" energySource="THERMAL" minP="50" maxP="160" ratedS="200" voltageRegulatorOn="true" targetP="85" targetV="130.68000799999999" targetQ="0" node="24" p="-94.107138838748199" q="-86.915625608093563">
                 <iidm:alias>_04633e38-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_0f6ab5a4-6b72-42f4-92bc-1993e1ae58a3"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_668eb671-5c36-4351-a95d-53ca850581db"/>
                 <iidm:property name="CGMES.normalPF" value="0.0"/>
                 <iidm:minMaxReactiveLimits minQ="-60" maxQ="170"/>
             </iidm:generator>
-            <iidm:load id="_048740f1-c766-11e1-8775-005056c00008" name="TwinBrch LD" loadType="UNDEFINED" p0="47" q0="10" node="23" p="47.000000006728229" q="10.000000002385899">
+            <iidm:load id="_048740f1-c766-11e1-8775-005056c00008" name="TwinBrch LD" loadType="UNDEFINED" p0="47" q0="10" node="23" p="47.000000005746436" q="10.000000002037744">
                 <iidm:alias>_044ecbda-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:danglingLine id="_045338a1-c766-11e1-8775-005056c00008" name="12-117" p0="20" q0="8" r="5.7324960000000003" x="24.393599999999999" g="0" b="0.00020546369999999999" ucteXnodeCode="XMO_TE32" node="73" p="20.1617936197859" q="5.1797255248887408">
+            <iidm:danglingLine id="_045338a1-c766-11e1-8775-005056c00008" name="12-117" p0="20" q0="8" r="5.7324960000000003" x="24.393599999999999" g="0" b="0.00020546369999999999" ucteXnodeCode="XMO_TE32" node="73" p="20.161793619224401" q="5.179725524744323">
                 <iidm:alias>_044afb42-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_0457f391-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_5631f3d0-d9d2-11e2-bb49-005056c00008</iidm:alias>
@@ -7851,9 +7851,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="124.51304530616135" angle="-6.4613884588492398" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="124.062905490322" angle="-6.5498635696593084" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0479fa87-c766-11e1-8775-005056c00008" name="Lincoln LD" loadType="UNDEFINED" p0="45" q0="25" node="14" p="45.058187463280703" q="25.053900499571618">
+            <iidm:load id="_0479fa87-c766-11e1-8775-005056c00008" name="Lincoln LD" loadType="UNDEFINED" p0="45" q0="25" node="14" p="44.995131174542699" q="24.995491990871134">
                 <iidm:alias>_047fc6e2-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7904,9 +7904,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="134.64774364240952" angle="3.5659031072079936" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="134.64626916171127" angle="4.4275849893210566" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044c81e4-c766-11e1-8775-005056c00008" name="Hinton NegG LD" loadType="UNDEFINED" p0="42" q0="0" node="8" p="42.00019913586334" q="0">
+            <iidm:load id="_044c81e4-c766-11e1-8775-005056c00008" name="Hinton NegG LD" loadType="UNDEFINED" p0="42" q0="0" node="8" p="41.999998221522752" q="0">
                 <iidm:alias>_04494d96-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -7957,9 +7957,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.28520142870607" angle="-3.3572194918721174" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.22562222940238" angle="-3.3521071526043462" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_048bfbe0-c766-11e1-8775-005056c00008" name="N. E. LD" loadType="UNDEFINED" p0="25" q0="10" node="8" p="25.004079731558228" q="10.002719968984666">
+            <iidm:load id="_048bfbe0-c766-11e1-8775-005056c00008" name="N. E. LD" loadType="UNDEFINED" p0="25" q0="10" node="8" p="24.999554494035191" q="9.9997029977876917">
                 <iidm:alias>_0480b140-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8010,9 +8010,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="126.13562503202759" angle="-18.788749574985587" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="126.13837236685242" angle="-18.075794043701315" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04854525-c766-11e1-8775-005056c00008" name="SCoshoct LD" loadType="UNDEFINED" p0="18" q0="5" node="8" p="17.99982935168698" q="4.9999209964010447">
+            <iidm:load id="_04854525-c766-11e1-8775-005056c00008" name="SCoshoct LD" loadType="UNDEFINED" p0="18" q0="5" node="8" p="17.999977328853891" q="4.9999895041034321">
                 <iidm:alias>_04747c42-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8063,9 +8063,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="125.09674678981388" angle="-3.6582960067001782" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="125.05284120164623" angle="-2.9611635409973567" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044aad24-c766-11e1-8775-005056c00008" name="WHuntngd LD" loadType="UNDEFINED" p0="33" q0="15" node="8" p="33.005750828395165" q="15.004356941249677">
+            <iidm:load id="_044aad24-c766-11e1-8775-005056c00008" name="WHuntngd LD" loadType="UNDEFINED" p0="33" q0="15" node="8" p="33.00107834228956" q="15.000816934875147">
                 <iidm:alias>_04784cd2-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8097,9 +8097,9 @@
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="3"/>
-                <iidm:bus v="129.36006562212361" angle="-2.2754720753438944" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="129.36000804540294" angle="-1.3688579662960365" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0452ea80-c766-11e1-8775-005056c00008" name="DanRiver SM" energySource="THERMAL" minP="20" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="36" targetV="129.36000000000001" targetQ="0" node="5" p="-39.729453544824622" q="-20.31207879692678">
+            <iidm:generator id="_0452ea80-c766-11e1-8775-005056c00008" name="DanRiver SM" energySource="THERMAL" minP="20" maxP="40" ratedS="50" voltageRegulatorOn="true" targetP="36" targetV="129.36000000000001" targetQ="0" node="5" p="-39.85714115523453" q="-20.275156459544394">
                 <iidm:alias>_046a4316-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_fec62959-21c5-4921-90b2-7c85e9f3bfab"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_9db08c95-4586-4a2b-87e3-5a17c944b43a"/>
@@ -8172,9 +8172,9 @@
                 <iidm:internalConnection node1="29" node2="3"/>
                 <iidm:internalConnection node1="30" node2="9"/>
                 <iidm:internalConnection node1="31" node2="6"/>
-                <iidm:bus v="130.28668380762028" angle="-2.0390955070488674" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
+                <iidm:bus v="130.17610367830426" angle="-1.5060299725264554" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31"/>
             </iidm:nodeBreakerTopology>
-            <iidm:danglingLine id="_044ef2e7-c766-11e1-8775-005056c00008" name="71-73" p0="6" q0="0" r="1.508918" x="7.9104960000000002" g="0" b="6.76079e-05" ucteXnodeCode="XMO_TE31" node="31" p="6.0032055067465704" q="-1.1308231993979825">
+            <iidm:danglingLine id="_044ef2e7-c766-11e1-8775-005056c00008" name="71-73" p0="6" q0="0" r="1.508918" x="7.9104960000000002" g="0" b="6.76079e-05" ucteXnodeCode="XMO_TE31" node="31" p="6.0032092146654881" q="-1.1288478623613207">
                 <iidm:alias>_04670ec2-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_046b2d7a-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:alias>_26a070b9-db0c-47cd-9991-0a461576aec2</iidm:alias>
@@ -8234,9 +8234,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="134.29653376002443" angle="-9.0710441588305173" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="134.29657297635862" angle="-8.3540437473215867" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0453add4-c766-11e1-8775-005056c00008" name="Summerfl LD" loadType="UNDEFINED" p0="28" q0="7" node="8" p="27.999911305670494" q="6.9999630440683909">
+            <iidm:load id="_0453add4-c766-11e1-8775-005056c00008" name="Summerfl LD" loadType="UNDEFINED" p0="28" q0="7" node="8" p="27.999905144799531" q="6.9999604770444366">
                 <iidm:alias>_04851e16-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8363,9 +8363,9 @@
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="132.66007299148242" angle="18.839953986362428" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="132.66001283972301" angle="19.766279295219661" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
             </iidm:nodeBreakerTopology>
-            <iidm:generator id="_0489b1fa-c766-11e1-8775-005056c00008" name="ClinchRv SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="607" targetV="132.66" targetQ="0" node="20" p="-669.88273060301515" q="-48.801286803473225">
+            <iidm:generator id="_0489b1fa-c766-11e1-8775-005056c00008" name="ClinchRv SM" energySource="THERMAL" minP="400" maxP="800" ratedS="1000" voltageRegulatorOn="true" targetP="607" targetV="132.66" targetQ="0" node="20" p="-672.03568558964901" q="-46.067071740807904">
                 <iidm:alias>_04840caa-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.GeneratingUnit" value="_2621b09a-22e3-4630-b3bd-32c102e36741"/>
                 <iidm:property name="CGMES.RegulatingControl" value="_b0d662e5-64c9-4d59-b8e0-9b1ed175769b"/>
@@ -8420,9 +8420,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.49434997634478" angle="-3.9888233676622185" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.48840332337303" angle="-3.9730530856499664" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0485e168-c766-11e1-8775-005056c00008" name="Pokagon LD" loadType="UNDEFINED" p0="20" q0="9" node="8" p="20.000322074596038" q="9.000241557243676">
+            <iidm:load id="_0485e168-c766-11e1-8775-005056c00008" name="Pokagon LD" loadType="UNDEFINED" p0="20" q0="9" node="8" p="19.999951037271778" q="8.9999632779838006">
                 <iidm:alias>_0462c902-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8473,9 +8473,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.12389236324981" angle="-4.1901246378669557" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.05254995676671" angle="-4.183608917671207" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04812679-c766-11e1-8775-005056c00008" name="GoshenJt LD" loadType="UNDEFINED" p0="14" q0="1" node="8" p="14.002675200810973" q="1.0003184965720189">
+            <iidm:load id="_04812679-c766-11e1-8775-005056c00008" name="GoshenJt LD" loadType="UNDEFINED" p0="14" q0="1" node="8" p="13.999650528650676" q="0.99995839661411268">
                 <iidm:alias>_045b9d17-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8526,9 +8526,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="118.00350663049247" angle="-22.649882898976649" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="117.95376880477552" angle="-22.147954302410529" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0489b1f2-c766-11e1-8775-005056c00008" name="S.Tiffin LD" loadType="UNDEFINED" p0="37" q0="10" node="8" p="36.996074846568419" q="9.9982319753920361">
+            <iidm:load id="_0489b1f2-c766-11e1-8775-005056c00008" name="S.Tiffin LD" loadType="UNDEFINED" p0="37" q0="10" node="8" p="36.989403391458772" q="9.9952272086016141">
                 <iidm:alias>_046476b8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8579,9 +8579,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="123.65928362730065" angle="-11.345711170390333" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="123.52443635961619" angle="-11.168829873843675" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_045cfca7-c766-11e1-8775-005056c00008" name="Haviland LD" loadType="UNDEFINED" p0="23" q0="9" node="8" p="23.00576602874423" q="9.003760767764776">
+            <iidm:load id="_045cfca7-c766-11e1-8775-005056c00008" name="Haviland LD" loadType="UNDEFINED" p0="23" q0="9" node="8" p="22.99575969212767" q="8.9972347517711579">
                 <iidm:alias>_0482ad17-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8651,9 +8651,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="131.00711594429839" angle="-8.9658054263066482" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="131.00725617028064" angle="-8.2362097768921991" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04555b82-c766-11e1-8775-005056c00008" name="SWKammer LD" loadType="UNDEFINED" p0="78" q0="3" node="11" p="77.999918499038245" q="2.999994775581194">
+            <iidm:load id="_04555b82-c766-11e1-8775-005056c00008" name="SWKammer LD" loadType="UNDEFINED" p0="78" q0="3" node="11" p="77.999921764064467" q="2.9999949848776044">
                 <iidm:alias>_0474ca6b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8761,9 +8761,9 @@
                 <iidm:internalConnection node1="50" node2="9"/>
                 <iidm:internalConnection node1="51" node2="12"/>
                 <iidm:internalConnection node1="52" node2="15"/>
-                <iidm:bus v="130.37072823252646" angle="3.6690455773781601" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
+                <iidm:bus v="130.39972350513298" angle="4.5108741044087557" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04817492-c766-11e1-8775-005056c00008" name="Baileysv LD" loadType="UNDEFINED" p0="38" q0="15" node="17" p="38.001540555737691" q="15.001013537207974">
+            <iidm:load id="_04817492-c766-11e1-8775-005056c00008" name="Baileysv LD" loadType="UNDEFINED" p0="38" q0="15" node="17" p="38.004789566792397" q="15.003151163169214">
                 <iidm:alias>_0474f17b-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8814,9 +8814,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="128.04814330991073" angle="12.058815665738399" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="128.04650431028989" angle="12.974765851887042" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_0461b790-c766-11e1-8775-005056c00008" name="HolstonT NegG LD" loadType="UNDEFINED" p0="10" q0="0" node="8" p="10.000145325044603" q="0">
+            <iidm:load id="_0461b790-c766-11e1-8775-005056c00008" name="HolstonT NegG LD" loadType="UNDEFINED" p0="10" q0="0" node="8" p="10.000085442937921" q="0">
                 <iidm:alias>_0464ebe7-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8867,9 +8867,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.16852341325355" angle="-1.5787128932882759" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.04931432389496" angle="-1.6066361044028281" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_044c81e5-c766-11e1-8775-005056c00008" name="WMedford LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="8.0028152925999656" q="3.0017597642698366">
+            <iidm:load id="_044c81e5-c766-11e1-8775-005056c00008" name="WMedford LD" loadType="UNDEFINED" p0="8" q0="3" node="8" p="7.9998908552471617" q="2.9999317848397">
                 <iidm:alias>_04570939-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -8959,12 +8959,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="124.68118222276054" angle="-15.990586133907891" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="124.60093316256895" angle="-15.594822392092649" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04854520-c766-11e1-8775-005056c00008" name="Rockhill LD" loadType="UNDEFINED" p0="59" q0="26" node="14" p="59.001010777133921" q="26.000742382925356">
+            <iidm:load id="_04854520-c766-11e1-8775-005056c00008" name="Rockhill LD" loadType="UNDEFINED" p0="59" q0="26" node="14" p="58.985479146191032" q="25.989335841098683">
                 <iidm:alias>_0461b799-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_0460cd38-c766-11e1-8775-005056c00008" name="Rockhill SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.81399999999999" targetDeadband="1" node="15" q="-12.482953951973574">
+            <iidm:shunt id="_0460cd38-c766-11e1-8775-005056c00008" name="Rockhill SC" sectionCount="5" voltageRegulatorOn="true" targetV="130.81399999999999" targetDeadband="1" node="15" q="-12.466890213621332">
                 <iidm:alias>_048b86b4-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_069d84c6-bd26-4c26-ac6c-e801a0202a00"/>
                 <iidm:shuntLinearModel bPerSection="0.0001606" gPerSection="0" maximumSectionCount="10"/>
@@ -9037,12 +9037,12 @@
                 <iidm:internalConnection node1="31" node2="3"/>
                 <iidm:internalConnection node1="32" node2="6"/>
                 <iidm:internalConnection node1="33" node2="9"/>
-                <iidm:bus v="128.55634146392575" angle="4.9655247645164584" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
+                <iidm:bus v="128.70174928281929" angle="5.8101800332083027" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_047a48a5-c766-11e1-8775-005056c00008" name="Sprigg LD" loadType="UNDEFINED" p0="20" q0="10" node="11" p="20.001000898176489" q="10.000834095727514">
+            <iidm:load id="_047a48a5-c766-11e1-8775-005056c00008" name="Sprigg LD" loadType="UNDEFINED" p0="20" q0="10" node="11" p="20.009720460644129" q="10.008101696123624">
                 <iidm:alias>_0472ce97-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:shunt id="_04553478-c766-11e1-8775-005056c00008" name="Sprigg SC" sectionCount="5" voltageRegulatorOn="true" targetV="129.935" targetDeadband="1" node="12" q="-9.4863447021583589">
+            <iidm:shunt id="_04553478-c766-11e1-8775-005056c00008" name="Sprigg SC" sectionCount="5" voltageRegulatorOn="true" targetV="129.935" targetDeadband="1" node="12" q="-9.5078165140947064">
                 <iidm:alias>_045bc428-c766-11e1-8775-005056c00008</iidm:alias>
                 <iidm:property name="CGMES.RegulatingControl" value="_f4cdc674-4a66-4ab8-8d4f-552cb066e259"/>
                 <iidm:shuntLinearModel bPerSection="0.0001148" gPerSection="0" maximumSectionCount="10"/>
@@ -9134,12 +9134,12 @@
                 <iidm:internalConnection node1="41" node2="6"/>
                 <iidm:internalConnection node1="42" node2="9"/>
                 <iidm:internalConnection node1="43" node2="12"/>
-                <iidm:bus v="118.46299631682518" angle="-21.686345942072137" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
+                <iidm:bus v="118.41192321033623" angle="-21.206663334096756" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_04819ba4-c766-11e1-8775-005056c00008" name="West End NegG LD" loadType="UNDEFINED" p0="46" q0="0" node="14" p="45.994990283087709" q="0">
+            <iidm:load id="_04819ba4-c766-11e1-8775-005056c00008" name="West End NegG LD" loadType="UNDEFINED" p0="46" q0="0" node="14" p="45.986518080264332" q="0">
                 <iidm:alias>_04627ae0-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
-            <iidm:load id="_04555b89-c766-11e1-8775-005056c00008" name="West End LD" loadType="UNDEFINED" p0="20" q0="23" node="15" p="19.997821862212049" q="22.995825387461778">
+            <iidm:load id="_04555b89-c766-11e1-8775-005056c00008" name="West End LD" loadType="UNDEFINED" p0="20" q0="23" node="15" p="19.994138295767101" q="22.988766164520275">
                 <iidm:alias>_04592c18-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9190,9 +9190,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.31248925083676" angle="-1.6735918971456067" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.13107689094983" angle="-1.6866783628402913" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046d0232-c766-11e1-8775-005056c00008" name="Deer Crk NegG LD" loadType="UNDEFINED" p0="6" q0="0" node="8" p="6.0029955674491795" q="0">
+            <iidm:load id="_046d0232-c766-11e1-8775-005056c00008" name="Deer Crk NegG LD" loadType="UNDEFINED" p0="6" q0="0" node="8" p="5.9997060060893466" q="0">
                 <iidm:alias>_0480150a-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9262,9 +9262,9 @@
                 <iidm:internalConnection node1="30" node2="3"/>
                 <iidm:internalConnection node1="31" node2="6"/>
                 <iidm:internalConnection node1="32" node2="9"/>
-                <iidm:bus v="133.92747668312646" angle="-11.353944414454475" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
+                <iidm:bus v="133.92475240280444" angle="-10.658350895158469" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046c3ee3-c766-11e1-8775-005056c00008" name="Crooksvl LD" loadType="UNDEFINED" p0="34" q0="0" node="11" p="34.000086884542377" q="0">
+            <iidm:load id="_046c3ee3-c766-11e1-8775-005056c00008" name="Crooksvl LD" loadType="UNDEFINED" p0="34" q0="0" node="11" p="33.999798544561138" q="0">
                 <iidm:alias>_047e4047-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9315,9 +9315,9 @@
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="132.05135837777328" angle="-14.596394308482802" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="132.05288247605807" angle="-13.893327422327186" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_046dc585-c766-11e1-8775-005056c00008" name="WCambrdg LD" loadType="UNDEFINED" p0="17" q0="4" node="8" p="16.999920271434359" q="3.9999687339447054">
+            <iidm:load id="_046dc585-c766-11e1-8775-005056c00008" name="WCambrdg LD" loadType="UNDEFINED" p0="17" q0="4" node="8" p="16.999991162655093" q="3.9999965343751458">
                 <iidm:alias>_045dbff8-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9406,9 +9406,9 @@
                 <iidm:internalConnection node1="40" node2="6"/>
                 <iidm:internalConnection node1="41" node2="9"/>
                 <iidm:internalConnection node1="42" node2="12"/>
-                <iidm:bus v="130.32016072358471" angle="-2.5344425813765787" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
+                <iidm:bus v="130.29470483245294" angle="-2.5162588953198242" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
-            <iidm:load id="_048b5fa5-c766-11e1-8775-005056c00008" name="SouthBnd LD" loadType="UNDEFINED" p0="70" q0="23" node="14" p="70.004742145095534" q="23.002596947622468">
+            <iidm:load id="_048b5fa5-c766-11e1-8775-005056c00008" name="SouthBnd LD" loadType="UNDEFINED" p0="70" q0="23" node="14" p="69.999353947460733" q="22.999646210412152">
                 <iidm:alias>_04522734-c766-11e1-8775-005056c00008</iidm:alias>
             </iidm:load>
         </iidm:voltageLevel>
@@ -9458,11 +9458,11 @@
                 <iidm:internalConnection node1="19" node2="6"/>
                 <iidm:internalConnection node1="20" node2="3"/>
                 <iidm:internalConnection node1="21" node2="6"/>
-                <iidm:bus v="228.10650946395356" angle="13.939127893842091" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
+                <iidm:bus v="228.02739985678096" angle="14.016324310123421" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
     </iidm:substation>
-    <iidm:line id="_044cd006-c766-11e1-8775-005056c00008" name="31-32" r="5.1923519999999996" x="17.16264" g1="0" b1="7.20271e-05" g2="0" b2="7.20271e-05" node1="31" voltageLevelId1="_04636548-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="-26.9554789049877" q1="7.019128095377436" p2="27.208425784881239" q2="-8.5311542072121398">
+    <iidm:line id="_044cd006-c766-11e1-8775-005056c00008" name="31-32" r="5.1923519999999996" x="17.16264" g1="0" b1="7.20271e-05" g2="0" b2="7.20271e-05" node1="31" voltageLevelId1="_04636548-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="-26.831692515284335" q1="8.0058465675951371" p2="27.087980247740575" q2="-9.5043127201710789">
         <iidm:alias>_04682030-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0471bd25-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9470,7 +9470,7 @@
             <iidm:temporaryLimit name="_de6da3cb-8cb5-4900-9c33-8ad45632b535" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045a3d89-c766-11e1-8775-005056c00008" name="2-12" r="3.2582879999999999" x="10.7331839" g1="0" b1="4.5110200000000001e-05" g2="0" b2="4.5110200000000001e-05" node1="21" voltageLevelId1="_045d4ac5-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-31.528847131816327" q1="-17.114103271026764" p2="31.777898178091629" q2="16.419342494303738">
+    <iidm:line id="_045a3d89-c766-11e1-8775-005056c00008" name="2-12" r="3.2582879999999999" x="10.7331839" g1="0" b1="4.5110200000000001e-05" g2="0" b2="4.5110200000000001e-05" node1="21" voltageLevelId1="_045d4ac5-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-31.493400622892569" q1="-17.195783778444859" p2="31.74256336275154" q2="16.501459870377612">
         <iidm:alias>_046adf51-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046fe868-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9478,7 +9478,7 @@
             <iidm:temporaryLimit name="_6bd63dd1-1344-4183-b7bd-af326919f4eb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04513cd7-c766-11e1-8775-005056c00008" name="32-114" r="2.3522400000000001" x="10.6634884" g1="0" b1="4.6717149999999997e-05" g2="0" b2="4.6717149999999997e-05" node1="49" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04791027-c766-11e1-8775-005056c00008" p1="7.5453684581076024" q1="3.9557295376696944" p2="-7.5339460624538539" q2="-5.4212834823674294">
+    <iidm:line id="_04513cd7-c766-11e1-8775-005056c00008" name="32-114" r="2.3522400000000001" x="10.6634884" g1="0" b1="4.6717149999999997e-05" g2="0" b2="4.6717149999999997e-05" node1="49" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04791027-c766-11e1-8775-005056c00008" p1="7.4231347815634212" q1="3.7654419669507151" p2="-7.4122087703535771" q2="-5.2301977483203821">
         <iidm:alias>_046d0237-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0470d2c7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9486,7 +9486,7 @@
             <iidm:temporaryLimit name="_5f05650a-c63d-46e5-a426-2db4f036929f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045d71d4-c766-11e1-8775-005056c00008" name="24-72" r="8.5029120000000002" x="34.151040000000002" g1="0" b1="0.00014003675" g2="0" b2="0.00014003675" node1="30" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="25.490706095664901" q1="-5.0255862166601375" p2="-25.170370923435598" q2="1.4613499202793121">
+    <iidm:line id="_045d71d4-c766-11e1-8775-005056c00008" name="24-72" r="8.5029120000000002" x="34.151040000000002" g1="0" b1="0.00014003675" g2="0" b2="0.00014003675" node1="30" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="23.380735587117695" q1="-4.9693305122282352" p2="-23.10976843047629" q2="1.2224602868664232">
         <iidm:alias>_04667281-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d0234-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9494,7 +9494,7 @@
             <iidm:temporaryLimit name="_d2074163-ab09-4251-a1d7-6983091dc4f1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045f94b8-c766-11e1-8775-005056c00008" name="17-18" r="2.1431520000000002" x="8.7991200000000003" g1="0" b1="3.7247499999999999e-05" g2="0" b2="3.7247499999999999e-05" node1="57" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04689563-c766-11e1-8775-005056c00008" p1="113.29553395743046" q1="38.547580617768872" p2="-111.45936221484236" q2="-32.2171727461564">
+    <iidm:line id="_045f94b8-c766-11e1-8775-005056c00008" name="17-18" r="2.1431520000000002" x="8.7991200000000003" g1="0" b1="3.7247499999999999e-05" g2="0" b2="3.7247499999999999e-05" node1="57" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04689563-c766-11e1-8775-005056c00008" p1="114.54250481445646" q1="40.255327506401159" p2="-112.64708882765034" q2="-33.676826923046306">
         <iidm:alias>_045e0e17-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0485ba59-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9502,7 +9502,7 @@
             <iidm:temporaryLimit name="_2b6693c7-4e29-4c2c-91d0-3485bbe8fe87" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048963d8-c766-11e1-8775-005056c00008" name="17-113" r="1.590811" x="5.244624" g1="0" b1="2.2038549999999999e-05" g2="0" b2="2.2038549999999999e-05" node1="58" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="5.109772974426023" q1="2.9618180320082503" p2="-5.1062439616816766" q2="-3.6883553653375971">
+    <iidm:line id="_048963d8-c766-11e1-8775-005056c00008" name="17-113" r="1.590811" x="5.244624" g1="0" b1="2.2038549999999999e-05" g2="0" b2="2.2038549999999999e-05" node1="58" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="5.1943367435539649" q1="2.7726172896455168" p2="-5.1908317367173371" q2="-3.4971291723715576">
         <iidm:alias>_045841b5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046958b4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9510,7 +9510,7 @@
             <iidm:temporaryLimit name="_786432da-fa4d-4751-a275-87d0e20529f1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0458ddf0-c766-11e1-8775-005056c00008" name="49-50" r="4.6522079999999999" x="13.102848099999999" g1="0" b1="5.3776400000000002e-05" g2="0" b2="5.3776400000000002e-05" node1="112" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044d1e26-c766-11e1-8775-005056c00008" p1="62.28473038277739" q1="11.672291194180168" p2="-61.258134502252538" q2="-10.703070517177077">
+    <iidm:line id="_0458ddf0-c766-11e1-8775-005056c00008" name="49-50" r="4.6522079999999999" x="13.102848099999999" g1="0" b1="5.3776400000000002e-05" g2="0" b2="5.3776400000000002e-05" node1="112" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044d1e26-c766-11e1-8775-005056c00008" p1="62.150970549223693" q1="11.697555277082104" p2="-61.128441309664986" q2="-10.739809265518868">
         <iidm:alias>_0464ebe8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f9fd8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9518,7 +9518,7 @@
             <iidm:temporaryLimit name="_1f0844a5-ea5c-42b2-abcb-6fac2c426092" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04535fb7-c766-11e1-8775-005056c00008" name="1-3" r="2.2476959999999999" x="7.3877759999999997" g1="0" b1="3.1049149999999997e-05" g2="0" b2="3.1049149999999997e-05" node1="21" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_047eb579-c766-11e1-8775-005056c00008" p1="-39.543936275908621" q1="-16.745040215734885" p2="39.799583436209907" q2="16.574259351746406">
+    <iidm:line id="_04535fb7-c766-11e1-8775-005056c00008" name="1-3" r="2.2476959999999999" x="7.3877759999999997" g1="0" b1="3.1049149999999997e-05" g2="0" b2="3.1049149999999997e-05" node1="21" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_047eb579-c766-11e1-8775-005056c00008" p1="-39.576718251076514" q1="-16.662035299497798" p2="39.83241601527169" q2="16.491702080338573">
         <iidm:alias>_044ef2e9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047c4474-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9526,7 +9526,7 @@
             <iidm:temporaryLimit name="_4ea43e34-67a3-42b8-9601-2189db7790d4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0478e912-c766-11e1-8775-005056c00008" name="92-102" r="2.1431520000000002" x="9.7400160000000007" g1="0" b1="4.2011000000000001e-05" g2="0" b2="4.2011000000000001e-05" node1="66" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="49.799893324445968" q1="-9.0162583648579471" p2="-49.479664768040109" q2="9.0398445066998772">
+    <iidm:line id="_0478e912-c766-11e1-8775-005056c00008" name="92-102" r="2.1431520000000002" x="9.7400160000000007" g1="0" b1="4.2011000000000001e-05" g2="0" b2="4.2011000000000001e-05" node1="66" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="49.917710066393589" q1="-9.0310654836462589" p2="-49.595963550656201" q2="9.0616054833244259">
         <iidm:alias>_045a1673-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0468bc79-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9534,7 +9534,7 @@
             <iidm:temporaryLimit name="_23cc194e-9273-46e9-a793-84a9c2911737" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04547127-c766-11e1-8775-005056c00008" name="93-94" r="3.8855520000000001" x="12.7543688" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="21" voltageLevelId1="_04789af0-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="56.851535438925069" q1="-21.929140878593696" p2="-56.003874999988156" q2="22.891163090030211">
+    <iidm:line id="_04547127-c766-11e1-8775-005056c00008" name="93-94" r="3.8855520000000001" x="12.7543688" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="21" voltageLevelId1="_04789af0-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="57.176112903958995" q1="-22.08335870501304" p2="-56.318430097275836" q2="23.078140955590083">
         <iidm:alias>_04500450-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047b0bfb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9542,7 +9542,7 @@
             <iidm:temporaryLimit name="_1a9fe09e-3f63-4904-8e36-aa38c5e16c59" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04791021-c766-11e1-8775-005056c00008" name="46-48" r="10.4718237" x="32.931359999999998" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044778d3-c766-11e1-8775-005056c00008" p1="-8.6626927831010416" q1="-7.9962479185796518" p2="8.7260897649444775" q2="3.3526742150723514">
+    <iidm:line id="_04791021-c766-11e1-8775-005056c00008" name="46-48" r="10.4718237" x="32.931359999999998" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044778d3-c766-11e1-8775-005056c00008" p1="-8.7814319484158005" q1="-7.9551235833974099" p2="8.8457877930284567" q2="3.3145831975342364">
         <iidm:alias>_0459ef69-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04640186-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9550,7 +9550,7 @@
             <iidm:temporaryLimit name="_467ba04d-dbad-4fe1-81c8-3bc87b41fcd1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046958b6-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="113" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-92.154562716893992" q1="-2.5673526451535702" p2="93.609820606518738" q2="7.3388894454456581">
+    <iidm:line id="_046958b6-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="113" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-92.393474100130007" q1="-2.4979783931731947" p2="93.856257524711921" q2="7.3079447900618435">
         <iidm:alias>_04776270-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a96c8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9558,7 +9558,7 @@
             <iidm:temporaryLimit name="_d0737ab4-5a3a-46c8-8aeb-789313f0f332" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046f4c26-c766-11e1-8775-005056c00008" name="75-118" r="2.5264799999999998" x="8.3809430000000003" g1="0" b1="3.4377849999999998e-05" g2="0" b2="3.4377849999999998e-05" node1="48" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="39.572821711103416" q1="28.799143751993405" p2="-39.197166205347798" q2="-28.652376510852882">
+    <iidm:line id="_046f4c26-c766-11e1-8775-005056c00008" name="75-118" r="2.5264799999999998" x="8.3809430000000003" g1="0" b1="3.4377849999999998e-05" g2="0" b2="3.4377849999999998e-05" node1="48" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="38.925890696072038" q1="28.845275172760349" p2="-38.55737738191938" q2="-28.72136654890447">
         <iidm:alias>_04619088-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04814d8a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9566,7 +9566,7 @@
             <iidm:temporaryLimit name="_173dc7ff-ae18-4410-b2e1-a4c2abac8ff6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c3954-c766-11e1-8775-005056c00008" name="94-96" r="4.6870560000000001" x="15.1414566" g1="0" b1="6.60009e-05" g2="0" b2="6.60009e-05" node1="49" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="37.720151080699956" q1="-12.761772144133857" p2="-37.289859442193304" q2="11.909702554191687">
+    <iidm:line id="_045c3954-c766-11e1-8775-005056c00008" name="94-96" r="4.6870560000000001" x="15.1414566" g1="0" b1="6.60009e-05" g2="0" b2="6.60009e-05" node1="49" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="38.239927878149373" q1="-13.076331518928392" p2="-37.796743625016191" q2="12.265265667813402">
         <iidm:alias>_046ba2a0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0472ce94-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9574,7 +9574,7 @@
             <iidm:temporaryLimit name="_efde58bf-c92e-496d-b558-d0095a271083" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04518af7-c766-11e1-8775-005056c00008" name="62-67" r="4.4953919999999998" x="20.38608" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="39" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="-2.6333597532592505" q1="-18.330752095706764" p2="2.7083273744425616" q2="15.525566043070004">
+    <iidm:line id="_04518af7-c766-11e1-8775-005056c00008" name="62-67" r="4.4953919999999998" x="20.38608" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="39" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="-2.5024544258821511" q1="-18.359766351242619" p2="2.5775006634305742" q2="15.554936156268884">
         <iidm:alias>_04544a10-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04814d86-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9582,7 +9582,7 @@
             <iidm:temporaryLimit name="_8a81d4ae-2bc8-4038-8650-27a6150946b1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0452c375-c766-11e1-8775-005056c00008" name="47-49" r="3.3279839999999998" x="10.890000000000001" g1="0" b1="4.6028449999999998e-05" g2="0" b2="4.6028449999999998e-05" node1="30" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="114" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="16.932648633718809" q1="-22.712628177092789" p2="-16.790568686203571" q2="21.509355532427207">
+    <iidm:line id="_0452c375-c766-11e1-8775-005056c00008" name="47-49" r="3.3279839999999998" x="10.890000000000001" g1="0" b1="4.6028449999999998e-05" g2="0" b2="4.6028449999999998e-05" node1="30" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="114" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="16.884575344490067" q1="-22.731161382471676" p2="-16.742640397039565" q2="21.527448354413877">
         <iidm:alias>_0465fd54-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0471e431-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9590,7 +9590,7 @@
             <iidm:temporaryLimit name="_8d6a074c-900d-4a37-830c-5da4c1de1ab5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046c17d9-c766-11e1-8775-005056c00008" name="100-106" r="10.54152" x="39.900959999999998" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="76" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="59.439459369581385" q1="10.055342100706916" p2="-57.269954427820544" q2="-7.9072117638625814">
+    <iidm:line id="_046c17d9-c766-11e1-8775-005056c00008" name="100-106" r="10.54152" x="39.900959999999998" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="76" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="59.403231504119944" q1="10.058378893057338" p2="-57.236196087571258" q2="-7.91961245992497">
         <iidm:alias>_045d98e5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0480d851-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9598,7 +9598,7 @@
             <iidm:temporaryLimit name="_3154dc30-b0e5-4570-8e52-9333bae20ef2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046b2d77-c766-11e1-8775-005056c00008" name="77-78" r="0.655142" x="2.1605759999999998" g1="0" b1="3.6271800000000001e-05" g2="0" b2="3.6271800000000001e-05" node1="66" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044fb634-c766-11e1-8775-005056c00008" p1="43.948615933627252" q1="3.9869200539332379" p2="-43.875576135449187" q2="-5.0139513887048945">
+    <iidm:line id="_046b2d77-c766-11e1-8775-005056c00008" name="77-78" r="0.655142" x="2.1605759999999998" g1="0" b1="3.6271800000000001e-05" g2="0" b2="3.6271800000000001e-05" node1="66" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044fb634-c766-11e1-8775-005056c00008" p1="43.631326133462409" q1="4.0794531214781031" p2="-43.55929499716364" q2="-5.1098403725450368">
         <iidm:alias>_046ed6fb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04893cc3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9606,7 +9606,7 @@
             <iidm:temporaryLimit name="_cce754c5-b9d5-4105-a431-32da96e4a6cf" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c8776-c766-11e1-8775-005056c00008" name="6-7" r="0.79976199999999997" x="3.6241919999999999" g1="0" b1="1.5782850000000001e-05" g2="0" b2="1.5782850000000001e-05" node1="21" voltageLevelId1="_044f6818-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047eb571-c766-11e1-8775-005056c00008" p1="38.372434220643811" q1="-5.6977628117137646" p2="-38.302073457589749" q2="5.4780603614160679">
+    <iidm:line id="_045c8776-c766-11e1-8775-005056c00008" name="6-7" r="0.79976199999999997" x="3.6241919999999999" g1="0" b1="1.5782850000000001e-05" g2="0" b2="1.5782850000000001e-05" node1="21" voltageLevelId1="_044f6818-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_047eb571-c766-11e1-8775-005056c00008" p1="38.543126858970503" q1="-6.0347906475053188" p2="-38.471950340352826" q2="5.8189314350236394">
         <iidm:alias>_046efe08-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04720b4a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9614,7 +9614,7 @@
             <iidm:temporaryLimit name="_361a9cc3-fb33-4037-9b9a-c20adb90b66b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047ba839-c766-11e1-8775-005056c00008" name="77-80" r="5.1226560000000001" x="18.295200000000001" g1="0" b1="6.5426999999999995e-05" g2="0" b2="6.5426999999999995e-05" node1="67" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="76" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-45.901174550184159" q1="-23.167357431284831" p2="46.659162247785382" q2="23.495388305482273">
+    <iidm:line id="_047ba839-c766-11e1-8775-005056c00008" name="77-80" r="5.1226560000000001" x="18.295200000000001" g1="0" b1="6.5426999999999995e-05" g2="0" b2="6.5426999999999995e-05" node1="67" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="76" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-46.218645898655993" q1="-23.053521048633762" p2="46.983706045546988" q2="23.406785198143179">
         <iidm:alias>_047c6b85-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0480b148-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9622,7 +9622,7 @@
             <iidm:temporaryLimit name="_da00c66f-a882-4938-923b-f2455f7f9a81" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04592c16-c766-11e1-8775-005056c00008" name="78-79" r="0.95135000000000003" x="4.2514560000000001" g1="0" b1="1.8595050000000001e-05" g2="0" b2="1.8595050000000001e-05" node1="22" voltageLevelId1="_044fb634-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04481510-c766-11e1-8775-005056c00008" p1="-27.12732965776723" q1="-20.987816914420613" p2="27.190766559257863" q2="20.618485483549769">
+    <iidm:line id="_04592c16-c766-11e1-8775-005056c00008" name="78-79" r="0.95135000000000003" x="4.2514560000000001" g1="0" b1="1.8595050000000001e-05" g2="0" b2="1.8595050000000001e-05" node1="22" voltageLevelId1="_044fb634-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04481510-c766-11e1-8775-005056c00008" p1="-27.443836980335796" q1="-20.892067098948548" p2="27.507999219396449" q2="20.525965518195267">
         <iidm:alias>_0453add6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045b7605-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9630,7 +9630,7 @@
             <iidm:temporaryLimit name="_ba4abe9d-8490-4c19-b19b-c9d2c3597fc9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047b3301-c766-11e1-8775-005056c00008" name="103-104" r="8.1195839999999997" x="27.599615100000001" g1="0" b1="0.00011679295" g2="0" b2="0.00011679295" node1="40" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="33.038111559518377" q1="13.987439502531293" p2="-32.421614385008091" q2="-15.884809987403123">
+    <iidm:line id="_047b3301-c766-11e1-8775-005056c00008" name="103-104" r="8.1195839999999997" x="27.599615100000001" g1="0" b1="0.00011679295" g2="0" b2="0.00011679295" node1="40" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="33.048507075618168" q1="13.983574209159713" p2="-32.43175228448861" q2="-15.88007375026449">
         <iidm:alias>_0459a142-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045d98e6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9638,7 +9638,7 @@
             <iidm:temporaryLimit name="_2320da74-eda7-4f7f-ade9-1ed0e994f3af" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045e5c32-c766-11e1-8775-005056c00008" name="95-96" r="2.9795039999999999" x="9.5309279999999994" g1="0" b1="4.2298000000000001e-05" g2="0" b2="4.2298000000000001e-05" node1="21" voltageLevelId1="_044f4108-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="14.199886653737162" q1="-24.768335954945933" p2="-14.059894971745479" q2="23.794329900876644">
+    <iidm:line id="_045e5c32-c766-11e1-8775-005056c00008" name="95-96" r="2.9795039999999999" x="9.5309279999999994" g1="0" b1="4.2298000000000001e-05" g2="0" b2="4.2298000000000001e-05" node1="21" voltageLevelId1="_044f4108-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="14.647439466516426" q1="-25.064651818112871" p2="-14.5026002430732" q2="24.105645404312479">
         <iidm:alias>_04597a34-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04801509-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9646,7 +9646,7 @@
             <iidm:temporaryLimit name="_3bc03415-e95f-47a7-8e92-01089d304a9c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045ed169-c766-11e1-8775-005056c00008" name="77-80" r="2.9620799999999998" x="8.4506409999999992" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="68" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="77" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-100.18020278525397" q1="-42.757434855003936" p2="102.15313708724334" q2="43.461013464335068">
+    <iidm:line id="_045ed169-c766-11e1-8775-005056c00008" name="77-80" r="2.9620799999999998" x="8.4506409999999992" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="68" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="77" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-100.83690198799037" q1="-42.473245816973794" p2="102.8282448708143" q2="43.229290298966816">
         <iidm:alias>_0464289a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04828605-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9654,7 +9654,7 @@
             <iidm:temporaryLimit name="_f93b6d4c-39fa-4f6f-a42d-c63a4cf21a67" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047f78c2-c766-11e1-8775-005056c00008" name="5-11" r="3.5370720000000002" x="11.8831682" g1="0" b1="4.987375e-05" g2="0" b2="4.987375e-05" node1="48" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="82.820561520627606" q1="10.768716380126552" p2="-81.429440521274671" q2="-7.8291648654903803">
+    <iidm:line id="_047f78c2-c766-11e1-8775-005056c00008" name="5-11" r="3.5370720000000002" x="11.8831682" g1="0" b1="4.987375e-05" g2="0" b2="4.987375e-05" node1="48" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="83.025347821337903" q1="10.523817202938526" p2="-81.627710393986604" q2="-7.5614784906299137">
         <iidm:alias>_045bc426-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0476c633-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9662,7 +9662,7 @@
             <iidm:temporaryLimit name="_3bc4ab96-7a0d-4e18-b9f5-d89f63a82f0a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04845ac7-c766-11e1-8775-005056c00008" name="71-72" r="7.7711040000000002" x="31.363201100000001" g1="0" b1="0.00012752525" g2="0" b2="0.00012752525" node1="29" voltageLevelId1="_04664b78-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="-13.086146831962262" q1="-2.5819227281348622" p2="13.164624754063423" q2="-1.4613546509897515">
+    <iidm:line id="_04845ac7-c766-11e1-8775-005056c00008" name="71-72" r="7.7711040000000002" x="31.363201100000001" g1="0" b1="0.00012752525" g2="0" b2="0.00012752525" node1="29" voltageLevelId1="_04664b78-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048433b5-c766-11e1-8775-005056c00008" p1="-11.053484955047384" q1="-2.9012295911855843" p2="11.10976596222903" q2="-1.2224602843575159">
         <iidm:alias>_04642891-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046b0661-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9670,7 +9670,7 @@
             <iidm:temporaryLimit name="_bcb69c6e-125e-449c-acb3-a4deb151668d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047343c2-c766-11e1-8775-005056c00008" name="66-67" r="3.9029759999999998" x="17.685359999999999" g1="0" b1="7.6962800000000001e-05" g2="0" b2="7.6962800000000001e-05" node1="50" voltageLevelId1="_047147f4-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="31.008999740499355" q1="21.034261438850084" p2="-30.708243275842456" q2="-22.525527768726295">
+    <iidm:line id="_047343c2-c766-11e1-8775-005056c00008" name="66-67" r="3.9029759999999998" x="17.685359999999999" g1="0" b1="7.6962800000000001e-05" g2="0" b2="7.6962800000000001e-05" node1="50" voltageLevelId1="_047147f4-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456e220-c766-11e1-8775-005056c00008" p1="30.876695883604583" q1="21.056991538167775" p2="-30.577405962587118" q2="-22.55489662343459">
         <iidm:alias>_0465af34-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04860874-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9678,7 +9678,7 @@
             <iidm:temporaryLimit name="_b4b8a31d-dc3c-4b51-88ad-a22e070eb96c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04569409-c766-11e1-8775-005056c00008" name="34-43" r="7.1961120000000003" x="29.289743399999999" g1="0" b1="0.0001212695" g2="0" b2="0.0001212695" node1="40" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_045e8349-c766-11e1-8775-005056c00008" p1="13.635998686072584" q1="-7.8127703991237691" p2="-13.533660155244917" q2="4.4390669850957121">
+    <iidm:line id="_04569409-c766-11e1-8775-005056c00008" name="34-43" r="7.1961120000000003" x="29.289743399999999" g1="0" b1="0.0001212695" g2="0" b2="0.0001212695" node1="40" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_045e8349-c766-11e1-8775-005056c00008" p1="12.843014039205283" q1="-7.7162913097787005" p2="-12.750788804052899" q2="4.3057156426262662">
         <iidm:alias>_04500454-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04505274-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9686,7 +9686,7 @@
             <iidm:temporaryLimit name="_5585c67a-0839-48e6-8847-4393e1e9b9c7" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04817498-c766-11e1-8775-005056c00008" name="52-53" r="7.0567200000000003" x="28.488240000000001" g1="0" b1="0.00011644859999999999" g2="0" b2="0.00011644859999999999" node1="21" voltageLevelId1="_04806326-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04876804-c766-11e1-8775-005056c00008" p1="13.438341583667802" q1="0.93851943063347421" p2="-13.354788545086516" q2="-4.2672352547660779">
+    <iidm:line id="_04817498-c766-11e1-8775-005056c00008" name="52-53" r="7.0567200000000003" x="28.488240000000001" g1="0" b1="0.00011644859999999999" g2="0" b2="0.00011644859999999999" node1="21" voltageLevelId1="_04806326-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04876804-c766-11e1-8775-005056c00008" p1="13.387778040432208" q1="0.95586908232669288" p2="-13.304786945034225" q2="-4.2869743741400939">
         <iidm:alias>_045115c7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0472a784-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9694,7 +9694,7 @@
             <iidm:temporaryLimit name="_e7c9dfab-fb45-4470-964f-4ba9e391f60b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044b7078-c766-11e1-8775-005056c00008" name="105-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="49" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="23" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="26.889711053786076" q1="1.3296797944122811" p2="-26.471381253948977" q2="-4.1925950816020414">
+    <iidm:line id="_044b7078-c766-11e1-8775-005056c00008" name="105-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="49" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="23" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="26.894001371590097" q1="1.3281746086101902" p2="-26.475547537966541" q2="-4.1906783765224969">
         <iidm:alias>_0452c378-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0481c2b7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9702,7 +9702,7 @@
             <iidm:temporaryLimit name="_fff133bf-25fd-46b2-b144-a227c31ee882" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048ac367-c766-11e1-8775-005056c00008" name="100-101" r="4.8264480000000001" x="21.9890881" g1="0" b1="9.4123049999999997e-05" g2="0" b2="9.4123049999999997e-05" node1="77" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046ed6f7-c766-11e1-8775-005056c00008" p1="-21.641053333542903" q1="24.672169784343399" p2="21.952692243244137" q2="-26.558421043430773">
+    <iidm:line id="_048ac367-c766-11e1-8775-005056c00008" name="100-101" r="4.8264480000000001" x="21.9890881" g1="0" b1="9.4123049999999997e-05" g2="0" b2="9.4123049999999997e-05" node1="77" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046ed6f7-c766-11e1-8775-005056c00008" p1="-21.752930324453736" q1="24.715054786271324" p2="22.066475861496194" q2="-26.592559669083833">
         <iidm:alias>_044afb45-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b5fa2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9710,7 +9710,7 @@
             <iidm:temporaryLimit name="_217e3c95-24b5-438f-a721-d2257e1a43b4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0481c2b1-c766-11e1-8775-005056c00008" name="56-57" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="57" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="-30.929734166232315" q1="-5.4126817551286646" p2="31.297394986829907" q2="4.2092397792371354">
+    <iidm:line id="_0481c2b1-c766-11e1-8775-005056c00008" name="56-57" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="57" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="-30.807725999154616" q1="-5.471536306722645" p2="31.172738242702909" q2="4.2605995400951242">
         <iidm:alias>_045e0e12-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0487dd35-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9718,7 +9718,7 @@
             <iidm:temporaryLimit name="_f5547027-3d48-4a53-937b-bd5ba63ef70d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047a6fb7-c766-11e1-8775-005056c00008" name="47-69" r="14.705855400000001" x="48.403869999999998" g1="0" b1="0.00020351240000000001" g2="0" b2="0.00020351240000000001" node1="31" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="57" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-83.477242331490814" q1="25.72912826991141" p2="89.89822513015946" q2="-12.043541708482417">
+    <iidm:line id="_047a6fb7-c766-11e1-8775-005056c00008" name="47-69" r="14.705855400000001" x="48.403869999999998" g1="0" b1="0.00020351240000000001" g2="0" b2="0.00020351240000000001" node1="31" voltageLevelId1="_0457f396-c766-11e1-8775-005056c00008" node2="57" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-83.63395210158258" q1="25.816058455301281" p2="90.080855097900425" q2="-12.045005627427145">
         <iidm:alias>_04758db9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0485ba56-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9726,7 +9726,7 @@
             <iidm:temporaryLimit name="_e9fec217-cf6f-4d39-9495-26ed10c05100" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0453fbf0-c766-11e1-8775-005056c00008" name="110-111" r="3.8332799999999998" x="13.1551189" g1="0" b1="5.7392100000000002e-05" g2="0" b2="5.7392100000000002e-05" node1="40" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_046a1c00-c766-11e1-8775-005056c00008" p1="-39.264264319166593" q1="-20.588022960459917" p2="39.729496626932274" q2="20.312108350062548">
+    <iidm:line id="_0453fbf0-c766-11e1-8775-005056c00008" name="110-111" r="3.8332799999999998" x="13.1551189" g1="0" b1="5.7392100000000002e-05" g2="0" b2="5.7392100000000002e-05" node1="40" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_046a1c00-c766-11e1-8775-005056c00008" p1="-39.389945934850651" q1="-20.544323644438652" p2="39.857146032914912" q2="20.275158680805681">
         <iidm:alias>_0447c6f5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04812675-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9734,7 +9734,7 @@
             <iidm:temporaryLimit name="_ea48fee0-31b6-4990-a332-25d08b7d731f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04778984-c766-11e1-8775-005056c00008" name="41-42" r="7.14384" x="23.522401800000001" g1="0" b1="9.8714400000000005e-05" g2="0" b2="9.8714400000000005e-05" node1="21" voltageLevelId1="_048c4a08-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="-9.8651035935645872" q1="-11.430986757877283" p2="9.9669149966285708" q2="8.9555915621222582">
+    <iidm:line id="_04778984-c766-11e1-8775-005056c00008" name="41-42" r="7.14384" x="23.522401800000001" g1="0" b1="9.8714400000000005e-05" g2="0" b2="9.8714400000000005e-05" node1="21" voltageLevelId1="_048c4a08-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="-10.469928167383888" q1="-11.256757221089588" p2="10.576368629598838" q2="8.7988331162323163">
         <iidm:alias>_044d1e2a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046512f1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9742,7 +9742,7 @@
             <iidm:temporaryLimit name="_063af52c-fe10-4c1e-85d4-dd80dcc1d2f9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04653a08-c766-11e1-8775-005056c00008" name="80-99" r="7.9104960000000002" x="35.893439999999998" g1="0" b1="0.00015668044999999999" g2="0" b2="0.00015668044999999999" node1="78" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04644fa4-c766-11e1-8775-005056c00008" p1="2.5630773124582484" q1="6.5502464082000724" p2="-2.5224134944437466" q2="-12.159125900711729">
+    <iidm:line id="_04653a08-c766-11e1-8775-005056c00008" name="80-99" r="7.9104960000000002" x="35.893439999999998" g1="0" b1="0.00015668044999999999" g2="0" b2="0.00015668044999999999" node1="78" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04644fa4-c766-11e1-8775-005056c00008" p1="2.04003632495998" q1="6.6707682751742121" p2="-1.9994154981183776" q2="-12.279778586143276">
         <iidm:alias>_04773b69-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0477b092-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9750,7 +9750,7 @@
             <iidm:temporaryLimit name="_c05229ce-6abb-4209-ad4f-0dcd4a070f28" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04581aa5-c766-11e1-8775-005056c00008" name="54-59" r="8.7642720000000001" x="39.953229999999998" g1="0" b1="0.0001716024" g2="0" b2="0.0001716024" node1="58" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-19.549275234181998" q1="-10.545290561610541" p2="19.793764152810382" q2="6.0318977267028648">
+    <iidm:line id="_04581aa5-c766-11e1-8775-005056c00008" name="54-59" r="8.7642720000000001" x="39.953229999999998" g1="0" b1="0.0001716024" g2="0" b2="0.0001716024" node1="58" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="67" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-19.649107732369732" q1="-10.518765158687819" p2="19.895526706604315" q2="6.014174469581425">
         <iidm:alias>_0457cc82-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045cae81-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9758,7 +9758,7 @@
             <iidm:temporaryLimit name="_ac528cbe-6fc1-41dd-ba9d-d8b7a4c77576" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04690a93-c766-11e1-8775-005056c00008" name="92-94" r="8.3809430000000003" x="27.529920000000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="67" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="64.752849213002079" q1="-16.292560650360553" p2="-62.592332990140441" q2="19.424394041102751">
+    <iidm:line id="_04690a93-c766-11e1-8775-005056c00008" name="92-94" r="8.3809430000000003" x="27.529920000000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="67" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_045ed163-c766-11e1-8775-005056c00008" p1="65.09172662084282" q1="-16.404825110453739" p2="-62.907932713155375" q2="19.612930821510083">
         <iidm:alias>_044c33c1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0483706b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9766,7 +9766,7 @@
             <iidm:temporaryLimit name="_6ac84228-6b04-4b10-b560-29655c8e93b4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046009e3-c766-11e1-8775-005056c00008" name="37-39" r="5.5931040000000003" x="18.469439999999999" g1="0" b1="7.7479350000000006e-05" g2="0" b2="7.7479350000000006e-05" node1="57" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046bf0c7-c766-11e1-8775-005056c00008" p1="67.685952172017068" q1="18.05231295548688" p2="-65.922705637226215" q2="-14.559472186068239">
+    <iidm:line id="_046009e3-c766-11e1-8775-005056c00008" name="37-39" r="5.5931040000000003" x="18.469439999999999" g1="0" b1="7.7479350000000006e-05" g2="0" b2="7.7479350000000006e-05" node1="57" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046bf0c7-c766-11e1-8775-005056c00008" p1="67.00803367927179" q1="18.057684884928026" p2="-65.275146844073845" q2="-14.662573607626067">
         <iidm:alias>_044c33c9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04789afa-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9774,7 +9774,7 @@
             <iidm:temporaryLimit name="_2ccdc288-c132-40d1-a928-3887bec4ff67" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0458b6e8-c766-11e1-8775-005056c00008" name="46-47" r="6.6211200000000003" x="22.12848" g1="0" b1="9.0679499999999998e-05" g2="0" b2="9.0679499999999998e-05" node1="33" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_0457f396-c766-11e1-8775-005056c00008" p1="-32.15281487804225" q1="1.103239425896295" p2="32.544501630054604" q2="-3.0165002176769122">
+    <iidm:line id="_0458b6e8-c766-11e1-8775-005056c00008" name="46-47" r="6.6211200000000003" x="22.12848" g1="0" b1="9.0679499999999998e-05" g2="0" b2="9.0679499999999998e-05" node1="33" voltageLevelId1="_048a7544-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_0457f396-c766-11e1-8775-005056c00008" p1="-32.352860274486048" q1="1.1885176427925623" p2="32.749578052602331" q2="-3.0848971375879324">
         <iidm:alias>_04507980-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0464c4da-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9782,7 +9782,7 @@
             <iidm:temporaryLimit name="_06ca3245-2668-448f-a5c6-961924217a5c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044f8f22-c766-11e1-8775-005056c00008" name="82-83" r="1.9514879999999999" x="6.3858959999999998" g1="0" b1="0.0001089302" g2="0" b2="0.0001089302" node1="31" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728074-c766-11e1-8775-005056c00008" p1="-65.561169866400206" q1="39.158856111103439" p2="66.256485848010243" q2="-40.511497223502381">
+    <iidm:line id="_044f8f22-c766-11e1-8775-005056c00008" name="82-83" r="1.9514879999999999" x="6.3858959999999998" g1="0" b1="0.0001089302" g2="0" b2="0.0001089302" node1="31" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728074-c766-11e1-8775-005056c00008" p1="-66.606403299255646" q1="38.156677133145614" p2="67.307515991939454" q2="-39.496649140946673">
         <iidm:alias>_047a48a6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b3891-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9790,7 +9790,7 @@
             <iidm:temporaryLimit name="_dfbd2f07-76ab-41e3-910f-dc706979ea4b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045cfca6-c766-11e1-8775-005056c00008" name="108-109" r="1.82952" x="5.0181120000000004" g1="0" b1="2.1809000000000001e-05" g2="0" b2="2.1809000000000001e-05" node1="21" voltageLevelId1="_046c65f4-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b7b99-c766-11e1-8775-005056c00008" p1="20.849106321009572" q1="-0.5540380276309721" p2="-20.799499784468249" q2="-0.0076236969579897632">
+    <iidm:line id="_045cfca6-c766-11e1-8775-005056c00008" name="108-109" r="1.82952" x="5.0181120000000004" g1="0" b1="2.1809000000000001e-05" g2="0" b2="2.1809000000000001e-05" node1="21" voltageLevelId1="_046c65f4-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b7b99-c766-11e1-8775-005056c00008" p1="20.786890967761096" q1="-0.5319756247631956" p2="-20.737581308412274" q2="-0.030504882271447861">
         <iidm:alias>_04481514-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04716f00-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9798,7 +9798,7 @@
             <iidm:temporaryLimit name="_11451cec-81c7-4f83-a7db-df7dcaffa94e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04784cd5-c766-11e1-8775-005056c00008" name="70-74" r="6.9870239999999999" x="23.051952400000001" g1="0" b1="9.6648299999999994e-05" g2="0" b2="9.6648299999999994e-05" node1="48" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047dcb11-c766-11e1-8775-005056c00008" p1="23.957300868651409" q1="9.4523507343044226" p2="-23.669230741602515" q2="-11.689552134670203">
+    <iidm:line id="_04784cd5-c766-11e1-8775-005056c00008" name="70-74" r="6.9870239999999999" x="23.051952400000001" g1="0" b1="9.6648299999999994e-05" g2="0" b2="9.6648299999999994e-05" node1="48" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047dcb11-c766-11e1-8775-005056c00008" p1="22.995965193731863" q1="9.4912635805853789" p2="-22.725796907643588" q2="-11.783393469300716">
         <iidm:alias>_045e5c33-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046ab84b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9806,7 +9806,7 @@
             <iidm:temporaryLimit name="_37a5cc00-bd7f-4ec7-a77c-e140e23450d2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04747c40-c766-11e1-8775-005056c00008" name="77-82" r="5.1923519999999996" x="14.8626719" g1="0" b1="0.0002345615" g2="0" b2="0.0002345615" node1="69" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_046512f8-c766-11e1-8775-005056c00008" p1="-26.508739796607237" q1="30.894965454339957" p2="27.080244598877425" q2="-37.303319826150528">
+    <iidm:line id="_04747c40-c766-11e1-8775-005056c00008" name="77-82" r="5.1923519999999996" x="14.8626719" g1="0" b1="0.0002345615" g2="0" b2="0.0002345615" node1="69" voltageLevelId1="_04703689-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_046512f8-c766-11e1-8775-005056c00008" p1="-27.648739850634012" q1="30.640497028394513" p2="28.233272963354374" q2="-37.016444049706429">
         <iidm:alias>_0451b202-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0452ea84-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9814,7 +9814,7 @@
             <iidm:temporaryLimit name="_e9798d58-b518-4fab-984c-c72076dfc2ae" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045e3524-c766-11e1-8775-005056c00008" name="23-24" r="2.3522400000000001" x="8.5726080000000007" g1="0" b1="0.00014290635" g2="0" b2="0.00014290635" node1="39" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_048c22fa-c766-11e1-8775-005056c00008" p1="57.52458007824616" q1="-9.1921309525794381" p2="-57.07548553917222" q2="5.8284103790633619">
+    <iidm:line id="_045e3524-c766-11e1-8775-005056c00008" name="23-24" r="2.3522400000000001" x="8.5726080000000007" g1="0" b1="0.00014290635" g2="0" b2="0.00014290635" node1="39" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_048c22fa-c766-11e1-8775-005056c00008" p1="53.234470643063133" q1="-9.751789586710192" p2="-52.845797702274488" q2="6.1914779372557902">
         <iidm:alias>_046cb413-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f9fd3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9822,7 +9822,7 @@
             <iidm:temporaryLimit name="_e8ec73b8-1ecf-4d18-9ef9-80eabf3a4969" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0474f177-c766-11e1-8775-005056c00008" name="15-17" r="2.2999679999999998" x="7.6142880000000002" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="48" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-159.91868496764286" q1="-14.464459299606144" p2="163.67731531516463" q2="22.764800955756183">
+    <iidm:line id="_0474f177-c766-11e1-8775-005056c00008" name="15-17" r="2.2999679999999998" x="7.6142880000000002" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="48" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-159.94049312831035" q1="-15.582214072763431" p2="163.72037994298526" q2="23.967587122869805">
         <iidm:alias>_044c5ad2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046931a7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9830,7 +9830,7 @@
             <iidm:temporaryLimit name="_2ceac3d1-f73d-43db-8d37-9e329f1787bb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0483be84-c766-11e1-8775-005056c00008" name="8-30" r="2.0860400000000001" x="24.393599999999999" g1="0" b1="0.00053099175999999997" g2="0" b2="0.00053099175999999997" node1="30" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="38" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="102.91382030696595" q1="19.969827239127746" p2="-102.37387764854675" q2="-64.47200988492402">
+    <iidm:line id="_0483be84-c766-11e1-8775-005056c00008" name="8-30" r="2.0860400000000001" x="24.393599999999999" g1="0" b1="0.00053099175999999997" g2="0" b2="0.00053099175999999997" node1="30" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="38" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="103.80176794147498" q1="20.89947780010834" p2="-103.24987611345865" q2="-65.182624267124041">
         <iidm:alias>_0454e651-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04801506-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9838,7 +9838,7 @@
             <iidm:temporaryLimit name="_ca795ad3-97e5-4416-aaba-53cce27f6434" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0488eea6-c766-11e1-8775-005056c00008" name="49-69" r="17.16264" x="56.453762099999999" g1="0" b1="0.00023760329999999999" g2="0" b2="0.00023760329999999999" node1="115" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-75.176899132016715" q1="26.443050833125785" p2="81.364409029983079" q2="-14.874689902136391">
+    <iidm:line id="_0488eea6-c766-11e1-8775-005056c00008" name="49-69" r="17.16264" x="56.453762099999999" g1="0" b1="0.00023760329999999999" g2="0" b2="0.00023760329999999999" node1="115" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_0471bd23-c766-11e1-8775-005056c00008" p1="-75.304407191282195" q1="26.522384570750262" p2="81.514496234077882" q2="-14.879747933842955">
         <iidm:alias>_04492681-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046735d6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9846,7 +9846,7 @@
             <iidm:temporaryLimit name="_c42dc3ef-3a2e-4070-8efb-78e5c0cd5554" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047566a0-c766-11e1-8775-005056c00008" name="13-15" r="12.9634562" x="42.584255200000001" g1="0" b1="0.00017986685000000001" g2="0" b2="0.00017986685000000001" node1="21" voltageLevelId1="_04851e1b-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="10.634179774122545" q1="-0.23755101266677267" p2="-10.538128782618038" q2="-5.1986593984165017">
+    <iidm:line id="_047566a0-c766-11e1-8775-005056c00008" name="13-15" r="12.9634562" x="42.584255200000001" g1="0" b1="0.00017986685000000001" g2="0" b2="0.00017986685000000001" node1="21" voltageLevelId1="_04851e1b-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="10.924368183251739" q1="0.22540584376945591" p2="-10.821052650931371" q2="-5.6220373425772632">
         <iidm:alias>_04662461-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04865694-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9854,7 +9854,7 @@
             <iidm:temporaryLimit name="_ad988fd9-9270-4230-95a2-1858f32259df" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0476c63a-c766-11e1-8775-005056c00008" name="69-70" r="5.2271999999999998" x="22.12848" g1="0" b1="0.00035009184999999998" g2="0" b2="0.00035009184999999998" node1="59" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="75.549946676144558" q1="19.455191274468344" p2="-73.762296101670103" q2="-24.339126337241765">
+    <iidm:line id="_0476c63a-c766-11e1-8775-005056c00008" name="69-70" r="5.2271999999999998" x="22.12848" g1="0" b1="0.00035009184999999998" g2="0" b2="0.00035009184999999998" node1="59" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="77.625985719109877" q1="19.773286646266907" p2="-75.744618608998735" q2="-24.251198881511549">
         <iidm:alias>_047e193a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b1184-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9862,7 +9862,7 @@
             <iidm:temporaryLimit name="_519e3ecb-3561-4d11-ac6b-172a0b4b09b2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04520028-c766-11e1-8775-005056c00008" name="19-20" r="4.3908480000000001" x="20.38608" g1="0" b1="8.5514249999999999e-05" g2="0" b2="8.5514249999999999e-05" node1="39" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b2d70-c766-11e1-8775-005056c00008" p1="-20.879331476211561" q1="-3.0574033492840118" p2="21.003647993737943" q2="0.96027715290440829">
+    <iidm:line id="_04520028-c766-11e1-8775-005056c00008" name="19-20" r="4.3908480000000001" x="20.38608" g1="0" b1="8.5514249999999999e-05" g2="0" b2="8.5514249999999999e-05" node1="39" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046b2d70-c766-11e1-8775-005056c00008" p1="-12.812632496041429" q1="1.1707445045319318" p2="12.861228739455804" q2="-3.578884490579417">
         <iidm:alias>_0472f5a9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04745537-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9870,7 +9870,7 @@
             <iidm:temporaryLimit name="_b88528bf-cb1c-4c00-ad79-d5937197d40c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04862f83-c766-11e1-8775-005056c00008" name="94-95" r="2.2999679999999998" x="7.5620159999999998" g1="0" b1="3.1852600000000001e-05" g2="0" b2="3.1852600000000001e-05" node1="51" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f4108-c766-11e1-8775-005056c00008" p1="56.643136787981831" q1="6.6157512948779225" p2="-56.201468155784731" q2="-6.2335987355525004">
+    <iidm:line id="_04862f83-c766-11e1-8775-005056c00008" name="94-95" r="2.2999679999999998" x="7.5620159999999998" g1="0" b1="3.1852600000000001e-05" g2="0" b2="3.1852600000000001e-05" node1="51" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f4108-c766-11e1-8775-005056c00008" p1="57.099284251280146" q1="6.3430750054956784" p2="-56.651162911945093" q2="-5.9399182999231455">
         <iidm:alias>_044ca8f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04837060-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9878,7 +9878,7 @@
             <iidm:temporaryLimit name="_b70e76a1-6e79-4fb6-b487-dffa9bfeab7b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047b0bf6-c766-11e1-8775-005056c00008" name="12-16" r="3.6938879999999998" x="14.5316162" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="68" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046f7338-c766-11e1-8775-005056c00008" p1="9.50209823886515" q1="9.0997250587540588" p2="-9.4602907999364252" q2="-11.010403249374143">
+    <iidm:line id="_047b0bf6-c766-11e1-8775-005056c00008" name="12-16" r="3.6938879999999998" x="14.5316162" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="68" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_046f7338-c766-11e1-8775-005056c00008" p1="9.7891246618191978" q1="9.5635773019736714" p2="-9.7440365345012445" q2="-11.460403566287344">
         <iidm:alias>_0450798a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045c8772-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9886,7 +9886,7 @@
             <iidm:temporaryLimit name="_af73f526-c58b-40e7-8e1c-14f05a39f6a2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04524e47-c766-11e1-8775-005056c00008" name="100-103" r="2.7878400000000001" x="9.1476000000000006" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="78" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0475b4c0-c766-11e1-8775-005056c00008" p1="115.59165790191206" q1="-20.691432888435575" p2="-113.47503009054788" q2="22.130850328998186">
+    <iidm:line id="_04524e47-c766-11e1-8775-005056c00008" name="100-103" r="2.7878400000000001" x="9.1476000000000006" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="78" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0475b4c0-c766-11e1-8775-005056c00008" p1="115.38790336728503" q1="-20.642862431263779" p2="-113.2788231465133" q2="22.057519002493002">
         <iidm:alias>_04684744-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048aea71-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9894,7 +9894,7 @@
             <iidm:temporaryLimit name="_1631e50b-21a3-470b-803b-f9665b6fcd60" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04682038-c766-11e1-8775-005056c00008" name="27-32" r="3.9900959999999999" x="13.1551189" g1="0" b1="5.5268600000000001e-05" g2="0" b2="5.5268600000000001e-05" node1="40" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="15.733223883372061" q1="-2.6096284189358689" p2="-15.672237606005568" q2="1.0038248192521544">
+    <iidm:line id="_04682038-c766-11e1-8775-005056c00008" name="27-32" r="3.9900959999999999" x="13.1551189" g1="0" b1="5.5268600000000001e-05" g2="0" b2="5.5268600000000001e-05" node1="40" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="15.978088600967293" q1="-2.2624974749142011" p2="-15.915377513593038" q2="0.66563720351180045">
         <iidm:alias>_0455347a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479ac63-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9902,7 +9902,7 @@
             <iidm:temporaryLimit name="_52eb4b09-42bb-4106-ac26-fe1059639d3a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0482fb31-c766-11e1-8775-005056c00008" name="59-61" r="5.7150720000000002" x="26.1360016" g1="0" b1="0.0001113407" g2="0" b2="0.0001113407" node1="68" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-100.83815123386731" q1="22.27657294925514" p2="104.47302695792446" q2="-9.4565529415317897">
+    <iidm:line id="_0482fb31-c766-11e1-8775-005056c00008" name="59-61" r="5.7150720000000002" x="26.1360016" g1="0" b1="0.0001113407" g2="0" b2="0.0001113407" node1="68" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-100.75570549678528" q1="22.243804194129723" p2="104.38442989019308" q2="-9.4519127766526427">
         <iidm:alias>_044a10e9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0473b8f5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9910,7 +9910,7 @@
             <iidm:temporaryLimit name="_b5a7dea0-bfce-4548-a04d-7bb7b6d9f80a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047d55e3-c766-11e1-8775-005056c00008" name="100-104" r="7.8582239999999999" x="35.544960000000003" g1="0" b1="0.00015524565000000001" g2="0" b2="0.00015524565000000001" node1="79" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="55.04501506016031" q1="10.976728854244636" p2="-53.641075660188122" q2="-9.9722539045417182">
+    <iidm:line id="_047d55e3-c766-11e1-8775-005056c00008" name="100-104" r="7.8582239999999999" x="35.544960000000003" g1="0" b1="0.00015524565000000001" g2="0" b2="0.00015524565000000001" node1="79" voltageLevelId1="_04765109-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_0483977a-c766-11e1-8775-005056c00008" p1="55.00105878025574" q1="10.980561123103652" p2="-53.599181448794376" q2="-9.9854197918027232">
         <iidm:alias>_04636547-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048aea76-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9918,7 +9918,7 @@
             <iidm:temporaryLimit name="_17a10cd0-b653-4dcf-bdc3-4d5005ea9591" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04653a02-c766-11e1-8775-005056c00008" name="75-77" r="10.4718237" x="34.830577900000002" g1="0" b1="0.00014284895" g2="0" b2="0.00014284895" node1="49" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-35.809721687529922" q1="-7.081000018001343" p2="36.646499502319443" q2="5.0293231079805132">
+    <iidm:line id="_04653a02-c766-11e1-8775-005056c00008" name="75-77" r="10.4718237" x="34.830577900000002" g1="0" b1="0.00014284895" g2="0" b2="0.00014284895" node1="49" voltageLevelId1="_048740f7-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-36.626099415131549" q1="-6.9611560516577491" p2="37.50079995300991" q2="5.037452883863148">
         <iidm:alias>_04642894-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04720b47-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9926,7 +9926,7 @@
             <iidm:temporaryLimit name="_6f81df11-7e71-4b6e-a6ee-a8c5f72f4ba5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04483c2a-c766-11e1-8775-005056c00008" name="23-32" r="5.5234079999999999" x="20.089872400000001" g1="0" b1="0.00033660465000000001" g2="0" b2="0.00033660465000000001" node1="40" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="81.152192430230173" q1="7.2564620045780499" p2="-79.02686803367294" q2="-10.928089918453384">
+    <iidm:line id="_04483c2a-c766-11e1-8775-005056c00008" name="23-32" r="5.5234079999999999" x="20.089872400000001" g1="0" b1="0.00033660465000000001" g2="0" b2="0.00033660465000000001" node1="40" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047b3309-c766-11e1-8775-005056c00008" p1="80.52069059809503" q1="5.8659583034851446" p2="-78.427103870051639" q2="-9.608741405555552">
         <iidm:alias>_044b978a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0461dea6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9934,7 +9934,7 @@
             <iidm:temporaryLimit name="_a8f6a7d2-e58d-4671-a776-97be7291355e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048719e5-c766-11e1-8775-005056c00008" name="96-97" r="3.0143520000000001" x="15.42024" g1="0" b1="6.8870549999999994e-05" g2="0" b2="6.8870549999999994e-05" node1="50" voltageLevelId1="_045a1672-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="2.6454270333590788" q1="-25.325814067246395" p2="-2.5407057427961059" q2="23.46960866786727">
+    <iidm:line id="_048719e5-c766-11e1-8775-005056c00008" name="96-97" r="3.0143520000000001" x="15.42024" g1="0" b1="6.8870549999999994e-05" g2="0" b2="6.8870549999999994e-05" node1="50" voltageLevelId1="_045a1672-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="3.0589820538909525" q1="-25.290493988711471" p2="-2.9541958455778681" q2="23.433826675243751">
         <iidm:alias>_0451b207-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04828601-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9942,7 +9942,7 @@
             <iidm:temporaryLimit name="_ea6d39aa-df95-4d3e-b7b6-a800e552e72a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048481d0-c766-11e1-8775-005056c00008" name="25-27" r="5.5408330000000001" x="28.401121100000001" g1="0" b1="0.000506198385" g2="0" b2="0.000506198385" node1="30" voltageLevelId1="_04728079-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0476c639-c766-11e1-8775-005056c00008" p1="148.73615959814802" q1="29.12246746077583" p2="-141.91999783067914" q2="-12.202493351669114">
+    <iidm:line id="_048481d0-c766-11e1-8775-005056c00008" name="25-27" r="5.5408330000000001" x="28.401121100000001" g1="0" b1="0.000506198385" g2="0" b2="0.000506198385" node1="30" voltageLevelId1="_04728079-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0476c639-c766-11e1-8775-005056c00008" p1="149.1708139283806" q1="29.587014004215906" p2="-142.30683114062117" q2="-12.40978221290753">
         <iidm:alias>_046d2947-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04725960-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9950,7 +9950,7 @@
             <iidm:temporaryLimit name="_d9d53af2-5ffa-4f2a-a4e6-ed22371332d6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04885268-c766-11e1-8775-005056c00008" name="110-112" r="4.3037280000000004" x="11.1513615" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="41" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="13" voltageLevelId2="_04784cd1-c766-11e1-8775-005056c00008" p1="69.35439222764451" q1="11.007409586584336" p2="-67.999994151833818" q2="-12.999989282032251">
+    <iidm:line id="_04885268-c766-11e1-8775-005056c00008" name="110-112" r="4.3037280000000004" x="11.1513615" g1="0" b1="0.00017791549999999999" g2="0" b2="0.00017791549999999999" node1="41" voltageLevelId1="_04740714-c766-11e1-8775-005056c00008" node2="13" voltageLevelId2="_04784cd1-c766-11e1-8775-005056c00008" p1="69.354406702497911" q1="11.007381726100114" p2="-68.0000145858981" q2="-13.000003560599293">
         <iidm:alias>_04611b55-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0481c2ba-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9958,7 +9958,7 @@
             <iidm:temporaryLimit name="_d50299b9-a055-408a-aa1e-2e93a715120f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0484a8e4-c766-11e1-8775-005056c00008" name="89-92" r="1.7249760000000001" x="8.7991200000000003" g1="0" b1="0.00015725434999999999" g2="0" b2="0.00015725434999999999" node1="57" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="68" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="227.6113771184356" q1="-3.2588800250804573" p2="-222.53337882814685" q2="23.711762385800402">
+    <iidm:line id="_0484a8e4-c766-11e1-8775-005056c00008" name="89-92" r="1.7249760000000001" x="8.7991200000000003" g1="0" b1="0.00015725434999999999" g2="0" b2="0.00015725434999999999" node1="57" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="68" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="228.25537654527585" q1="-3.2766337031746695" p2="-223.14859617602579" q2="23.876428043840818">
         <iidm:alias>_04481517-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04808a3c-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9966,7 +9966,7 @@
             <iidm:temporaryLimit name="_eee9ca2b-764f-4ab8-a745-405338044743" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04689568-c766-11e1-8775-005056c00008" name="49-54" r="15.1414566" x="50.703842199999997" g1="0" b1="0.00020948120000000001" g2="0" b2="0.00020948120000000001" node1="116" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="46.672066269105848" q1="9.6001474234145867" p2="-44.721058155554637" q2="-10.230530030397823">
+    <iidm:line id="_04689568-c766-11e1-8775-005056c00008" name="49-54" r="15.1414566" x="50.703842199999997" g1="0" b1="0.00020948120000000001" g2="0" b2="0.00020948120000000001" node1="116" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="46.528526831795588" q1="9.6237889072459382" p2="-44.588056977437994" q2="-10.289456283952202">
         <iidm:alias>_046030f0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04605808-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9974,7 +9974,7 @@
             <iidm:temporaryLimit name="_690202a4-aad2-4ad3-8842-961b39e37709" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046c8d04-c766-11e1-8775-005056c00008" name="40-41" r="2.5264799999999998" x="8.4854880000000001" g1="0" b1="3.5066600000000001e-05" g2="0" b2="3.5066600000000001e-05" node1="40" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048c4a08-c766-11e1-8775-005056c00008" p1="27.265198917840312" q1="-1.9623588476822578" p2="-27.130975345345103" q2="1.4327620743490921">
+    <iidm:line id="_046c8d04-c766-11e1-8775-005056c00008" name="40-41" r="2.5264799999999998" x="8.4854880000000001" g1="0" b1="3.5066600000000001e-05" g2="0" b2="3.5066600000000001e-05" node1="40" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048c4a08-c766-11e1-8775-005056c00008" p1="26.64773080429238" q1="-1.8103093056681869" p2="-26.519465975047769" q2="1.2615351492036213">
         <iidm:alias>_045cae80-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a2194-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9982,7 +9982,7 @@
             <iidm:temporaryLimit name="_34f2ef7c-32da-4444-b989-d02f5f931c50" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046735d5-c766-11e1-8775-005056c00008" name="39-40" r="3.206016" x="10.54152" g1="0" b1="4.4536249999999999e-05" g2="0" b2="4.4536249999999999e-05" node1="22" voltageLevelId1="_046bf0c7-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="38.925142354446201" q1="3.5611334044162097" p2="-38.582894883283657" q2="-3.7002889119208433">
+    <iidm:line id="_046735d5-c766-11e1-8775-005056c00008" name="39-40" r="3.206016" x="10.54152" g1="0" b1="4.4536249999999999e-05" g2="0" b2="4.4536249999999999e-05" node1="22" voltageLevelId1="_046bf0c7-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="38.282993065385632" q1="3.6679016528484931" p2="-37.951300357951787" q2="-3.8406181950235609">
         <iidm:alias>_045115c1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048badc2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9990,7 +9990,7 @@
             <iidm:temporaryLimit name="_38d58455-5205-46bb-8e44-c66873f62938" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0470d2c4-c766-11e1-8775-005056c00008" name="89-92" r="6.8476319999999999" x="27.5473423" g1="0" b1="0.00011880164999999999" g2="0" b2="0.00011880164999999999" node1="58" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="71.801212392058588" q1="-5.843133435978304" p2="-69.789768037561288" q2="9.8176091232481753">
+    <iidm:line id="_0470d2c4-c766-11e1-8775-005056c00008" name="89-92" r="6.8476319999999999" x="27.5473423" g1="0" b1="0.00011880164999999999" g2="0" b2="0.00011880164999999999" node1="58" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="72.004106758592783" q1="-5.8589116912410786" p2="-69.981261543573638" q2="9.8793231507726205">
         <iidm:alias>_04690a97-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04690a98-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -9998,7 +9998,7 @@
             <iidm:temporaryLimit name="_0cce41c7-b99f-4fec-93d2-73ea24433fa1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0479ac60-c766-11e1-8775-005056c00008" name="33-37" r="7.2309599999999996" x="24.742080000000001" g1="0" b1="0.00010502754999999999" g2="0" b2="0.00010502754999999999" node1="21" voltageLevelId1="_0456bb11-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="42.271832805341717" q1="-20.535593845609036" p2="-41.257413408441046" q2="20.750572621736048">
+    <iidm:line id="_0479ac60-c766-11e1-8775-005056c00008" name="33-37" r="7.2309599999999996" x="24.742080000000001" g1="0" b1="0.00010502754999999999" g2="0" b2="0.00010502754999999999" node1="21" voltageLevelId1="_0456bb11-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="39.740259361854498" q1="-20.269246970975431" p2="-38.826698811048367" q2="20.144614187100636">
         <iidm:alias>_04716f08-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0483be89-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10006,7 +10006,7 @@
             <iidm:temporaryLimit name="_343677c6-7477-4bf6-a12c-2c7e4a684d6f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048c4a00-c766-11e1-8775-005056c00008" name="105-108" r="4.5476640000000002" x="12.249072099999999" g1="0" b1="5.2915499999999998e-05" g2="0" b2="5.2915499999999998e-05" node1="50" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_046c65f4-c766-11e1-8775-005056c00008" p1="22.997237006271778" q1="-0.86260788588862336" p2="-22.849105781575826" q2="-0.44596085503065541">
+    <iidm:line id="_048c4a00-c766-11e1-8775-005056c00008" name="105-108" r="4.5476640000000002" x="12.249072099999999" g1="0" b1="5.2915499999999998e-05" g2="0" b2="5.2915499999999998e-05" node1="50" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_046c65f4-c766-11e1-8775-005056c00008" p1="22.934211624411908" q1="-0.84273666011642145" p2="-22.786891560478605" q2="-0.46802478520483737">
         <iidm:alias>_046adf53-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04795e46-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10014,7 +10014,7 @@
             <iidm:temporaryLimit name="_74cf84b9-e14f-4f81-9e8b-3a791cd474a0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04631724-c766-11e1-8775-005056c00008" name="34-37" r="0.44605400000000001" x="1.637856" g1="0" b1="2.8236900000000001e-05" g2="0" b2="2.8236900000000001e-05" node1="41" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-54.300985135197379" q1="-35.72845529995282" p2="54.421324700714159" q2="35.287765936876362">
+    <iidm:line id="_04631724-c766-11e1-8775-005056c00008" name="34-37" r="0.44605400000000001" x="1.637856" g1="0" b1="2.8236900000000001e-05" g2="0" b2="2.8236900000000001e-05" node1="41" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="59" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-56.385183214168869" q1="-35.456107833395976" p2="56.511756765172414" q2="35.039410145146086">
         <iidm:alias>_04592c19-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04719611-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10022,7 +10022,7 @@
             <iidm:temporaryLimit name="_8e90bf2e-3be4-41be-a84e-c1d4e709f8a1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04814d85-c766-11e1-8775-005056c00008" name="61-62" r="1.435738" x="6.5514239999999999" g1="0" b1="2.812215e-05" g2="0" b2="2.812215e-05" node1="40" voltageLevelId1="_0448d867-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="59.941592561283194" q1="-18.17434269406774" p2="-59.616503485889979" q2="18.685568470057074">
+    <iidm:line id="_04814d85-c766-11e1-8775-005056c00008" name="61-62" r="1.435738" x="6.5514239999999999" g1="0" b1="2.812215e-05" g2="0" b2="2.812215e-05" node1="40" voltageLevelId1="_0448d867-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="60.101783689740948" q1="-18.206006574268699" p2="-59.775000576519531" q2="18.724962824231511">
         <iidm:alias>_045a3d85-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047abdd8-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10030,7 +10030,7 @@
             <iidm:temporaryLimit name="_39a23399-348e-44d9-8032-8fc62e6c7d63" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046a4318-c766-11e1-8775-005056c00008" name="101-102" r="4.2863040000000003" x="19.5148811" g1="0" b1="8.4366399999999999e-05" g2="0" b2="8.4366399999999999e-05" node1="22" voltageLevelId1="_046ed6f7-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="-43.953042552277857" q1="11.55803128559697" p2="44.479548896566463" q2="-12.039958819465857">
+    <iidm:line id="_046a4318-c766-11e1-8775-005056c00008" name="101-102" r="4.2863040000000003" x="19.5148811" g1="0" b1="8.4366399999999999e-05" g2="0" b2="8.4366399999999999e-05" node1="22" voltageLevelId1="_046ed6f7-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0467d214-c766-11e1-8775-005056c00008" p1="-44.066641688268902" q1="11.592372985852021" p2="44.595896826210009" q2="-12.061671768297593">
         <iidm:alias>_04878f1b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04885261-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10038,7 +10038,7 @@
             <iidm:temporaryLimit name="_0501dacc-29fc-44a2-8cad-31a20b011d25" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c81e3-c766-11e1-8775-005056c00008" name="26-30" r="3.8671600000000002" x="41.624000000000002" g1="0" b1="0.00093801650000000002" g2="0" b2="0.00093801650000000002" node1="21" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="238.23529894586537" q1="-4.9594837957776079" p2="-233.69794206216042" q2="-36.677135679271935">
+    <iidm:line id="_044c81e3-c766-11e1-8775-005056c00008" name="26-30" r="3.8671600000000002" x="41.624000000000002" g1="0" b1="0.00093801650000000002" g2="0" b2="0.00093801650000000002" node1="21" voltageLevelId1="_044f8f2a-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" p1="238.50150031401762" q1="-3.7237404543460917" p2="-233.94616791505447" q2="-37.628591151334085">
         <iidm:alias>_0463654b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04747c4a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10046,7 +10046,7 @@
             <iidm:temporaryLimit name="_c95a66fd-913c-48c7-b8ef-cf3007c60af6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048915b9-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="41" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="117" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-52.969956729242064" q1="-19.076899676789218" p2="55.578191893760376" q2="22.751748443656979">
+    <iidm:line id="_048915b9-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="41" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="117" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-53.574699088790581" q1="-18.911349156608782" p2="56.235798773932785" q2="22.827691576537976">
         <iidm:alias>_044bbe98-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0456e224-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10054,7 +10054,7 @@
             <iidm:temporaryLimit name="_6cd83bc2-204f-44d5-afd4-fbfef8d2146f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c5ad6-c766-11e1-8775-005056c00008" name="105-106" r="2.4393600000000002" x="9.5309279999999994" g1="0" b1="4.1150150000000001e-05" g2="0" b2="4.1150150000000001e-05" node1="51" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="9.6080188245320812" q1="6.1491637029425199" p2="-9.5871672087740052" q2="-7.3967220093629464">
+    <iidm:line id="_044c5ad6-c766-11e1-8775-005056c00008" name="105-106" r="2.4393600000000002" x="9.5309279999999994" g1="0" b1="4.1150150000000001e-05" g2="0" b2="4.1150150000000001e-05" node1="51" voltageLevelId1="_0465611a-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04479fe8-c766-11e1-8775-005056c00008" p1="9.6376016775189424" q1="6.1385073388390543" p2="-9.6166863922541186" q2="-7.385823208172507">
         <iidm:alias>_04505270-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04531190-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10062,7 +10062,7 @@
             <iidm:temporaryLimit name="_487e1317-48f9-4747-b931-f3f79e95f55a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048badc5-c766-11e1-8775-005056c00008" name="60-61" r="0.45999400000000001" x="2.3522400000000001" g1="0" b1="4.1781450000000003e-05" g2="0" b2="4.1781450000000003e-05" node1="30" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-169.27706333569105" q1="15.878460330038251" p2="170.05244026871424" q2="-13.351296126967634">
+    <iidm:line id="_048badc5-c766-11e1-8775-005056c00008" name="60-61" r="0.45999400000000001" x="2.3522400000000001" g1="0" b1="4.1781450000000003e-05" g2="0" b2="4.1781450000000003e-05" node1="30" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_0448d867-c766-11e1-8775-005056c00008" p1="-169.28871698959361" q1="15.891216265394077" p2="170.06420936249879" q2="-13.363462816034833">
         <iidm:alias>_04793734-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048a4e31-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10070,7 +10070,7 @@
             <iidm:temporaryLimit name="_3c55a929-a755-409b-af5f-bae188892af1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044cd003-c766-11e1-8775-005056c00008" name="23-25" r="2.7181440000000001" x="13.9391994" g1="0" b1="0.00024793390000000002" g2="0" b2="0.00024793390000000002" node1="41" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="-196.3777974040307" q1="-9.1404731016745711" p2="202.34875249014976" q2="30.642764233725156">
+    <iidm:line id="_044cd003-c766-11e1-8775-005056c00008" name="23-25" r="2.7181440000000001" x="13.9391994" g1="0" b1="0.00024793390000000002" g2="0" b2="0.00024793390000000002" node1="41" voltageLevelId1="_047f9fdb-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_04728079-c766-11e1-8775-005056c00008" p1="-197.46551470742313" q1="-12.088952855496379" p2="203.54194607171064" q2="34.156099974942542">
         <iidm:alias>_045ed161-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0473b8f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10078,7 +10078,7 @@
             <iidm:temporaryLimit name="_9658628a-596f-41a9-96a7-c5a8aaf5400c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0457a574-c766-11e1-8775-005056c00008" name="19-34" r="13.102848099999999" x="43.037277199999998" g1="0" b1="0.00018135905000000001" g2="0" b2="0.00018135905000000001" node1="40" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0483be8b-c766-11e1-8775-005056c00008" p1="55.902923080441106" q1="-15.340530679031311" p2="-53.129035101361467" q2="18.820573431172491">
+    <iidm:line id="_0457a574-c766-11e1-8775-005056c00008" name="19-34" r="13.102848099999999" x="43.037277199999998" g1="0" b1="0.00018135905000000001" g2="0" b2="0.00018135905000000001" node1="40" voltageLevelId1="_04633e3a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_0483be8b-c766-11e1-8775-005056c00008" p1="52.489552497000346" q1="-15.856631431147372" p2="-49.998778373054208" q2="18.430686713404214">
         <iidm:alias>_04502b61-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04686e5b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10086,7 +10086,7 @@
             <iidm:temporaryLimit name="_b69ab61b-751d-487a-a538-2d47eea7572e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04595326-c766-11e1-8775-005056c00008" name="59-60" r="5.5234079999999999" x="25.264800000000001" g1="0" b1="0.00010789715" g2="0" b2="0.00010789715" node1="69" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_045cfca4-c766-11e1-8775-005056c00008" p1="-89.196104957655947" q1="19.150724157591352" p2="91.939276668688692" q2="-10.278941663133999">
+    <iidm:line id="_04595326-c766-11e1-8775-005056c00008" name="59-60" r="5.5234079999999999" x="25.264800000000001" g1="0" b1="0.00010789715" g2="0" b2="0.00010789715" node1="69" voltageLevelId1="_0455a9a2-c766-11e1-8775-005056c00008" node2="31" voltageLevelId2="_045cfca4-c766-11e1-8775-005056c00008" p1="-89.109401108859458" q1="19.117633035105385" p2="91.847070300559253" q2="-10.271022536925365">
         <iidm:alias>_04611b57-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0463b366-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10094,7 +10094,7 @@
             <iidm:temporaryLimit name="_a38d4859-b54a-482f-a2ad-0b4ce4c4da2a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045a8ba1-c766-11e1-8775-005056c00008" name="15-19" r="2.0908799999999998" x="6.865056" g1="0" b1="2.8983e-05" g2="0" b2="2.8983e-05" node1="50" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="29.130040419157865" q1="8.417794113274887" p2="-29.006890216493765" q2="-8.9191007438074141">
+    <iidm:line id="_045a8ba1-c766-11e1-8775-005056c00008" name="15-19" r="2.0908799999999998" x="6.865056" g1="0" b1="2.8983e-05" g2="0" b2="2.8983e-05" node1="50" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="41" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="32.524256577492245" q1="10.758214732570822" p2="-32.366410450212513" q2="-11.140434223755621">
         <iidm:alias>_047629f1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0481e9c1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10102,7 +10102,7 @@
             <iidm:temporaryLimit name="_15d16bd2-d87c-4584-93d2-b294dc1be116" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04513cd6-c766-11e1-8775-005056c00008" name="90-91" r="4.4256960000000003" x="14.566463499999999" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="31" voltageLevelId1="_047d07c3-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044f8f29-c766-11e1-8775-005056c00008" p1="4.2547238029305472" q1="-16.320251956488125" p2="-4.1845651245677322" q2="14.562740290916048">
+    <iidm:line id="_04513cd6-c766-11e1-8775-005056c00008" name="90-91" r="4.4256960000000003" x="14.566463499999999" g1="0" b1="6.1409550000000006e-05" g2="0" b2="6.1409550000000006e-05" node1="31" voltageLevelId1="_047d07c3-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_044f8f29-c766-11e1-8775-005056c00008" p1="4.3611198737421013" q1="-16.347451149943865" p2="-4.2904746612553826" q2="14.591584809846214">
         <iidm:alias>_045f94b9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04627ae1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10110,7 +10110,7 @@
             <iidm:temporaryLimit name="_7d2a67fb-9d8c-4745-a67e-ce6ade5e520e" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0487b623-c766-11e1-8775-005056c00008" name="22-23" r="5.9590079999999999" x="27.704158799999998" g1="0" b1="0.00011593205" g2="0" b2="0.00011593205" node1="21" voltageLevelId1="_04773b6a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_047f9fdb-c766-11e1-8775-005056c00008" p1="-49.787389838520923" q1="-7.8089218073316538" p2="50.693839012558172" q2="8.0710134951678736">
+    <iidm:line id="_0487b623-c766-11e1-8775-005056c00008" name="22-23" r="5.9590079999999999" x="27.704158799999998" g1="0" b1="0.00011593205" g2="0" b2="0.00011593205" node1="21" voltageLevelId1="_04773b6a-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_047f9fdb-c766-11e1-8775-005056c00008" p1="-55.536678251624849" q1="-11.411884521131563" p2="56.71047467664291" q2="12.974870706104067">
         <iidm:alias>_045e0e18-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0477b095-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10118,7 +10118,7 @@
             <iidm:temporaryLimit name="_6477d99a-dd64-4083-8f56-1396610879f0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048b1189-c766-11e1-8775-005056c00008" name="83-85" r="7.4923200000000003" x="25.787520000000001" g1="0" b1="9.9862250000000004e-05" g2="0" b2="9.9862250000000004e-05" node1="32" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-54.247849981284055" q1="19.082776499086439" p2="55.776845492272031" q2="-17.110069332085107">
+    <iidm:line id="_048b1189-c766-11e1-8775-005056c00008" name="83-85" r="7.4923200000000003" x="25.787520000000001" g1="0" b1="9.9862250000000004e-05" g2="0" b2="9.9862250000000004e-05" node1="32" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="48" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-54.829542645298446" q1="18.457431452461233" p2="56.372300559475107" q2="-16.449031437592318">
         <iidm:alias>_0455d0b1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0462c906-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10126,7 +10126,7 @@
             <iidm:temporaryLimit name="_38cb3e5b-af1a-4684-aa2f-242826ed460c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045868c5-c766-11e1-8775-005056c00008" name="17-31" r="8.2589760000000005" x="27.233711199999998" g1="0" b1="0.00011449725" g2="0" b2="0.00011449725" node1="60" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="17.170622802839421" q1="1.9571553863936311" p2="-17.018044337563698" q2="-5.2399811728016585">
+    <iidm:line id="_045868c5-c766-11e1-8775-005056c00008" name="17-31" r="8.2589760000000005" x="27.233711199999998" g1="0" b1="0.00011449725" g2="0" b2="0.00011449725" node1="60" voltageLevelId1="_047bcf46-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="17.216222450138496" q1="1.0530679027574219" p2="-17.065501285696353" q2="-4.3364522310211919">
         <iidm:alias>_04544a16-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0467f924-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10134,7 +10134,7 @@
             <iidm:temporaryLimit name="_9066b19a-f404-42c3-88ce-51d375f6fdb5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0488c796-c766-11e1-8775-005056c00008" name="89-90" r="9.0256319999999999" x="32.75712" g1="0" b1="0.00015151515000000001" g2="0" b2="0.00015151515000000001" node1="59" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="59.660243932132275" q1="9.2564763011569333" p2="-57.761899259255912" q2="-7.4549351045146235">
+    <iidm:line id="_0488c796-c766-11e1-8775-005056c00008" name="89-90" r="9.0256319999999999" x="32.75712" g1="0" b1="0.00015151515000000001" g2="0" b2="0.00015151515000000001" node1="59" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="59.698759552503766" q1="9.2547112835006171" p2="-57.798077065555098" q2="-7.4446380309804798">
         <iidm:alias>_0459ef61-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04837069-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10142,7 +10142,7 @@
             <iidm:temporaryLimit name="_924b4a0b-bef5-432a-ad87-ab5c10d9c019" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0462c907-c766-11e1-8775-005056c00008" name="70-75" r="7.4574720000000001" x="24.56784" g1="0" b1="0.0001033058" g2="0" b2="0.0001033058" node1="50" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="9.4278670391285608" q1="7.1647021638913415" p2="-9.3536151465089112" q2="-10.353113658667775">
+    <iidm:line id="_0462c907-c766-11e1-8775-005056c00008" name="70-75" r="7.4574720000000001" x="24.56784" g1="0" b1="0.0001033058" g2="0" b2="0.0001033058" node1="50" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="8.2526908136746204" q1="7.2391347323307915" p2="-8.1869373775495653" q2="-10.451432614896307">
         <iidm:alias>_04649dc9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04784cdb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10150,7 +10150,7 @@
             <iidm:temporaryLimit name="_d432d118-553c-4f4c-a734-e98e0762ec40" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045fbbc3-c766-11e1-8775-005056c00008" name="50-57" r="8.2589760000000005" x="23.34816" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="22" voltageLevelId1="_044d1e26-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="44.258211501604976" q1="6.7031025723908968" p2="-43.297330733156784" q2="-7.2092115531327829">
+    <iidm:line id="_045fbbc3-c766-11e1-8775-005056c00008" name="50-57" r="8.2589760000000005" x="23.34816" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="22" voltageLevelId1="_044d1e26-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0489b1f8-c766-11e1-8775-005056c00008" p1="44.128450072306904" q1="6.7398127463556081" p2="-43.172731720002091" q2="-7.2605967872262562">
         <iidm:alias>_04500455-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0468e383-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10158,7 +10158,7 @@
             <iidm:temporaryLimit name="_2f32bda4-7275-4485-9901-12f8cff9e4a1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044b9789-c766-11e1-8775-005056c00008" name="5-6" r="2.0734560000000002" x="9.4089600000000004" g1="0" b1="4.0920549999999999e-05" g2="0" b2="4.0920549999999999e-05" node1="49" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f6818-c766-11e1-8775-005056c00008" p1="91.39708152675216" q1="19.513844892838332" p2="-90.375478767578414" q2="-16.304383876187686">
+    <iidm:line id="_044b9789-c766-11e1-8775-005056c00008" name="5-6" r="2.0734560000000002" x="9.4089600000000004" g1="0" b1="4.0920549999999999e-05" g2="0" b2="4.0920549999999999e-05" node1="49" voltageLevelId1="_044be5a3-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_044f6818-c766-11e1-8775-005056c00008" p1="91.567079795458994" q1="19.187554343698256" p2="-90.542729718201088" q2="-15.964929298591946">
         <iidm:alias>_044a5f01-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0455d0b2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10166,7 +10166,7 @@
             <iidm:temporaryLimit name="_b3b0e81b-a434-4e9c-ad94-1161ff47b077" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04720b41-c766-11e1-8775-005056c00008" name="55-59" r="8.2572340000000004" x="37.600994100000001" g1="0" b1="0.00016201790000000001" g2="0" b2="0.00016201790000000001" node1="30" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-24.078982370758791" q1="-11.567635484027596" p2="24.42515299460154" q2="7.8504078754296325">
+    <iidm:line id="_04720b41-c766-11e1-8775-005056c00008" name="55-59" r="8.2572340000000004" x="37.600994100000001" g1="0" b1="0.00016201790000000001" g2="0" b2="0.00016201790000000001" node1="30" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-24.177343678453738" q1="-11.539750795804633" p2="24.525735672124611" q2="7.8326302125952481">
         <iidm:alias>_04656113-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04675ce4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10174,7 +10174,7 @@
             <iidm:temporaryLimit name="_6db0d250-4a2e-4169-abf0-f842aeca485d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048963d9-c766-11e1-8775-005056c00008" name="1-2" r="5.2794720000000002" x="17.4065762" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="22" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_045d4ac5-c766-11e1-8775-005056c00008" p1="-11.458268006758127" q1="-10.256904626532309" p2="11.52852506791878" q2="8.1138617388545278">
+    <iidm:line id="_048963d9-c766-11e1-8775-005056c00008" name="1-2" r="5.2794720000000002" x="17.4065762" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="22" voltageLevelId1="_0488c79a-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_045d4ac5-c766-11e1-8775-005056c00008" p1="-11.422954369798674" q1="-10.337675817080537" p2="11.49344958428326" q2="8.1958205026222188">
         <iidm:alias>_044b9786-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04845acb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10182,7 +10182,7 @@
             <iidm:temporaryLimit name="_9f39cb45-314c-445e-b177-909854a9ce45" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0484f709-c766-11e1-8775-005056c00008" name="11-12" r="1.0367280000000001" x="3.4151039999999999" g1="0" b1="1.4405399999999999e-05" g2="0" b2="1.4405399999999999e-05" node1="40" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="34.613527952049175" q1="-24.307894754130356" p2="-34.505044805618915" q2="24.17459430740114">
+    <iidm:line id="_0484f709-c766-11e1-8775-005056c00008" name="11-12" r="1.0367280000000001" x="3.4151039999999999" g1="0" b1="1.4405399999999999e-05" g2="0" b2="1.4405399999999999e-05" node1="40" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="69" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="34.702318544888854" q1="-25.299948057888649" p2="-34.590441148258044" q2="25.177924238719307">
         <iidm:alias>_0456e227-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04880440-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10190,7 +10190,7 @@
             <iidm:temporaryLimit name="_70fad3e1-4529-4a7f-9e6c-8ab249d65460" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044bbe91-c766-11e1-8775-005056c00008" name="8-9" r="1.18096" x="14.762" g1="0" b1="0.001200413215" g2="0" b2="0.001200413215" node1="31" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_045c8779-c766-11e1-8775-005056c00008" p1="-485.13651874939569" q1="-83.423068826996442" p2="490.81054915630989" q2="32.934875747259355">
+    <iidm:line id="_044bbe91-c766-11e1-8775-005056c00008" name="8-9" r="1.18096" x="14.762" g1="0" b1="0.001200413215" g2="0" b2="0.001200413215" node1="31" voltageLevelId1="_047d07c9-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_045c8779-c766-11e1-8775-005056c00008" p1="-486.6513514288348" q1="-83.533897286887338" p2="492.36710207207216" q2="33.673598690219642">
         <iidm:alias>_04745535-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048a7548-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="2000">
@@ -10198,7 +10198,7 @@
             <iidm:temporaryLimit name="_205e5d8a-f05a-479d-adaa-3514f48f6857" acceptableDuration="60" value="2400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04566cf8-c766-11e1-8775-005056c00008" name="64-65" r="1.30196" x="14.6168" g1="0" b1="0.000392562" g2="0" b2="0.000392562" node1="35" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-157.89158576309489" q1="-33.92273885832288" p2="158.57512794492001" q2="3.5949293050304711">
+    <iidm:line id="_04566cf8-c766-11e1-8775-005056c00008" name="64-65" r="1.30196" x="14.6168" g1="0" b1="0.000392562" g2="0" b2="0.000392562" node1="35" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-157.40756924907376" q1="-33.953507309801068" p2="158.08697543456725" q2="3.578872233006325">
         <iidm:alias>_044a10e2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04793738-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10206,7 +10206,7 @@
             <iidm:temporaryLimit name="_8cee2b62-2953-439b-ba4b-4a48d55116c0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046783f3-c766-11e1-8775-005056c00008" name="54-56" r="0.47915999999999997" x="1.6639919999999999" g1="0" b1="2.1005500000000001e-05" g2="0" b2="2.1005500000000001e-05" node1="60" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="29.60613101447586" q1="2.7080802106002415" p2="-29.579422508900262" q2="-3.2821261863811664">
+    <iidm:line id="_046783f3-c766-11e1-8775-005056c00008" name="54-56" r="0.47915999999999997" x="1.6639919999999999" g1="0" b1="2.1005500000000001e-05" g2="0" b2="2.1005500000000001e-05" node1="60" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="58" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="29.576269925823762" q1="2.6939118500894073" p2="-29.549617283412083" q2="-3.2681529765510238">
         <iidm:alias>_0460f444-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d2949-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10214,7 +10214,7 @@
             <iidm:temporaryLimit name="_640627c7-0672-413e-8dc8-c9965709a5cb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04670ec6-c766-11e1-8775-005056c00008" name="84-85" r="5.2620480000000001" x="11.1687832" g1="0" b1="3.541095e-05" g2="0" b2="3.541095e-05" node1="21" voltageLevelId1="_047b0bf4-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-44.008026632797211" q1="14.233716314203631" p2="44.705548753814483" q2="-13.910528918633732">
+    <iidm:line id="_04670ec6-c766-11e1-8775-005056c00008" name="84-85" r="5.2620480000000001" x="11.1687832" g1="0" b1="3.541095e-05" g2="0" b2="3.541095e-05" node1="21" voltageLevelId1="_047b0bf4-c766-11e1-8775-005056c00008" node2="49" voltageLevelId2="_04664b7a-c766-11e1-8775-005056c00008" p1="-44.50183305342906" q1="13.841726058350517" p2="45.206975585512176" q2="-13.507495045751442">
         <iidm:alias>_0453fbf5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046512f7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10222,7 +10222,7 @@
             <iidm:temporaryLimit name="_8b888209-5038-4b98-80fc-062b5ea55747" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0460cd36-c766-11e1-8775-005056c00008" name="34-36" r="1.51763" x="4.669632" g1="0" b1="1.6299349999999998e-05" g2="0" b2="1.6299349999999998e-05" node1="43" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="34.793008078238955" q1="11.202864089027237" p2="-34.662014042244707" q2="-11.303133847305229">
+    <iidm:line id="_0460cd36-c766-11e1-8775-005056c00008" name="34-36" r="1.51763" x="4.669632" g1="0" b1="1.6299349999999998e-05" g2="0" b2="1.6299349999999998e-05" node1="43" voltageLevelId1="_0483be8b-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="34.555480566915215" q1="11.219276312798032" p2="-34.425891868858045" q2="-11.323227001746726">
         <iidm:alias>_046a6a26-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0487b620-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10230,7 +10230,7 @@
             <iidm:temporaryLimit name="_c0a08025-3a61-4d24-9944-f3ef0b079f64" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04549836-c766-11e1-8775-005056c00008" name="24-70" r="0.38507000000000002" x="71.699759999999998" g1="0" b1="0.00029264234999999998" g2="0" b2="0.00029264234999999998" node1="32" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="18.575242535702884" q1="-0.8028277135123042" p2="-18.567209654996855" q2="-7.746915961761272">
+    <iidm:line id="_04549836-c766-11e1-8775-005056c00008" name="24-70" r="0.38507000000000002" x="71.699759999999998" g1="0" b1="0.00029264234999999998" g2="0" b2="0.00029264234999999998" node1="32" voltageLevelId1="_048c22fa-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045d98e1-c766-11e1-8775-005056c00008" p1="16.46524120322858" q1="-1.2221474512638244" p2="-16.458896390559318" q2="-7.6140698972947991">
         <iidm:alias>_04549834-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04854522-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10238,7 +10238,7 @@
             <iidm:temporaryLimit name="_32793450-bbfd-4dcd-a911-89e199600780" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0452273a-c766-11e1-8775-005056c00008" name="85-86" r="6.0983999999999998" x="21.431519999999999" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="50" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0484f70a-c766-11e1-8775-005056c00008" p1="21.283026953872" q1="16.354030319297546" p2="-20.99899457227048" q2="-17.877761657590145">
+    <iidm:line id="_0452273a-c766-11e1-8775-005056c00008" name="85-86" r="6.0983999999999998" x="21.431519999999999" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="50" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0484f70a-c766-11e1-8775-005056c00008" p1="21.298638810354678" q1="12.334772997889837" p2="-21.062155515448602" q2="-14.051501158618496">
         <iidm:alias>_044afb43-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479fa85-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10246,7 +10246,7 @@
             <iidm:temporaryLimit name="_2ec4bef5-7abb-4f52-bb62-49ee474d672b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0450eeb5-c766-11e1-8775-005056c00008" name="16-17" r="7.9104960000000002" x="31.380622899999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="22" voltageLevelId1="_046f7338-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-15.543786632852536" q1="1.0076855276918202" p2="15.663109156063515" q2="-5.0124093552778248">
+    <iidm:line id="_0450eeb5-c766-11e1-8775-005056c00008" name="16-17" r="7.9104960000000002" x="31.380622899999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="22" voltageLevelId1="_046f7338-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_047bcf46-c766-11e1-8775-005056c00008" p1="-15.255517940052455" q1="1.4607005992754705" p2="15.372226545876705" q2="-5.467233679949695">
         <iidm:alias>_044ef2ea-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04837066-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10254,7 +10254,7 @@
             <iidm:temporaryLimit name="_9280074c-8555-49ff-9e62-8ed8f7d95060" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048a4e33-c766-11e1-8775-005056c00008" name="62-66" r="8.3983679999999996" x="37.984317799999999" g1="0" b1="0.00016586315" g2="0" b2="0.00016586315" node1="41" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-15.420033600304794" q1="-21.537270612223995" p2="15.70424937630669" q2="16.790577005953171">
+    <iidm:line id="_048a4e33-c766-11e1-8775-005056c00008" name="62-66" r="8.3983679999999996" x="37.984317799999999" g1="0" b1="0.00016586315" g2="0" b2="0.00016586315" node1="41" voltageLevelId1="_046bf0c5-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-15.288554910155655" q1="-21.568432100708801" p2="15.571377491627441" q2="16.81545364338433">
         <iidm:alias>_046e13a9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a96c7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10262,7 +10262,7 @@
             <iidm:temporaryLimit name="_ace48562-0a49-4b76-ae82-c896a00b04f9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0478e913-c766-11e1-8775-005056c00008" name="76-77" r="7.736256" x="25.787520000000001" g1="0" b1="0.00010560145" g2="0" b2="0.00010560145" node1="21" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-61.863276089836759" q1="-21.301627723547028" p2="63.987985858534749" q2="24.913780684268112">
+    <iidm:line id="_0478e913-c766-11e1-8775-005056c00008" name="76-77" r="7.736256" x="25.787520000000001" g1="0" b1="0.00010560145" g2="0" b2="0.00010560145" node1="21" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="-62.489530821930593" q1="-21.219688145724408" p2="64.653132018347819" q2="24.96236103650552">
         <iidm:alias>_044b9785-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04725965-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10270,7 +10270,7 @@
             <iidm:temporaryLimit name="_3f744dba-88dc-4d89-90d4-a6f196054b28" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048badc1-c766-11e1-8775-005056c00008" name="60-62" r="2.1431520000000002" x="9.7748640000000009" g1="0" b1="4.2125800000000002e-05" g2="0" b2="4.2125800000000002e-05" node1="32" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="-0.66214490180276364" q1="-8.5995127107044897" p2="0.66994660835297171" q2="7.1824757129068066">
+    <iidm:line id="_048badc1-c766-11e1-8775-005056c00008" name="60-62" r="2.1431520000000002" x="9.7748640000000009" g1="0" b1="4.2125800000000002e-05" g2="0" b2="4.2125800000000002e-05" node1="32" voltageLevelId1="_045cfca4-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_046bf0c5-c766-11e1-8775-005056c00008" p1="-0.55827555524673844" q1="-8.6201887231615668" p2="0.56610213798756404" q2="7.2032637692406425">
         <iidm:alias>_045b7600-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04720b44-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10278,7 +10278,7 @@
             <iidm:temporaryLimit name="_43f91aaf-c5f4-4995-85a2-37afac616331" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0472a780-c766-11e1-8775-005056c00008" name="27-28" r="3.3332109999999999" x="14.89752" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="42" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04819ba0-c766-11e1-8775-005056c00008" p1="32.599300772070769" q1="-1.0939757955529756" p2="-32.383113421203689" q2="0.041373131563141215">
+    <iidm:line id="_0472a780-c766-11e1-8775-005056c00008" name="27-28" r="3.3332109999999999" x="14.89752" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="42" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04819ba0-c766-11e1-8775-005056c00008" p1="32.64932544687241" q1="-1.4219522795248414" p2="-32.432123668130941" q2="0.37626375219186725">
         <iidm:alias>_04531198-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0475188b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10286,7 +10286,7 @@
             <iidm:temporaryLimit name="_2c20e8bd-84e6-4a1e-b88e-071f631327cb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c81e1-c766-11e1-8775-005056c00008" name="45-46" r="6.9695999999999998" x="23.626943600000001" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="31" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="34" voltageLevelId2="_048a7544-c766-11e1-8775-005056c00008" p1="-33.312338209177916" q1="-7.0180145831912952" p2="33.783818342333319" q2="5.3355694428633678">
+    <iidm:line id="_044c81e1-c766-11e1-8775-005056c00008" name="45-46" r="6.9695999999999998" x="23.626943600000001" g1="0" b1="9.5270899999999996e-05" g2="0" b2="9.5270899999999996e-05" node1="31" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="34" voltageLevelId2="_048a7544-c766-11e1-8775-005056c00008" p1="-33.687890069069617" q1="-7.0243924838948386" p2="34.170003174555895" q2="5.3786134610913345">
         <iidm:alias>_04561ed6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045c877a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10294,7 +10294,7 @@
             <iidm:temporaryLimit name="_6ad31f7e-233f-4801-898f-9ffc883ec724" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c1249-c766-11e1-8775-005056c00008" name="18-19" r="1.949746" x="8.5900320000000008" g1="0" b1="3.2770900000000002e-05" g2="0" b2="3.2770900000000002e-05" node1="22" voltageLevelId1="_04689563-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="51.403637116534384" q1="-1.8354043336665029" p2="-51.074607207624524" q2="2.2634947853077869">
+    <iidm:line id="_045c1249-c766-11e1-8775-005056c00008" name="18-19" r="1.949746" x="8.5900320000000008" g1="0" b1="3.2770900000000002e-05" g2="0" b2="3.2770900000000002e-05" node1="22" voltageLevelId1="_04689563-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04633e3a-c766-11e1-8775-005056c00008" p1="52.652435007983499" q1="-0.3181236770495588" p2="-52.305639006148276" q2="0.83083111711176949">
         <iidm:alias>_046b066b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047ae4e0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10302,7 +10302,7 @@
             <iidm:temporaryLimit name="_a025c9d8-58f9-4320-a1fe-73ecc68d4147" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044a5f09-c766-11e1-8775-005056c00008" name="9-10" r="1.2487200000000001" x="15.584800700000001" g1="0" b1="0.0012706611300000001" g2="0" b2="0.0012706611300000001" node1="21" voltageLevelId1="_045c8779-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_044f4102-c766-11e1-8775-005056c00008" p1="-490.81054915631012" q1="-32.934875747258886" p2="496.61816442941495" q2="-28.50199784608747">
+    <iidm:line id="_044a5f09-c766-11e1-8775-005056c00008" name="9-10" r="1.2487200000000001" x="15.584800700000001" g1="0" b1="0.0012706611300000001" g2="0" b2="0.0012706611300000001" node1="21" voltageLevelId1="_045c8779-c766-11e1-8775-005056c00008" node2="12" voltageLevelId2="_044f4102-c766-11e1-8775-005056c00008" p1="-492.36710207207193" q1="-33.673598690219698" p2="498.21426461860898" q2="-27.223848268839433">
         <iidm:alias>_04614262-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04834957-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="2000">
@@ -10310,7 +10310,7 @@
             <iidm:temporaryLimit name="_b7fac0a3-c5af-48b9-af49-261fd8d46e00" acceptableDuration="60" value="2400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0480b14b-c766-11e1-8775-005056c00008" name="85-88" r="3.4847999999999999" x="17.772480000000002" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="51" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0470f9d2-c766-11e1-8775-005056c00008" p1="-62.580440343980662" q1="3.5056140795532307" p2="63.416625891752822" q2="-1.8688792499167495">
+    <iidm:line id="_0480b14b-c766-11e1-8775-005056c00008" name="85-88" r="3.4847999999999999" x="17.772480000000002" g1="0" b1="7.9201099999999996e-05" g2="0" b2="7.9201099999999996e-05" node1="51" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0470f9d2-c766-11e1-8775-005056c00008" p1="-63.084662751496126" q1="4.9778218390149744" p2="63.93366670968912" q2="-3.2845189523242473">
         <iidm:alias>_047602e2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04765105-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10318,7 +10318,7 @@
             <iidm:temporaryLimit name="_51646744-d343-42b5-8ba7-fcedc7cc3a98" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04486330-c766-11e1-8775-005056c00008" name="69-77" r="5.3840159999999999" x="17.598240000000001" g1="0" b1="0.00029786500000000002" g2="0" b2="0.00029786500000000002" node1="60" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="33.47500242122824" q1="17.69143696708424" p2="-32.995824672031588" q2="-26.902364841218358">
+    <iidm:line id="_04486330-c766-11e1-8775-005056c00008" name="69-77" r="5.3840159999999999" x="17.598240000000001" g1="0" b1="0.00029786500000000002" g2="0" b2="0.00029786500000000002" node1="60" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04703689-c766-11e1-8775-005056c00008" p1="32.548848660891103" q1="17.937450532350223" p2="-32.08399174675634" q2="-27.195304184956026">
         <iidm:alias>_046205b9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479d379-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10326,7 +10326,7 @@
             <iidm:temporaryLimit name="_76311a15-b79a-4439-a7ce-47afa8fa6fe2" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04553477-c766-11e1-8775-005056c00008" name="11-13" r="3.8768400000000001" x="12.7369442" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="41" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04851e1b-c766-11e1-8775-005056c00008" p1="45.170666016450987" q1="15.717879495875744" p2="-44.641753285103086" q2="-15.768387643936755">
+    <iidm:line id="_04553477-c766-11e1-8775-005056c00008" name="11-13" r="3.8768400000000001" x="12.7369442" g1="0" b1="5.3833799999999999e-05" g2="0" b2="5.3833799999999999e-05" node1="41" voltageLevelId1="_04605807-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04851e1b-c766-11e1-8775-005056c00008" p1="45.462236562285085" q1="16.20846657114604" p2="-44.923303644760075" q2="-16.224570859562391">
         <iidm:alias>_0479fa89-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0485452a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10334,7 +10334,7 @@
             <iidm:temporaryLimit name="_efbf8de7-4b84-4834-bb7c-6250b6072211" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04488a45-c766-11e1-8775-005056c00008" name="103-105" r="9.3218399999999999" x="28.314" g1="0" b1="0.0001170799" g2="0" b2="0.0001170799" node1="42" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="43.794170222232637" q1="12.537082176292468" p2="-42.67622632785924" q2="-13.123434904150718">
+    <iidm:line id="_04488a45-c766-11e1-8775-005056c00008" name="103-105" r="9.3218399999999999" x="28.314" g1="0" b1="0.0001170799" g2="0" b2="0.0001170799" node1="42" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="43.796533405938369" q1="12.535360681003057" p2="-42.678506418285991" q2="-13.121464658724355">
         <iidm:alias>_044f8f24-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04611b58-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10342,7 +10342,7 @@
             <iidm:temporaryLimit name="_22b6919a-a7a0-49fc-9e90-329069c55055" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046009e6-c766-11e1-8775-005056c00008" name="45-49" r="11.918016400000001" x="32.408639999999998" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="32" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="118" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-40.323472693920223" q1="-8.1588173433326965" p2="41.499984596173597" q2="6.8804468218429946">
+    <iidm:line id="_046009e6-c766-11e1-8775-005056c00008" name="45-49" r="11.918016400000001" x="32.408639999999998" g1="0" b1="0.00012741044999999999" g2="0" b2="0.00012741044999999999" node1="32" voltageLevelId1="_045d23b4-c766-11e1-8775-005056c00008" node2="118" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-40.732280265612417" q1="-8.07199013711306" p2="41.931983231148976" q2="6.8575127687240283">
         <iidm:alias>_044ca8f9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047dcb1b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10350,7 +10350,7 @@
             <iidm:temporaryLimit name="_8b91f4fd-4038-45b7-870c-fbc08592b95a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046a6a27-c766-11e1-8775-005056c00008" name="88-89" r="2.4219360000000001" x="12.4058876" g1="0" b1="5.549815e-05" g2="0" b2="5.549815e-05" node1="22" voltageLevelId1="_0470f9d2-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-111.41723095302207" q1="-8.1313252534394564" p2="113.21844223721193" q2="15.450745660976573">
+    <iidm:line id="_046a6a27-c766-11e1-8775-005056c00008" name="88-89" r="2.4219360000000001" x="12.4058876" g1="0" b1="5.549815e-05" g2="0" b2="5.549815e-05" node1="22" voltageLevelId1="_0470f9d2-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-111.9517681456317" q1="-6.7217408994529606" p2="113.76415764711237" q2="14.096662476520127">
         <iidm:alias>_045ef879-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04649dc1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10358,7 +10358,7 @@
             <iidm:temporaryLimit name="_970bc323-73bf-440d-a3c5-00aebc3a1992" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048a7540-c766-11e1-8775-005056c00008" name="80-98" r="4.1469120000000004" x="18.817920000000001" g1="0" b1="8.20707e-05" g2="0" b2="8.20707e-05" node1="79" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04773b62-c766-11e1-8775-005056c00008" p1="11.965505461485652" q1="11.845583448817177" p2="-11.894535420223622" q2="-14.567923428036419">
+    <iidm:line id="_048a7540-c766-11e1-8775-005056c00008" name="80-98" r="4.1469120000000004" x="18.817920000000001" g1="0" b1="8.20707e-05" g2="0" b2="8.20707e-05" node1="79" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04773b62-c766-11e1-8775-005056c00008" p1="11.444862353526187" q1="11.967531524018757" p2="-11.375852260112255" q2="-14.698726567127549">
         <iidm:alias>_045338a2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04887972-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10366,7 +10366,7 @@
             <iidm:temporaryLimit name="_cb084dc7-1b26-415f-9495-4695df661912" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04640183-c766-11e1-8775-005056c00008" name="91-92" r="6.7430880000000002" x="22.163329999999998" g1="0" b1="9.3778700000000004e-05" g2="0" b2="9.3778700000000004e-05" node1="22" voltageLevelId1="_044f8f29-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="-5.8155828550810282" q1="-14.562740614256317" p2="5.8992630104811079" q2="11.700406237566794">
+    <iidm:line id="_04640183-c766-11e1-8775-005056c00008" name="91-92" r="6.7430880000000002" x="22.163329999999998" g1="0" b1="9.3778700000000004e-05" g2="0" b2="9.3778700000000004e-05" node1="22" voltageLevelId1="_044f8f29-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_0468bc77-c766-11e1-8775-005056c00008" p1="-5.7096112292978001" q1="-14.591584730161147" p2="5.793101017966805" q2="11.728718756325216">
         <iidm:alias>_04492680-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_044c5ad5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10374,7 +10374,7 @@
             <iidm:temporaryLimit name="_3a165a76-f6ba-461b-84d6-159a5e0b5077" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0474a358-c766-11e1-8775-005056c00008" name="7-12" r="1.501949" x="5.9241599999999996" g1="0" b1="2.5080350000000001e-05" g2="0" b2="2.5080350000000001e-05" node1="22" voltageLevelId1="_047eb571-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="19.301383730833361" q1="-7.4781813517982787" p2="-19.264188761775884" q2="6.7689466806371179">
+    <iidm:line id="_0474a358-c766-11e1-8775-005056c00008" name="7-12" r="1.501949" x="5.9241599999999996" g1="0" b1="2.5080350000000001e-05" g2="0" b2="2.5080350000000001e-05" node1="22" voltageLevelId1="_047eb571-c766-11e1-8775-005056c00008" node2="70" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="19.472040442349336" q1="-7.8189156248444931" p2="-19.433821072554068" q2="7.1138105738506052">
         <iidm:alias>_046ab848-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0477feb7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10382,7 +10382,7 @@
             <iidm:temporaryLimit name="_b19bc945-cc51-4d77-8eaa-3f6afe2d9316" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04765108-c766-11e1-8775-005056c00008" name="99-100" r="3.13632" x="14.165711399999999" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_04644fa4-c766-11e1-8775-005056c00008" node2="80" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-39.477795144575111" q1="12.159125537711084" p2="39.77792176352029" q2="-13.044348995405342">
+    <iidm:line id="_04765108-c766-11e1-8775-005056c00008" name="99-100" r="3.13632" x="14.165711399999999" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_04644fa4-c766-11e1-8775-005056c00008" node2="80" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-40.000583885065979" q1="12.279778580263578" p2="40.308461951285949" q2="-13.129965787269709">
         <iidm:alias>_0471e436-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047e4040-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10390,7 +10390,7 @@
             <iidm:temporaryLimit name="_a9e283ed-fcad-4f4c-ab57-8531875bb098" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047b8128-c766-11e1-8775-005056c00008" name="114-115" r="0.400752" x="1.8120959999999999" g1="0" b1="7.9201000000000006e-06" g2="0" b2="7.9201000000000006e-06" node1="22" voltageLevelId1="_04791027-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="-0.46886568114174171" q1="2.4195268709542472" p2="0.46903196442333783" q2="-2.6748699171045458">
+    <iidm:line id="_047b8128-c766-11e1-8775-005056c00008" name="114-115" r="0.400752" x="1.8120959999999999" g1="0" b1="7.9201000000000006e-06" g2="0" b2="7.9201000000000006e-06" node1="22" voltageLevelId1="_04791027-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="-0.58768207826713703" q1="2.2302659635785744" p2="0.58782870996372349" q2="-2.4852240229251676">
         <iidm:alias>_046c17d3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d0233-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10398,7 +10398,7 @@
             <iidm:temporaryLimit name="_c59e4022-b1c0-4811-a32e-f54656bff32d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046931a5-c766-11e1-8775-005056c00008" name="83-84" r="10.890000000000001" x="22.999680000000001" g1="0" b1="7.4035799999999993e-05" g2="0" b2="7.4035799999999993e-05" node1="33" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b0bf4-c766-11e1-8775-005056c00008" p1="-32.009639485404229" q1="20.914231556112803" p2="33.00772393152733" q2="-21.234034174327803">
+    <iidm:line id="_046931a5-c766-11e1-8775-005056c00008" name="83-84" r="10.890000000000001" x="22.999680000000001" g1="0" b1="7.4035799999999993e-05" g2="0" b2="7.4035799999999993e-05" node1="33" voltageLevelId1="_04728074-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b0bf4-c766-11e1-8775-005056c00008" p1="-32.487684312633803" q1="20.53896165495275" p2="33.493033683326161" q2="-20.851031135496108">
         <iidm:alias>_0465d645-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0479102b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10406,7 +10406,7 @@
             <iidm:temporaryLimit name="_1268eb09-e233-44ce-b8af-22dc30eb16ad" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047ae4ea-c766-11e1-8775-005056c00008" name="14-15" r="10.367279999999999" x="33.976799999999997" g1="0" b1="0.0001440542" g2="0" b2="0.0001440542" node1="21" voltageLevelId1="_047b8129-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="16.147910199215143" q1="6.7231590949304785" p2="-15.933998052451843" q2="-10.691922175420357">
+    <iidm:line id="_047ae4ea-c766-11e1-8775-005056c00008" name="14-15" r="10.367279999999999" x="33.976799999999997" g1="0" b1="0.0001440542" g2="0" b2="0.0001440542" node1="21" voltageLevelId1="_047b8129-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_0467ab04-c766-11e1-8775-005056c00008" p1="16.496428929792785" q1="7.352546904264627" p2="-16.267833592219361" q2="-11.260963318223682">
         <iidm:alias>_0449e9d9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046ed6fa-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10414,7 +10414,7 @@
             <iidm:temporaryLimit name="_9c0c454b-ecc3-40f6-b505-f32fec412522" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046e3ab2-c766-11e1-8775-005056c00008" name="80-96" r="6.2029439999999996" x="31.711680000000001" g1="0" b1="0.0001417585" g2="0" b2="0.0001417585" node1="80" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="5.15128216089128" q1="26.231562784576688" p2="-4.867586361310031" q2="-29.862164157983241">
+    <iidm:line id="_046e3ab2-c766-11e1-8775-005056c00008" name="80-96" r="6.2029439999999996" x="31.711680000000001" g1="0" b1="0.0001417585" g2="0" b2="0.0001417585" node1="80" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="4.7357267033763977" q1="26.187621711527477" p2="-4.4542184633871909" q2="-29.830476683227904">
         <iidm:alias>_045338a4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04865695-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10422,7 +10422,7 @@
             <iidm:temporaryLimit name="_1432f4d6-9299-4b0d-bd7f-16e059f9de66" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04893cc4-c766-11e1-8775-005056c00008" name="56-59" r="13.9914722" x="41.643360000000001" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="59" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-20.044411080590368" q1="-7.7117595879629661" p2="20.423559148210259" q2="3.8016940728431572">
+    <iidm:line id="_04893cc4-c766-11e1-8775-005056c00008" name="56-59" r="13.9914722" x="41.643360000000001" g1="0" b1="0.00015381085000000001" g2="0" b2="0.00015381085000000001" node1="59" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="71" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-20.132773471017774" q1="-7.6765181307798303" p2="20.514726243012461" q2="3.7747920835187694">
         <iidm:alias>_046b5484-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04798557-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10430,7 +10430,7 @@
             <iidm:temporaryLimit name="_193f6952-4267-4cc8-a541-726c095028ba" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c1243-c766-11e1-8775-005056c00008" name="92-100" r="11.290752400000001" x="51.400799999999997" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="71" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="36.684057695022318" q1="-17.255144206460727" p2="-35.64553745072665" q2="17.231519660847379">
+    <iidm:line id="_045c1243-c766-11e1-8775-005056c00008" name="92-100" r="11.290752400000001" x="51.400799999999997" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="71" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="36.802899900120977" q1="-17.272022807857262" p2="-35.758227871986648" q2="17.276485178755223">
         <iidm:alias>_045e8348-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045ed164-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10438,7 +10438,7 @@
             <iidm:temporaryLimit name="_579249ce-1c81-4d29-8d3f-5fc627a18f99" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0474a356-c766-11e1-8775-005056c00008" name="43-44" r="10.593792000000001" x="42.7584953" g1="0" b1="0.00017412765" g2="0" b2="0.00017412765" node1="22" voltageLevelId1="_045e8349-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04544a15-c766-11e1-8775-005056c00008" p1="-4.4665187138473383" q1="-11.439181769785371" p2="4.5310587851670414" q2="6.0806809860693196">
+    <iidm:line id="_0474a356-c766-11e1-8775-005056c00008" name="43-44" r="10.593792000000001" x="42.7584953" g1="0" b1="0.00017412765" g2="0" b2="0.00017412765" node1="22" voltageLevelId1="_045e8349-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04544a15-c766-11e1-8775-005056c00008" p1="-5.2457551075164508" q1="-11.303475935000328" p2="5.3139159220418666" q2="5.9639357994285938">
         <iidm:alias>_04642899-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047b0bf2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10446,7 +10446,7 @@
             <iidm:temporaryLimit name="_3d2cb4b5-ee82-4866-9855-4a5f4803cd3b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04627ae6-c766-11e1-8775-005056c00008" name="109-110" r="4.8438720000000002" x="13.2770882" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="22" voltageLevelId1="_046b7b99-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="12.799502146039815" q1="-2.9923728131255816" p2="-12.748481947645313" q2="1.285881883382423">
+    <iidm:line id="_04627ae6-c766-11e1-8775-005056c00008" name="109-110" r="4.8438720000000002" x="13.2770882" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="22" voltageLevelId1="_046b7b99-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="12.737578965939431" q1="-2.9694963300349588" p2="-12.687067602351096" q2="1.2616003176928923">
         <iidm:alias>_0466e7b5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047a6fbb-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10454,7 +10454,7 @@
             <iidm:temporaryLimit name="_6fc48d8d-05f8-4104-a6a2-3686d430a091" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0478c207-c766-11e1-8775-005056c00008" name="68-81" r="0.84699999999999998" x="9.7767990000000005" g1="0" b1="0.00083471078000000004" g2="0" b2="0.00083471078000000004" node1="38" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_048a272b-c766-11e1-8775-005056c00008" p1="-147.83698447805969" q1="-4.149594614215486" p2="148.24339345515389" q2="-71.40399767501934">
+    <iidm:line id="_0478c207-c766-11e1-8775-005056c00008" name="68-81" r="0.84699999999999998" x="9.7767990000000005" g1="0" b1="0.00083471078000000004" g2="0" b2="0.00083471078000000004" node1="38" voltageLevelId1="_0449e9d2-c766-11e1-8775-005056c00008" node2="20" voltageLevelId2="_048a272b-c766-11e1-8775-005056c00008" p1="-150.06853276347695" q1="-3.9139213104952346" p2="150.48691439999754" q2="-71.500135414334864">
         <iidm:alias>_044a37f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045b4ef6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10462,7 +10462,7 @@
             <iidm:temporaryLimit name="_191836a1-39cd-402b-8dcf-4f3867c45bd0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0467d215-c766-11e1-8775-005056c00008" name="85-89" r="4.1643359999999996" x="30.143518400000001" g1="0" b1="0.00013487144999999999" g2="0" b2="0.00013487144999999999" node1="52" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-83.18521122517906" q1="-3.8392770256338498" p2="84.941102151863618" q2="11.961472575179616">
+    <iidm:line id="_0467d215-c766-11e1-8775-005056c00008" name="85-89" r="4.1643359999999996" x="30.143518400000001" g1="0" b1="0.00013487144999999999" g2="0" b2="0.00013487144999999999" node1="52" voltageLevelId1="_04664b7a-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0448d866-c766-11e1-8775-005056c00008" p1="-83.815738479120654" q1="-2.3794163525043182" p2="85.58908679686526" q2="10.617255911119623">
         <iidm:alias>_047629f9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0478e915-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10470,7 +10470,7 @@
             <iidm:temporaryLimit name="_66cbdeeb-a4e4-4bfc-aec1-9fb7a2d2b6bc" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044a37f2-c766-11e1-8775-005056c00008" name="89-90" r="4.1469120000000004" x="17.371727" g1="0" b1="0.00030417815" g2="0" b2="0.00030417815" node1="62" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="112.65106593855879" q1="21.234816569794216" p2="-109.4941878317871" q2="-18.225371349358969">
+    <iidm:line id="_044a37f2-c766-11e1-8775-005056c00008" name="89-90" r="4.1469120000000004" x="17.371727" g1="0" b1="0.00030417815" g2="0" b2="0.00030417815" node1="62" voltageLevelId1="_0448d866-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_047d07c3-c766-11e1-8775-005056c00008" p1="112.72441314815016" q1="21.233990608064708" p2="-109.56364734165356" q2="-18.208164511328661">
         <iidm:alias>_045386c2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048719e9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10478,7 +10478,7 @@
             <iidm:temporaryLimit name="_8489e809-6588-4ed2-a9a4-43c44a0d47da" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04658820-c766-11e1-8775-005056c00008" name="98-100" r="6.9173280000000004" x="31.188960999999999" g1="0" b1="0.0001365932" g2="0" b2="0.0001365932" node1="22" voltageLevelId1="_04773b62-c766-11e1-8775-005056c00008" node2="82" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-22.105652883755262" q1="6.5678536737422579" p2="22.321999437229724" q2="-10.546671889778041">
+    <iidm:line id="_04658820-c766-11e1-8775-005056c00008" name="98-100" r="6.9173280000000004" x="31.188960999999999" g1="0" b1="0.0001365932" g2="0" b2="0.0001365932" node1="22" voltageLevelId1="_04773b62-c766-11e1-8775-005056c00008" node2="82" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-22.624145449300961" q1="6.6987279597830494" p2="22.850193772351972" q2="-10.63373778726911">
         <iidm:alias>_046f4c22-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046fe865-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10486,7 +10486,7 @@
             <iidm:temporaryLimit name="_620beaaf-63c8-4020-bea5-c3609c0eaadf" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c5ada-c766-11e1-8775-005056c00008" name="28-29" r="4.1294880000000003" x="16.430831900000001" g1="0" b1="6.8296599999999999e-05" g2="0" b2="6.8296599999999999e-05" node1="22" voltageLevelId1="_04819ba0-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04588fd5-c766-11e1-8775-005056c00008" p1="15.37991525140621" q1="-4.8313060139859569" p2="-15.316022583851263" q2="2.8747332500035592">
+    <iidm:line id="_044c5ada-c766-11e1-8775-005056c00008" name="28-29" r="4.1294880000000003" x="16.430831900000001" g1="0" b1="6.8296599999999999e-05" g2="0" b2="6.8296599999999999e-05" node1="22" voltageLevelId1="_04819ba0-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_04588fd5-c766-11e1-8775-005056c00008" p1="15.431895675375848" q1="-5.1661303157487914" p2="-15.366869202819533" q2="3.2153092898015454">
         <iidm:alias>_0461697a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04697fc1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10494,13 +10494,13 @@
             <iidm:temporaryLimit name="_6748d0d0-aec8-4b7b-a9ab-be6aecda7c5d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c5ada-c766-11e1-8775-005056c00008-1" name="28-29-open-ended" r="4.1294880000000003" x="16.430831900000001" g1="0" b1="6.8296599999999999e-05" g2="0" b2="6.8296599999999999e-05" node1="25" voltageLevelId1="_04819ba0-c766-11e1-8775-005056c00008" node2="25" voltageLevelId2="_04588fd5-c766-11e1-8775-005056c00008" p1="0.00031245752501864264" q1="-2.2120469412013315" p2="0" q2="0">
+    <iidm:line id="_044c5ada-c766-11e1-8775-005056c00008-1" name="28-29-open-ended" r="4.1294880000000003" x="16.430831900000001" g1="0" b1="6.8296599999999999e-05" g2="0" b2="6.8296599999999999e-05" node1="25" voltageLevelId1="_04819ba0-c766-11e1-8775-005056c00008" node2="25" voltageLevelId2="_04588fd5-c766-11e1-8775-005056c00008" p1="0.00031217907687040164" q1="-2.2100756640668116" p2="0" q2="0">
         <iidm:currentLimits1 permanentLimit="1000">
             <iidm:temporaryLimit name="_accb8136-1faf-4399-9787-3cd567284fd2-1" acceptableDuration="900" value="1150"/>
             <iidm:temporaryLimit name="_6748d0d0-aec8-4b7b-a9ab-be6aecda7c5d-1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0468e382-c766-11e1-8775-005056c00008" name="3-5" r="4.1991839999999998" x="18.817920000000001" g1="0" b1="8.1496799999999995e-05" g2="0" b2="8.1496799999999995e-05" node1="31" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-70.1030452023832" q1="-16.943266309004244" p2="71.416177959857166" q2="20.034176223186318">
+    <iidm:line id="_0468e382-c766-11e1-8775-005056c00008" name="3-5" r="4.1991839999999998" x="18.817920000000001" g1="0" b1="8.1496799999999995e-05" g2="0" b2="8.1496799999999995e-05" node1="31" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-70.181585973735963" q1="-16.755608231869957" p2="71.496449553965761" q2="19.855608683411937">
         <iidm:alias>_046b0668-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04742e24-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10508,7 +10508,7 @@
             <iidm:temporaryLimit name="_828ca44c-560b-4f94-b825-21e237285fae" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0447c6f1-c766-11e1-8775-005056c00008" name="82-96" r="2.8226879999999999" x="9.2347199999999994" g1="0" b1="0.00015610649999999999" g2="0" b2="0.00015610649999999999" node1="33" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="-15.521647217953809" q1="-9.5960311548428407" p2="15.570367085091972" q2="4.4829323922376876">
+    <iidm:line id="_0447c6f1-c766-11e1-8775-005056c00008" name="82-96" r="2.8226879999999999" x="9.2347199999999994" g1="0" b1="0.00015610649999999999" g2="0" b2="0.00015610649999999999" node1="33" voltageLevelId1="_046512f8-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_045a1672-c766-11e1-8775-005056c00008" p1="-15.642122844235255" q1="-8.8678281107676789" p2="15.689789395699682" q2="3.7469146318886768">
         <iidm:alias>_0478e91a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0480d856-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10516,7 +10516,7 @@
             <iidm:temporaryLimit name="_233b7735-85f4-4a6f-9d87-15129fe42ef5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0483e594-c766-11e1-8775-005056c00008" name="38-65" r="4.3608399999999996" x="47.7224" g1="0" b1="0.0010805785" g2="0" b2="0.0010805785" node1="29" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-157.29337645408546" q1="-98.340284278466868" p2="160.25469155891702" q2="33.86434775892743">
+    <iidm:line id="_0483e594-c766-11e1-8775-005056c00008" name="38-65" r="4.3608399999999996" x="47.7224" g1="0" b1="0.0010805785" g2="0" b2="0.0010805785" node1="29" voltageLevelId1="_04742e21-c766-11e1-8775-005056c00008" node2="40" voltageLevelId2="_0463da78-c766-11e1-8775-005056c00008" p1="-160.6969372324298" q1="-97.986925274747577" p2="163.77558685490499" q2="34.864670928711021">
         <iidm:alias>_04638c56-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046d5054-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10524,7 +10524,7 @@
             <iidm:temporaryLimit name="_990ce3c5-c90c-41b9-abee-fb803d9df3a5" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04784cd4-c766-11e1-8775-005056c00008" name="106-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_04479fe8-c766-11e1-8775-005056c00008" node2="24" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="23.857135257742858" q1="-0.69604717950810624" p2="-23.528611298150093" q2="-2.4531143327069325">
+    <iidm:line id="_04784cd4-c766-11e1-8775-005056c00008" name="106-107" r="9.2347199999999994" x="31.885919999999999" g1="0" b1="0.00013544535" g2="0" b2="0.00013544535" node1="32" voltageLevelId1="_04479fe8-c766-11e1-8775-005056c00008" node2="24" voltageLevelId2="_046205b3-c766-11e1-8775-005056c00008" p1="23.85286839772774" q1="-0.69457171602759193" p2="-23.524461153979811" q2="-2.4550178464412662">
         <iidm:alias>_04483c21-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f0395-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10532,7 +10532,7 @@
             <iidm:temporaryLimit name="_1372c3b0-62d7-47d7-a8c0-ed8e10bc1f1a" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046f9a43-c766-11e1-8775-005056c00008" name="27-115" r="2.8575360000000001" x="12.9111843" g1="0" b1="5.6588600000000002e-05" g2="0" b2="5.6588600000000002e-05" node1="43" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="22.567950642045581" q1="2.9001421857855068" p2="-22.476573174594776" q2="-4.329127533037858">
+    <iidm:line id="_046f9a43-c766-11e1-8775-005056c00008" name="27-115" r="2.8575360000000001" x="12.9111843" g1="0" b1="5.6588600000000002e-05" g2="0" b2="5.6588600000000002e-05" node1="43" voltageLevelId1="_0476c639-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04555b83-c766-11e1-8775-005056c00008" p1="22.680196806034438" q1="3.0944698818393288" p2="-22.587533883819869" q2="-4.5146196409108521">
         <iidm:alias>_046d0238-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048c22f4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10540,7 +10540,7 @@
             <iidm:temporaryLimit name="_64cfd0fb-1d8e-45d2-a52f-469238dfc0c6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04529c61-c766-11e1-8775-005056c00008" name="12-14" r="3.7461600000000002" x="12.3187675" g1="0" b1="5.2112050000000002e-05" g2="0" b2="5.2112050000000002e-05" node1="71" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b8129-c766-11e1-8775-005056c00008" p1="30.365391666202363" q1="6.6710518265456713" p2="-30.150583532760646" q2="-7.7234771905054895">
+    <iidm:line id="_04529c61-c766-11e1-8775-005056c00008" name="12-14" r="3.7461600000000002" x="12.3187675" g1="0" b1="5.2112050000000002e-05" g2="0" b2="5.2112050000000002e-05" node1="71" voltageLevelId1="_04479fe2-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047b8129-c766-11e1-8775-005056c00008" p1="30.717870128256859" q1="7.3240010403361646" p2="-30.49607943077725" q2="-8.3525052883504181">
         <iidm:alias>_045fbbc1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047bf65b-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10548,7 +10548,7 @@
             <iidm:temporaryLimit name="_efe2501d-bcee-42ff-a037-3d8a280487b0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0463da77-c766-11e1-8775-005056c00008" name="76-118" r="2.8575360000000001" x="9.4786560000000009" g1="0" b1="3.8911849999999999e-05" g2="0" b2="3.8911849999999999e-05" node1="22" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="-6.1473055581771305" q1="-14.707725624954589" p2="6.1914205896825196" q2="13.648014911672174">
+    <iidm:line id="_0463da77-c766-11e1-8775-005056c00008" name="76-118" r="2.8575360000000001" x="9.4786560000000009" g1="0" b1="3.8911849999999999e-05" g2="0" b2="3.8911849999999999e-05" node1="22" voltageLevelId1="_04808a33-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_047a96c5-c766-11e1-8775-005056c00008" p1="-5.5131390259082185" q1="-14.782663516622947" p2="5.5562983190591213" q2="13.720550510411321">
         <iidm:alias>_046931a0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04806320-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10556,7 +10556,7 @@
             <iidm:temporaryLimit name="_2ae204bf-78cc-49cb-b886-a933b33057e4" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046931a3-c766-11e1-8775-005056c00008" name="74-75" r="2.1431520000000002" x="7.0741440000000004" g1="0" b1="2.9671699999999999e-05" g2="0" b2="2.9671699999999999e-05" node1="23" voltageLevelId1="_047dcb11-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="-44.346104389081511" q1="-4.2416180718888388" p2="44.610102540998859" q2="4.1513748383208373">
+    <iidm:line id="_046931a3-c766-11e1-8775-005056c00008" name="74-75" r="2.1431520000000002" x="7.0741440000000004" g1="0" b1="2.9671699999999999e-05" g2="0" b2="2.9671699999999999e-05" node1="23" voltageLevelId1="_047dcb11-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="-45.275877707650544" q1="-4.1499086716401639" p2="45.551169807868682" q2="4.0978206128458332">
         <iidm:alias>_044f4103-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04638c58-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10564,7 +10564,7 @@
             <iidm:temporaryLimit name="_e822432e-79af-4bba-8f40-5250468f81a0" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045ed162-c766-11e1-8775-005056c00008" name="3-12" r="8.4332159999999998" x="27.878398900000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="32" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-8.6986255056748938" q1="-9.6318849828020436" p2="8.7677093719801569" q2="5.9490442405282895">
+    <iidm:line id="_045ed162-c766-11e1-8775-005056c00008" name="3-12" r="8.4332159999999998" x="27.878398900000001" g1="0" b1="0.00011650595" g2="0" b2="0.00011650595" node1="32" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_04479fe2-c766-11e1-8775-005056c00008" p1="-8.6505402470902251" q1="-9.7359699938825255" p2="8.7200498436863558" q2="6.0551270963200849">
         <iidm:alias>_047a48a1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047b5a14-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10572,7 +10572,7 @@
             <iidm:temporaryLimit name="_c437e52c-43d7-4ae9-87ad-dc19396dc6ff" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04499bb6-c766-11e1-8775-005056c00008" name="49-51" r="8.468064" x="23.8708782" g1="0" b1="9.81405e-05" g2="0" b2="9.81405e-05" node1="119" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04542300-c766-11e1-8775-005056c00008" p1="77.005214918751903" q1="18.639450523185541" p2="-74.069009283886118" q2="-13.753720499044467">
+    <iidm:line id="_04499bb6-c766-11e1-8775-005056c00008" name="49-51" r="8.468064" x="23.8708782" g1="0" b1="9.81405e-05" g2="0" b2="9.81405e-05" node1="119" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04542300-c766-11e1-8775-005056c00008" p1="76.842440131125144" q1="18.66531912397836" p2="-73.917327568083294" q2="-13.810924407692818">
         <iidm:alias>_0487dd38-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b1180-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10580,7 +10580,7 @@
             <iidm:temporaryLimit name="_90dcdbe1-437b-443f-b0b5-c2353f7c6954" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04839779-c766-11e1-8775-005056c00008" name="40-42" r="9.6703209999999995" x="31.885919999999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="42" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="0.065173997515429599" q1="-9.8771027131922828" p2="-0.021063901323111617" q2="6.2005962043192362">
+    <iidm:line id="_04839779-c766-11e1-8775-005056c00008" name="40-42" r="9.6703209999999995" x="31.885919999999999" g1="0" b1="0.00013372359999999999" g2="0" b2="0.00013372359999999999" node1="42" voltageLevelId1="_0479d371-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_048719e8-c766-11e1-8775-005056c00008" p1="-0.55162040924900535" q1="-9.7108679993213833" p2="0.59417753453427768" q2="6.0323088905724846">
         <iidm:alias>_044974a9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04616975-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10588,7 +10588,7 @@
             <iidm:temporaryLimit name="_9b8510fa-bd0e-4e63-8f4c-0e5443a3eb63" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0484a8e1-c766-11e1-8775-005056c00008" name="32-113" r="10.71576" x="35.370719999999999" g1="0" b1="0.00014864555000000001" g2="0" b2="0.00014864555000000001" node1="52" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="0.92168842393959027" q1="-8.5156516364878065" p2="-0.89674608851548676" q2="3.6883554761939483">
+    <iidm:line id="_0484a8e1-c766-11e1-8775-005056c00008" name="32-113" r="10.71576" x="35.370719999999999" g1="0" b1="0.00014864555000000001" g2="0" b2="0.00014864555000000001" node1="52" voltageLevelId1="_047b3309-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04662460-c766-11e1-8775-005056c00008" p1="0.83224290417787672" q1="-8.3174555722460131" p2="-0.8088742223380827" q2="3.4971291714493611">
         <iidm:alias>_04723258-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0482860a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10596,7 +10596,7 @@
             <iidm:temporaryLimit name="_336bfd86-a922-4154-9e06-cd87382cdc5f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04898ae4-c766-11e1-8775-005056c00008" name="51-58" r="4.4431200000000004" x="12.5278568" g1="0" b1="5.1308550000000002e-05" g2="0" b2="5.1308550000000002e-05" node1="31" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="25.405009349971188" q1="0.44913213187575546" p2="-25.228074453903883" q2="-1.6047704743979221">
+    <iidm:line id="_04898ae4-c766-11e1-8775-005056c00008" name="51-58" r="4.4431200000000004" x="12.5278568" g1="0" b1="5.1308550000000002e-05" g2="0" b2="5.1308550000000002e-05" node1="31" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="25.304290092863042" q1="0.49081562766581377" p2="-25.128729286854089" q2="-1.65038664955382">
         <iidm:alias>_044778d4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04789af1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10604,7 +10604,7 @@
             <iidm:temporaryLimit name="_2be10dec-f0ac-470d-83f7-a2a4e70f3491" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046efe04-c766-11e1-8775-005056c00008" name="29-31" r="1.8817919999999999" x="5.7673439999999996" g1="0" b1="2.3817700000000001e-05" g2="0" b2="2.3817700000000001e-05" node1="22" voltageLevelId1="_04588fd5-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="-8.6850362781336088" q1="-6.8750272512135" p2="8.6987026781348362" q2="6.1433568635796947">
+    <iidm:line id="_046efe04-c766-11e1-8775-005056c00008" name="29-31" r="1.8817919999999999" x="5.7673439999999996" g1="0" b1="2.3817700000000001e-05" g2="0" b2="2.3817700000000001e-05" node1="22" voltageLevelId1="_04588fd5-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_04636548-c766-11e1-8775-005056c00008" p1="-8.6331011483279507" q1="-7.2153010544455709" p2="8.6471933178775515" q2="6.4850246239609319">
         <iidm:alias>_04492688-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047cb9a5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10612,7 +10612,7 @@
             <iidm:temporaryLimit name="_f0e21213-6535-44a7-89b6-3063f8738d6b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044a10e4-c766-11e1-8775-005056c00008" name="65-68" r="0.66791999999999996" x="7.7439999999999998" g1="0" b1="0.00065909092999999995" g2="0" b2="0.00065909092999999995" node1="41" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0449e9d2-c766-11e1-8775-005056c00008" p1="-160.25628294124982" q1="23.466176718134513" p2="160.6495457178217" q2="-82.942344681730091">
+    <iidm:line id="_044a10e4-c766-11e1-8775-005056c00008" name="65-68" r="0.66791999999999996" x="7.7439999999999998" g1="0" b1="0.00065909092999999995" g2="0" b2="0.00065909092999999995" node1="41" voltageLevelId1="_0463da78-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_0449e9d2-c766-11e1-8775-005056c00008" p1="-162.13006903986383" q1="23.746089178690539" p2="162.53201263518028" q2="-83.120881182307343">
         <iidm:alias>_0461dea7-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047629f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10620,7 +10620,7 @@
             <iidm:temporaryLimit name="_ab31cd46-6d0c-4d9c-95f1-396a45a237e1" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046b7b92-c766-11e1-8775-005056c00008" name="49-54" r="12.719519999999999" x="50.355361899999998" g1="0" b1="0.00021177684999999999" g2="0" b2="0.00021177684999999999" node1="120" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="46.923351100987695" q1="11.832406587502639" p2="-45.222018535872579" q2="-12.339176658693821">
+    <iidm:line id="_046b7b92-c766-11e1-8775-005056c00008" name="49-54" r="12.719519999999999" x="50.355361899999998" g1="0" b1="0.00021177684999999999" g2="0" b2="0.00021177684999999999" node1="120" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="61" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="46.776208681058257" q1="11.850217984200237" p2="-45.084065766883711" q2="-12.393364502045619">
         <iidm:alias>_0462f017-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047120e1-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10628,7 +10628,7 @@
             <iidm:temporaryLimit name="_1bf78539-b6fa-4d8b-ba8e-9b5970019be6" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04607f15-c766-11e1-8775-005056c00008" name="70-71" r="1.536797" x="6.1855200000000004" g1="0" b1="2.5195149999999999e-05" g2="0" b2="2.5195149999999999e-05" node1="52" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04664b78-c766-11e1-8775-005056c00008" p1="-7.0768473094091515" q1="-4.5417390839546616" p2="7.0829413252158666" q2="3.7127459275323473">
+    <iidm:line id="_04607f15-c766-11e1-8775-005056c00008" name="70-71" r="1.536797" x="6.1855200000000004" g1="0" b1="2.5195149999999999e-05" g2="0" b2="2.5195149999999999e-05" node1="52" voltageLevelId1="_045d98e1-c766-11e1-8775-005056c00008" node2="30" voltageLevelId2="_04664b78-c766-11e1-8775-005056c00008" p1="-5.0461611502601755" q1="-4.8656437509594674" p2="5.0502757403820171" q2="4.0300774535470829">
         <iidm:alias>_04486336-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047f51b4-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10636,7 +10636,7 @@
             <iidm:temporaryLimit name="_08ff3ae4-d1dd-49f7-9eda-32ffc8eb0010" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044c5ad7-c766-11e1-8775-005056c00008" name="55-56" r="0.85029100000000002" x="2.631024" g1="0" b1="1.0732300000000001e-05" g2="0" b2="1.0732300000000001e-05" node1="31" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="-28.763579080484586" q1="-6.9789629152809747" p2="28.810695399677826" q2="6.7853931512846968">
+    <iidm:line id="_044c5ad7-c766-11e1-8775-005056c00008" name="55-56" r="0.85029100000000002" x="2.631024" g1="0" b1="1.0732300000000001e-05" g2="0" b2="1.0732300000000001e-05" node1="31" voltageLevelId1="_04767817-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_047e675c-c766-11e1-8775-005056c00008" p1="-28.686447521681512" q1="-7.0046078622408334" p2="28.733343563278694" q2="6.8103551220565093">
         <iidm:alias>_04558294-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_045868c2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10644,7 +10644,7 @@
             <iidm:temporaryLimit name="_94316214-afd8-4c0d-bca4-916acb92af85" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_048a2725-c766-11e1-8775-005056c00008" name="35-37" r="1.9166399999999999" x="8.6597279999999994" g1="0" b1="3.7821399999999997e-05" g2="0" b2="3.7821399999999997e-05" node1="21" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-29.339284293694579" q1="-14.466145041828321" p2="29.470823662778734" q2="13.885652613290722">
+    <iidm:line id="_048a2725-c766-11e1-8775-005056c00008" name="35-37" r="1.9166399999999999" x="8.6597279999999994" g1="0" b1="3.7821399999999997e-05" g2="0" b2="3.7821399999999997e-05" node1="21" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="60" voltageLevelId2="_04878f10-c766-11e1-8775-005056c00008" p1="-29.558698540473404" q1="-14.434847639963492" p2="29.691913597330988" q2="13.863377524445431">
         <iidm:alias>_0471bd29-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04808a30-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10652,7 +10652,7 @@
             <iidm:temporaryLimit name="_4ea6b532-d914-4b0c-97ee-9f02a14a40b3" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04614263-c766-11e1-8775-005056c00008" name="4-5" r="0.30666199999999999" x="1.3904350000000001" g1="0" b1="6.0261499999999999e-06" g2="0" b2="6.0261499999999999e-06" node1="22" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-108.37269835648262" q1="-20.169351121773115" p2="108.58360569329906" q2="20.912010804178934">
+    <iidm:line id="_04614263-c766-11e1-8775-005056c00008" name="4-5" r="0.30666199999999999" x="1.3904350000000001" g1="0" b1="6.0261499999999999e-06" g2="0" b2="6.0261499999999999e-06" node1="22" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="51" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008" p1="-108.54973673231913" q1="-19.947601246907237" p2="108.76128660955733" q2="20.693307454869466">
         <iidm:alias>_04529c66-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04753f92-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10660,7 +10660,7 @@
             <iidm:temporaryLimit name="_2a95fb2b-6661-46e7-a9f6-fe63c1b7433c" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0451b208-c766-11e1-8775-005056c00008" name="20-21" r="3.1885919999999999" x="14.7929754" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_046b2d70-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0460f448-c766-11e1-8775-005056c00008" p1="-39.079938411873677" q1="-3.9813154247976295" p2="39.390565744100073" q2="3.4451526394896841">
+    <iidm:line id="_0451b208-c766-11e1-8775-005056c00008" name="20-21" r="3.1885919999999999" x="14.7929754" g1="0" b1="6.19835e-05" g2="0" b2="6.19835e-05" node1="22" voltageLevelId1="_046b2d70-c766-11e1-8775-005056c00008" node2="21" voltageLevelId2="_0460f448-c766-11e1-8775-005056c00008" p1="-30.859524788243082" q1="0.5793578034850182" p2="31.057092770023758" q2="-1.5830618234838949">
         <iidm:alias>_046c65f3-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048c22f6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10668,7 +10668,7 @@
             <iidm:temporaryLimit name="_4b67f5f5-f0e1-4bfb-9d57-4d3474720a45" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047d55e4-c766-11e1-8775-005056c00008" name="104-105" r="1.731946" x="6.5862720000000001" g1="0" b1="2.8294300000000001e-05" g2="0" b2="2.8294300000000001e-05" node1="32" voltageLevelId1="_0483977a-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="48.062680897376815" q1="0.85707029374534205" p2="-47.818749807348496" q2="-0.85326571580869226">
+    <iidm:line id="_047d55e4-c766-11e1-8775-005056c00008" name="104-105" r="1.731946" x="6.5862720000000001" g1="0" b1="2.8294300000000001e-05" g2="0" b2="2.8294300000000001e-05" node1="32" voltageLevelId1="_0483977a-c766-11e1-8775-005056c00008" node2="53" voltageLevelId2="_0465611a-c766-11e1-8775-005056c00008" p1="48.030924806309592" q1="0.86548585398841116" p2="-47.787314179824541" q2="-0.86290282484507708">
         <iidm:alias>_0451d910-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046c65f2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10676,7 +10676,7 @@
             <iidm:temporaryLimit name="_1ca40dc7-6736-4fa8-b4cb-ca696949e421" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046dc589-c766-11e1-8775-005056c00008" name="44-45" r="3.9029759999999998" x="15.699023199999999" g1="0" b1="6.4279149999999996e-05" g2="0" b2="6.4279149999999996e-05" node1="23" voltageLevelId1="_04544a15-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_045d23b4-c766-11e1-8775-005056c00008" p1="-20.531605375804702" q1="-4.5756422161839483" p2="20.633863520152264" q2="2.840190928646591">
+    <iidm:line id="_046dc589-c766-11e1-8775-005056c00008" name="44-45" r="3.9029759999999998" x="15.699023199999999" g1="0" b1="6.4279149999999996e-05" g2="0" b2="6.4279149999999996e-05" node1="23" voltageLevelId1="_04544a15-c766-11e1-8775-005056c00008" node2="33" voltageLevelId2="_045d23b4-c766-11e1-8775-005056c00008" p1="-21.312561844213519" q1="-4.4628151131038472" p2="21.422402646395071" q2="2.7588975743519795">
         <iidm:alias>_04518afa-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04667287-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10684,7 +10684,7 @@
             <iidm:temporaryLimit name="_ba738481-ddba-4ebe-a218-8aad0b537f5b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04642896-c766-11e1-8775-005056c00008" name="4-11" r="3.641616" x="11.9877129" g1="0" b1="5.0160700000000002e-05" g2="0" b2="5.0160700000000002e-05" node1="23" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="69.368540421300111" q1="8.1672188918170132" p2="-68.359494492712784" q2="-6.5834159434684274">
+    <iidm:line id="_04642896-c766-11e1-8775-005056c00008" name="4-11" r="3.641616" x="11.9877129" g1="0" b1="5.0160700000000002e-05" g2="0" b2="5.0160700000000002e-05" node1="23" voltageLevelId1="_048a9c58-c766-11e1-8775-005056c00008" node2="42" voltageLevelId2="_04605807-c766-11e1-8775-005056c00008" p1="69.550258530077642" q1="7.9478688539790312" p2="-68.536198651179092" q2="-6.3466862007741875">
         <iidm:alias>_0455f7c5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04803c17-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10692,7 +10692,7 @@
             <iidm:temporaryLimit name="_b1d87c24-e527-4174-aa04-cd0b9de271ea" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047d07c0-c766-11e1-8775-005056c00008" name="92-93" r="4.4953919999999998" x="14.775551800000001" g1="0" b1="6.2557400000000005e-05" g2="0" b2="6.2557400000000005e-05" node1="72" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04789af0-c766-11e1-8775-005056c00008" p1="70.185535815653026" q1="-12.666208121764596" p2="-68.851961610011131" q2="14.928729398117957">
+    <iidm:line id="_047d07c0-c766-11e1-8775-005056c00008" name="92-93" r="4.4953919999999998" x="14.775551800000001" g1="0" b1="6.2557400000000005e-05" g2="0" b2="6.2557400000000005e-05" node1="72" voltageLevelId1="_0468bc77-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04789af0-c766-11e1-8775-005056c00008" p1="70.523399061853482" q1="-12.776816240607927" p2="-69.176571128294086" q2="15.082914683422693">
         <iidm:alias>_044a5f07-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047602e5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10700,7 +10700,7 @@
             <iidm:temporaryLimit name="_4e1daf8e-7708-4b96-8d3f-67f58f2505f9" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044f4109-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="43" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="121" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-52.969956729242064" q1="-19.076899676789218" p2="55.578191893760376" q2="22.751748443656979">
+    <iidm:line id="_044f4109-c766-11e1-8775-005056c00008" name="42-49" r="12.458159999999999" x="56.279521899999999" g1="0" b1="0.00024678605" g2="0" b2="0.00024678605" node1="43" voltageLevelId1="_048719e8-c766-11e1-8775-005056c00008" node2="121" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-53.574699088790581" q1="-18.911349156608782" p2="56.235798773932785" q2="22.827691576537976">
         <iidm:alias>_046958b0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04758db0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10708,7 +10708,7 @@
             <iidm:temporaryLimit name="_c58940cb-bd36-4dfc-9615-11716dd652a7" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046e61c8-c766-11e1-8775-005056c00008" name="69-75" r="7.0567200000000003" x="21.257280000000002" g1="0" b1="0.00035583104999999999" g2="0" b2="0.00035583104999999999" node1="61" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="89.411917523337507" q1="24.259876901992154" p2="-86.028406518592007" q2="-26.519857334968666">
+    <iidm:line id="_046e61c8-c766-11e1-8775-005056c00008" name="69-75" r="7.0567200000000003" x="21.257280000000002" g1="0" b1="0.00035583104999999999" g2="0" b2="0.00035583104999999999" node1="61" voltageLevelId1="_0471bd23-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_048740f7-c766-11e1-8775-005056c00008" p1="90.099350523560418" q1="24.428148195728934" p2="-86.665240292074699" q2="-26.53098060645393">
         <iidm:alias>_046d294a-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048ac362-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10716,7 +10716,7 @@
             <iidm:temporaryLimit name="_3c9a454c-10ee-4c72-a059-77f723f5b7c7" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0463da71-c766-11e1-8775-005056c00008" name="79-80" r="2.7181440000000001" x="12.2664957" g1="0" b1="5.3661600000000001e-05" g2="0" b2="5.3661600000000001e-05" node1="23" voltageLevelId1="_04481510-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-66.191995544586774" q1="-32.337346580955071" p2="67.017635620731497" q2="34.103924862743263">
+    <iidm:line id="_0463da71-c766-11e1-8775-005056c00008" name="79-80" r="2.7181440000000001" x="12.2664957" g1="0" b1="5.3661600000000001e-05" g2="0" b2="5.3661600000000001e-05" node1="23" voltageLevelId1="_04481510-c766-11e1-8775-005056c00008" node2="81" voltageLevelId2="_046efe09-c766-11e1-8775-005056c00008" p1="-66.509276590948872" q1="-32.24465414289017" p2="67.34049009437561" q2="34.036373580871157">
         <iidm:alias>_0464ebe9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04662468-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10724,7 +10724,7 @@
             <iidm:temporaryLimit name="_270a7d04-9ff9-4178-8b72-b610735a72ac" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044fdd41-c766-11e1-8775-005056c00008" name="51-52" r="3.5370720000000002" x="10.2453117" g1="0" b1="4.0059699999999999e-05" g2="0" b2="4.0059699999999999e-05" node1="32" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04806326-c766-11e1-8775-005056c00008" p1="31.664148139112125" q1="5.3047084973888881" p2="-31.438173983284141" q2="-5.9384392834258755">
+    <iidm:line id="_044fdd41-c766-11e1-8775-005056c00008" name="51-52" r="3.5370720000000002" x="10.2453117" g1="0" b1="4.0059699999999999e-05" g2="0" b2="4.0059699999999999e-05" node1="32" voltageLevelId1="_04542300-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04806326-c766-11e1-8775-005056c00008" p1="31.613056647558874" q1="5.3201239058016467" p2="-31.38775544936178" q2="-5.9558585700244988">
         <iidm:alias>_045115c2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0464ebe5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10732,7 +10732,7 @@
             <iidm:temporaryLimit name="_9d1eb182-ceb5-426e-9440-5f4d426a31cb" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045c3958-c766-11e1-8775-005056c00008" name="53-54" r="4.5825120000000004" x="21.257280000000002" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="22" voltageLevelId1="_04876804-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="-9.6451065201296231" q1="-6.7326759231088582" p2="9.6808984002278464" q2="4.0998438895674854">
+    <iidm:line id="_045c3958-c766-11e1-8775-005056c00008" name="53-54" r="4.5825120000000004" x="21.257280000000002" g1="0" b1="8.8957749999999994e-05" g2="0" b2="8.8957749999999994e-05" node1="22" voltageLevelId1="_04876804-c766-11e1-8775-005056c00008" node2="62" voltageLevelId2="_0450eeb4-c766-11e1-8775-005056c00008" p1="-9.6951968119696872" q1="-6.713012547596402" p2="9.7312111158880992" q2="4.0811825129919272">
         <iidm:alias>_044f6817-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0455f7c6-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10740,7 +10740,7 @@
             <iidm:temporaryLimit name="_735ac8df-6a6a-43f0-86f2-49d3280c9a3b" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044ef2e1-c766-11e1-8775-005056c00008" name="54-55" r="2.9446560000000002" x="12.3187675" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="63" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04767817-c766-11e1-8775-005056c00008" p1="10.177894498268206" q1="1.7038941507760106" p2="-10.157422285305161" q2="-3.4533822104988849">
+    <iidm:line id="_044ef2e1-c766-11e1-8775-005056c00008" name="54-55" r="2.9446560000000002" x="12.3187675" g1="0" b1="5.7966e-05" g2="0" b2="5.7966e-05" node1="63" voltageLevelId1="_0450eeb4-c766-11e1-8775-005056c00008" node2="32" voltageLevelId2="_04767817-c766-11e1-8775-005056c00008" p1="10.156603230304315" q1="1.7058225244610921" p2="-10.136209353955058" q2="-3.4556413783578583">
         <iidm:alias>_04640181-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047dcb17-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10748,7 +10748,7 @@
             <iidm:temporaryLimit name="_52aadf8d-53f2-4827-8c70-421bdf1ba822" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0456e226-c766-11e1-8775-005056c00008" name="80-97" r="3.1885919999999999" x="16.2740154" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="82" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="12.662290559111794" q1="30.838138714231139" p2="-12.459608093856964" q2="-32.469918800441896">
+    <iidm:line id="_0456e226-c766-11e1-8775-005056c00008" name="80-97" r="3.1885919999999999" x="16.2740154" g1="0" b1="7.2887949999999994e-05" g2="0" b2="7.2887949999999994e-05" node1="82" voltageLevelId1="_046efe09-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_048bd4da-c766-11e1-8775-005056c00008" p1="12.247181855317978" q1="30.791173219753563" p2="-12.046760301171274" q2="-32.434780862585512">
         <iidm:alias>_04479fe9-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047df222-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10756,7 +10756,7 @@
             <iidm:temporaryLimit name="_fece5807-6af8-4161-8de8-8f8473d92f11" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0487b624-c766-11e1-8775-005056c00008" name="103-110" r="6.8058139999999998" x="31.5897121" g1="0" b1="0.00013228879999999999" g2="0" b2="0.00013228879999999999" node1="43" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="57.786611650762453" q1="18.491400429894611" p2="-56.341644927594423" q2="-16.238213234218776">
+    <iidm:line id="_0487b624-c766-11e1-8775-005056c00008" name="103-110" r="6.8058139999999998" x="31.5897121" g1="0" b1="0.00013228879999999999" g2="0" b2="0.00013228879999999999" node1="43" voltageLevelId1="_0475b4c0-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_04740714-c766-11e1-8775-005056c00008" p1="57.719497572677312" q1="18.497463083501771" p2="-56.277401164762566" q2="-16.257606593432435">
         <iidm:alias>_046a9139-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b3895-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10764,7 +10764,7 @@
             <iidm:temporaryLimit name="_3eacc034-737e-41de-a7b6-b610d3bd0921" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_045338a8-c766-11e1-8775-005056c00008" name="56-58" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="61" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="-13.162745528116332" q1="-0.63246555859964237" p2="13.228145637285893" q2="-1.3951983903947789">
+    <iidm:line id="_045338a8-c766-11e1-8775-005056c00008" name="56-58" r="5.976432" x="16.831584899999999" g1="0" b1="6.9444449999999999e-05" g2="0" b2="6.9444449999999999e-05" node1="61" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0478c204-c766-11e1-8775-005056c00008" p1="-13.064327520009167" q1="-0.6808781287089366" p2="13.128738044569246" q2="-1.3496096669217992">
         <iidm:alias>_0451d915-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04817494-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10772,7 +10772,7 @@
             <iidm:temporaryLimit name="_0d0c3ec5-798a-48a4-9bc8-d19c57128a13" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04854529-c766-11e1-8775-005056c00008" name="15-33" r="6.6211200000000003" x="21.675455100000001" g1="0" b1="9.1655200000000003e-05" g2="0" b2="9.1655200000000003e-05" node1="52" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456bb11-c766-11e1-8775-005056c00008" p1="67.195061955707857" q1="-8.0992325870253676" p2="-65.277592534383587" q2="11.53183465991534">
+    <iidm:line id="_04854529-c766-11e1-8775-005056c00008" name="15-33" r="6.6211200000000003" x="21.675455100000001" g1="0" b1="9.1655200000000003e-05" g2="0" b2="9.1655200000000003e-05" node1="52" voltageLevelId1="_0467ab04-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0456bb11-c766-11e1-8775-005056c00008" p1="64.513570094508395" q1="-8.2883068075051582" p2="-62.736016417918187" q2="11.272014198329563">
         <iidm:alias>_0448d862-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_047d2ed5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10780,7 +10780,7 @@
             <iidm:temporaryLimit name="_5b0395f4-534d-4975-a1af-e0b6ef439193" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_04649dc2-c766-11e1-8775-005056c00008" name="35-36" r="0.39029799999999998" x="1.7772479999999999" g1="0" b1="7.6905500000000004e-06" g2="0" b2="7.6905500000000004e-06" node1="22" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="-3.6607845268845036" q1="5.4661149967765503" p2="3.6619180182879503" q2="-5.696951480778381">
+    <iidm:line id="_04649dc2-c766-11e1-8775-005056c00008" name="35-36" r="0.39029799999999998" x="1.7772479999999999" g1="0" b1="7.6905500000000004e-06" g2="0" b2="7.6905500000000004e-06" node1="22" voltageLevelId1="_04817490-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_0485e169-c766-11e1-8775-005056c00008" p1="-3.4328009098938281" q1="5.4387113958523843" p2="3.4338868525088766" q2="-5.6694657563834632">
         <iidm:alias>_044c0cb5-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0456e225-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10788,7 +10788,7 @@
             <iidm:temporaryLimit name="_74c4b341-7b99-4a81-b88a-2ed3b0c4b1de" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_0470d2c9-c766-11e1-8775-005056c00008" name="37-40" r="10.3324327" x="29.272320000000001" g1="0" b1="0.0001205234" g2="0" b2="0.0001205234" node1="61" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="56.97099887062209" q1="10.190941900585671" p2="-54.740297848316445" q2="-7.4560611721563506">
+    <iidm:line id="_0470d2c9-c766-11e1-8775-005056c00008" name="37-40" r="10.3324327" x="29.272320000000001" g1="0" b1="0.0001205234" g2="0" b2="0.0001205234" node1="61" voltageLevelId1="_04878f10-c766-11e1-8775-005056c00008" node2="43" voltageLevelId2="_0479d371-c766-11e1-8775-005056c00008" p1="56.310235406643997" q1="10.235508202816559" p2="-54.125448942239032" q2="-7.6269583413503401">
         <iidm:alias>_045b9d10-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_046a4317-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10796,7 +10796,7 @@
             <iidm:temporaryLimit name="_e98d56fe-a54b-45e4-acff-0ac310beb3dd" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_044e56a2-c766-11e1-8775-005056c00008" name="48-49" r="3.1188959999999999" x="8.7991200000000003" g1="0" b1="3.6099649999999999e-05" g2="0" b2="3.6099649999999999e-05" node1="23" voltageLevelId1="_044778d3-c766-11e1-8775-005056c00008" node2="122" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-28.726129472415508" q1="1.2804741572286351" p2="28.868519293467266" q2="-2.1950651945235378">
+    <iidm:line id="_044e56a2-c766-11e1-8775-005056c00008" name="48-49" r="3.1188959999999999" x="8.7991200000000003" g1="0" b1="3.6099649999999999e-05" g2="0" b2="3.6099649999999999e-05" node1="23" voltageLevelId1="_044778d3-c766-11e1-8775-005056c00008" node2="122" voltageLevelId2="_0457f394-c766-11e1-8775-005056c00008" p1="-28.845791542746728" q1="1.3184885494957936" p2="28.989391238496371" q2="-2.2296614404663897">
         <iidm:alias>_0454bf49-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_0460a623-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10804,7 +10804,7 @@
             <iidm:temporaryLimit name="_f2e58700-2366-46e0-8408-9472d85acd23" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_047eb573-c766-11e1-8775-005056c00008" name="56-59" r="14.3748007" x="43.734237700000001" g1="0" b1="0.0001632805" g2="0" b2="0.0001632805" node1="62" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-19.094359838382385" q1="-7.7463439548334154" p2="19.449085631405435" q2="3.4768246564949679">
+    <iidm:line id="_047eb573-c766-11e1-8775-005056c00008" name="56-59" r="14.3748007" x="43.734237700000001" g1="0" b1="0.0001632805" g2="0" b2="0.0001632805" node1="62" voltageLevelId1="_047e675c-c766-11e1-8775-005056c00008" node2="72" voltageLevelId2="_0455a9a2-c766-11e1-8775-005056c00008" p1="-19.178900963898364" q1="-7.7132699440517216" p2="19.536250800319028" q2="3.4517253059587034">
         <iidm:alias>_0468bc78-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048915b0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10812,7 +10812,7 @@
             <iidm:temporaryLimit name="_89654167-95a6-4c76-aad7-63a881116e17" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046f9a4b-c766-11e1-8775-005056c00008" name="94-100" r="3.1014719999999998" x="10.105919999999999" g1="0" b1="0.00017332415000000001" g2="0" b2="0.00017332415000000001" node1="52" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-5.7680604186933184" q1="-52.170401470900984" p2="6.216931831369763" q2="47.567366911911442">
+    <iidm:line id="_046f9a4b-c766-11e1-8775-005056c00008" name="94-100" r="3.1014719999999998" x="10.105919999999999" g1="0" b1="0.00017332415000000001" g2="0" b2="0.00017332415000000001" node1="52" voltageLevelId1="_045ed163-c766-11e1-8775-005056c00008" node2="83" voltageLevelId2="_04765109-c766-11e1-8775-005056c00008" p1="-6.1145621087762256" q1="-51.95933375704508" p2="6.5603317606630931" q2="47.345809976185436">
         <iidm:alias>_04812676-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048a2722-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10820,7 +10820,7 @@
             <iidm:temporaryLimit name="_216c0f3b-03e8-4b7d-96fc-a5f891331f7f" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046735d0-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="123" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-92.154562716893992" q1="-2.5673526451535702" p2="93.609820606518738" q2="7.3388894454456581">
+    <iidm:line id="_046735d0-c766-11e1-8775-005056c00008" name="49-66" r="3.13632" x="16.012655299999999" g1="0" b1="7.1166200000000003e-05" g2="0" b2="7.1166200000000003e-05" node1="123" voltageLevelId1="_0457f394-c766-11e1-8775-005056c00008" node2="52" voltageLevelId2="_047147f4-c766-11e1-8775-005056c00008" p1="-92.393474100130007" q1="-2.4979783931731947" p2="93.856257524711921" q2="7.3079447900618435">
         <iidm:alias>_04570934-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_048b3894-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10828,7 +10828,7 @@
             <iidm:temporaryLimit name="_32655e4f-e7da-46b0-a908-b601224ddb73" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_046d294b-c766-11e1-8775-005056c00008" name="21-22" r="3.641616" x="16.901281399999998" g1="0" b1="7.0592299999999998e-05" g2="0" b2="7.0592299999999998e-05" node1="22" voltageLevelId1="_0460f448-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04773b6a-c766-11e1-8775-005056c00008" p1="-39.39056574410003" q1="-3.4451526394896592" p2="39.742066390710924" q2="2.7713951100007073">
+    <iidm:line id="_046d294b-c766-11e1-8775-005056c00008" name="21-22" r="3.641616" x="16.901281399999998" g1="0" b1="7.0592299999999998e-05" g2="0" b2="7.0592299999999998e-05" node1="22" voltageLevelId1="_0460f448-c766-11e1-8775-005056c00008" node2="22" voltageLevelId2="_04773b6a-c766-11e1-8775-005056c00008" p1="-45.055957223752181" q1="-6.4158567326753611" p2="45.537270670463329" q2="6.4123781654285121">
         <iidm:alias>_044a37f0-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_044be5a2-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10836,7 +10836,7 @@
             <iidm:temporaryLimit name="_bafaeace-e459-4dc2-87a0-467a9ea25f8d" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_6a131803-f462-47e2-bc21-bda919364fe9" name="reactor1" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="36" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="37" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="5.8286708792820718e-14" q1="-83.151439201261041" p2="-6.106226635438361e-14" q2="92.151084564051018">
+    <iidm:line id="_6a131803-f462-47e2-bc21-bda919364fe9" name="reactor1" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="36" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="37" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="-5.5511151231257827e-15" q1="-83.15138356414586" p2="5.5511151231257827e-15" q2="92.151022905220387">
         <iidm:alias>_04531196-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_ca0adad2-ffe3-4efa-b56b-7d333b8ae18f</iidm:alias>
         <iidm:currentLimits1 permanentLimit="1000">
@@ -10844,7 +10844,7 @@
             <iidm:temporaryLimit name="_ae4eadea-f3fc-4ac6-8899-c1698ece7a89" acceptableDuration="60" value="1400"/>
         </iidm:currentLimits1>
     </iidm:line>
-    <iidm:line id="_9803b364-2a93-4f21-94b7-8bdbe27a16f2" name="reactor2" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="38" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="5.9466509529093603e-07" q1="27.482702004563027" p2="-5.9466509529093603e-07" q2="-26.596964400879997">
+    <iidm:line id="_9803b364-2a93-4f21-94b7-8bdbe27a16f2" name="reactor2" r="0" x="60" g1="0" b1="0" g2="0" b2="0" node1="38" voltageLevelId1="_04544a18-c766-11e1-8775-005056c00008" node2="39" voltageLevelId2="_04544a18-c766-11e1-8775-005056c00008" p1="-6.7146812068874517e-08" q1="27.473581514564149" p2="6.7146812415819213e-08" q2="-26.58843114677995">
         <iidm:alias>_0461b792-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_afe0e60b-3870-44fb-ba93-a056228f9636</iidm:alias>
     </iidm:line>

--- a/tests/main_sa/res/TestIIDM_launch.iidm
+++ b/tests/main_sa/res/TestIIDM_launch.iidm
@@ -37,8 +37,14 @@ cas-1.1.3-data-4.0.3/SmallGrid/NodeBreaker/CGMES_v2.4.15_SmallGridTestConfigurat
                     <iidm:alias>_bea273f1-1e21-476d-b0d0-92dd6cb9a2d4</iidm:alias>
                     <iidm:alias>_c94e6b68-da6c-43d1-94fd-09ad60c74134</iidm:alias>
                 </iidm:switch>
+                <!-- connect load with a switch instead of an internal connection to obtain proper list of lost equipment -->
+                <iidm:switch id="_047abdd7-c766-11e1-8775-005056c00008-BREAKER" name="BREAKER-Jay LD" kind="BREAKER" retained="true" open="false" node1="0" node2="8"/>
+
                 <iidm:internalConnection node1="7" node2="0"/>
-                <iidm:internalConnection node1="8" node2="0"/>
+
+                <!-- connect load with a switch instead of an internal connection to obtain proper list of lost equipment -->
+                <!-- <iidm:internalConnection node1="8" node2="0"/> -->
+
                 <iidm:internalConnection node1="9" node2="1"/>
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="4"/>
@@ -1296,6 +1302,12 @@ cas-1.1.3-data-4.0.3/SmallGrid/NodeBreaker/CGMES_v2.4.15_SmallGridTestConfigurat
                     <iidm:alias>_a0244ab3-80e5-4c20-b201-a142d50e6ec1</iidm:alias>
                     <iidm:alias>_8ef85f09-3622-4a12-87bf-fefcecc01e4a</iidm:alias>
                 </iidm:switch>
+
+                <!-- switches for twoWindingsTransformer 045e3525-1 that will be open-ended -->
+                <iidm:switch id="_dffdb415-95a8-496a-ad1a-93cdeb444fae-1" name="DISCONNECTOR723-1" kind="DISCONNECTOR" retained="false" open="false" node1="24" node2="25"/>
+                <iidm:switch id="_aa063f2e-1205-4d1a-a549-3ccc5b31e65d-1" name="BREAKER362-1" kind="BREAKER" retained="false" open="false" node1="23" node2="24"/>
+                <iidm:switch id="_28b3e895-483c-478d-a5a3-7b9d7c9e11f3-1" name="DISCONNECTOR724-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="23"/>
+
                 <iidm:internalConnection node1="7" node2="0"/>
                 <iidm:internalConnection node1="8" node2="0"/>
                 <iidm:internalConnection node1="9" node2="1"/>
@@ -1312,7 +1324,7 @@ cas-1.1.3-data-4.0.3/SmallGrid/NodeBreaker/CGMES_v2.4.15_SmallGridTestConfigurat
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="129.886963" angle="1.179708" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="129.886963" angle="1.179708" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="_044afb49-c766-11e1-8775-005056c00008" name="Hazard LD" loadType="UNDEFINED" p0="21.0" q0="10.0" node="8" p="21.0" q="10.0">
                 <iidm:alias>_045e5c31-c766-11e1-8775-005056c00008</iidm:alias>
@@ -1335,6 +1347,12 @@ cas-1.1.3-data-4.0.3/SmallGrid/NodeBreaker/CGMES_v2.4.15_SmallGridTestConfigurat
                     <iidm:alias>_2a61ce12-8d9c-4aae-8bc7-c8f820ecae6c</iidm:alias>
                     <iidm:alias>_a3d5e8cc-be34-4d4a-a586-ce582737826b</iidm:alias>
                 </iidm:switch>
+
+                <!-- switches for for twoWindingsTransformer 045e3525-1 that will be open-ended -->
+                <iidm:switch id="_83a05cd7-017e-4e7a-bc5e-a01ee9681f9f-1" name="DISCONNECTOR725-1" kind="DISCONNECTOR" retained="false" open="false" node1="14" node2="15"/>
+                <iidm:switch id="_cf4393c0-21c2-4e35-b330-c1acda2647ba-1" name="BREAKER363-1" kind="BREAKER" retained="false" open="true" node1="13" node2="14"/>
+                <iidm:switch id="_b9ab29b9-3d90-4536-8d1a-7757d8c22ae4-1" name="DISCONNECTOR726-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="13"/>
+
                 <iidm:internalConnection node1="4" node2="0"/>
                 <iidm:internalConnection node1="5" node2="0"/>
                 <iidm:internalConnection node1="6" node2="1"/>
@@ -1344,7 +1362,7 @@ cas-1.1.3-data-4.0.3/SmallGrid/NodeBreaker/CGMES_v2.4.15_SmallGridTestConfigurat
                 <iidm:internalConnection node1="10" node2="2"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="3"/>
-                <iidm:bus v="33.495" angle="1.4182179" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="33.495" angle="1.4182179" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15"/>
             </iidm:nodeBreakerTopology>
             <!--
             A generator in the original network is replaced by an Static Var Compensator,
@@ -1437,6 +1455,84 @@ cas-1.1.3-data-4.0.3/SmallGrid/NodeBreaker/CGMES_v2.4.15_SmallGridTestConfigurat
             <iidm:currentLimits2 permanentLimit="8747.0">
                 <iidm:temporaryLimit name="_1a7f23f9-e2c0-46a6-a93c-687f2209e33d" acceptableDuration="900" value="10059.0"/>
                 <iidm:temporaryLimit name="_257d56c1-d70a-4a96-b85c-d928ade03ad4" acceptableDuration="60" value="12246.0"/>
+            </iidm:currentLimits2>
+        </iidm:twoWindingsTransformer>
+
+        <!-- parallel TwoWindingsTransformer to 045e3525 that will be open-ended -->
+        <iidm:twoWindingsTransformer id="_045e3525-c766-11e1-8775-005056c00008-1" name="86-87-open-ended" r="0.3079691875" x="2.25858593125" g="0.0" b="-0.0040863184" ratedU1="132.0" ratedU2="33.0" node1="25" voltageLevelId1="_0484f70a-c766-11e1-8775-005056c00008" node2="15" voltageLevelId2="_04555b88-c766-11e1-8775-005056c00008">
+            <iidm:alias>_048c7110-c766-11e1-8775-005056c00008-1</iidm:alias>
+            <iidm:alias>_04682034-c766-11e1-8775-005056c00008-1</iidm:alias>
+            <iidm:alias>_0452755a-c766-11e1-8775-005056c00008-1</iidm:alias>
+            <iidm:ratioTapChanger lowTapPosition="1" tapPosition="31" loadTapChangingCapabilities="false">
+                <iidm:step r="-78.46097048774399" x="-78.46097048774399" g="364.2734712959033" b="364.2734712959033" rho="0.4641016"/>
+                <iidm:step r="-76.77098544465856" x="-76.77098544465856" g="330.4960925559595" b="330.4960925559595" rho="0.48196488000000004"/>
+                <iidm:step r="-75.01718104710143" x="-75.01718104710143" g="300.2750858041092" b="300.2750858041092" rho="0.49982816"/>
+                <iidm:step r="-73.19955729507262" x="-73.19955729507262" g="273.1281647135425" b="273.1281647135425" rho="0.5176914400000001"/>
+                <iidm:step r="-71.31811418857215" x="-71.31811418857215" g="248.65210975826625" b="248.65210975826625" rho="0.53555472"/>
+                <iidm:step r="-69.37285172760001" x="-69.37285172760001" g="226.5077084898438" b="226.5077084898438" rho="0.553418"/>
+                <iidm:step r="-67.36376991215616" x="-67.36376991215616" g="206.40793906293555" b="206.40793906293555" rho="0.57128128"/>
+                <iidm:step r="-65.29086874224063" x="-65.29086874224063" g="188.10862264852744" b="188.10862264852744" rho="0.58914456"/>
+                <iidm:step r="-63.15414821785343" x="-63.15414821785343" g="171.40097232995538" b="171.40097232995538" rho="0.6070078400000001"/>
+                <iidm:step r="-60.953608338994556" x="-60.953608338994556" g="156.1056111616768" b="156.1056111616768" rho="0.62487112"/>
+                <iidm:step r="-58.689249105664" x="-58.689249105664" g="142.0677374172608" b="142.0677374172608" rho="0.6427344"/>
+                <iidm:step r="-56.36107051786177" x="-56.36107051786177" g="129.1531923140571" b="129.1531923140571" rho="0.66059768"/>
+                <iidm:step r="-53.96907257558784" x="-53.96907257558784" g="117.24524269951107" b="117.24524269951107" rho="0.67846096"/>
+                <iidm:step r="-51.51325527884223" x="-51.51325527884223" g="106.24193390397649" b="106.24193390397649" rho="0.69632424"/>
+                <iidm:step r="-48.99361862762495" x="-48.99361862762495" g="96.05390013838502" b="96.05390013838502" rho="0.7141875200000001"/>
+                <iidm:step r="-46.410162621936" x="-46.410162621936" g="86.60254423711527" b="86.60254423711527" rho="0.7320508"/>
+                <iidm:step r="-43.762887261775354" x="-43.762887261775354" g="77.81851722275475" b="77.81851722275475" rho="0.7499140799999999"/>
+                <iidm:step r="-41.05179254714304" x="-41.05179254714304" g="69.64044255285229" b="69.64044255285229" rho="0.76777736"/>
+                <iidm:step r="-38.276878478039045" x="-38.276878478039045" g="62.01384106022605" b="62.01384106022605" rho="0.78564064"/>
+                <iidm:step r="-35.438145054463355" x="-35.438145054463355" g="54.89022129918419" b="54.89022129918419" rho="0.80350392"/>
+                <iidm:step r="-32.53559227641599" x="-32.53559227641599" g="48.2263068397802" b="48.2263068397802" rho="0.8213672000000001"/>
+                <iidm:step r="-29.569220143896956" x="-29.569220143896956" g="41.9833774442222" b="41.9833774442222" rho="0.83923048"/>
+                <iidm:step r="-26.53902865690624" x="-26.53902865690624" g="36.12670533984335" b="36.12670533984335" rho="0.85709376"/>
+                <iidm:step r="-23.445017815443848" x="-23.445017815443848" g="30.6250712186483" b="30.6250712186483" rho="0.8749570400000001"/>
+                <iidm:step r="-20.287187619509762" x="-20.287187619509762" g="25.45034733271443" b="25.45034733271443" rho="0.8928203200000001"/>
+                <iidm:step r="-17.06553806910399" x="-17.06553806910399" g="20.57713726209933" b="20.57713726209933" rho="0.9106836"/>
+                <iidm:step r="-13.780069164226571" x="-13.780069164226571" g="15.982463718828566" b="15.982463718828566" rho="0.92854688"/>
+                <iidm:step r="-10.430780904877434" x="-10.430780904877434" g="11.64549720345327" b="11.64549720345327" rho="0.94641016"/>
+                <iidm:step r="-7.017673291056637" x="-7.017673291056637" g="7.5473195169912355" b="7.5473195169912355" rho="0.96427344"/>
+                <iidm:step r="-3.5407463227641656" x="-3.5407463227641656" g="3.670717103630028" b="3.670717103630028" rho="0.9821367199999999"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
+                <iidm:step r="3.604565677235838" x="3.604565677235838" g="-3.479157171958336" b="-3.479157171958336" rho="1.01786328"/>
+                <iidm:step r="7.272950708943382" x="7.272950708943382" g="-6.779855183322592" b="-6.779855183322592" rho="1.03572656"/>
+                <iidm:step r="11.005155095122543" x="11.005155095122543" g="-9.914093706451743" b="-9.914093706451743" rho="1.0535898399999999"/>
+                <iidm:step r="14.801178835773431" x="14.801178835773431" g="-12.892880531259154" b="-12.892880531259154" rho="1.07145312"/>
+                <iidm:step r="18.661021930895984" x="18.661021930895984" g="-15.726328348801433" b="-15.726328348801433" rho="1.0893164"/>
+                <iidm:step r="22.584684380490238" x="22.584684380490238" g="-18.423740693731116" b="-18.423740693731116" rho="1.10717968"/>
+                <iidm:step r="26.572166184556178" x="26.572166184556178" g="-20.993688411566747" b="-20.993688411566747" rho="1.12504296"/>
+                <iidm:step r="30.62346734309378" x="30.62346734309378" g="-23.444077826121855" b="-23.444077826121855" rho="1.14290624"/>
+                <iidm:step r="34.73858785610307" x="34.73858785610307" g="-25.78221162092249" b="-25.78221162092249" rho="1.16076952"/>
+                <iidm:step r="38.91752772358399" x="38.91752772358399" g="-28.01484331122096" b="-28.01484331122096" rho="1.1786328"/>
+                <iidm:step r="43.16028694553664" x="43.16028694553664" g="-30.148226066322692" b="-30.148226066322692" rho="1.19649608"/>
+                <iidm:step r="47.466865521960955" x="47.466865521960955" g="-32.18815654211632" b="-32.18815654211632" rho="1.21435936"/>
+                <iidm:step r="51.83726345285697" x="51.83726345285697" g="-34.140014298236885" b="-34.140014298236885" rho="1.23222264"/>
+                <iidm:step r="56.27148073822465" x="56.27148073822465" g="-36.0087973009527" b="-36.0087973009527" rho="1.25008592"/>
+                <iidm:step r="60.76951737806397" x="60.76951737806397" g="-37.799153949787" b="-37.799153949787" rho="1.2679491999999999"/>
+                <iidm:step r="65.33137337237503" x="65.33137337237503" g="-39.51541201150582" b="-39.51541201150582" rho="1.28581248"/>
+                <iidm:step r="69.95704872115776" x="69.95704872115776" g="-41.161604798123854" b="-41.161604798123854" rho="1.30367576"/>
+                <iidm:step r="74.64654342441217" x="74.64654342441217" g="-42.74149488490709" b="-42.74149488490709" rho="1.32153904"/>
+                <iidm:step r="79.39985748213824" x="79.39985748213824" g="-44.25859562906487" b="-44.25859562906487" rho="1.33940232"/>
+                <iidm:step r="84.21699089433596" x="84.21699089433596" g="-45.716190719151165" b="-45.716190719151165" rho="1.3572655999999998"/>
+                <iidm:step r="89.09794366100547" x="89.09794366100547" g="-47.11735195848069" b="-47.11735195848069" rho="1.37512888"/>
+                <iidm:step r="94.04271578214653" x="94.04271578214653" g="-48.46495546255347" b="-48.46495546255347" rho="1.39299216"/>
+                <iidm:step r="99.05130725775935" x="99.05130725775935" g="-49.76169643010378" b="-49.76169643010378" rho="1.41085544"/>
+                <iidm:step r="104.12371808784383" x="104.12371808784383" g="-51.01010262954087" b="-51.01010262954087" rho="1.42871872"/>
+                <iidm:step r="109.25994827240002" x="109.25994827240002" g="-52.21254672689349" b="-52.21254672689349" rho="1.446582"/>
+                <iidm:step r="114.45999781142788" x="114.45999781142788" g="-53.371257567609966" b="-53.371257567609966" rho="1.46444528"/>
+                <iidm:step r="119.72386670492732" x="119.72386670492732" g="-54.48833051245521" b="-54.48833051245521" rho="1.4823085599999999"/>
+                <iidm:step r="125.05155495289854" x="125.05155495289854" g="-55.5657369170681" b="-55.5657369170681" rho="1.50017184"/>
+                <iidm:step r="130.44306255534144" x="130.44306255534144" g="-56.60533283531382" b="-56.60533283531382" rho="1.51803512"/>
+                <iidm:step r="135.898389512256" x="135.898389512256" g="-57.60886701822754" b="-57.60886701822754" rho="1.5358984"/>
+            </iidm:ratioTapChanger>
+            <iidm:currentLimits1 permanentLimit="2186.0">
+                <iidm:temporaryLimit name="_580d3b53-5508-4d8d-97cc-4ea463e0cdb9-1" acceptableDuration="900" value="2514.0"/>
+                <iidm:temporaryLimit name="_a867e68a-58d1-49cb-955f-bb8e59cf2a11-1" acceptableDuration="60" value="3061.0"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="8747.0">
+                <iidm:temporaryLimit name="_1a7f23f9-e2c0-46a6-a93c-687f2209e33d-1" acceptableDuration="900" value="10059.0"/>
+                <iidm:temporaryLimit name="_257d56c1-d70a-4a96-b85c-d928ade03ad4-1" acceptableDuration="60" value="12246.0"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
     </iidm:substation>
@@ -2815,6 +2911,12 @@ cas-1.1.3-data-4.0.3/SmallGrid/NodeBreaker/CGMES_v2.4.15_SmallGridTestConfigurat
                     <iidm:alias>_a4edf081-2fb2-4da4-94db-98a2a596247f</iidm:alias>
                     <iidm:alias>_7f359893-b7c5-41b0-ada8-8df06cf7a8e6</iidm:alias>
                 </iidm:switch>
+
+                <!-- switches for line 044c5ada...-1 that will be open-ended -->
+                <iidm:switch id="_312f25f3-55bc-4417-848c-236d31d823f4-1" name="DISCONNECTOR524-1" kind="DISCONNECTOR" retained="false" open="false" node1="24" node2="25"/>
+                <iidm:switch id="_686e884a-a0b1-454e-b7d1-33c7ad46f89f-1" name="BREAKER262-1" kind="BREAKER" retained="false" open="false" node1="23" node2="24"/>
+                <iidm:switch id="_346a5319-3ec2-40a2-aefd-38dfacbbe97c-1" name="DISCONNECTOR523-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="23"/>
+
                 <iidm:internalConnection node1="7" node2="0"/>
                 <iidm:internalConnection node1="8" node2="0"/>
                 <iidm:internalConnection node1="9" node2="1"/>
@@ -2831,7 +2933,7 @@ cas-1.1.3-data-4.0.3/SmallGrid/NodeBreaker/CGMES_v2.4.15_SmallGridTestConfigurat
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.114494" angle="-16.3455257" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.114494" angle="-16.3455257" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="_047a48a2-c766-11e1-8775-005056c00008" name="Mullin LD" loadType="UNDEFINED" p0="17.0" q0="7.0" node="8" p="17.0" q="7.0">
                 <iidm:alias>_0474553a-c766-11e1-8775-005056c00008</iidm:alias>
@@ -3965,6 +4067,12 @@ cas-1.1.3-data-4.0.3/SmallGrid/NodeBreaker/CGMES_v2.4.15_SmallGridTestConfigurat
                     <iidm:alias>_0b877750-4384-4ec3-bb38-08ee5ccf16d3</iidm:alias>
                     <iidm:alias>_1ed822d3-f3ab-4432-80f0-4c55ae3b4b78</iidm:alias>
                 </iidm:switch>
+
+                <!-- switches for line 044c5ada...-1 that will be open-ended -->
+                <iidm:switch id="_3be2355e-0065-43df-a264-57a295042faa-1" name="DISCONNECTOR526-1" kind="DISCONNECTOR" retained="false" open="false" node1="24" node2="25"/>
+                <iidm:switch id="_2463ff2c-7690-4dd6-bf44-039f9f475bb1-1" name="BREAKER263-1" kind="BREAKER" retained="false" open="true" node1="23" node2="24"/>
+                <iidm:switch id="_ddcf7aac-e7c3-45e9-bd81-6146e951addd-1" name="DISCONNECTOR525-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="23"/>
+
                 <iidm:internalConnection node1="7" node2="0"/>
                 <iidm:internalConnection node1="8" node2="0"/>
                 <iidm:internalConnection node1="9" node2="1"/>
@@ -3981,7 +4089,7 @@ cas-1.1.3-data-4.0.3/SmallGrid/NodeBreaker/CGMES_v2.4.15_SmallGridTestConfigurat
                 <iidm:internalConnection node1="20" node2="6"/>
                 <iidm:internalConnection node1="21" node2="3"/>
                 <iidm:internalConnection node1="22" node2="6"/>
-                <iidm:bus v="127.193932" angle="-17.3328686" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"/>
+                <iidm:bus v="127.193932" angle="-17.3328686" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="_047d7cf6-c766-11e1-8775-005056c00008" name="Grant LD" loadType="UNDEFINED" p0="24.0" q0="4.0" node="8" p="24.0" q="4.0">
                 <iidm:alias>_0481e9c0-c766-11e1-8775-005056c00008</iidm:alias>
@@ -4464,6 +4572,12 @@ cas-1.1.3-data-4.0.3/SmallGrid/NodeBreaker/CGMES_v2.4.15_SmallGridTestConfigurat
                     <iidm:alias>_2b636cdd-aa2f-4a65-92fc-12b4fc392e5f</iidm:alias>
                     <iidm:alias>_c96e50b9-ea15-4421-b6c8-bd9c9158a69a</iidm:alias>
                 </iidm:switch>
+
+                <!-- switches for new threeWindingsTransformer 086d83c7d...-1 end2 -->
+                <iidm:switch id="_e5318967-afcc-4fcc-b0de-d5f2522a95a6-1" name="DISCONNECTOR699-1" kind="DISCONNECTOR" retained="false" open="false" node1="43" node2="44"/>
+                <iidm:switch id="_e9f91b69-a29b-44ea-aa0f-cff86ee80320-1" name="BREAKER350-1" kind="BREAKER" retained="true" open="true" node1="42" node2="43"/>
+                <iidm:switch id="_ad86e83d-6334-4dd8-b642-b4c16d65329a-1" name="DISCONNECTOR700-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="42"/>
+
                 <iidm:internalConnection node1="13" node2="0"/>
                 <iidm:internalConnection node1="14" node2="1"/>
                 <iidm:internalConnection node1="15" node2="2"/>
@@ -4493,7 +4607,7 @@ cas-1.1.3-data-4.0.3/SmallGrid/NodeBreaker/CGMES_v2.4.15_SmallGridTestConfigurat
                 <iidm:internalConnection node1="39" node2="9"/>
                 <iidm:internalConnection node1="40" node2="12"/>
                 <iidm:internalConnection node1="41" node2="3"/>
-                <iidm:bus v="215.342422" angle="-11.185832" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41"/>
+                <iidm:bus v="215.342422" angle="-11.185832" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42"/>
             </iidm:nodeBreakerTopology>
         </iidm:voltageLevel>
         <iidm:voltageLevel id="_047bcf46-c766-11e1-8775-005056c00008" name="STN132KV" nominalV="132.0" topologyKind="NODE_BREAKER">
@@ -4573,6 +4687,12 @@ cas-1.1.3-data-4.0.3/SmallGrid/NodeBreaker/CGMES_v2.4.15_SmallGridTestConfigurat
                     <iidm:alias>_e9315b98-af75-40bb-bf8e-05bd03d43db5</iidm:alias>
                     <iidm:alias>_4aab41d6-d1b6-4dbe-a6aa-cb7ccd941912</iidm:alias>
                 </iidm:switch>
+
+                <!-- switches for new threeWindingsTransformer 086d83c7d...-1 end3 -->
+                <iidm:switch id="_b8b0b9a9-af8b-41d2-a4f8-940637e63f70-1" name="DISCONNECTOR701-1" kind="DISCONNECTOR" retained="false" open="false" node1="64" node2="65"/>
+                <iidm:switch id="_0b78ffaa-9859-4658-af17-c8d355633556-1" name="BREAKER351-1" kind="BREAKER" retained="true" open="false" node1="63" node2="64"/>
+                <iidm:switch id="_9dfeeaef-5c49-4c2c-97b1-03876970bee4-1" name="DISCONNECTOR702-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="63"/>
+
                 <iidm:internalConnection node1="19" node2="0"/>
                 <iidm:internalConnection node1="20" node2="0"/>
                 <iidm:internalConnection node1="21" node2="1"/>
@@ -4617,7 +4737,7 @@ cas-1.1.3-data-4.0.3/SmallGrid/NodeBreaker/CGMES_v2.4.15_SmallGridTestConfigurat
                 <iidm:internalConnection node1="60" node2="12"/>
                 <iidm:internalConnection node1="61" node2="15"/>
                 <iidm:internalConnection node1="62" node2="18"/>
-                <iidm:bus v="130.402969" angle="-16.17867" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62"/>
+                <iidm:bus v="130.402969" angle="-16.17867" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65"/>
             </iidm:nodeBreakerTopology>
             <iidm:load id="_045dbff4-c766-11e1-8775-005056c00008" name="Sorenson LD" loadType="UNDEFINED" p0="11.0" q0="3.0" node="20" p="11.0" q="3.0">
                 <iidm:alias>_044d4536-c766-11e1-8775-005056c00008</iidm:alias>
@@ -4640,6 +4760,12 @@ cas-1.1.3-data-4.0.3/SmallGrid/NodeBreaker/CGMES_v2.4.15_SmallGridTestConfigurat
                     <iidm:alias>_340082f1-db9c-446d-97df-80e45aa0058b</iidm:alias>
                     <iidm:alias>_90c04b95-703a-4bae-82b8-7edf3075aa24</iidm:alias>
                 </iidm:switch>
+
+                <!-- switches for new threeWindingsTransformer 086d83c7d...-1 end1 -->
+                <iidm:switch id="_4d08a684-cdcb-484a-a767-03b10f4ada7f-1" name="DISCONNECTOR735-1" kind="DISCONNECTOR" retained="false" open="false" node1="14" node2="15"/>
+                <iidm:switch id="_f468d841-1bf6-470e-85d4-55d34fab8bff-1" name="BREAKER368-1" kind="BREAKER" retained="true" open="false" node1="13" node2="14"/>
+                <iidm:switch id="_f193bd8f-badf-4600-82ac-f212d1f33534-1" name="DISCONNECTOR736-1" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="13"/>
+
                 <iidm:internalConnection node1="4" node2="0"/>
                 <iidm:internalConnection node1="5" node2="1"/>
                 <iidm:internalConnection node1="6" node2="2"/>
@@ -4649,7 +4775,7 @@ cas-1.1.3-data-4.0.3/SmallGrid/NodeBreaker/CGMES_v2.4.15_SmallGridTestConfigurat
                 <iidm:internalConnection node1="10" node2="3"/>
                 <iidm:internalConnection node1="11" node2="3"/>
                 <iidm:internalConnection node1="12" node2="0"/>
-                <iidm:bus v="382.187561" angle="-12.6222725" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12"/>
+                <iidm:bus v="382.187561" angle="-12.6222725" nodes="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15"/>
             </iidm:nodeBreakerTopology>
             <iidm:lccConverterStation id="_7393a68e-c4e6-48dd-9347-543858363fdb" name="Conv1" lossFactor="0.0" powerFactor="0.8" node="12" p="10.0" q="6.0">
                 <iidm:alias>_739658a7-e08b-4395-8d79-93e87b7855e3</iidm:alias>
@@ -4694,6 +4820,34 @@ cas-1.1.3-data-4.0.3/SmallGrid/NodeBreaker/CGMES_v2.4.15_SmallGridTestConfigurat
                 <iidm:temporaryLimit name="_611bb05e-9b9a-469c-b1d1-80a944c3ce2f" acceptableDuration="60" value="1400.0"/>
             </iidm:currentLimits2>
         </iidm:twoWindingsTransformer>
+
+        <!-- new threeWindingsTransformer 86d83c7d...-1 -->
+        <iidm:threeWindingsTransformer id="_86d83c7d-7826-4c16-b161-4ce17174e77f-1" name="T422" r1="-1.51999998092651" x1="23.2" g1="0.0" b1="0.0" ratedU1="400.0" r2="2.000000063052846" x2="19.999999999999996" g2="0.0" b2="0.0" ratedU2="220.0" r3="1.2000000564689806" x3="12.0" g3="0.0" b3="0.0" ratedU3="132.0" ratedU0="400.0" node1="15" voltageLevelId1="_3bbfa58a-a1ad-4b23-a526-3d76b096c1f4" node2="44" voltageLevelId2="_047b8123-c766-11e1-8775-005056c00008" node3="65" voltageLevelId3="_047bcf46-c766-11e1-8775-005056c00008">
+            <iidm:alias type="CGMES.Terminal2">_ae46e10e-1fbe-4139-b493-ed8e2844ee8d-1</iidm:alias>
+            <iidm:alias type="CGMES.Terminal3">_206474da-93c8-46b1-863f-9a308bfc2117-1</iidm:alias>
+            <iidm:alias type="CGMES.Terminal1">_9ac069ea-557b-4b8c-b12e-f9f2aecc3bf5-1</iidm:alias>
+            <iidm:alias type="CGMES.RatioTapChanger1">_1b2d419c-ac88-4dae-8dfe-2eb92d18c40a-1</iidm:alias>
+            <iidm:ratioTapChanger1 lowTapPosition="1" tapPosition="11" targetDeadband="0.0" loadTapChangingCapabilities="true" regulating="false" targetV="220.0">
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9523809523809523"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9638554216867469"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9756097560975611"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9876543209876544"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0126582278481011"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0256410256410258"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0389610389610389"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0526315789473684"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0666666666666667"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.081081081081081"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.095890410958904"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.1111111111111112"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.1267605633802817"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.1428571428571428"/>
+            </iidm:ratioTapChanger1>
+            <iidm:currentLimits1 permanentLimit="500.0">
+                <iidm:temporaryLimit name="_3fd18f6e-749a-4fa7-af1b-b0c2d3952638-1" acceptableDuration="1800" value="533.0"/>
+            </iidm:currentLimits1>
+        </iidm:threeWindingsTransformer>
     </iidm:substation>
     <iidm:substation id="_04642898-c766-11e1-8775-005056c00008" name="Rómenna" country="GB" geographicalTags="_0472a781-c766-11e1-8775-005056c00008">
         <iidm:voltageLevel id="_0457f394-c766-11e1-8775-005056c00008" name="RÓM132KV" nominalV="132.0" topologyKind="NODE_BREAKER">
@@ -10414,6 +10568,15 @@ cas-1.1.3-data-4.0.3/SmallGrid/NodeBreaker/CGMES_v2.4.15_SmallGridTestConfigurat
             <iidm:temporaryLimit name="_6748d0d0-aec8-4b7b-a9ab-be6aecda7c5d" acceptableDuration="60" value="1400.0"/>
         </iidm:currentLimits1>
     </iidm:line>
+
+    <!-- parallel line to 044c5ada that will be open-ended -->
+    <iidm:line id="_044c5ada-c766-11e1-8775-005056c00008-1" name="28-29-open-ended" r="4.129488" x="16.4308319" g1="0.0" b1="6.82966E-5" g2="0.0" b2="6.82966E-5" node1="25" voltageLevelId1="_04819ba0-c766-11e1-8775-005056c00008" node2="25" voltageLevelId2="_04588fd5-c766-11e1-8775-005056c00008">
+        <iidm:currentLimits1 permanentLimit="1000.0">
+            <iidm:temporaryLimit name="_accb8136-1faf-4399-9787-3cd567284fd2-1" acceptableDuration="900" value="1150.0"/>
+            <iidm:temporaryLimit name="_6748d0d0-aec8-4b7b-a9ab-be6aecda7c5d-1" acceptableDuration="60" value="1400.0"/>
+        </iidm:currentLimits1>
+    </iidm:line>
+
     <iidm:line id="_0468e382-c766-11e1-8775-005056c00008" name="3-5" r="4.199184" x="18.81792" g1="0.0" b1="8.14968E-5" g2="0.0" b2="8.14968E-5" node1="31" voltageLevelId1="_047eb579-c766-11e1-8775-005056c00008" node2="50" voltageLevelId2="_044be5a3-c766-11e1-8775-005056c00008">
         <iidm:alias>_046b0668-c766-11e1-8775-005056c00008</iidm:alias>
         <iidm:alias>_04742e24-c766-11e1-8775-005056c00008</iidm:alias>

--- a/tests/main_sa/res/contingencies_launch.json
+++ b/tests/main_sa/res/contingencies_launch.json
@@ -138,10 +138,37 @@
       ]
     },
     {
+      "id": "dangling_line_contingency_bad_id",
+      "elements": [
+        {
+          "id": "_XXX",
+          "type": "DANGLING_LINE"
+        }
+      ]
+    },
+    {
       "id": "line_contingency",
       "elements": [
         {
           "id": "_044cd006-c766-11e1-8775-005056c00008",
+          "type": "LINE"
+        }
+      ]
+    },
+    {
+      "id": "line_contingency_bad_id",
+      "elements": [
+        {
+          "id": "_XXX",
+          "type": "LINE"
+        }
+      ]
+    },
+    {
+      "id": "line_contingency_open_ended",
+      "elements": [
+        {
+          "id": "_044c5ada-c766-11e1-8775-005056c00008-1",
           "type": "LINE"
         }
       ]
@@ -165,6 +192,15 @@
       ]
     },
     {
+      "id": "two_windings_transformer_open_ended",
+      "elements": [
+        {
+          "id": "_045e3525-c766-11e1-8775-005056c00008-1",
+          "type": "TWO_WINDINGS_TRANSFORMER"
+        }
+      ]
+    },
+    {
       "id": "contingency_bad_type",
       "elements": [
         {
@@ -181,6 +217,16 @@
           "type" : "STATIC_VAR_COMPENSATOR"
         }
       ]
+    },
+    {
+      "id": "three_windings_transformer_contingency",
+      "elements": [
+          {
+            "id": "_86d83c7d-7826-4c16-b161-4ce17174e77f-1",
+            "type": "THREE_WINDINGS_TRANSFORMER"
+          }
+      ]
     }
   ]
 }
+


### PR DESCRIPTION
Closes #237.

These are changes made on top of #212, that provides the implementation for Security Analysis requested in #132.

Depends on #230 to avoid fictitious nodes to be considered for slack selection. Currently a workaround that checks the node identifier is used. There is a `FIXME` label for this in `Algo.cpp`.

Depends on #234 to validate and run contingencies on Static Var Compensators. Currently a part of the unit tests verification is commented in `scripts/diffContingencies.py` (`FIXME` label added). 

