### PR TITLE
#476 Tentative to disable the warning which requieres to use one argu…

### DIFF
--- a/cmake/Warnings.cmake
+++ b/cmake/Warnings.cmake
@@ -77,7 +77,7 @@ function(target_set_warnings)
         # Unless you'd like to support MSVC in the code with pragmas, this is probably the best option
         list(APPEND WarningFlags "/W4")
       elseif(WGCC)
-        list(APPEND WarningFlags "-Wall" "-Wextra" "-Wpedantic")
+        list(APPEND WarningFlags "-Wall" "-Wextra")
       elseif(WCLANG)
         list(APPEND WarningFlags "-Wall" "-Weverything" "-Wpedantic")
       endif()


### PR DESCRIPTION
…ment with DYN::Error macro by removing the -Wpedantic flag

**Checklist before requesting a review**

*use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes*

- [ ] unit tests and non regression tests were added (update of inputs, outputs, SA, algos)
- [ ] main documentation was updated (update of input/output file)
- [x] if this commit targets a release branch: the corresponding milestone was added in the ticket and in this PR
