### PR TITLE
#719 Clean error if input config file contains a setting file without an assembling file or contains an assembling file without a settting file

### DIFF
--- a/etc/Dictionaries/DFLError_en_GB.dic
+++ b/etc/Dictionaries/DFLError_en_GB.dic
@@ -11,7 +11,7 @@
 ErrorConfigFileRead           =     error while reading configuration file: %1%
 StartingPointModeDoesntExist  =     starting point mode %1% doesn't exist
 SettingFileWithoutAssemblingFile =  %1% contains a setting file but not an assembling file
-AssemblingFileWithoutSettingFile =  %1% contains a assembling file but not an setting file
+AssemblingFileWithoutSettingFile =  %1% contains an assembling file but not a setting file
 InvalidActivePowerCompensation =    parameter ActivePowerCompensation can't be set on P in flat starting point mode in the input config file : %1%
 ChosenOutputDoesntExist       =     chosen output %1% doesn't exist
 NoFlatStartingPointModeInSA   =     flat mode cannot be used in security analysis

--- a/etc/Dictionaries/DFLError_en_GB.dic
+++ b/etc/Dictionaries/DFLError_en_GB.dic
@@ -10,6 +10,8 @@
 //------------------ Inputs -------------------------
 ErrorConfigFileRead           =     error while reading configuration file: %1%
 StartingPointModeDoesntExist  =     starting point mode %1% doesn't exist
+SettingFileWithoutAssemblingFile =  %1% contains a setting file but not an assembling file
+AssemblingFileWithoutSettingFile =  %1% contains a assembling file but not an setting file
 InvalidActivePowerCompensation =    parameter ActivePowerCompensation can't be set on P in flat starting point mode in the input config file : %1%
 ChosenOutputDoesntExist       =     chosen output %1% doesn't exist
 NoFlatStartingPointModeInSA   =     flat mode cannot be used in security analysis

--- a/sources/Inputs/src/Configuration.cpp
+++ b/sources/Inputs/src/Configuration.cpp
@@ -222,6 +222,14 @@ Configuration::Configuration(const boost::filesystem::path &filepath, dfl::input
     throw Error(ErrorConfigFileRead, e.what());
   }
 
+  if (!settingFilePath_.empty() && assemblingFilePath_.empty()) {
+    throw Error(SettingFileWithoutAssemblingFile, filepath.generic_string());
+  }
+
+  if (!assemblingFilePath_.empty() && settingFilePath_.empty()) {
+    throw Error(AssemblingFileWithoutSettingFile, filepath.generic_string());
+  }
+
   if (startingPointMode_ == Configuration::StartingPointMode::FLAT && activePowerCompensation_ == Configuration::ActivePowerCompensation::P) {
     throw Error(InvalidActivePowerCompensation, filepath.generic_string());
   }

--- a/tests/inputs/TestConfig.cpp
+++ b/tests/inputs/TestConfig.cpp
@@ -21,6 +21,10 @@ using DYN::doubleEquals;
 TEST(Config, Incorrect) {
   ASSERT_THROW_DYNAWO(dfl::inputs::Configuration config("res/incorrect_config.json"), DYN::Error::GENERAL, dfl::KeyError_t::ErrorConfigFileRead);
   ASSERT_THROW_DYNAWO(dfl::inputs::Configuration config("res/incorrect_config_2.json"), DYN::Error::GENERAL, dfl::KeyError_t::ErrorConfigFileRead);
+  ASSERT_THROW_DYNAWO(dfl::inputs::Configuration config("res/config_setting_file_without_assembling_file.json"), DYN::Error::GENERAL,
+                      dfl::KeyError_t::SettingFileWithoutAssemblingFile);
+  ASSERT_THROW_DYNAWO(dfl::inputs::Configuration config("res/config_assembling_file_without_setting_file.json"), DYN::Error::GENERAL,
+                      dfl::KeyError_t::AssemblingFileWithoutSettingFile);
   ASSERT_THROW_DYNAWO(dfl::inputs::Configuration config("res/config_flat_activepowercompensation_p.json"), DYN::Error::GENERAL,
                       dfl::KeyError_t::InvalidActivePowerCompensation);
 }

--- a/tests/inputs/res/config_assembling_file_without_setting_file.json
+++ b/tests/inputs/res/config_assembling_file_without_setting_file.json
@@ -1,0 +1,6 @@
+{
+  "dfl-config": {
+    "OutputDir": "resultsTestsTmp",
+    "AssemblingPath": "assembling.xml"
+  }
+}

--- a/tests/inputs/res/config_setting_file_without_assembling_file.json
+++ b/tests/inputs/res/config_setting_file_without_assembling_file.json
@@ -1,0 +1,6 @@
+{
+  "dfl-config": {
+    "OutputDir": "resultsTestsTmp",
+    "SettingPath": "setting.xml"
+  }
+}


### PR DESCRIPTION
… an assembling file or contains an assembling file without a settting file

**Checklist before requesting a review**

*use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes*

- [x] unit tests and non regression tests were added (update of inputs, outputs, SA, algos)
- [ ] main documentation was updated (update of input/output file)
- [x] the corresponding milestone was added in the ticket and in this PR
