### PR TITLE
#769 Execute sanity checks on the Configuration class after log initialization to log any potential errors in the configuration

### DIFF
--- a/sources/Inputs/include/Configuration.h
+++ b/sources/Inputs/include/Configuration.h
@@ -48,6 +48,16 @@ class Configuration {
    */
   explicit Configuration(const boost::filesystem::path &filepath,
                          dfl::inputs::Configuration::SimulationKind simulationKind = dfl::inputs::Configuration::SimulationKind::STEADY_STATE_CALCULATION);
+
+  /**
+   * @brief performs sanity checks on the configuration
+   * 
+   * @attention This method should be called after the constructor to verify that the configuration is properly set up.
+   * 
+   * @attention The sanity checks should be executed after log initialization to ensure that any potential errors in the configuration are logged appropriately.
+   */
+  void sanityCheck() const;
+
   /**
    * @brief determines if we use infinite reactive limits
    *
@@ -272,9 +282,12 @@ class Configuration {
    * @param simulationKind simulation kind of the simulation
    * @param saMode true if simulation is in SA, false otherwise
    */
-  void updateChosenOutput(const boost::property_tree::ptree &tree, dfl::inputs::Configuration::SimulationKind simulationKind, const bool saMode);
+  void updateChosenOutput(const boost::property_tree::ptree &tree, SimulationKind simulationKind, const bool saMode);
 
  private:
+  boost::filesystem::path filepath_;                                                 ///< the configuration file path
+  SimulationKind simulationKind_;                                                    ///< the simulation kind (Steady state or Security analysis)
+
   // General
   StartingPointMode startingPointMode_ = StartingPointMode::WARM;                    ///< simulation starting point mode
   bool useInfiniteReactiveLimits_ = false;                                           ///< infinite reactive limits

--- a/sources/main.cpp
+++ b/sources/main.cpp
@@ -173,6 +173,11 @@ int main(int argc, char *argv[]) {
     try {
       if (mpiContext.isRootProc()) {
         dfl::common::Log::init(options, outputDir.generic_string());
+
+        // IMPORTANT: Call inputs::Configuration::sanityCheck() after the constructor to ensure configuration is correct.
+        // Sanity checks are performed after log initialization so that any potential errors in the configuration can be logged.
+        configN.sanityCheck();
+
         DYN::Trace::info(dfl::common::Log::getTag()) << " ============================================================ " << DYN::Trace::endline;
         DYN::Trace::info(dfl::common::Log::getTag()) << " " << runtimeConfig.programName << " v" << DYNAFLOW_LAUNCHER_VERSION_STRING << DYN::Trace::endline;
         DYN::Trace::info(dfl::common::Log::getTag()) << " "
@@ -270,6 +275,8 @@ int main(int argc, char *argv[]) {
 
     if (userRequest == dfl::common::Options::Request::RUN_SIMULATION_SA || userRequest == dfl::common::Options::Request::RUN_SIMULATION_NSA) {
       dfl::inputs::Configuration configSA(configPath, dfl::inputs::Configuration::SimulationKind::SECURITY_ANALYSIS);
+      // IMPORTANT: Call inputs::Configuration::sanityCheck() after the constructor to ensure configuration is correct.
+      configSA.sanityCheck();
       if (configSA.getStartingPointMode() == dfl::inputs::Configuration::StartingPointMode::FLAT) {
         if (userRequest == dfl::common::Options::Request::RUN_SIMULATION_NSA)
           configSA.setStartingPointMode(dfl::inputs::Configuration::StartingPointMode::WARM);  // In NSA starting point mode for SA is forced to warm

--- a/tests/inputs/TestConfig.cpp
+++ b/tests/inputs/TestConfig.cpp
@@ -21,12 +21,22 @@ using DYN::doubleEquals;
 TEST(Config, Incorrect) {
   ASSERT_THROW_DYNAWO(dfl::inputs::Configuration config("res/incorrect_config.json"), DYN::Error::GENERAL, dfl::KeyError_t::ErrorConfigFileRead);
   ASSERT_THROW_DYNAWO(dfl::inputs::Configuration config("res/incorrect_config_2.json"), DYN::Error::GENERAL, dfl::KeyError_t::ErrorConfigFileRead);
-  ASSERT_THROW_DYNAWO(dfl::inputs::Configuration config("res/config_setting_file_without_assembling_file.json"), DYN::Error::GENERAL,
-                      dfl::KeyError_t::SettingFileWithoutAssemblingFile);
-  ASSERT_THROW_DYNAWO(dfl::inputs::Configuration config("res/config_assembling_file_without_setting_file.json"), DYN::Error::GENERAL,
-                      dfl::KeyError_t::AssemblingFileWithoutSettingFile);
-  ASSERT_THROW_DYNAWO(dfl::inputs::Configuration config("res/config_flat_activepowercompensation_p.json"), DYN::Error::GENERAL,
-                      dfl::KeyError_t::InvalidActivePowerCompensation);
+
+  dfl::inputs::Configuration config1("res/config_setting_file_without_assembling_file.json");
+  ASSERT_THROW_DYNAWO(config1.sanityCheck(), DYN::Error::GENERAL, dfl::KeyError_t::SettingFileWithoutAssemblingFile);
+
+  dfl::inputs::Configuration config2("res/config_assembling_file_without_setting_file.json");
+  ASSERT_THROW_DYNAWO(config2.sanityCheck(), DYN::Error::GENERAL, dfl::KeyError_t::AssemblingFileWithoutSettingFile);
+
+  dfl::inputs::Configuration config3("res/config_flat_activepowercompensation_p.json");
+  ASSERT_THROW_DYNAWO(config3.sanityCheck(), DYN::Error::GENERAL, dfl::KeyError_t::InvalidActivePowerCompensation);
+
+  std::string configFile = "res/config_SA_dumpState.json";
+  dfl::inputs::Configuration config4(configFile, dfl::inputs::Configuration::SimulationKind::STEADY_STATE_CALCULATION);
+  ASSERT_NO_THROW(config4.sanityCheck());
+
+  dfl::inputs::Configuration config5(configFile, dfl::inputs::Configuration::SimulationKind::SECURITY_ANALYSIS);
+  ASSERT_THROW_DYNAWO(config5.sanityCheck(), DYN::Error::GENERAL, dfl::KeyError_t::StartingDumpFileNotFound);
 }
 
 TEST(Config, CaseInsensitive) {
@@ -179,13 +189,6 @@ TEST(Config, ConfigSA) {
     ASSERT_TRUE(config.isChosenOutput(dfl::inputs::Configuration::ChosenOutputEnum::LOSTEQ));
 #endif
   }
-}
-
-TEST(Config, ConfigSAWrongDumpState) {
-  std::string configFile = "res/config_SA_dumpState.json";
-  ASSERT_NO_THROW(dfl::inputs::Configuration config(configFile, dfl::inputs::Configuration::SimulationKind::STEADY_STATE_CALCULATION));
-  ASSERT_THROW_DYNAWO(dfl::inputs::Configuration config2(configFile, dfl::inputs::Configuration::SimulationKind::SECURITY_ANALYSIS), DYN::Error::GENERAL,
-                      dfl::KeyError_t::ErrorConfigFileRead);
 }
 
 TEST(Config, ChosenOutputTest) {


### PR DESCRIPTION
**Checklist before requesting a review**

*use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes*

- [ ] unit tests and non regression tests were added (update of inputs, outputs, SA, algos)
- [ ] main documentation was updated (update of input/output file)
- [x] the corresponding milestone was added in the ticket and in this PR
