### PR TITLE
#873 Allow defining an initial dump state in N

### DIFF
--- a/documentation/configuringDynaflowLauncher/DynaflowLaunchersInputFiles.tex
+++ b/documentation/configuringDynaflowLauncher/DynaflowLaunchersInputFiles.tex
@@ -174,6 +174,8 @@ The parameters are described below:
 \small{AssemblingPath} & \small{string} & \small{Path to assembling file (see \ref{DFL_Dyn_Models})} & \small{None} \\
 \rowcolor{white}
 \small{SettingPath} & \small{string} & \small{Path to setting file (see \ref{DFL_Dyn_Models})} & \small{None} \\
+\rowcolor{gray!10}
+\small{StartingDumpFile} & \small{string} & \small{Path to a \Dynawo dump file} & \small{None} \\
 \bottomrule
 \end{tabular}
 \caption{Simulation parameters}
@@ -209,8 +211,6 @@ The systematic analysis parameters are described below:
 \midrule
 \rowcolor{white}
 TimeOfEvent & integer & Time when the contingency occurs & 10 \\
-\rowcolor{gray!10}
-StartingDumpFile & string & Path to a \Dynawo dump file &  \\
 \bottomrule
 \end{tabular}
 \caption{Systematic Analysis parameters}

--- a/sources/Inputs/src/Configuration.cpp
+++ b/sources/Inputs/src/Configuration.cpp
@@ -211,9 +211,9 @@ Configuration::Configuration(const boost::filesystem::path &filepath, Simulation
     helper::updateValue(minTimeStep_, config, "MinTimeStep", saMode, parameterValueModified_);
     helper::updateValue(tfoVoltageLevel_, config, "TfoVoltageLevel", saMode, parameterValueModified_);
     helper::updateActivePowerCompensationValue(activePowerCompensation_, config, saMode, parameterValueModified_);
+    helper::updatePathValue(startingDumpFilePath_, config, "StartingDumpFile", prefixConfigFile, true);
     if (simulationKind_ == dfl::inputs::Configuration::SimulationKind::SECURITY_ANALYSIS) {
       helper::updateValue(timeOfEvent_, config, "TimeOfEvent", true, parameterValueModified_);
-      helper::updatePathValue(startingDumpFilePath_, config, "StartingDumpFile", prefixConfigFile, true);
     }
   } catch (std::exception &e) {
     throw Error(ErrorConfigFileRead, e.what());


### PR DESCRIPTION
**Checklist before requesting a review**

*use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes*

- [ ] unit tests and non regression tests were added (update of inputs, outputs, SA, algos)
- [ ] main documentation was updated (update of input/output file)
- [ ] the corresponding milestone was added in the ticket and in this PR
