### PR TITLE
#913 fix generation of connexions and parameters when remote voltage

### DIFF
--- a/sources/Algo/include/SVarCDefinitionAlgorithm.h
+++ b/sources/Algo/include/SVarCDefinitionAlgorithm.h
@@ -60,31 +60,31 @@ class StaticVarCompensatorDefinition {
    * @param b0 the initial susceptance value  of the SVarC
    * @param slope the slope (kV/MVar) of the SVarC voltage regulation
    * @param UNomRemote the nominal voltage of the remotely regulated bus
+   * @param regulatedBusId id of the regulated bus
    */
-  StaticVarCompensatorDefinition(const inputs::StaticVarCompensator::SVarCid& sVarCId, ModelType modelType, const double bMin, const double bMax,
+  StaticVarCompensatorDefinition(const inputs::StaticVarCompensator::SVarCid &sVarCId, ModelType modelType, const double bMin, const double bMax,
                                  const double voltageSetPoint, const double UNom, const double UMinActivation, const double UMaxActivation,
-                                 const double USetPointMin, const double USetPointMax, const double b0, const double slope, const double UNomRemote) :
-      id{sVarCId},
-      model{modelType},
-      bMin{bMin},
-      bMax{bMax},
-      voltageSetPoint{voltageSetPoint},
-      UNom{UNom},
-      UMinActivation{UMinActivation},
-      UMaxActivation{UMaxActivation},
-      USetPointMin{USetPointMin},
-      USetPointMax{USetPointMax},
-      b0{b0},
-      slope{slope},
-      UNomRemote{UNomRemote} {}
+                                 const double USetPointMin, const double USetPointMax, const double b0, const double slope, const double UNomRemote,
+                                 const std::string &regulatedBusId = "")
+      : id{sVarCId}, model{modelType}, bMin{bMin}, bMax{bMax}, voltageSetPoint{voltageSetPoint}, UNom{UNom}, UMinActivation{UMinActivation},
+        UMaxActivation{UMaxActivation}, USetPointMin{USetPointMin}, USetPointMax{USetPointMax}, b0{b0}, slope{slope}, UNomRemote{UNomRemote},
+        regulatedBusId{regulatedBusId} {}
 
   /**
    * @brief determines if the SVarC model type is network
    *
    * @return true when model type is network
    */
-  bool isNetwork() const {
-    return model == ModelType::NETWORK;
+  bool isNetwork() const { return model == ModelType::NETWORK; }
+
+  /**
+   * @brief determines if the SVarC has a remote regulation
+   *
+   * @return true when model type has a remote regulation
+   */
+  bool isRemoteRegulation() const {
+    return model == ModelType::SVARCPVREMOTE || model == ModelType::SVARCPVREMOTEMODEHANDLING || model == ModelType::SVARCPVPROPREMOTE ||
+           model == ModelType::SVARCPVPROPREMOTEMODEHANDLING;
   }
 
   inputs::StaticVarCompensator::SVarCid id;  ///< the id of the SVarC
@@ -100,6 +100,7 @@ class StaticVarCompensatorDefinition {
   const double b0;                           ///< the initial susceptance value of the SVarC
   const double slope;                        ///< the slope (kV/MVar) of the SVarC voltage regulation
   const double UNomRemote;                   ///< the nominal voltage of the remotely regulated bus
+  const std::string regulatedBusId;          ///< The bus id regulated by this sVarC
 };
 
 /// @brief Static var compensator algorithm
@@ -112,7 +113,7 @@ class StaticVarCompensatorAlgorithm {
    * @brief Constructor
    * @param svarcs the list of SVarCs to update
    */
-  explicit StaticVarCompensatorAlgorithm(SVarCDefinitions& svarcs);
+  explicit StaticVarCompensatorAlgorithm(SVarCDefinitions &svarcs);
 
   /**
    * @brief Perform algorithm
@@ -120,10 +121,10 @@ class StaticVarCompensatorAlgorithm {
    * @param node the node to process
    * @param algoRes pointer to algorithms results class
    */
-  void operator()(const NodePtr& node, std::shared_ptr<AlgorithmsResults>& algoRes);
+  void operator()(const NodePtr &node, std::shared_ptr<AlgorithmsResults> &algoRes);
 
  private:
-  SVarCDefinitions& svarcs_;  ///< the list of SVarCs to update
+  SVarCDefinitions &svarcs_;  ///< the list of SVarCs to update
 };
 }  // namespace algo
 }  // namespace dfl

--- a/sources/Algo/src/SVarCDefinitionAlgorithm.cpp
+++ b/sources/Algo/src/SVarCDefinitionAlgorithm.cpp
@@ -15,12 +15,11 @@
 namespace dfl {
 namespace algo {
 
-StaticVarCompensatorAlgorithm::StaticVarCompensatorAlgorithm(SVarCDefinitions& svarcs) : svarcs_(svarcs) {}
+StaticVarCompensatorAlgorithm::StaticVarCompensatorAlgorithm(SVarCDefinitions &svarcs) : svarcs_(svarcs) {}
 
-void
-StaticVarCompensatorAlgorithm::operator()(const NodePtr& node, std::shared_ptr<AlgorithmsResults>&) {
-  const auto& svarcs = node->svarcs;
-  for (const auto& svarc : svarcs) {
+void StaticVarCompensatorAlgorithm::operator()(const NodePtr &node, std::shared_ptr<AlgorithmsResults> &) {
+  const auto &svarcs = node->svarcs;
+  for (const auto &svarc : svarcs) {
     ModelType model = ModelType::NETWORK;
     if (svarc.isRegulatingVoltage) {
       model = ModelType::SVARCPV;
@@ -38,7 +37,7 @@ StaticVarCompensatorAlgorithm::operator()(const NodePtr& node, std::shared_ptr<A
       }
     }
     svarcs_.emplace_back(svarc.id, model, svarc.bMin, svarc.bMax, svarc.voltageSetPoint, svarc.UNom, svarc.UMinActivation, svarc.UMaxActivation,
-                         svarc.USetPointMin, svarc.USetPointMax, svarc.b0, svarc.slope, svarc.UNomRemote);
+                         svarc.USetPointMin, svarc.USetPointMax, svarc.b0, svarc.slope, svarc.UNomRemote, svarc.regulatedBusId);
   }
 }
 

--- a/sources/Outputs/src/DydSVarC.cpp
+++ b/sources/Outputs/src/DydSVarC.cpp
@@ -31,9 +31,8 @@ const std::unordered_map<algo::StaticVarCompensatorDefinition::ModelType, std::s
     std::make_pair(algo::StaticVarCompensatorDefinition::ModelType::SVARCPVREMOTE, "StaticVarCompensatorPVRemote"),
     std::make_pair(algo::StaticVarCompensatorDefinition::ModelType::SVARCPVREMOTEMODEHANDLING, "StaticVarCompensatorPVRemoteModeHandling")};
 
-void
-DydSVarC::write(boost::shared_ptr<dynamicdata::DynamicModelsCollection>& dynamicModelsToConnect, const std::string& basename) {
-  for (const auto& svarc : svarcsDefinitions_) {
+void DydSVarC::write(boost::shared_ptr<dynamicdata::DynamicModelsCollection> &dynamicModelsToConnect, const std::string &basename) {
+  for (const auto &svarc : svarcsDefinitions_) {
     if (svarc.isNetwork()) {
       continue;
     }
@@ -51,17 +50,26 @@ DydSVarC::write(boost::shared_ptr<dynamicdata::DynamicModelsCollection>& dynamic
     default:
       break;
     }
-    std::unique_ptr<dynamicdata::MacroConnect>
-        sVarCMacroConnectRef = dynamicdata::MacroConnectFactory::newMacroConnect(macroConnectorSVarCName_, svarc.id, constants::networkModelName);
+    std::unique_ptr<dynamicdata::MacroConnect> sVarCMacroConnectRef =
+        dynamicdata::MacroConnectFactory::newMacroConnect(macroConnectorSVarCName_, svarc.id, constants::networkModelName);
     dynamicModelsToConnect->addModel(std::move(blackBoxModel));
     dynamicModelsToConnect->addMacroConnect(std::move(sVarCMacroConnectRef));
+    switch (svarc.model) {
+    case algo::StaticVarCompensatorDefinition::ModelType::SVARCPVPROPREMOTE:
+    case algo::StaticVarCompensatorDefinition::ModelType::SVARCPVPROPREMOTEMODEHANDLING:
+    case algo::StaticVarCompensatorDefinition::ModelType::SVARCPVREMOTE:
+    case algo::StaticVarCompensatorDefinition::ModelType::SVARCPVREMOTEMODEHANDLING:
+      dynamicModelsToConnect->addConnect(svarc.id, "SVarC_URegulatedPu", "NETWORK", svarc.regulatedBusId + "_Upu_value");
+      break;
+    default:
+      break;
+    }
   }
   writeMacroConnector(dynamicModelsToConnect);
   writeMacroStaticReference(dynamicModelsToConnect);
 }
 
-void
-DydSVarC::writeMacroConnector(boost::shared_ptr<dynamicdata::DynamicModelsCollection>& dynamicModelsToConnect) {
+void DydSVarC::writeMacroConnector(boost::shared_ptr<dynamicdata::DynamicModelsCollection> &dynamicModelsToConnect) {
   if (!svarcsDefinitions_.empty()) {
     std::unique_ptr<dynamicdata::MacroConnector> connector = dynamicdata::MacroConnectorFactory::newMacroConnector(macroConnectorSVarCName_);
     connector->addConnect("SVarC_terminal", "@STATIC_ID@@NODE@_ACPIN");
@@ -69,8 +77,7 @@ DydSVarC::writeMacroConnector(boost::shared_ptr<dynamicdata::DynamicModelsCollec
   }
 }
 
-void
-DydSVarC::writeMacroStaticReference(boost::shared_ptr<dynamicdata::DynamicModelsCollection>& dynamicModelsToConnect) {
+void DydSVarC::writeMacroStaticReference(boost::shared_ptr<dynamicdata::DynamicModelsCollection> &dynamicModelsToConnect) {
   if (!svarcsDefinitions_.empty()) {
     std::unique_ptr<dynamicdata::MacroStaticReference> macroStaticReference =
         dynamicdata::MacroStaticReferenceFactory::newMacroStaticReference(macroStaticRefSVarCName_);

--- a/tests/outputs/reference/TestDydSVarC/TestDydSVarC.dyd
+++ b/tests/outputs/reference/TestDydSVarC/TestDydSVarC.dyd
@@ -44,4 +44,8 @@
   <dyn:macroConnect connector="StaticVarCompensatorMacroConnector" id1="SVARC5" id2="NETWORK"/>
   <dyn:macroConnect connector="StaticVarCompensatorMacroConnector" id1="SVARC6" id2="NETWORK"/>
   <dyn:macroConnect connector="StaticVarCompensatorMacroConnector" id1="SVARC7" id2="NETWORK"/>
+  <dyn:connect id1="SVARC4" var1="SVarC_URegulatedPu" id2="NETWORK" var2="_Upu_value"/>
+  <dyn:connect id1="SVARC5" var1="SVarC_URegulatedPu" id2="NETWORK" var2="_Upu_value"/>
+  <dyn:connect id1="SVARC6" var1="SVarC_URegulatedPu" id2="NETWORK" var2="_Upu_value"/>
+  <dyn:connect id1="SVARC7" var1="SVarC_URegulatedPu" id2="NETWORK" var2="_Upu_value"/>
 </dyn:dynamicModelsArchitecture>

--- a/tests/outputs/reference/TestParSVarC/TestParSVarC.par
+++ b/tests/outputs/reference/TestParSVarC/TestParSVarC.par
@@ -26,10 +26,10 @@
     <par name="SVarC_BMaxPu" type="DOUBLE" value="5290"/>
     <par name="SVarC_BMinPu" type="DOUBLE" value="0"/>
     <par name="SVarC_BShuntPu" type="DOUBLE" value="0"/>
-    <par name="SVarC_LambdaPu" type="DOUBLE" value="4.3478260869565215"/>
+    <par name="SVarC_LambdaPu" type="DOUBLE" value="100"/>
     <par name="SVarC_UNom" type="DOUBLE" value="230"/>
     <par name="SVarC_UNomRemote" type="DOUBLE" value="10"/>
-    <par name="SVarC_URef0Pu" type="DOUBLE" value="0.43478260869565216"/>
+    <par name="SVarC_URef0Pu" type="DOUBLE" value="10"/>
     <macroParSet id="MacroParameterSetStaticCompensator"/>
   </set>
   <set id="3ec41c13-b32e-549c-b6b0-e05a368810d6">
@@ -38,7 +38,7 @@
     <par name="SVarC_BShuntPu" type="DOUBLE" value="0"/>
     <par name="SVarC_UNom" type="DOUBLE" value="230"/>
     <par name="SVarC_UNomRemote" type="DOUBLE" value="10"/>
-    <par name="SVarC_URef0Pu" type="DOUBLE" value="0.43478260869565216"/>
+    <par name="SVarC_URef0Pu" type="DOUBLE" value="10"/>
     <macroParSet id="MacroParameterSetStaticCompensator"/>
   </set>
   <set id="5af224bc-7a03-5bcd-af4e-25de959b69f6">
@@ -68,10 +68,10 @@
     <par name="SVarC_BMaxPu" type="DOUBLE" value="5290"/>
     <par name="SVarC_BMinPu" type="DOUBLE" value="0"/>
     <par name="SVarC_BShuntPu" type="DOUBLE" value="0"/>
-    <par name="SVarC_LambdaPu" type="DOUBLE" value="4.3478260869565215"/>
+    <par name="SVarC_LambdaPu" type="DOUBLE" value="100"/>
     <par name="SVarC_UNom" type="DOUBLE" value="230"/>
     <par name="SVarC_UNomRemote" type="DOUBLE" value="10"/>
-    <par name="SVarC_URef0Pu" type="DOUBLE" value="0.43478260869565216"/>
+    <par name="SVarC_URef0Pu" type="DOUBLE" value="10"/>
     <par name="SVarC_URefDown" type="DOUBLE" value="235"/>
     <par name="SVarC_URefUp" type="DOUBLE" value="245"/>
     <par name="SVarC_UThresholdDown" type="DOUBLE" value="215"/>
@@ -96,7 +96,7 @@
     <par name="SVarC_BShuntPu" type="DOUBLE" value="0"/>
     <par name="SVarC_UNom" type="DOUBLE" value="230"/>
     <par name="SVarC_UNomRemote" type="DOUBLE" value="10"/>
-    <par name="SVarC_URef0Pu" type="DOUBLE" value="0.43478260869565216"/>
+    <par name="SVarC_URef0Pu" type="DOUBLE" value="10"/>
     <par name="SVarC_URefDown" type="DOUBLE" value="235"/>
     <par name="SVarC_URefUp" type="DOUBLE" value="245"/>
     <par name="SVarC_UThresholdDown" type="DOUBLE" value="215"/>

--- a/tests/outputs/reference/TestStartingPointMode/TestStartingPointModeFlatNoIRL.par
+++ b/tests/outputs/reference/TestStartingPointMode/TestStartingPointModeFlatNoIRL.par
@@ -63,10 +63,10 @@
     <par name="SVarC_BMaxPu" type="DOUBLE" value="5290"/>
     <par name="SVarC_BMinPu" type="DOUBLE" value="0"/>
     <par name="SVarC_BShuntPu" type="DOUBLE" value="0"/>
-    <par name="SVarC_LambdaPu" type="DOUBLE" value="4.3478260869565215"/>
+    <par name="SVarC_LambdaPu" type="DOUBLE" value="100"/>
     <par name="SVarC_UNom" type="DOUBLE" value="230"/>
     <par name="SVarC_UNomRemote" type="DOUBLE" value="10"/>
-    <par name="SVarC_URef0Pu" type="DOUBLE" value="0.43478260869565216"/>
+    <par name="SVarC_URef0Pu" type="DOUBLE" value="10"/>
     <macroParSet id="MacroParameterSetStaticCompensator"/>
   </set>
   <set id="3ec41c13-b32e-549c-b6b0-e05a368810d6">
@@ -75,7 +75,7 @@
     <par name="SVarC_BShuntPu" type="DOUBLE" value="0"/>
     <par name="SVarC_UNom" type="DOUBLE" value="230"/>
     <par name="SVarC_UNomRemote" type="DOUBLE" value="10"/>
-    <par name="SVarC_URef0Pu" type="DOUBLE" value="0.43478260869565216"/>
+    <par name="SVarC_URef0Pu" type="DOUBLE" value="10"/>
     <macroParSet id="MacroParameterSetStaticCompensator"/>
   </set>
   <set id="5af224bc-7a03-5bcd-af4e-25de959b69f6">
@@ -346,10 +346,10 @@
     <par name="SVarC_BMaxPu" type="DOUBLE" value="5290"/>
     <par name="SVarC_BMinPu" type="DOUBLE" value="0"/>
     <par name="SVarC_BShuntPu" type="DOUBLE" value="0"/>
-    <par name="SVarC_LambdaPu" type="DOUBLE" value="4.3478260869565215"/>
+    <par name="SVarC_LambdaPu" type="DOUBLE" value="100"/>
     <par name="SVarC_UNom" type="DOUBLE" value="230"/>
     <par name="SVarC_UNomRemote" type="DOUBLE" value="10"/>
-    <par name="SVarC_URef0Pu" type="DOUBLE" value="0.43478260869565216"/>
+    <par name="SVarC_URef0Pu" type="DOUBLE" value="10"/>
     <par name="SVarC_URefDown" type="DOUBLE" value="235"/>
     <par name="SVarC_URefUp" type="DOUBLE" value="245"/>
     <par name="SVarC_UThresholdDown" type="DOUBLE" value="215"/>
@@ -374,7 +374,7 @@
     <par name="SVarC_BShuntPu" type="DOUBLE" value="0"/>
     <par name="SVarC_UNom" type="DOUBLE" value="230"/>
     <par name="SVarC_UNomRemote" type="DOUBLE" value="10"/>
-    <par name="SVarC_URef0Pu" type="DOUBLE" value="0.43478260869565216"/>
+    <par name="SVarC_URef0Pu" type="DOUBLE" value="10"/>
     <par name="SVarC_URefDown" type="DOUBLE" value="235"/>
     <par name="SVarC_URefUp" type="DOUBLE" value="245"/>
     <par name="SVarC_UThresholdDown" type="DOUBLE" value="215"/>

--- a/tests/outputs/reference/TestStartingPointMode/TestStartingPointModeFlatWithIRL.par
+++ b/tests/outputs/reference/TestStartingPointMode/TestStartingPointModeFlatWithIRL.par
@@ -63,10 +63,10 @@
     <par name="SVarC_BMaxPu" type="DOUBLE" value="5290"/>
     <par name="SVarC_BMinPu" type="DOUBLE" value="0"/>
     <par name="SVarC_BShuntPu" type="DOUBLE" value="0"/>
-    <par name="SVarC_LambdaPu" type="DOUBLE" value="4.3478260869565215"/>
+    <par name="SVarC_LambdaPu" type="DOUBLE" value="100"/>
     <par name="SVarC_UNom" type="DOUBLE" value="230"/>
     <par name="SVarC_UNomRemote" type="DOUBLE" value="10"/>
-    <par name="SVarC_URef0Pu" type="DOUBLE" value="0.43478260869565216"/>
+    <par name="SVarC_URef0Pu" type="DOUBLE" value="10"/>
     <macroParSet id="MacroParameterSetStaticCompensator"/>
   </set>
   <set id="3ec41c13-b32e-549c-b6b0-e05a368810d6">
@@ -75,7 +75,7 @@
     <par name="SVarC_BShuntPu" type="DOUBLE" value="0"/>
     <par name="SVarC_UNom" type="DOUBLE" value="230"/>
     <par name="SVarC_UNomRemote" type="DOUBLE" value="10"/>
-    <par name="SVarC_URef0Pu" type="DOUBLE" value="0.43478260869565216"/>
+    <par name="SVarC_URef0Pu" type="DOUBLE" value="10"/>
     <macroParSet id="MacroParameterSetStaticCompensator"/>
   </set>
   <set id="5af224bc-7a03-5bcd-af4e-25de959b69f6">
@@ -346,10 +346,10 @@
     <par name="SVarC_BMaxPu" type="DOUBLE" value="5290"/>
     <par name="SVarC_BMinPu" type="DOUBLE" value="0"/>
     <par name="SVarC_BShuntPu" type="DOUBLE" value="0"/>
-    <par name="SVarC_LambdaPu" type="DOUBLE" value="4.3478260869565215"/>
+    <par name="SVarC_LambdaPu" type="DOUBLE" value="100"/>
     <par name="SVarC_UNom" type="DOUBLE" value="230"/>
     <par name="SVarC_UNomRemote" type="DOUBLE" value="10"/>
-    <par name="SVarC_URef0Pu" type="DOUBLE" value="0.43478260869565216"/>
+    <par name="SVarC_URef0Pu" type="DOUBLE" value="10"/>
     <par name="SVarC_URefDown" type="DOUBLE" value="235"/>
     <par name="SVarC_URefUp" type="DOUBLE" value="245"/>
     <par name="SVarC_UThresholdDown" type="DOUBLE" value="215"/>
@@ -374,7 +374,7 @@
     <par name="SVarC_BShuntPu" type="DOUBLE" value="0"/>
     <par name="SVarC_UNom" type="DOUBLE" value="230"/>
     <par name="SVarC_UNomRemote" type="DOUBLE" value="10"/>
-    <par name="SVarC_URef0Pu" type="DOUBLE" value="0.43478260869565216"/>
+    <par name="SVarC_URef0Pu" type="DOUBLE" value="10"/>
     <par name="SVarC_URefDown" type="DOUBLE" value="235"/>
     <par name="SVarC_URefUp" type="DOUBLE" value="245"/>
     <par name="SVarC_UThresholdDown" type="DOUBLE" value="215"/>

--- a/tests/outputs/reference/TestStartingPointMode/TestStartingPointModeWarmNoIRL.par
+++ b/tests/outputs/reference/TestStartingPointMode/TestStartingPointModeWarmNoIRL.par
@@ -63,10 +63,10 @@
     <par name="SVarC_BMaxPu" type="DOUBLE" value="5290"/>
     <par name="SVarC_BMinPu" type="DOUBLE" value="0"/>
     <par name="SVarC_BShuntPu" type="DOUBLE" value="0"/>
-    <par name="SVarC_LambdaPu" type="DOUBLE" value="4.3478260869565215"/>
+    <par name="SVarC_LambdaPu" type="DOUBLE" value="100"/>
     <par name="SVarC_UNom" type="DOUBLE" value="230"/>
     <par name="SVarC_UNomRemote" type="DOUBLE" value="10"/>
-    <par name="SVarC_URef0Pu" type="DOUBLE" value="0.43478260869565216"/>
+    <par name="SVarC_URef0Pu" type="DOUBLE" value="10"/>
     <macroParSet id="MacroParameterSetStaticCompensator"/>
   </set>
   <set id="3ec41c13-b32e-549c-b6b0-e05a368810d6">
@@ -75,7 +75,7 @@
     <par name="SVarC_BShuntPu" type="DOUBLE" value="0"/>
     <par name="SVarC_UNom" type="DOUBLE" value="230"/>
     <par name="SVarC_UNomRemote" type="DOUBLE" value="10"/>
-    <par name="SVarC_URef0Pu" type="DOUBLE" value="0.43478260869565216"/>
+    <par name="SVarC_URef0Pu" type="DOUBLE" value="10"/>
     <macroParSet id="MacroParameterSetStaticCompensator"/>
   </set>
   <set id="5af224bc-7a03-5bcd-af4e-25de959b69f6">
@@ -346,10 +346,10 @@
     <par name="SVarC_BMaxPu" type="DOUBLE" value="5290"/>
     <par name="SVarC_BMinPu" type="DOUBLE" value="0"/>
     <par name="SVarC_BShuntPu" type="DOUBLE" value="0"/>
-    <par name="SVarC_LambdaPu" type="DOUBLE" value="4.3478260869565215"/>
+    <par name="SVarC_LambdaPu" type="DOUBLE" value="100"/>
     <par name="SVarC_UNom" type="DOUBLE" value="230"/>
     <par name="SVarC_UNomRemote" type="DOUBLE" value="10"/>
-    <par name="SVarC_URef0Pu" type="DOUBLE" value="0.43478260869565216"/>
+    <par name="SVarC_URef0Pu" type="DOUBLE" value="10"/>
     <par name="SVarC_URefDown" type="DOUBLE" value="235"/>
     <par name="SVarC_URefUp" type="DOUBLE" value="245"/>
     <par name="SVarC_UThresholdDown" type="DOUBLE" value="215"/>
@@ -374,7 +374,7 @@
     <par name="SVarC_BShuntPu" type="DOUBLE" value="0"/>
     <par name="SVarC_UNom" type="DOUBLE" value="230"/>
     <par name="SVarC_UNomRemote" type="DOUBLE" value="10"/>
-    <par name="SVarC_URef0Pu" type="DOUBLE" value="0.43478260869565216"/>
+    <par name="SVarC_URef0Pu" type="DOUBLE" value="10"/>
     <par name="SVarC_URefDown" type="DOUBLE" value="235"/>
     <par name="SVarC_URefUp" type="DOUBLE" value="245"/>
     <par name="SVarC_UThresholdDown" type="DOUBLE" value="215"/>

--- a/tests/outputs/reference/TestStartingPointMode/TestStartingPointModeWarmWithIRL.par
+++ b/tests/outputs/reference/TestStartingPointMode/TestStartingPointModeWarmWithIRL.par
@@ -63,10 +63,10 @@
     <par name="SVarC_BMaxPu" type="DOUBLE" value="5290"/>
     <par name="SVarC_BMinPu" type="DOUBLE" value="0"/>
     <par name="SVarC_BShuntPu" type="DOUBLE" value="0"/>
-    <par name="SVarC_LambdaPu" type="DOUBLE" value="4.3478260869565215"/>
+    <par name="SVarC_LambdaPu" type="DOUBLE" value="100"/>
     <par name="SVarC_UNom" type="DOUBLE" value="230"/>
     <par name="SVarC_UNomRemote" type="DOUBLE" value="10"/>
-    <par name="SVarC_URef0Pu" type="DOUBLE" value="0.43478260869565216"/>
+    <par name="SVarC_URef0Pu" type="DOUBLE" value="10"/>
     <macroParSet id="MacroParameterSetStaticCompensator"/>
   </set>
   <set id="3ec41c13-b32e-549c-b6b0-e05a368810d6">
@@ -75,7 +75,7 @@
     <par name="SVarC_BShuntPu" type="DOUBLE" value="0"/>
     <par name="SVarC_UNom" type="DOUBLE" value="230"/>
     <par name="SVarC_UNomRemote" type="DOUBLE" value="10"/>
-    <par name="SVarC_URef0Pu" type="DOUBLE" value="0.43478260869565216"/>
+    <par name="SVarC_URef0Pu" type="DOUBLE" value="10"/>
     <macroParSet id="MacroParameterSetStaticCompensator"/>
   </set>
   <set id="5af224bc-7a03-5bcd-af4e-25de959b69f6">
@@ -346,10 +346,10 @@
     <par name="SVarC_BMaxPu" type="DOUBLE" value="5290"/>
     <par name="SVarC_BMinPu" type="DOUBLE" value="0"/>
     <par name="SVarC_BShuntPu" type="DOUBLE" value="0"/>
-    <par name="SVarC_LambdaPu" type="DOUBLE" value="4.3478260869565215"/>
+    <par name="SVarC_LambdaPu" type="DOUBLE" value="100"/>
     <par name="SVarC_UNom" type="DOUBLE" value="230"/>
     <par name="SVarC_UNomRemote" type="DOUBLE" value="10"/>
-    <par name="SVarC_URef0Pu" type="DOUBLE" value="0.43478260869565216"/>
+    <par name="SVarC_URef0Pu" type="DOUBLE" value="10"/>
     <par name="SVarC_URefDown" type="DOUBLE" value="235"/>
     <par name="SVarC_URefUp" type="DOUBLE" value="245"/>
     <par name="SVarC_UThresholdDown" type="DOUBLE" value="215"/>
@@ -374,7 +374,7 @@
     <par name="SVarC_BShuntPu" type="DOUBLE" value="0"/>
     <par name="SVarC_UNom" type="DOUBLE" value="230"/>
     <par name="SVarC_UNomRemote" type="DOUBLE" value="10"/>
-    <par name="SVarC_URef0Pu" type="DOUBLE" value="0.43478260869565216"/>
+    <par name="SVarC_URef0Pu" type="DOUBLE" value="10"/>
     <par name="SVarC_URefDown" type="DOUBLE" value="235"/>
     <par name="SVarC_URefUp" type="DOUBLE" value="245"/>
     <par name="SVarC_UThresholdDown" type="DOUBLE" value="215"/>


### PR DESCRIPTION
control is used in static var compensators

closes #913

**Checklist before requesting a review**

*use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes*

- [ ] unit tests and non regression tests were added (update of inputs, outputs, SA, algos)
- [ ] main documentation was updated (update of input/output file)
- [ ] the corresponding milestone was added in the ticket and in this PR
